### PR TITLE
POC: decompose iso Page into composable hooks (direction #2)

### DIFF
--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useRef, useState } from 'preact/hooks';
 import { ReloadContext } from './page.js';
 import { cacheRegistry } from './cache-registry.js';
+import type { LoaderCache } from './cache.js';
 
 export type ActionStub<TPayload, TResult> = {
   readonly __module: string;
@@ -18,6 +19,8 @@ export function defineAction<TPayload, TResult>(
 
 export type UseActionOptions<TPayload, TResult, TSnapshot = unknown> = {
   invalidate?: 'auto' | false | string[];
+  cache?: LoaderCache<unknown>;
+  reload?: () => void;
   onMutate?: (payload: TPayload) => TSnapshot;
   onError?: (err: Error, snapshot: TSnapshot) => void;
   onSuccess?: (data: TResult, snapshot: TSnapshot) => void;
@@ -121,7 +124,12 @@ export function useAction<TPayload, TResult, TSnapshot = unknown>(
       }
 
       if (currentOptions?.invalidate === 'auto') {
-        reloadCtx?.reload();
+        const reload = currentOptions.reload ?? reloadCtx?.reload;
+        if (reload) {
+          reload();
+        } else if (currentOptions.cache) {
+          currentOptions.cache.invalidate();
+        }
       } else if (Array.isArray(currentOptions?.invalidate)) {
         for (const name of currentOptions.invalidate) {
           cacheRegistry.invalidate(name);

--- a/packages/iso/src/guard-gate.tsx
+++ b/packages/iso/src/guard-gate.tsx
@@ -1,0 +1,28 @@
+import { type ComponentChildren } from 'preact';
+import { useLocation } from 'preact-iso';
+import { GuardRedirect, type GuardResult } from './guard.js';
+import { isBrowser } from './is-browser.js';
+
+type GuardGateProps = {
+  result: GuardResult | null;
+  children: ComponentChildren;
+};
+
+export function GuardGate({ result, children }: GuardGateProps) {
+  const { route } = useLocation();
+
+  if (result && 'redirect' in result) {
+    if (isBrowser()) {
+      route(result.redirect);
+      return null;
+    }
+    throw new GuardRedirect(result.redirect);
+  }
+
+  if (result && 'render' in result) {
+    const Fallback = result.render;
+    return <Fallback />;
+  }
+
+  return <>{children}</>;
+}

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -20,3 +20,15 @@ export type {
   UseOptimisticActionOptions,
   UseOptimisticActionResult,
 } from './optimistic-action.js';
+export { useGuards, useGuardSuspender } from './use-guards.js';
+export type { GuardSuspender } from './use-guards.js';
+export { GuardGate } from './guard-gate.js';
+export { useLoader, useLoaderState } from './use-loader.js';
+export type {
+  UseLoaderOptions,
+  UseLoaderResult,
+  UseLoaderStateResult,
+  LoaderSuspender,
+} from './use-loader.js';
+export { useLoaderData } from './loader-data-context.js';
+export { prefetch } from './prefetch.js';

--- a/packages/iso/src/loader-data-context.ts
+++ b/packages/iso/src/loader-data-context.ts
@@ -1,0 +1,16 @@
+import { createContext } from 'preact';
+import { useContext } from 'preact/hooks';
+
+const SENTINEL = Symbol('loader-data-uninitialized');
+
+export const LoaderDataContext = createContext<unknown>(SENTINEL);
+
+export function useLoaderData<T>(): T {
+  const data = useContext(LoaderDataContext);
+  if (data === SENTINEL) {
+    throw new Error(
+      'useLoaderData must be called inside a component rendered by getLoaderData'
+    );
+  }
+  return data as T;
+}

--- a/packages/iso/src/page.tsx
+++ b/packages/iso/src/page.tsx
@@ -1,19 +1,20 @@
 import {
   createContext,
-  type ComponentChildren,
   type ComponentType,
   type FunctionComponent,
   type JSX,
 } from 'preact';
-import { RouteHook, useLocation } from 'preact-iso';
+import { type RouteHook } from 'preact-iso';
 import { memo, Suspense } from 'preact/compat';
-import { useCallback, useContext, useId, useRef, useState } from 'preact/hooks';
-import { type LoaderCache } from './cache';
-import { type GuardFn, GuardRedirect, runGuards } from './guard.js';
-import { isBrowser } from './is-browser';
-import { Loader, LoaderData } from './loader';
-import { getPreloadedData } from './preload';
-import wrapPromise from './wrap-promise';
+import { useContext, useId } from 'preact/hooks';
+import { type LoaderCache } from './cache.js';
+import { type GuardFn } from './guard.js';
+import { GuardGate } from './guard-gate.js';
+import { isBrowser } from './is-browser.js';
+import { type Loader, type LoaderData } from './loader.js';
+import { LoaderDataContext } from './loader-data-context.js';
+import { useGuardSuspender, type GuardSuspender } from './use-guards.js';
+import { useLoaderState, type LoaderSuspender } from './use-loader.js';
 
 type ReloadContextValue = {
   reload: () => void;
@@ -37,7 +38,7 @@ export function useReload(): ReloadContextValue {
 export type WrapperProps = {
   id: string;
   'data-loader': string;
-  children: ComponentChildren;
+  children: JSX.Element | JSX.Element[] | string | null;
 };
 
 const DefaultWrapper: FunctionComponent<WrapperProps> = (props) => (
@@ -55,6 +56,8 @@ type PageProps<T> = {
   Wrapper?: ComponentType<WrapperProps>;
 };
 
+const defaultLoader: Loader<Record<string, unknown>> = async () => ({});
+
 export const Page = memo(function <T extends Record<string, unknown>>({
   Child,
   serverLoader,
@@ -67,174 +70,84 @@ export const Page = memo(function <T extends Record<string, unknown>>({
 }: PageProps<T>) {
   const id = useId();
   const guards = isBrowser() ? clientGuards : serverGuards;
-  const prevGuardPath = useRef(location.path);
-  const guardRef = useRef(wrapPromise(runGuards(guards, { location })));
+  const loader = (serverLoader ?? defaultLoader) as Loader<T>;
 
-  if (prevGuardPath.current !== location.path) {
-    prevGuardPath.current = location.path;
-    guardRef.current = wrapPromise(runGuards(guards, { location }));
-  }
+  // These hooks live outside the Suspense boundaries below. Their refs/state
+  // persist across re-mounts of the suspending children.
+  const guardSuspender = useGuardSuspender(guards, location);
+  const { suspender: loaderSuspender, reload, reloading, error } =
+    useLoaderState<T>(loader, { id, cache, location });
 
   return (
-    <Suspense fallback={fallback}>
-      <GuardedPage
-        id={id}
-        Child={Child}
-        serverLoader={serverLoader}
-        location={location}
-        cache={cache}
-        guardRef={guardRef}
-        fallback={fallback}
-        Wrapper={Wrapper}
-      />
-    </Suspense>
+    <ReloadContext.Provider value={{ reload, reloading, error }}>
+      <Suspense fallback={fallback}>
+        <GuardBoundary guardSuspender={guardSuspender}>
+          <Suspense fallback={fallback}>
+            <LoaderBoundary
+              id={id}
+              Child={Child}
+              suspender={loaderSuspender}
+              Wrapper={Wrapper}
+            />
+          </Suspense>
+        </GuardBoundary>
+      </Suspense>
+    </ReloadContext.Provider>
   );
 });
 
-type GuardedPageProps<T> = {
+type GuardBoundaryProps = {
+  guardSuspender: GuardSuspender;
+  children: JSX.Element | JSX.Element[];
+};
+
+const GuardBoundary = memo(function ({
+  guardSuspender,
+  children,
+}: GuardBoundaryProps) {
+  const result = guardSuspender.read() ?? null;
+  return <GuardGate result={result}>{children}</GuardGate>;
+});
+
+type LoaderBoundaryProps<T> = {
   id: string;
   Child: FunctionComponent<LoaderData<T>>;
-  serverLoader?: Loader<T>;
-  location: RouteHook;
-  cache?: LoaderCache<T>;
-  guardRef: { current: { read: () => import('./guard.js').GuardResult } };
-  fallback?: JSX.Element;
+  suspender: LoaderSuspender<T>;
   Wrapper?: ComponentType<WrapperProps>;
 };
 
-const GuardedPage = memo(function <T extends Record<string, unknown>>({
+const LoaderBoundary = memo(function <T>({
   id,
   Child,
-  serverLoader = async () => ({}) as T,
-  location,
-  cache,
-  guardRef,
-  fallback,
+  suspender,
   Wrapper,
-}: GuardedPageProps<T>) {
-  const { route } = useLocation();
-  const [reloading, setReloading] = useState(false);
-  const [overrideData, setOverrideData] = useState<T | undefined>(undefined);
-  const [loadError, setLoadError] = useState<Error | null>(null);
-
-  const prevPath = useRef(location.path);
-  if (prevPath.current !== location.path) {
-    prevPath.current = location.path;
-    setOverrideData(undefined);
-  }
-
-  const serverLoaderRef = useRef(serverLoader);
-  serverLoaderRef.current = serverLoader;
-  const locationRef = useRef(location);
-  locationRef.current = location;
-
-  const reload = useCallback(() => {
-    if (reloading) return;
-    setReloading(true);
-    setLoadError(null);
-    serverLoaderRef
-      .current({ location: locationRef.current })
-      .then((result) => {
-        if (isBrowser()) cache?.set(result);
-        setOverrideData(result);
-        setReloading(false);
-      })
-      .catch((err: unknown) => {
-        setLoadError(err instanceof Error ? err : new Error(String(err)));
-        setReloading(false);
-      });
-  }, [reloading, cache]);
-
-  const guardResult = guardRef.current.read();
-
-  if (guardResult && 'redirect' in guardResult) {
-    if (isBrowser()) {
-      route(guardResult.redirect);
-      return null;
-    } else {
-      throw new GuardRedirect(guardResult.redirect);
-    }
-  }
-
-  if (guardResult && 'render' in guardResult) {
-    const Fallback = guardResult.render;
-    return <Fallback />;
-  }
-
-  const preloaded = getPreloadedData<T>(id);
-
-  if (preloaded !== null) {
-    cache?.set(preloaded);
-    return (
-      <ReloadContext.Provider value={{ reload, reloading, error: loadError }}>
-        <Helper
-          id={id}
-          Child={Child}
-          loader={{ read: () => preloaded }}
-          overrideData={overrideData}
-          Wrapper={Wrapper}
-        />
-      </ReloadContext.Provider>
-    );
-  }
-
-  if (isBrowser() && cache?.has()) {
-    const cached = cache.get()!;
-    return (
-      <ReloadContext.Provider value={{ reload, reloading, error: loadError }}>
-        <Helper
-          id={id}
-          Child={Child}
-          loader={{ read: () => cached }}
-          overrideData={overrideData}
-          Wrapper={Wrapper}
-        />
-      </ReloadContext.Provider>
-    );
-  }
-
-  const loaderRef = wrapPromise(
-    serverLoader({ location }).then((r) => {
-      if (isBrowser()) cache?.set(r);
-      return r;
-    })
-  );
-
+}: LoaderBoundaryProps<T>) {
+  const data = suspender.read();
   return (
-    <ReloadContext.Provider value={{ reload, reloading, error: loadError }}>
-      <Suspense fallback={fallback}>
-        <Helper
-          id={id}
-          Child={Child}
-          loader={loaderRef}
-          overrideData={overrideData}
-          Wrapper={Wrapper}
-        />
-      </Suspense>
-    </ReloadContext.Provider>
+    <LoaderDataContext.Provider value={data}>
+      <Helper id={id} Child={Child} data={data} Wrapper={Wrapper} />
+    </LoaderDataContext.Provider>
   );
 });
 
 type HelperProps<T> = {
   id: string;
   Child: FunctionComponent<LoaderData<T>>;
-  loader: { read: () => T };
-  overrideData?: T;
+  data: T;
   Wrapper?: ComponentType<WrapperProps>;
 };
+
 export const Helper = memo(function <T>({
   id,
   Child,
-  loader,
-  overrideData,
+  data,
   Wrapper = DefaultWrapper,
 }: HelperProps<T>) {
-  const loaderData = overrideData !== undefined ? overrideData : loader.read();
-  const stringified = !isBrowser() ? JSON.stringify(loaderData) : 'null';
+  const stringified = !isBrowser() ? JSON.stringify(data) : 'null';
 
   return (
     <Wrapper id={id} data-loader={stringified}>
-      <Child loaderData={loaderData} id={id} />
+      <Child loaderData={data} id={id} />
     </Wrapper>
   );
 });

--- a/packages/iso/src/prefetch.ts
+++ b/packages/iso/src/prefetch.ts
@@ -1,0 +1,24 @@
+import { type RouteHook } from 'preact-iso';
+import { type LoaderCache } from './cache.js';
+import { isBrowser } from './is-browser.js';
+import { type Loader } from './loader.js';
+
+export async function prefetch<T>(
+  loader: Loader<T>,
+  cache?: LoaderCache<T>,
+  location?: RouteHook
+): Promise<T> {
+  const fakeLocation =
+    location ??
+    ({
+      path: '',
+      url: '',
+      query: {},
+      params: {},
+      pathParams: {},
+      route: () => {},
+    } as unknown as RouteHook);
+  const result = await loader({ location: fakeLocation });
+  if (isBrowser()) cache?.set(result);
+  return result;
+}

--- a/packages/iso/src/use-guards.ts
+++ b/packages/iso/src/use-guards.ts
@@ -1,0 +1,40 @@
+import { useRef } from 'preact/hooks';
+import { type RouteHook } from 'preact-iso';
+import { type GuardFn, type GuardResult, runGuards } from './guard.js';
+import wrapPromise from './wrap-promise.js';
+
+export type GuardSuspender = { read: () => GuardResult };
+
+/**
+ * Returns a stable suspender that survives across re-renders. Does NOT throw.
+ * Must be called in a component that does NOT live inside the Suspense
+ * boundary that catches the suspender's read — otherwise useRef is reset on
+ * each suspend (Preact's compat Suspense remounts children of the boundary).
+ */
+export function useGuardSuspender(
+  guards: GuardFn[],
+  location: RouteHook
+): GuardSuspender {
+  const prevPath = useRef<string | null>(null);
+  const ref = useRef<GuardSuspender | null>(null);
+
+  if (ref.current === null || prevPath.current !== location.path) {
+    prevPath.current = location.path;
+    ref.current = wrapPromise(runGuards(guards, { location }));
+  }
+  return ref.current;
+}
+
+/**
+ * Convenience hook combining {@link useGuardSuspender} with read.
+ * The caller must place the catching `<Suspense>` ABOVE this component.
+ * For Page-style nesting (Suspense inside the orchestrator), use
+ * {@link useGuardSuspender} and call `.read()` in a child component.
+ */
+export function useGuards(
+  guards: GuardFn[],
+  location: RouteHook
+): GuardResult | null {
+  const susp = useGuardSuspender(guards, location);
+  return susp.read() ?? null;
+}

--- a/packages/iso/src/use-loader.ts
+++ b/packages/iso/src/use-loader.ts
@@ -1,0 +1,140 @@
+import { useCallback, useRef, useState } from 'preact/hooks';
+import { type RouteHook } from 'preact-iso';
+import { type LoaderCache } from './cache.js';
+import { isBrowser } from './is-browser.js';
+import { type Loader } from './loader.js';
+import { getPreloadedData } from './preload.js';
+import wrapPromise from './wrap-promise.js';
+
+export type UseLoaderOptions<T> = {
+  id: string;
+  cache?: LoaderCache<T>;
+  location: RouteHook;
+};
+
+export type UseLoaderResult<T> = {
+  data: T;
+  reload: () => void;
+  reloading: boolean;
+  error: Error | null;
+};
+
+export type LoaderSuspender<T> = { read: () => T };
+
+export type UseLoaderStateResult<T> = {
+  suspender: LoaderSuspender<T>;
+  reload: () => void;
+  reloading: boolean;
+  error: Error | null;
+};
+
+type LazyPromise<T> = { read: () => T };
+
+function makeLazyPromise<T>(
+  loader: Loader<T>,
+  location: RouteHook,
+  cache?: LoaderCache<T>
+): LazyPromise<T> {
+  let started: { read: () => T } | null = null;
+  return {
+    read: () => {
+      if (!started) {
+        started = wrapPromise(
+          loader({ location }).then((r) => {
+            if (isBrowser()) cache?.set(r);
+            return r;
+          })
+        );
+      }
+      return started.read();
+    },
+  };
+}
+
+/**
+ * Holds reload state and a stable lazy fetch promise. Does NOT throw.
+ * Must be called in a component that lives ABOVE the catching `<Suspense>`,
+ * because Preact's compat Suspense remounts children of the boundary on
+ * each suspend — that would reset useState/useRef.
+ */
+export function useLoaderState<T>(
+  loader: Loader<T>,
+  { id, cache, location }: UseLoaderOptions<T>
+): UseLoaderStateResult<T> {
+  const [reloading, setReloading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [override, setOverride] = useState<T | undefined>(undefined);
+
+  const prevPath = useRef(location.path);
+  if (prevPath.current !== location.path) {
+    prevPath.current = location.path;
+    setOverride(undefined);
+  }
+
+  const loaderRef = useRef(loader);
+  loaderRef.current = loader;
+  const locationRef = useRef(location);
+  locationRef.current = location;
+
+  const reload = useCallback(() => {
+    if (reloading) return;
+    setReloading(true);
+    setError(null);
+    loaderRef
+      .current({ location: locationRef.current })
+      .then((result) => {
+        if (isBrowser()) cache?.set(result);
+        setOverride(result);
+        setReloading(false);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setReloading(false);
+      });
+  }, [reloading, cache]);
+
+  const promiseRef = useRef<LazyPromise<T> | null>(null);
+  const promisePathRef = useRef<string | null>(null);
+  if (
+    promiseRef.current === null ||
+    promisePathRef.current !== location.path
+  ) {
+    promisePathRef.current = location.path;
+    promiseRef.current = makeLazyPromise(loader, location, cache);
+  }
+
+  // Capture the current state in closures so the suspender's `read` reflects
+  // the latest values from this render. The suspender object is recreated
+  // each render, but the underlying promiseRef / cache / preload stores
+  // persist.
+  const currentOverride = override;
+  const suspender: LoaderSuspender<T> = {
+    read: () => {
+      if (currentOverride !== undefined) return currentOverride;
+      const preloaded = getPreloadedData<T>(id);
+      if (preloaded !== null) {
+        if (isBrowser()) cache?.set(preloaded);
+        return preloaded;
+      }
+      if (isBrowser() && cache?.has()) return cache.get()!;
+      return promiseRef.current!.read();
+    },
+  };
+
+  return { suspender, reload, reloading, error };
+}
+
+/**
+ * Convenience hook combining {@link useLoaderState} with read.
+ * The caller must place the catching `<Suspense>` ABOVE this component.
+ * For Page-style nesting (Suspense inside the orchestrator), use
+ * {@link useLoaderState} and call `suspender.read()` in a child component.
+ */
+export function useLoader<T>(
+  loader: Loader<T>,
+  opts: UseLoaderOptions<T>
+): UseLoaderResult<T> {
+  const { suspender, reload, reloading, error } = useLoaderState(loader, opts);
+  const data = suspender.read();
+  return { data, reload, reloading, error };
+}


### PR DESCRIPTION
## Summary

Working POC of [direction #2](../blob/main/docs/superpowers/research/2026-04-26-iso-page-direction-2-hooks.md) from the iso composability research. Page becomes a thin composition over four hook primitives, with zero consumer migration cost.

- New hooks: `useGuards` / `useGuardSuspender`, `useLoader` / `useLoaderState`, `useLoaderData`, plus `<GuardGate>` and `prefetch()`
- `useAction` decoupled from `ReloadContext` via optional `cache`/`reload` options (fallback to context preserved — no breaking change)
- `Page` rewritten as `<Suspense><GuardBoundary><Suspense><LoaderBoundary><Helper/></LoaderBoundary></Suspense></GuardBoundary></Suspense>` with state owned by `Page` itself

## Design note on Preact Suspense

The original research doc assumed `useRef`/`useState` survive a Suspense throw. They don't in `preact/compat` — children of the catching boundary are remounted, resetting hooks. So the state-holding hooks (`useGuardSuspender`, `useLoaderState`) live in `Page` (above its Suspense) and pass stable suspenders down to memo'd boundary components that just call `.read()`. The convenience hooks (`useGuards`, `useLoader`) are documented to require Suspense placement above the calling component.

## Test plan

- [x] Full vitest suite (174/174 passing)
- [x] SSR populates `data-loader` attributes for `/`, `/movies`, `/watched`
- [x] Hydration: home toggle button reacts to clicks
- [x] `useOptimisticAction`: "Mark watched" updates UI optimistically and reload syncs server state
- [x] Cross-page cache invalidation: `/watched` "Remove" updates list correctly
- [x] No console errors on fresh page loads
- [ ] (suggested) full manual regression on each route in dev + preview build
- [ ] (suggested) production build smoke test

## Notes

- Public API of `Page` and `getLoaderData` unchanged — no migration needed in `apps/app/`
- New exports in `index.ts`: `useGuards`, `useGuardSuspender`, `GuardGate`, `useLoader`, `useLoaderState`, `useLoaderData`, `prefetch`, plus the corresponding types
- This is a POC — if approved as the direction, follow-up should consider whether convenience hooks (`useGuards`/`useLoader` that suspend on read) should be the public API at all, or whether to expose only the suspender variants for fewer footguns

🤖 Generated with [Claude Code](https://claude.com/claude-code)