### PR TITLE
feat(iso): route-level loaders via custom <Route>/<Router> + plugin support

### DIFF
--- a/apps/app/src/iso.tsx
+++ b/apps/app/src/iso.tsx
@@ -44,8 +44,8 @@ export const Base: FunctionComponent = () => {
     <Router onRouteChange={onRouteChange}>
       {/* Migrated to route-level Page wrapping */}
       <Route path="/" component={Home} />
-      {/* Still self-wrapping in <Page> — will migrate in subsequent tasks */}
-      <IsoRoute path="/test" component={Test} />
+      {/* Migrated to route-level Page wrapping */}
+      <Route path="/test" component={Test} />
       <IsoRoute path="/movies" component={Movies} />
       <IsoRoute path="/movies/*" component={Movies} />
       <IsoRoute path="/watched" component={Watched} />

--- a/apps/app/src/iso.tsx
+++ b/apps/app/src/iso.tsx
@@ -4,6 +4,7 @@ import { lazy, Route, Router } from '@hono-preact/iso';
 import { Route as IsoRoute } from 'preact-iso';
 import NotFound from './pages/not-found.js';
 import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
+import { loader as watchedLoader, cache as watchedCache } from './pages/watched.server.js';
 
 const Home = lazy(() => import('./pages/home.js'));
 const Test = lazy(() => import('./pages/test.js'));
@@ -50,7 +51,14 @@ export const Base: FunctionComponent = () => {
       {/* Migrated to route-level Page wrapping */}
       <Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
       <Route path="/movies/*" component={Movies} loader={moviesLoader} cache={moviesCache} />
-      <IsoRoute path="/watched" component={Watched} />
+      {/* Migrated to route-level Page wrapping */}
+      <Route
+        path="/watched"
+        component={Watched}
+        loader={watchedLoader}
+        cache={watchedCache}
+        fallback={<p class="p-1">Loading watched list…</p>}
+      />
       {mdxRoutes.map(({ route, Component }) => (
         <IsoRoute path={route} component={Component} />
       ))}

--- a/apps/app/src/iso.tsx
+++ b/apps/app/src/iso.tsx
@@ -3,6 +3,7 @@ import { flushSync } from 'preact/compat';
 import { lazy, Route, Router } from '@hono-preact/iso';
 import { Route as IsoRoute } from 'preact-iso';
 import NotFound from './pages/not-found.js';
+import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
 
 const Home = lazy(() => import('./pages/home.js'));
 const Test = lazy(() => import('./pages/test.js'));
@@ -46,8 +47,9 @@ export const Base: FunctionComponent = () => {
       <Route path="/" component={Home} />
       {/* Migrated to route-level Page wrapping */}
       <Route path="/test" component={Test} />
-      <IsoRoute path="/movies" component={Movies} />
-      <IsoRoute path="/movies/*" component={Movies} />
+      {/* Migrated to route-level Page wrapping */}
+      <Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
+      <Route path="/movies/*" component={Movies} loader={moviesLoader} cache={moviesCache} />
       <IsoRoute path="/watched" component={Watched} />
       {mdxRoutes.map(({ route, Component }) => (
         <IsoRoute path={route} component={Component} />

--- a/apps/app/src/iso.tsx
+++ b/apps/app/src/iso.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType, FunctionComponent } from 'preact';
 import { flushSync } from 'preact/compat';
-import { lazy, Route, Router } from 'preact-iso';
+import { lazy, Route, Router } from '@hono-preact/iso';
+import { Route as IsoRoute } from 'preact-iso';
 import NotFound from './pages/not-found.js';
 
 const Home = lazy(() => import('./pages/home.js'));
@@ -41,13 +42,15 @@ function onRouteChange() {
 export const Base: FunctionComponent = () => {
   return (
     <Router onRouteChange={onRouteChange}>
+      {/* Migrated to route-level Page wrapping */}
       <Route path="/" component={Home} />
-      <Route path="/test" component={Test} />
-      <Route path="/movies" component={Movies} />
-      <Route path="/movies/*" component={Movies} />
-      <Route path="/watched" component={Watched} />
+      {/* Still self-wrapping in <Page> — will migrate in subsequent tasks */}
+      <IsoRoute path="/test" component={Test} />
+      <IsoRoute path="/movies" component={Movies} />
+      <IsoRoute path="/movies/*" component={Movies} />
+      <IsoRoute path="/watched" component={Watched} />
       {mdxRoutes.map(({ route, Component }) => (
-        <Route path={route} component={Component} />
+        <IsoRoute path={route} component={Component} />
       ))}
       <NotFound />
     </Router>

--- a/apps/app/src/pages/docs/action-guards.mdx
+++ b/apps/app/src/pages/docs/action-guards.mdx
@@ -117,4 +117,4 @@ See [Route Guards — Composing guards](/docs/guards#composing-guards) for the f
 
 ## The server/client boundary
 
-`serverOnlyPlugin` replaces any imported `actionGuards` in the client bundle with an empty array — guard logic never reaches the browser. `serverLoaderValidationPlugin` enforces that `actionGuards` is one of only three permitted named exports from `.server.*` files (`serverGuards`, `serverActions`, `actionGuards`). See [Overview — The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.
+`serverOnlyPlugin` replaces any imported `actionGuards` in the client bundle with an empty array — guard logic never reaches the browser. `serverLoaderValidationPlugin` enforces that `actionGuards` is one of the permitted named exports from `.server.*` files (`loader`, `cache`, `serverGuards`, `serverActions`, `actionGuards`). See [Overview — The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.

--- a/apps/app/src/pages/docs/actions.mdx
+++ b/apps/app/src/pages/docs/actions.mdx
@@ -279,4 +279,4 @@ Guards run before every action in the module. See [Action Guards](/docs/action-g
 
 ## The server/client boundary
 
-`serverOnlyPlugin` rewrites `serverActions` imports in the client bundle with a Proxy — each property access returns an `ActionStub` with the module and action name. Any imported `actionGuards` become empty arrays. `serverLoaderValidationPlugin` enforces that `.server.*` files only export `serverGuards`, `serverActions`, or `actionGuards` as named exports. See [Overview — The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.
+`serverOnlyPlugin` rewrites `serverActions` imports in the client bundle with a Proxy — each property access returns an `ActionStub` with the module and action name. Any imported `actionGuards` become empty arrays. `serverLoaderValidationPlugin` enforces that `.server.*` files only export `loader`, `cache`, `serverGuards`, `serverActions`, or `actionGuards` as named exports. See [Overview — The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.

--- a/apps/app/src/pages/docs/actions.mdx
+++ b/apps/app/src/pages/docs/actions.mdx
@@ -60,11 +60,10 @@ app
 
 ```tsx
 import { useAction, useLoaderData } from '@hono-preact/iso';
-import { moviesLoader } from './movies.js';
-import { serverActions } from './movies.server.js';
+import { loader, serverActions } from './movies.server.js';
 
 const Movies = () => {
-  const { movies } = useLoaderData(moviesLoader);
+  const { movies } = useLoaderData(loader);
   const { mutate, pending, error } = useAction(serverActions.addMovie, {
     invalidate: 'auto',
     onSuccess: (data) => console.log('added', data),
@@ -131,7 +130,7 @@ FormData values are collected with `Object.fromEntries(new FormData(form))`. Str
 Use `onMutate` to update local state before the request fires, and `onError` to roll it back:
 
 ```tsx
-const { movies } = useLoaderData(moviesLoader);
+const { movies } = useLoaderData(loader);
 const [items, setItems] = useState(movies.results);
 
 const { mutate } = useAction(serverActions.addMovie, {
@@ -150,10 +149,12 @@ const { mutate } = useAction(serverActions.addMovie, {
 
 When a mutation on one page should refresh data on another, pass the target cache's name to `invalidate`:
 
-```tsx
-// ratings.tsx — a different page that shows the movie list in a sidebar
-const cache = createCache<{ movies: MovieList }>('movies'); // named cache
+```ts
+// ratings.server.ts — a different page that shows the movie list in a sidebar
+export const cache = createCache<{ movies: MovieList }>('movies'); // named cache
+```
 
+```tsx
 // movies.tsx — action that should also refresh the ratings sidebar
 const { mutate } = useAction(serverActions.addMovie, {
   invalidate: ['movies'], // clears the 'movies' cache on success

--- a/apps/app/src/pages/docs/guards.mdx
+++ b/apps/app/src/pages/docs/guards.mdx
@@ -11,7 +11,9 @@ Guards are async functions that receive a context object and a `next()` callback
 Like loaders, guards are split by environment:
 
 - `serverGuards` — exported from `*.server.ts`, run during SSR, tree-shaken from the browser bundle
-- `clientGuards` — defined inline in the page file, run during client-side navigation
+- `clientGuards` — defined in the page file (or any browser-safe module), run during client-side navigation
+
+Both are passed to the route at registration time via `<Route serverGuards={...} clientGuards={...}>`.
 
 ## API
 
@@ -47,12 +49,11 @@ guards: [checkAuthenticated, checkRole('admin')]
 
 ## Example: protected page
 
-**`src/pages/admin.server.ts`** — server guards (never reaches the browser bundle):
+**`src/pages/admin.server.ts`** — server guards plus the loader ref (never reaches the browser bundle):
 
 ```ts
-import type { LoaderFn } from '@hono-preact/iso';
-import { createGuard } from '@hono-preact/iso';
-import { getCurrentUser } from '@/server/auth.js';
+import { createCache, createGuard, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { getCurrentUser, getAdminStats } from '@/server/admin.js';
 
 const serverLoader: LoaderFn<{ stats: Stats }> = async () => {
   const stats = await getAdminStats();
@@ -60,6 +61,9 @@ const serverLoader: LoaderFn<{ stats: Stats }> = async () => {
 };
 
 export default serverLoader;
+
+export const loader = defineLoader<{ stats: Stats }>(serverLoader);
+export const cache = createCache<{ stats: Stats }>();
 
 export const serverGuards = [
   createGuard(async (_ctx, next) => {
@@ -71,24 +75,28 @@ export const serverGuards = [
 ];
 ```
 
-**`src/pages/admin.tsx`** — the page component:
+**`src/pages/admin.tsx`** — pure component:
 
 ```tsx
-import {
-  createCache,
-  createGuard,
-  defineLoader,
-  Page,
-  useLoaderData,
-} from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
-import serverLoader, { serverGuards } from './admin.server.js';
+import { useLoaderData } from '@hono-preact/iso';
+import { loader } from './admin.server.js';
 
-const cache = createCache<{ stats: Stats }>();
-const adminLoader = defineLoader<{ stats: Stats }>(serverLoader);
+const Admin: FunctionComponent = () => {
+  const { stats } = useLoaderData(loader);
+  return <section>...</section>;
+};
 
-const clientGuards = [
+export default Admin;
+```
+
+**`src/pages/admin.guards.ts`** — client guards in a browser-safe module:
+
+```ts
+import { createGuard } from '@hono-preact/iso';
+import { getCurrentUser } from '@/client/auth.js';
+
+export const clientGuards = [
   createGuard(async (_ctx, next) => {
     const user = await getCurrentUser(); // client-side auth check
     if (!user) return { redirect: '/login' };
@@ -96,32 +104,36 @@ const clientGuards = [
     return next();
   }),
 ];
+```
 
-const Admin: FunctionComponent = () => {
-  const { stats } = useLoaderData(adminLoader);
-  return <section>...</section>;
-};
+**`src/iso.tsx`** — wire loader, cache, and both guard chains into the route:
 
-export default function AdminPage(location: RouteHook) {
-  return (
-    <Page
-      loader={adminLoader}
-      location={location}
-      cache={cache}
-      serverGuards={serverGuards}
-      clientGuards={clientGuards}
-    >
-      <Admin />
-    </Page>
-  );
-}
+```tsx
+import { lazy, Route } from '@hono-preact/iso';
+import {
+  loader as adminLoader,
+  cache as adminCache,
+  serverGuards,
+} from './pages/admin.server.js';
+import { clientGuards } from './pages/admin.guards.js';
+
+const Admin = lazy(() => import('./pages/admin.js'));
+
+<Route
+  path="/admin"
+  component={Admin}
+  loader={adminLoader}
+  cache={adminCache}
+  serverGuards={serverGuards}
+  clientGuards={clientGuards}
+/>
 ```
 
 ## Build conventions
 
 The same Vite plugins that enforce loader conventions also enforce guard conventions.
 
-**`serverLoaderValidationPlugin`** — `.server.ts` files may only have `serverGuards` as a named export alongside the default loader. Any other named export fails the build:
+**`serverLoaderValidationPlugin`** — `.server.ts` files may only export `loader`, `cache`, `serverGuards`, `serverActions`, and `actionGuards` as named exports (alongside the default loader). Any other named export fails the build:
 
 ```ts
 // ❌ build error
@@ -129,18 +141,20 @@ export const helper = () => {};
 export default serverLoader;
 
 // ✅ allowed
+export const loader = defineLoader(serverLoader);
 export const serverGuards = [...];
 export default serverLoader;
 ```
 
-**`serverOnlyPlugin`** — in the client bundle, `serverGuards` imports are replaced with an empty array stub. Your server-side auth logic never reaches the browser:
+**`serverOnlyPlugin`** — in the client bundle, the default `serverLoader` import is rewritten to an RPC stub and `serverGuards` is replaced with an empty array. Your server-side auth logic never reaches the browser:
 
 ```ts
-// What you write:
-import serverLoader, { serverGuards } from './admin.server.js';
+// What you write (in admin.server.ts):
+const serverLoader = async () => ({ /* db calls, secrets, etc. */ });
+export const serverGuards = [/* auth checks */];
 
 // What the client bundle sees:
-const serverLoader = async () => ({});
+const serverLoader = /* RPC stub */;
 const serverGuards = [];
 ```
 

--- a/apps/app/src/pages/docs/index.mdx
+++ b/apps/app/src/pages/docs/index.mdx
@@ -6,21 +6,19 @@ Every route is a file pair: a `.tsx` page component and a `.server.ts` file that
 
 ```tsx
 // movies.server.ts — runs only on the server
-const serverLoader = async () => ({
-  movies: await getMovies(),
-});
+const serverLoader = async () => ({ movies: await getMovies() });
 export default serverLoader;
+export const loader = defineLoader(serverLoader);
 
-// movies.tsx — the page component
-const moviesLoader = defineLoader(serverLoader);
-
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page loader={moviesLoader} location={location}>
-      <Movies />
-    </Page>
-  );
+// movies.tsx — the page component (pure, no wrappers)
+export default function Movies() {
+  const { movies } = useLoaderData(loader);
+  return <ul>{movies.map((m) => <li key={m.id}>{m.title}</li>)}</ul>;
 }
+
+// iso.tsx — the route ties them together
+import { loader as moviesLoader } from './pages/movies.server.js';
+<Route path="/movies" component={Movies} loader={moviesLoader} />
 ```
 
 On the first request, the server runs the loader directly and preloads the result into the HTML. On hydration, the client reads from that preloaded data. On client-side navigation, the framework calls the loader over RPC. Same loader, three environments, zero config.

--- a/apps/app/src/pages/docs/index.mdx
+++ b/apps/app/src/pages/docs/index.mdx
@@ -27,6 +27,6 @@ On the first request, the server runs the loader directly and preloads the resul
 
 ## The server/client boundary
 
-Two Vite plugins enforce the boundary between server and client code. During the client bundle build, `serverOnlyPlugin` rewrites `*.server.*` imports: the default export becomes an RPC function, any imported `serverGuards` or `actionGuards` become empty arrays, and `serverActions` becomes a Proxy. Database clients, secrets, and internal API URLs in `.server.*` files never reach the browser bundle.
+Two Vite plugins enforce the boundary between server and client code. During the client bundle build, `serverOnlyPlugin` rewrites `*.server.*` imports: the default export becomes an RPC function, the `loader` named export becomes a client-safe `LoaderRef` that calls the same RPC, the `cache` named export becomes a `cacheRegistry`-deduped client cache, any imported `serverGuards` or `actionGuards` become empty arrays, and `serverActions` becomes a Proxy. Side-effect-only `.server.*` imports are stripped entirely. Database clients, secrets, and internal API URLs in `.server.*` files never reach the browser bundle.
 
-`serverLoaderValidationPlugin` enforces the contract at build time: `.server.*` files may only export `serverGuards`, `serverActions`, or `actionGuards` as named exports. Any other named export fails the build.
+`serverLoaderValidationPlugin` enforces the contract at build time: `.server.*` files may only export `loader`, `cache`, `serverGuards`, `serverActions`, or `actionGuards` as named exports (alongside the default loader). Any other named export fails the build, and re-exporting from a `.server.*` module (`export { loader } from './x.server.js'`) fails the build too.

--- a/apps/app/src/pages/docs/loaders.mdx
+++ b/apps/app/src/pages/docs/loaders.mdx
@@ -6,10 +6,12 @@ Pages often need data. On the server, that data should come from a direct functi
 
 ## How it works
 
-Define a `serverLoader` as the default export of a `.server.ts` file. That single function handles all three load cases:
+A page is a file pair:
 
-- `movies.server.ts` — the loader; runs directly on the server or via RPC from the browser
-- `movies.tsx` — wraps the loader with `defineLoader` and passes the resulting reference to `<Page loader={...}>`
+- `movies.server.ts` — the server loader (default export) plus its `defineLoader` reference (named export). Never reaches the browser bundle.
+- `movies.tsx` — a pure component that consumes the loader data via `useLoaderData(loader)`.
+
+The two are bound together at the route registration in `iso.tsx`, which passes the loader reference to `<Route loader={...}>`.
 
 **At runtime:**
 1. **SSR:** `serverLoader` runs directly during `prerender`. Its return value is JSON-serialized into a `data-loader` attribute on the page's wrapper element.
@@ -18,11 +20,11 @@ Define a `serverLoader` as the default export of a `.server.ts` file. That singl
 
 ## Example: listing page
 
-**`src/pages/movies.server.ts`** — server-only data fetching:
+**`src/pages/movies.server.ts`** — server-only data fetching plus the loader ref:
 
 ```ts
 import { getMovies } from '@/server/movies.js';
-import type { LoaderFn } from '@hono-preact/iso';
+import { defineLoader, type LoaderFn } from '@hono-preact/iso';
 
 const serverLoader: LoaderFn<{ movies: MovieList }> = async () => {
   const movies = await getMovies(); // direct call — never runs in the browser
@@ -30,43 +32,41 @@ const serverLoader: LoaderFn<{ movies: MovieList }> = async () => {
 };
 
 export default serverLoader;
+
+export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
 ```
 
-**`src/pages/movies.tsx`** — the page component:
+**`src/pages/movies.tsx`** — a pure component:
 
 ```tsx
-import {
-  createCache,
-  defineLoader,
-  Page,
-  useLoaderData,
-} from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
-import serverLoader from './movies.server.js';
-
-const cache = createCache<{ movies: MovieList }>();
-const moviesLoader = defineLoader<{ movies: MovieList }>(serverLoader);
+import { useLoaderData } from '@hono-preact/iso';
+import { loader } from './movies.server.js';
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(moviesLoader);
+  const { movies } = useLoaderData(loader);
   return (
     <ul>
-      {movies.results.map(m => <li key={m.id}>{m.title}</li>)}
+      {movies.results.map((m) => <li key={m.id}>{m.title}</li>)}
     </ul>
   );
 };
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page loader={moviesLoader} location={location} cache={cache}>
-      <Movies />
-    </Page>
-  );
-}
+export default Movies;
 ```
 
-`defineLoader(fn)` returns a typed reference (`LoaderRef<T>`). The `<Page loader={...}>` prop and the `useLoaderData(ref)` hook both consume that reference, so the data type flows through with no extra annotations.
+**`src/iso.tsx`** — registration ties the loader to the route:
+
+```tsx
+import { lazy, Route } from '@hono-preact/iso';
+import { loader as moviesLoader } from './pages/movies.server.js';
+
+const Movies = lazy(() => import('./pages/movies.js'));
+
+<Route path="/movies" component={Movies} loader={moviesLoader} />
+```
+
+`defineLoader(fn)` returns a typed reference (`LoaderRef<T>`). The `<Route loader={...}>` prop and the `useLoaderData(ref)` hook both consume that reference, so the data type flows through with no extra annotations.
 
 ## Example: detail page (using route params)
 
@@ -75,7 +75,7 @@ export default function MoviesPage(location: RouteHook) {
 ```ts
 // src/pages/movie.server.ts
 import { getMovie } from '@/server/movies.js';
-import type { LoaderFn } from '@hono-preact/iso';
+import { defineLoader, type LoaderFn } from '@hono-preact/iso';
 
 const serverLoader: LoaderFn<{ movie: Movie }> = async ({ location }) => {
   const movie = await getMovie(location.pathParams.id);
@@ -83,6 +83,8 @@ const serverLoader: LoaderFn<{ movie: Movie }> = async ({ location }) => {
 };
 
 export default serverLoader;
+
+export const loader = defineLoader<{ movie: Movie }>(serverLoader);
 ```
 
 ## Registering the loader endpoint
@@ -103,21 +105,30 @@ app
 
 ## Caching navigation results
 
-Pass a `cache` to `<Page>` so repeated navigations to the same page don't re-fetch:
+Export a `cache` from the `.server.ts` file alongside the loader, then pass it to the route so repeated navigations to the same page don't re-fetch:
+
+```ts
+// src/pages/movies.server.ts
+import { createCache, defineLoader, type LoaderFn } from '@hono-preact/iso';
+
+const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
+  movies: await getMovies(),
+});
+
+export default serverLoader;
+
+export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const cache = createCache<{ movies: MovieList }>();
+```
 
 ```tsx
-import { createCache, defineLoader, Page } from '@hono-preact/iso';
+// src/iso.tsx
+import { lazy, Route } from '@hono-preact/iso';
+import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
 
-const cache = createCache<{ movies: MovieList }>();
-const moviesLoader = defineLoader<{ movies: MovieList }>(serverLoader);
+const Movies = lazy(() => import('./pages/movies.js'));
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page loader={moviesLoader} location={location} cache={cache}>
-      <Movies />
-    </Page>
-  );
-}
+<Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
 ```
 
 On a cache hit, the RPC call is skipped entirely. After a successful fetch the result is stored in the cache for the session.
@@ -127,12 +138,15 @@ On a cache hit, the RPC call is skipped entirely. After a successful fetch the r
 Pass a string to `createCache` to register the cache with the global `cacheRegistry`. Actions on other pages can then invalidate it by name using `invalidate: ['cache-name']`:
 
 ```ts
-// movies.tsx
-const cache = createCache<{ movies: MovieList }>('movies');
+// movies.server.ts
+export const cache = createCache<{ movies: MovieList }>('movies');
 ```
 
 ```tsx
 // reviews.tsx — a different page whose action should also refresh the movie list
+import { useAction } from '@hono-preact/iso';
+import { serverActions } from './reviews.server.js';
+
 const { mutate } = useAction(serverActions.addReview, {
   invalidate: ['movies'], // clears the 'movies' cache on success
 });
@@ -142,4 +156,4 @@ Unnamed caches (`createCache<T>()`) work exactly as before and cannot be targete
 
 ## The server/client boundary
 
-Two Vite plugins enforce that `.server.*` code never reaches the browser. `serverOnlyPlugin` rewrites `*.server.*` imports in the client bundle: the default export becomes an RPC stub, and any imported `serverGuards`, `serverActions`, or `actionGuards` become empty arrays or Proxies. `serverLoaderValidationPlugin` fails the build if a `.server.*` file has any named export other than those three. See [Overview — The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.
+Two Vite plugins enforce that `.server.*` code never reaches the browser. `serverOnlyPlugin` rewrites `*.server.*` imports in the client bundle: the default export becomes an RPC stub, the `loader` and `cache` exports remain (their construction is browser-safe — only the inner `serverLoader` reference matters), and any imported `serverGuards`, `serverActions`, or `actionGuards` become empty arrays or Proxies. `serverLoaderValidationPlugin` fails the build if a `.server.*` file has unrecognised named exports. See [Overview — The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.

--- a/apps/app/src/pages/docs/loading-states.mdx
+++ b/apps/app/src/pages/docs/loading-states.mdx
@@ -2,27 +2,23 @@
 
 # Loading States
 
-By default, a page renders nothing while its loader is fetching. Pass a `fallback` to `<Page>` to show a loading UI during client-side navigation.
+By default, a page renders nothing while its loader is fetching. Pass a `fallback` to `<Route>` to show a loading UI during client-side navigation.
 
 ## Basic usage
 
 ```tsx
-import { defineLoader, Page } from '@hono-preact/iso';
+import { lazy, Route } from '@hono-preact/iso';
+import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
 
-const moviesLoader = defineLoader<{ movies: MovieList }>(serverLoader);
+const Movies = lazy(() => import('./pages/movies.js'));
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page
-      loader={moviesLoader}
-      location={location}
-      cache={cache}
-      fallback={<p>Loading…</p>}
-    >
-      <Movies />
-    </Page>
-  );
-}
+<Route
+  path="/movies"
+  component={Movies}
+  loader={moviesLoader}
+  cache={moviesCache}
+  fallback={<p>Loading…</p>}
+/>
 ```
 
 `fallback` is rendered by the `Suspense` boundary that wraps the loader fetch. It only appears on client-side navigation — SSR and first-load hydration read from preloaded data and render immediately.
@@ -49,16 +45,11 @@ const MoviesSkeleton = () => (
   </ul>
 );
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page
-      loader={moviesLoader}
-      location={location}
-      cache={cache}
-      fallback={<MoviesSkeleton />}
-    >
-      <Movies />
-    </Page>
-  );
-}
+<Route
+  path="/movies"
+  component={Movies}
+  loader={moviesLoader}
+  cache={moviesCache}
+  fallback={<MoviesSkeleton />}
+/>
 ```

--- a/apps/app/src/pages/docs/pages.mdx
+++ b/apps/app/src/pages/docs/pages.mdx
@@ -2,18 +2,16 @@
 
 # Adding Pages
 
-There are two kinds of pages in this template: standard Preact pages and MDX content pages. Both are lazy-loaded (code-split) and registered as preact-iso routes.
+There are two kinds of pages in this template: standard Preact pages and MDX content pages. Both are lazy-loaded (code-split) and registered as routes.
 
 ## Standard Preact pages
 
-Standard pages require three steps: create the file, register it in `iso.tsx`, and add a `<Route>`.
+A standard page is a pure component plus a `<Route>` registration. Loaders, caches, and guards live in the sibling `.server.ts` file and are wired in at the route — the page itself imports only what it consumes.
 
 ### Step 1 — Create `src/pages/about.tsx`
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
-import { Page } from '@hono-preact/iso';
 
 const About: FunctionComponent = () => {
   return <section>About this app.</section>;
@@ -21,25 +19,32 @@ const About: FunctionComponent = () => {
 
 About.displayName = 'About';
 
-export default function AboutPage(location: RouteHook) {
-  return (
-    <Page location={location}>
-      <About />
-    </Page>
-  );
-}
+export default About;
 ```
 
-Note: **`<Page>`** wraps every route component. It hosts the Suspense boundary, runs guards, and (when a `loader` prop is supplied) coordinates SSR preload, hydration, and client-side fetching. For pages with no data, omit the `loader` prop — children render directly inside the page wrapper.
+The page is a default-exported component. No `<Page>` wrapper, no `RouteHook` plumbing — those concerns belong to the route registration in the next step.
 
 ### Step 2 — Register in `src/iso.tsx`
 
 ```tsx
+import { lazy, Route } from '@hono-preact/iso';
+
 // Add the lazy import near the top with the other page imports:
 const About = lazy(() => import('./pages/about.js'));
 
 // Add a Route inside <Router>:
 <Route path="/about" component={About} />
+```
+
+`<Route>` from `@hono-preact/iso` is the registration surface. It hosts the Suspense boundary, runs guards, and (when a `loader` prop is supplied) coordinates SSR preload, hydration, and client-side fetching. For pages with data, import the loader from the `.server.ts` sibling and pass it through:
+
+```tsx
+import { lazy, Route } from '@hono-preact/iso';
+import { loader as aboutLoader } from './pages/about.server.js';
+
+const About = lazy(() => import('./pages/about.js'));
+
+<Route path="/about" component={About} loader={aboutLoader} />
 ```
 
 ### Step 3 — Link to it

--- a/apps/app/src/pages/docs/quick-start.mdx
+++ b/apps/app/src/pages/docs/quick-start.mdx
@@ -17,12 +17,10 @@ Open `http://localhost:5173`. The dev server runs both the Hono server and the V
 
 ## 1. Create a page
 
-Create `src/pages/movies.tsx`:
+Create `src/pages/movies.tsx` as a pure component with a default export:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
-import { Page } from '@hono-preact/iso';
 
 const Movies: FunctionComponent = () => {
   return (
@@ -34,33 +32,30 @@ const Movies: FunctionComponent = () => {
 
 Movies.displayName = 'Movies';
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page location={location}>
-      <Movies />
-    </Page>
-  );
-}
+export default Movies;
 ```
 
 Register the route in `src/iso.tsx` alongside the other lazy imports:
 
 ```tsx
+import { lazy, Route } from '@hono-preact/iso';
+
 const Movies = lazy(() => import('./pages/movies.js'));
+
 // inside <Router>:
 <Route path="/movies" component={Movies} />
 ```
 
 Open `http://localhost:5173/movies`. You should see "Movies".
 
-> `<Page>` wires the component into the loader/preload, guard, and Suspense system. It is required even for pages with no data — `loader` is the only optional prop.
+> `<Route>` from `@hono-preact/iso` is the registration surface — it wires the component into the loader/preload, guard, and Suspense system. For a page with no data, `loader` is omitted and the component renders directly.
 
 ## 2. Add a server loader
 
-Create `src/pages/movies.server.ts`:
+Create `src/pages/movies.server.ts`. The loader ref lives next to the server function as a named export — the page never needs to import `defineLoader` itself:
 
 ```ts
-import { type LoaderFn } from '@hono-preact/iso';
+import { defineLoader, type LoaderFn } from '@hono-preact/iso';
 
 export type Movie = { id: string; title: string };
 
@@ -78,20 +73,19 @@ const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
 });
 
 export default serverLoader;
+
+export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
 ```
 
-Update `src/pages/movies.tsx` to use the loader data:
+Update `src/pages/movies.tsx` to a pure consumer of the loader data:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
-import { defineLoader, Page, useLoaderData } from '@hono-preact/iso';
-import serverLoader, { type Movie } from './movies.server.js';
-
-const moviesLoader = defineLoader<{ movies: Movie[] }>(serverLoader);
+import { useLoaderData } from '@hono-preact/iso';
+import { loader } from './movies.server.js';
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(moviesLoader);
+  const { movies } = useLoaderData(loader);
   return (
     <main>
       <h1>Movies</h1>
@@ -106,25 +100,31 @@ const Movies: FunctionComponent = () => {
 
 Movies.displayName = 'Movies';
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page loader={moviesLoader} location={location}>
-      <Movies />
-    </Page>
-  );
-}
+export default Movies;
+```
+
+Wire the loader into the route in `src/iso.tsx`:
+
+```tsx
+import { lazy, Route } from '@hono-preact/iso';
+import { loader as moviesLoader } from './pages/movies.server.js';
+
+const Movies = lazy(() => import('./pages/movies.js'));
+
+// inside <Router>:
+<Route path="/movies" component={Movies} loader={moviesLoader} />
 ```
 
 Reload `http://localhost:5173/movies`. The list renders server-side on first load — the data is preloaded into the HTML. On client-side navigation away and back, the framework calls the loader over RPC. Same function, no manual wiring.
 
-`defineLoader(fn)` returns a typed reference. The `loader` prop on `<Page>` and the `useLoaderData(ref)` hook both take that reference, so the data type flows through without any explicit annotations on the consuming side.
+`defineLoader(fn)` returns a typed reference. The `loader` prop on `<Route>` and the `useLoaderData(ref)` hook both take that reference, so the data type flows through without any explicit annotations on the consuming side.
 
 ## 3. Add a server action
 
 Add `serverActions` to `src/pages/movies.server.ts`:
 
 ```ts
-import { defineAction, type LoaderFn } from '@hono-preact/iso';
+import { defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
 
 export type Movie = { id: string; title: string };
 
@@ -142,6 +142,8 @@ const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
 });
 
 export default serverLoader;
+
+export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
 
 export const serverActions = {
   addMovie: defineAction<{ title: string }, { ok: boolean }>(
@@ -157,17 +159,8 @@ Update `src/pages/movies.tsx` to add the form:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
-import {
-  defineLoader,
-  Form,
-  Page,
-  useAction,
-  useLoaderData,
-} from '@hono-preact/iso';
-import serverLoader, { serverActions, type Movie } from './movies.server.js';
-
-const moviesLoader = defineLoader<{ movies: Movie[] }>(serverLoader);
+import { Form, useAction, useLoaderData } from '@hono-preact/iso';
+import { loader, serverActions } from './movies.server.js';
 
 const AddMovieForm: FunctionComponent = () => {
   const { mutate, pending } = useAction(serverActions.addMovie, { invalidate: 'auto' });
@@ -180,7 +173,7 @@ const AddMovieForm: FunctionComponent = () => {
 };
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(moviesLoader);
+  const { movies } = useLoaderData(loader);
   return (
     <main>
       <h1>Movies</h1>
@@ -196,14 +189,10 @@ const Movies: FunctionComponent = () => {
 
 Movies.displayName = 'Movies';
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page loader={moviesLoader} location={location}>
-      <Movies />
-    </Page>
-  );
-}
+export default Movies;
 ```
+
+The `<Route>` registration in `iso.tsx` doesn't change — actions don't need any route-level wiring.
 
 Submit a title in the form. The action runs on the server, `invalidate: 'auto'` re-fetches the loader, and the list updates — no manual state management.
 

--- a/apps/app/src/pages/docs/reloading.mdx
+++ b/apps/app/src/pages/docs/reloading.mdx
@@ -6,18 +6,30 @@ Sometimes you need to re-run the loader imperatively — for example, after a us
 
 ## Basic usage
 
-```tsx
-import {
-  defineLoader,
-  Page,
-  useLoaderData,
-  useReload,
-} from '@hono-preact/iso';
+**`src/pages/movies.server.ts`** — loader and cache exports:
 
-const moviesLoader = defineLoader<{ movies: MovieList }>(serverLoader);
+```ts
+import { createCache, defineLoader, type LoaderFn } from '@hono-preact/iso';
+
+const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
+  movies: await getMovies(),
+});
+
+export default serverLoader;
+
+export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const cache = createCache<{ movies: MovieList }>();
+```
+
+**`src/pages/movies.tsx`** — pure component using `useReload`:
+
+```tsx
+import type { FunctionComponent } from 'preact';
+import { useLoaderData, useReload } from '@hono-preact/iso';
+import { loader } from './movies.server.js';
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(moviesLoader);
+  const { movies } = useLoaderData(loader);
   const { reload, reloading } = useReload();
 
   const handleAdd = async () => {
@@ -31,22 +43,27 @@ const Movies: FunctionComponent = () => {
         {reloading ? 'Adding...' : 'Add Movie'}
       </button>
       <ul>
-        {movies.results.map(m => <li key={m.id}>{m.title}</li>)}
+        {movies.results.map((m) => <li key={m.id}>{m.title}</li>)}
       </ul>
     </>
   );
 };
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page loader={moviesLoader} location={location}>
-      <Movies />
-    </Page>
-  );
-}
+export default Movies;
 ```
 
-`useReload` must be called inside a `<Page>` that has a `loader` prop. Calling it elsewhere throws an error.
+**`src/iso.tsx`** — register with the loader:
+
+```tsx
+import { lazy, Route } from '@hono-preact/iso';
+import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
+
+const Movies = lazy(() => import('./pages/movies.js'));
+
+<Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
+```
+
+`useReload` must be called inside a component rendered by a `<Route>` that has a `loader` prop. Calling it elsewhere throws an error.
 
 ## Background refresh
 
@@ -57,6 +74,8 @@ Reload is a background refresh — the current content stays visible while the n
 `reload()` re-runs the `serverLoader`. If you're using a cache, invalidate it first so the RPC call fires rather than returning stale cached data:
 
 ```tsx
+import { cache } from './movies.server.js';
+
 const { reload } = useReload();
 
 const handleAdd = async () => {

--- a/apps/app/src/pages/docs/structure.mdx
+++ b/apps/app/src/pages/docs/structure.mdx
@@ -9,8 +9,8 @@ hono-preact/                    # monorepo root
 │       ├── src/
 │       │   ├── server.tsx      # Hono app — API routes + catch-all SSR handler
 │       │   ├── client.tsx      # Browser entry — hydrates the Preact app
-│       │   ├── iso.tsx         # Shared component tree — Router + route registration
-│       │   ├── pages/          # Page components (one file per route)
+│       │   ├── iso.tsx         # Shared component tree — Router + Route registration
+│       │   ├── pages/          # Page components (one .tsx + one .server.ts per route)
 │       │   │   └── docs/       # MDX content pages (auto-discovered as /docs/* routes)
 │       │   ├── server/         # Server-only app code
 │       │   │   └── layout.tsx  # HTML shell rendered on every request
@@ -20,7 +20,7 @@ hono-preact/                    # monorepo root
 │       ├── vite.config.ts      # Two build configs: client bundle + Worker bundle
 │       └── wrangler.jsonc      # Cloudflare Workers deployment config
 └── packages/
-    ├── iso/                    # @hono-preact/iso — isomorphic loader utilities
+    ├── iso/                    # @hono-preact/iso — isomorphic loader utilities + <Route>/<Router>
     ├── server/                 # @hono-preact/server — HonoContext + server middleware
     └── vite/                   # @hono-preact/vite — server-only Vite plugins
 ```
@@ -50,12 +50,20 @@ hydrate(<App />, document.getElementById('app'));
 
 ### `apps/app/src/iso.tsx`
 
-The shared component tree used by both the server (via `Layout`) and the client (via hydration). Defines the `<Router>` with all routes, including lazy-loaded standard pages and auto-discovered MDX pages.
+The shared component tree used by both the server (via `Layout`) and the client (via hydration). Defines the `<Router>` from `@hono-preact/iso` with all routes — each `<Route>` registers a lazy-loaded page component and (optionally) imports its sibling `.server.ts` loader, cache, and guards.
 
-```ts
-const mdxModules = import.meta.glob('./pages/docs/*.mdx');
-// Each .mdx file becomes a lazy /docs/* route — no manual registration needed.
+```tsx
+import { lazy, Route, Router } from '@hono-preact/iso';
+import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
+
+const Movies = lazy(() => import('./pages/movies.js'));
+
+<Router>
+  <Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
+</Router>
 ```
+
+MDX files in `src/pages/docs/` are auto-discovered via `import.meta.glob` — no manual `<Route>` per page.
 
 ### `apps/app/src/server/layout.tsx`
 
@@ -65,7 +73,8 @@ Renders the full HTML shell: `<head>`, `<body>`, the `#app` mount point, and the
 
 Isomorphic utilities shared between server and client (`packages/iso/`):
 
-- `page.tsx` — `<Page>` component: composes the route boundary, guards, loader, and envelope into a single page wrapper
+- `route.tsx` — `<Route>` and `<Router>` components: the user-facing registration surface that wires loader, cache, guards, and fallback into the page boundary
+- `page.tsx` — `<Page>` component: composes the route boundary, guards, loader, and envelope into a single page wrapper (used internally by `<Route>`)
 - `loader.tsx` — `<Loader>` component that fetches and caches loader data, plus the `useReload` provider context
 - `define-loader.ts` — `defineLoader` factory and `LoaderFn<T>` / `LoaderRef<T>` types
 - `use-loader-data.ts` — `useLoaderData(ref)` hook for typed access to loader data inside children
@@ -88,4 +97,4 @@ Vite plugins for the framework (`packages/vite/`). The primary export is `honoPr
 
 - **`honoPreact()`** — configures resolve deduplication, SSR bundling, client/server build outputs, `@hono/vite-build`, and `@hono/vite-dev-server`
 - **`serverOnlyPlugin`** — during the client bundle build, replaces any `*.server.*` import with a no-op stub so server code never reaches the browser
-- **`serverLoaderValidationPlugin`** — fails the build if a `.server.*` file has named exports other than `serverGuards`; the server loader must be the default export
+- **`serverLoaderValidationPlugin`** — fails the build if a `.server.*` file has named exports other than `loader`, `cache`, `serverGuards`, `serverActions`, or `actionGuards`; the server loader must be the default export

--- a/apps/app/src/pages/home.tsx
+++ b/apps/app/src/pages/home.tsx
@@ -1,7 +1,5 @@
-import { Page } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
 import { useState } from 'preact/hooks';
-import type { RouteHook } from 'preact-iso';
 
 const Home: FunctionComponent = () => {
   const [toggle, setToggle] = useState(false);
@@ -10,15 +8,9 @@ const Home: FunctionComponent = () => {
   return (
     <section class="p-1">
       <div class="flex gap-2">
-        <a href="/test" class="bg-red-300">
-          test
-        </a>
-        <a href="/movies" class="bg-purple-300">
-          movies
-        </a>
-        <a href="/docs" class="bg-purple-300">
-          docs
-        </a>
+        <a href="/test" class="bg-red-300">test</a>
+        <a href="/movies" class="bg-purple-300">movies</a>
+        <a href="/docs" class="bg-purple-300">docs</a>
       </div>
       <h1 class={`${lagging ? 'bg-green-300' : ''}`}>Hello Hono!</h1>
       <button
@@ -33,13 +25,6 @@ const Home: FunctionComponent = () => {
     </section>
   );
 };
-
 Home.displayName = 'Home';
 
-export default function HomePage(location: RouteHook) {
-  return (
-    <Page location={location}>
-      <Home />
-    </Page>
-  );
-}
+export default Home;

--- a/apps/app/src/pages/movie.server.ts
+++ b/apps/app/src/pages/movie.server.ts
@@ -1,6 +1,6 @@
 // apps/app/src/pages/movie.server.ts
 import { getMovie } from '@/server/movies.js';
-import { defineAction, type LoaderFn } from '@hono-preact/iso';
+import { defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
 import type { Movie } from '@/server/data/movie.js';
 import {
   getWatched,
@@ -23,6 +23,8 @@ const serverLoader: LoaderFn<{ movie: Movie | null; watched: WatchedRecord | nul
   };
 
 export default serverLoader;
+
+export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>(serverLoader);
 
 export const serverActions = {
   toggleWatched: defineAction<{ movieId: number; watched: boolean }, { ok: boolean }>(

--- a/apps/app/src/pages/movie.tsx
+++ b/apps/app/src/pages/movie.tsx
@@ -1,24 +1,14 @@
 // apps/app/src/pages/movie.tsx
 import {
   cacheRegistry,
-  defineLoader,
   Form,
-  Page,
   useAction,
   useLoaderData,
   useOptimisticAction,
   useReload,
-  type WrapperProps,
 } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
-import type { Movie } from '@/server/data/movie.js';
-import type { WatchedRecord } from '@/server/watched.js';
-import serverLoader, { serverActions } from './movie.server.js';
-
-type Data = { movie: Movie | null; watched: WatchedRecord | null };
-
-const movieLoaderRef = defineLoader<Data>(serverLoader);
+import { loader as movieLoader, serverActions } from './movie.server.js';
 
 const NotesForm: FunctionComponent<{
   movieIdStr: string;
@@ -69,7 +59,7 @@ const PhotoForm: FunctionComponent<{ movieIdStr: string }> = ({ movieIdStr }) =>
 };
 
 const MovieDetail: FunctionComponent = () => {
-  const { movie, watched } = useLoaderData(movieLoaderRef);
+  const { movie, watched } = useLoaderData(movieLoader);
   if (!movie) return <p>Movie not found.</p>;
 
   const isWatched = !!watched && watched.watchedAt > 0;
@@ -150,14 +140,4 @@ const MovieDetail: FunctionComponent = () => {
 };
 MovieDetail.displayName = 'MovieDetail';
 
-function MovieWrapper(props: WrapperProps) {
-  return <article {...props} />;
-}
-
-export default function MoviePage(location: RouteHook) {
-  return (
-    <Page loader={movieLoaderRef} location={location} Wrapper={MovieWrapper}>
-      <MovieDetail />
-    </Page>
-  );
-}
+export default MovieDetail;

--- a/apps/app/src/pages/movies.server.ts
+++ b/apps/app/src/pages/movies.server.ts
@@ -1,6 +1,6 @@
 // apps/app/src/pages/movies.server.ts
 import { getMovies } from '@/server/movies.js';
-import { defineAction, type LoaderFn } from '@hono-preact/iso';
+import { createCache, defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
 import type { MoviesData } from '@/server/data/movies.js';
 import { listWatched, markWatched, unmarkWatched } from '@/server/watched.js';
 
@@ -10,6 +10,9 @@ const serverLoader: LoaderFn<{ movies: MoviesData; watchedIds: number[] }> = asy
 };
 
 export default serverLoader;
+
+export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>(serverLoader);
+export const cache = createCache<{ movies: MoviesData; watchedIds: number[] }>('movies-list');
 
 export const serverActions = {
   toggleWatched: defineAction<{ movieId: number; watched: boolean }, { ok: boolean }>(

--- a/apps/app/src/pages/movies.tsx
+++ b/apps/app/src/pages/movies.tsx
@@ -9,7 +9,7 @@ import {
   type WrapperProps,
 } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
-import type { MovieSummary, MoviesData } from '@/server/data/movies.js';
+import type { MovieSummary } from '@/server/data/movies.js';
 import { loader as movieLoader } from './movie.server.js';
 import { loader as moviesLoader, serverActions } from './movies.server.js';
 import Noop from './noop.js';

--- a/apps/app/src/pages/movies.tsx
+++ b/apps/app/src/pages/movies.tsx
@@ -1,27 +1,15 @@
 // apps/app/src/pages/movies.tsx
-import {
-  cacheRegistry,
-  createCache,
-  defineLoader,
-  Page,
-  useLoaderData,
-  useOptimisticAction,
-} from '@hono-preact/iso';
+import { cacheRegistry, useLoaderData, useOptimisticAction } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
-import { lazy, Route, type RouteHook, Router } from 'preact-iso';
+import { lazy, Route, Router } from 'preact-iso';
 import type { MovieSummary, MoviesData } from '@/server/data/movies.js';
-import serverLoader, { serverActions } from './movies.server.js';
+import { loader as moviesLoader, serverActions } from './movies.server.js';
 import Noop from './noop.js';
-
-type Data = { movies: MoviesData; watchedIds: number[] };
-
-const cache = createCache<Data>('movies-list');
-const moviesLoaderRef = defineLoader<Data>(serverLoader);
 
 const Movie = lazy(() => import('./movie.js'));
 
 const Movies: FunctionComponent = () => {
-  const { movies, watchedIds } = useLoaderData(moviesLoaderRef);
+  const { movies, watchedIds } = useLoaderData(moviesLoader);
 
   const { mutate, value: optimisticWatchedIds } = useOptimisticAction(
     serverActions.toggleWatched,
@@ -76,10 +64,4 @@ const Movies: FunctionComponent = () => {
 };
 Movies.displayName = 'Movies';
 
-export default function MoviesPage(location: RouteHook) {
-  return (
-    <Page loader={moviesLoaderRef} location={location} cache={cache}>
-      <Movies />
-    </Page>
-  );
-}
+export default Movies;

--- a/apps/app/src/pages/movies.tsx
+++ b/apps/app/src/pages/movies.tsx
@@ -1,12 +1,24 @@
 // apps/app/src/pages/movies.tsx
-import { cacheRegistry, useLoaderData, useOptimisticAction } from '@hono-preact/iso';
+import {
+  cacheRegistry,
+  lazy,
+  Route,
+  Router,
+  useLoaderData,
+  useOptimisticAction,
+  type WrapperProps,
+} from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
-import { lazy, Route, Router } from 'preact-iso';
 import type { MovieSummary, MoviesData } from '@/server/data/movies.js';
+import { loader as movieLoader } from './movie.server.js';
 import { loader as moviesLoader, serverActions } from './movies.server.js';
 import Noop from './noop.js';
 
 const Movie = lazy(() => import('./movie.js'));
+
+function MovieWrapper(props: WrapperProps) {
+  return <article {...props} />;
+}
 
 const Movies: FunctionComponent = () => {
   const { movies, watchedIds } = useLoaderData(moviesLoader);
@@ -56,7 +68,7 @@ const Movies: FunctionComponent = () => {
         ))}
       </ul>
       <Router>
-        <Route path="/:id" component={Movie} />
+        <Route path="/:id" component={Movie} loader={movieLoader} Wrapper={MovieWrapper} />
         <Noop />
       </Router>
     </section>

--- a/apps/app/src/pages/test.tsx
+++ b/apps/app/src/pages/test.tsx
@@ -1,7 +1,5 @@
-import { Page } from '@hono-preact/iso';
 import { useLink } from 'hoofd/preact';
 import { type FunctionComponent } from 'preact';
-import type { RouteHook } from 'preact-iso';
 import test from './test.css?url';
 import styles from './test.module.scss';
 import inline from './test.module.scss?inline';
@@ -19,10 +17,4 @@ const Test: FunctionComponent = () => {
 };
 Test.displayName = 'Test';
 
-export default function TestPage(location: RouteHook) {
-  return (
-    <Page location={location}>
-      <Test />
-    </Page>
-  );
-}
+export default Test;

--- a/apps/app/src/pages/watched.server.ts
+++ b/apps/app/src/pages/watched.server.ts
@@ -1,6 +1,6 @@
 // apps/app/src/pages/watched.server.ts
 import { getMovie, getMovies } from '@/server/movies.js';
-import { defineAction, type LoaderFn } from '@hono-preact/iso';
+import { createCache, defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
 import type { Movie } from '@/server/data/movie.js';
 import {
   listWatched,
@@ -33,6 +33,9 @@ const serverLoader: LoaderFn<{ entries: Entry[] }> = async () => {
 };
 
 export default serverLoader;
+
+export const loader = defineLoader<{ entries: Entry[] }>(serverLoader);
+export const cache = createCache<{ entries: Entry[] }>('watched');
 
 export const serverActions = {
   removeWatched: defineAction<{ movieId: number }, { ok: boolean }>(

--- a/apps/app/src/pages/watched.tsx
+++ b/apps/app/src/pages/watched.tsx
@@ -1,30 +1,23 @@
 // apps/app/src/pages/watched.tsx
 import {
   cacheRegistry,
-  createCache,
-  defineLoader,
-  Page,
   useAction,
   useLoaderData,
   useReload,
 } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
 import { useState } from 'preact/hooks';
-import type { RouteHook } from 'preact-iso';
 import type { Movie } from '@/server/data/movie.js';
-import serverLoader, {
+import {
   serverActions,
   type WireWatched,
+  loader as watchedLoader,
 } from './watched.server.js';
 
 type Entry = { movie: Movie | null; watched: WireWatched };
-type Data = { entries: Entry[] };
-
-const cache = createCache<Data>('watched');
-const watchedLoaderRef = defineLoader<Data>(serverLoader);
 
 const WatchedPage: FunctionComponent = () => {
-  const { entries } = useLoaderData(watchedLoaderRef);
+  const { entries } = useLoaderData(watchedLoader);
   const [progress, setProgress] = useState<{ count: number; total: number } | null>(null);
 
   const reload = useReload();
@@ -117,15 +110,4 @@ const WatchedPage: FunctionComponent = () => {
 };
 WatchedPage.displayName = 'WatchedPage';
 
-export default function WatchedRoute(location: RouteHook) {
-  return (
-    <Page
-      loader={watchedLoaderRef}
-      location={location}
-      cache={cache}
-      fallback={<p class="p-1">Loading watched list…</p>}
-    >
-      <WatchedPage />
-    </Page>
-  );
-}
+export default WatchedPage;

--- a/apps/app/src/pages/watched.tsx
+++ b/apps/app/src/pages/watched.tsx
@@ -7,14 +7,10 @@ import {
 } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
 import { useState } from 'preact/hooks';
-import type { Movie } from '@/server/data/movie.js';
 import {
   serverActions,
-  type WireWatched,
   loader as watchedLoader,
 } from './watched.server.js';
-
-type Entry = { movie: Movie | null; watched: WireWatched };
 
 const WatchedPage: FunctionComponent = () => {
   const { entries } = useLoaderData(watchedLoader);

--- a/docs/superpowers/plans/2026-04-30-server-only-plugin-loader-cache.md
+++ b/docs/superpowers/plans/2026-04-30-server-only-plugin-loader-cache.md
@@ -1,0 +1,712 @@
+# Server-Only Plugin: loader & cache Stubs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the two critical bugs the final reviewer of `feat/iso-route-level-loaders` uncovered:
+1. `.server.*` modules leak into client bundles when imported with only `loader`/`cache` specifiers (broken framework guarantee).
+2. `loader`/`cache` specifiers are silently dropped from rewritten import statements, causing `ReferenceError` at runtime.
+
+**Architecture:** Extend `serverOnlyPlugin` (in `@hono-preact/vite`) to recognize and stub `loader` and `cache` named imports from `*.server.*` files. Broaden `isServerImport` to match ANY `.server.*` import (not only ones with known default/named specifiers). Add a build-level integration test that asserts no `.server.ts` source string appears in any client chunk.
+
+**Tech Stack:** TypeScript, `@babel/parser` (already used in the plugin), `magic-string` (already used), Vitest, Vite (`vite build` programmatically for the integration test).
+
+---
+
+## Pre-flight context for the executing engineer
+
+You are working in a branch (`feat/iso-route-level-loaders`) inside the worktree at `/Users/stevenbeshensky/Documents/repos/hono-preact/.worktrees/route-level-loaders`. The previous 11 tasks of `docs/superpowers/plans/2026-04-29-route-level-loaders.md` are landed but the resulting branch has two critical bugs (see Goal). This plan fixes them on the same branch — no new branch.
+
+Before touching anything:
+
+1. Run `pnpm test` from worktree root. Expect 182/182 passing.
+2. Read these to understand the surfaces you'll touch:
+   - `packages/vite/src/server-only.ts` — the plugin you're extending (read fully — it's ~95 lines)
+   - `packages/vite/src/__tests__/server-only-plugin.test.ts` — existing test patterns
+   - `packages/iso/src/define-loader.ts` — `LoaderRef<T>` shape (you'll synthesize one in client stubs)
+   - `packages/iso/src/cache.ts` — `createCache(name?)` signature and `cacheRegistry` integration
+   - `apps/app/src/pages/movies.server.ts` — example file with `loader` + `cache` named exports + `serverActions`
+   - `apps/app/src/iso.tsx` — example consumer that imports only `loader`/`cache` (the leak vector)
+3. Read the deferred `superpowers:test-driven-development` workflow if unfamiliar with the TDD cadence used in this plan.
+
+This work happens **on the same branch** (`feat/iso-route-level-loaders`). Do NOT create a new branch — these commits stack on top of `b1fafd1`.
+
+---
+
+## Decision: cache naming convention
+
+The current pattern allows `export const cache = createCache<T>('any-name-you-want')` in `.server.ts`. The plugin needs to emit a client-side `cache` stub that registers with `cacheRegistry` under THE SAME name (so cross-page `cacheRegistry.invalidate('any-name-you-want')` works).
+
+Two options:
+- **A — source extraction:** plugin reads the `.server.ts` source synchronously, AST-parses it, finds `export const cache = createCache(<literal>)`, extracts the string literal argument. Falls back to module name if not found.
+- **B — filename convention:** plugin uses the filename as the cache name. Requires updating any existing custom names (e.g. `'movies-list'` → `'movies'`) and all corresponding `cacheRegistry.invalidate(...)` callers.
+
+**This plan uses A (source extraction).** Reason: preserves user ergonomics (cache names are arbitrary and can match cross-page semantics), avoids a sweeping rename across `.server.ts` and consumer files, and the implementation is bounded (~30 lines).
+
+**Fallback behavior:** If extraction fails (file not found, unexpected AST shape, no `createCache(...)` call, non-literal argument), fall back to the module name (filename without `.server.*`). Emit a Vite warning so the developer notices.
+
+---
+
+## File Structure
+
+### Modified files
+
+**vite package (production code):**
+- `packages/vite/src/server-only.ts` — the plugin extension
+
+**vite package (tests):**
+- `packages/vite/src/__tests__/server-only-plugin.test.ts` — new test cases for `loader`, `cache`, mixed, and unknown specifiers
+- `packages/vite/src/__tests__/build-bundle-leak.test.ts` — NEW integration test that runs `vite build` on a fixture and asserts no `.server.ts` content leaks
+
+**Test fixtures (new):**
+- `packages/vite/src/__tests__/fixtures/leak-test/` — minimal Vite app with `pages/foo.tsx` + `pages/foo.server.ts` setup
+
+### Files NOT touched
+- `apps/app/**` — the integration test runs against a fixture inside `packages/vite/`, not the real app
+- `packages/iso/**` — runtime types and helpers are already correct
+- Docs MDX — the current docs describe the user-facing API, which doesn't change shape; only the plugin's transform behavior changes
+
+---
+
+## Task 1: Establish baseline with a failing build-leak integration test
+
+**Why:** The first thing to lock down is "the bug actually happens." Write a test that builds a minimal app and asserts a `.server.ts` source string is NOT present in client output. The test will fail before the fix and pass after — the strongest possible regression guard.
+
+**Files:**
+- Create: `packages/vite/src/__tests__/fixtures/leak-test/pages/foo.tsx`
+- Create: `packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts`
+- Create: `packages/vite/src/__tests__/fixtures/leak-test/iso.tsx`
+- Create: `packages/vite/src/__tests__/fixtures/leak-test/client.tsx`
+- Create: `packages/vite/src/__tests__/fixtures/leak-test/server.tsx`
+- Create: `packages/vite/src/__tests__/fixtures/leak-test/index.html`
+- Create: `packages/vite/src/__tests__/fixtures/leak-test/vite.config.ts`
+- Create: `packages/vite/src/__tests__/build-bundle-leak.test.ts`
+
+> **Tip for the engineer:** the fixture must be small — only enough surface area to exercise the leak. Keep dependencies to `preact`, `preact-iso`, `@hono-preact/iso`, `@hono-preact/vite` (workspace links). No real database, no real UI. The "secret" we're checking for leakage is a unique sentinel string in `foo.server.ts` like `const SUPER_SECRET_DATABASE_URL = 'sentinel-must-not-leak-XYZ123';`.
+
+- [ ] **Step 1: Create the fixture `foo.server.ts`**
+
+```ts
+// packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts
+import { defineLoader, createCache, defineAction } from '@hono-preact/iso';
+
+const SUPER_SECRET_DATABASE_URL = 'sentinel-must-not-leak-XYZ123';
+
+const serverLoader = async () => {
+  // referencing the secret keeps tree-shakers from removing it
+  return { secret: SUPER_SECRET_DATABASE_URL.length };
+};
+export default serverLoader;
+
+export const loader = defineLoader<{ secret: number }>(serverLoader);
+export const cache = createCache<{ secret: number }>('foo');
+
+export const serverActions = {
+  noop: defineAction<void, { ok: boolean }>(async () => ({ ok: true })),
+};
+```
+
+- [ ] **Step 2: Create the fixture `foo.tsx`, `iso.tsx`, `client.tsx`, `server.tsx`, `index.html`, `vite.config.ts`**
+
+`pages/foo.tsx`:
+```tsx
+import { useLoaderData } from '@hono-preact/iso';
+import { loader } from './foo.server.js';
+
+export default function Foo() {
+  const { secret } = useLoaderData(loader);
+  return <p>{secret}</p>;
+}
+```
+
+`iso.tsx`:
+```tsx
+import { lazy, Route, Router } from '@hono-preact/iso';
+import { loader, cache } from './pages/foo.server.js';
+
+const Foo = lazy(() => import('./pages/foo.js'));
+
+export const Base = () => (
+  <Router>
+    <Route path="/foo" component={Foo} loader={loader} cache={cache} />
+  </Router>
+);
+```
+
+`client.tsx`, `server.tsx`, `index.html`: minimal scaffolding sufficient for `vite build` to produce a client bundle. Look at `apps/app/src/client.tsx` etc. for reference shapes — strip everything except what's needed to make the build run.
+
+`vite.config.ts`:
+```ts
+import { honoPreact } from '@hono-preact/vite';
+import preact from '@preact/preset-vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [honoPreact({ entry: 'server.tsx' }), preact()],
+  build: { outDir: 'dist' },
+});
+```
+
+> If the fixture refuses to build with the full `honoPreact` plugin (because of missing entry assumptions, etc.), reduce scope: just use the `serverOnlyPlugin` and `serverLoaderValidationPlugin` directly without the full `honoPreact` bundle. The leak test only cares about the client transform output, not a fully-functional server bundle.
+
+- [ ] **Step 3: Add the test file**
+
+```ts
+// packages/vite/src/__tests__/build-bundle-leak.test.ts
+import { describe, it, expect } from 'vitest';
+import { build } from 'vite';
+import { resolve } from 'node:path';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const fixtureDir = resolve(__dirname, 'fixtures/leak-test');
+
+function readAllFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...readAllFilesRecursive(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+describe('client bundle does not leak server-only sources', () => {
+  it('produces no chunk containing a sentinel from a *.server.ts file', async () => {
+    await build({
+      root: fixtureDir,
+      logLevel: 'error',
+      configFile: resolve(fixtureDir, 'vite.config.ts'),
+      build: {
+        outDir: resolve(fixtureDir, 'dist'),
+        emptyOutDir: true,
+      },
+    });
+
+    const distFiles = readAllFilesRecursive(resolve(fixtureDir, 'dist'));
+    const offending: string[] = [];
+    for (const f of distFiles) {
+      const content = readFileSync(f, 'utf8');
+      if (content.includes('sentinel-must-not-leak-XYZ123')) {
+        offending.push(f);
+      }
+    }
+    expect(offending, `Server-only sentinel found in: ${offending.join(', ')}`).toEqual([]);
+  }, 60_000);
+});
+```
+
+- [ ] **Step 4: Run the test to verify it fails (this is the bug)**
+
+```bash
+pnpm vitest run packages/vite/src/__tests__/build-bundle-leak.test.ts
+```
+
+Expected: FAILS. The dist contains the sentinel because the current `serverOnlyPlugin` doesn't transform the `iso.tsx` `loader`/`cache` import.
+
+If the test fails for OTHER reasons (fixture build errors, missing dependencies), STOP and fix the fixture before proceeding. The test must fail specifically because of the leak.
+
+- [ ] **Step 5: Commit the failing test and fixture**
+
+```bash
+git add packages/vite/src/__tests__/fixtures/leak-test/ packages/vite/src/__tests__/build-bundle-leak.test.ts
+git commit -m "test(vite): add failing bundle-leak regression test for .server.ts content"
+```
+
+(Yes — committing a failing test. Mark it with `it.fails(...)` if your test runner refuses to commit failing tests in CI, OR leave the commit and add a follow-up `expect.assertions(...)` workaround. The point is to land the regression coverage in the same branch as the fix.)
+
+> **Alternative:** if landing a failing test is uncomfortable, batch this commit with Task 5's "fix" commit so the failing test is never on the branch. The plan is structured to allow either ordering.
+
+---
+
+## Task 2: Plugin unit tests for the new specifier shapes (TDD red)
+
+**Why:** Before changing the plugin, write the unit tests that describe what it should do. These give fast feedback during implementation; the integration test (Task 1) is the slow safety net.
+
+**Files:**
+- Modify: `packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+- [ ] **Step 1: Read the existing test file to learn the `transform()` helper signature and the assertion patterns**
+
+The helper at the top is:
+```ts
+function transform(code, id, options = {}): { code: string; map: unknown } | undefined
+```
+
+The convention: feed source code and an importer ID, assert on what's in `result.code`.
+
+- [ ] **Step 2: Add new test cases (each will fail until Task 3/4)**
+
+Add a new `describe` block at the bottom of the file:
+
+```ts
+describe('loader and cache specifiers', () => {
+  it('replaces a `loader` named import with a client-side LoaderRef stub', () => {
+    const code = `import { loader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toMatch(/const loader = \{[\s\S]*__id: Symbol\.for\(['"]@hono-preact\/loader:movies['"]\)[\s\S]*fn:\s*async/);
+    expect(result?.code).toContain("fetch('/__loaders'");
+    expect(result?.code).toContain('"movies"');
+  });
+
+  it('replaces a `cache` named import with a createCache call using the source-file name', () => {
+    // The fixture file isn't available here; the plugin should fall back to module name.
+    const code = `import { cache } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain("import { createCache as");
+    // Expect the fallback name (module name) since no fixture exists for source-extraction.
+    expect(result?.code).toMatch(/createCache\(['"]movies['"]\)/);
+  });
+
+  it('handles `loader` aliased to a different local name', () => {
+    const code = `import { loader as moviesLoader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toMatch(/const moviesLoader = \{[\s\S]*Symbol\.for/);
+    expect(result?.code).toContain('"movies"');
+  });
+
+  it('handles `cache` aliased to a different local name', () => {
+    const code = `import { cache as moviesCache } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain('const moviesCache =');
+    expect(result?.code).toMatch(/createCache\(['"]movies['"]\)/);
+  });
+
+  it('handles mixed loader + cache + serverActions in one import statement', () => {
+    const code = `import { loader, cache, serverActions } from './movies.server.js';`;
+    const result = transform(code, '/src/pages/movies.tsx');
+    expect(result?.code).toContain('const loader =');
+    expect(result?.code).toContain('const cache =');
+    expect(result?.code).toContain('const serverActions = new Proxy');
+  });
+
+  it('handles mixed default + loader in one import statement', () => {
+    const code = `import serverLoader, { loader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain('const serverLoader =');
+    expect(result?.code).toContain('const loader =');
+  });
+
+  it('matches an import that has ONLY loader (no default, no actions, no guards)', () => {
+    // This is the bug from the route-level-loaders migration: imports with only
+    // `loader` were silently passed through.
+    const code = `import { loader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result).toBeDefined();
+    expect(result?.code).not.toContain("import { loader }");
+    expect(result?.code).toContain('const loader =');
+  });
+
+  it('matches an import that has ONLY cache (no default, no actions, no guards)', () => {
+    const code = `import { cache } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result).toBeDefined();
+    expect(result?.code).not.toContain("import { cache }");
+    expect(result?.code).toContain('const cache =');
+  });
+});
+
+describe('unknown specifiers from .server.* imports', () => {
+  it('throws a clear error when an unknown named export is imported from .server.*', () => {
+    const code = `import { unknownExport } from './movies.server.js';`;
+    expect(() => transform(code, '/src/iso.tsx')).toThrow(
+      /unknownExport.*not a recognized.*server/i
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+```bash
+pnpm vitest run packages/vite/src/__tests__/server-only-plugin.test.ts -t "loader and cache"
+pnpm vitest run packages/vite/src/__tests__/server-only-plugin.test.ts -t "unknown specifiers"
+```
+
+Expected: all new tests fail (the plugin doesn't handle these cases yet).
+
+> Note: do NOT commit yet — these are red. Task 3 makes them green.
+
+---
+
+## Task 3: Implement broadened `isServerImport` + `loader`/`cache` stubs + unknown-specifier guard
+
+**Why:** Make the failing tests from Task 2 pass.
+
+**Files:**
+- Modify: `packages/vite/src/server-only.ts`
+
+- [ ] **Step 1: Read the file end-to-end again** to make sure you understand the existing `isServerImport`, the per-specifier stub loop, and the `MagicString.overwrite` call.
+
+- [ ] **Step 2: Broaden `isServerImport` to match ANY .server.* import**
+
+Replace:
+```ts
+const isServerImport = (node: unknown): node is ImportDeclaration =>
+  (node as ImportDeclaration).type === 'ImportDeclaration' &&
+  /\.server(\.[jt]sx?)?$/.test((node as ImportDeclaration).source.value) &&
+  (node as ImportDeclaration).specifiers.some(
+    (s) =>
+      s.type === 'ImportDefaultSpecifier' ||
+      (s.type === 'ImportSpecifier' &&
+        s.imported.type === 'Identifier' &&
+        (s.imported.name === 'serverGuards' ||
+          s.imported.name === 'actionGuards' ||
+          s.imported.name === 'serverActions'))
+  );
+```
+
+With:
+```ts
+const isServerImport = (node: unknown): node is ImportDeclaration =>
+  (node as ImportDeclaration).type === 'ImportDeclaration' &&
+  /\.server(\.[jt]sx?)?$/.test((node as ImportDeclaration).source.value);
+```
+
+Any import from a `*.server.*` file is now in scope. This is the central safety fix.
+
+- [ ] **Step 3: Add the `loader` stub branch in the specifier loop**
+
+Inside the `for (const specifier of serverImport.specifiers)` loop, after the existing `serverActions` branch, add:
+
+```ts
+} else if (
+  specifier.type === 'ImportSpecifier' &&
+  specifier.imported.type === 'Identifier' &&
+  specifier.imported.name === 'loader'
+) {
+  stubs.push(
+    `const ${specifier.local.name} = {\n` +
+    `  __id: Symbol.for('@hono-preact/loader:${moduleName}'),\n` +
+    `  fn: async ({ location }) => {\n` +
+    `    const res = await fetch('/__loaders', {\n` +
+    `      method: 'POST',\n` +
+    `      headers: { 'Content-Type': 'application/json' },\n` +
+    `      body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, query: location.query } }),\n` +
+    `    });\n` +
+    `    if (!res.ok) {\n` +
+    `      const body = await res.json().catch(() => ({}));\n` +
+    `      throw new Error(body.error ?? \`Loader failed with status \${res.status}\`);\n` +
+    `    }\n` +
+    `    return res.json();\n` +
+    `  },\n` +
+    `};`
+  );
+}
+```
+
+`Symbol.for(...)` (not `Symbol(...)`) is critical — multiple files importing `loader` from the same `.server.ts` must get the same symbol so `useLoaderData(ref).__id` matching works.
+
+- [ ] **Step 4: Add the `cache` stub branch + helper for source-extracting the cache name**
+
+First, add a helper at module scope:
+
+```ts
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function extractCacheName(
+  importerPath: string,
+  importSource: string,
+  fallbackModuleName: string
+): string {
+  // Resolve the import source relative to the importer.
+  const importerDir = path.dirname(importerPath);
+  const baseResolved = path.resolve(importerDir, importSource);
+  // Try common TS/JS extensions.
+  const candidates = [
+    baseResolved,
+    baseResolved.replace(/\.js$/, '.ts'),
+    baseResolved.replace(/\.jsx$/, '.tsx'),
+    baseResolved.replace(/\.mjs$/, '.mts'),
+    baseResolved + '.ts',
+    baseResolved + '.tsx',
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      try {
+        const src = fs.readFileSync(candidate, 'utf8');
+        const ast = parse(src, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+          errorRecovery: true,
+        });
+        for (const node of ast.program.body) {
+          if (
+            node.type === 'ExportNamedDeclaration' &&
+            node.declaration?.type === 'VariableDeclaration'
+          ) {
+            for (const decl of node.declaration.declarations) {
+              if (
+                decl.id.type === 'Identifier' &&
+                decl.id.name === 'cache' &&
+                decl.init?.type === 'CallExpression' &&
+                decl.init.callee.type === 'Identifier' &&
+                decl.init.callee.name === 'createCache'
+              ) {
+                const arg = decl.init.arguments[0];
+                if (arg?.type === 'StringLiteral') return arg.value;
+              }
+            }
+          }
+        }
+      } catch {
+        // Source-parse failure — fall through to the fallback.
+      }
+      break; // file exists but no extractable name; don't keep trying extensions
+    }
+  }
+  return fallbackModuleName;
+}
+```
+
+Then in the specifier loop, after the `loader` branch:
+
+```ts
+} else if (
+  specifier.type === 'ImportSpecifier' &&
+  specifier.imported.type === 'Identifier' &&
+  specifier.imported.name === 'cache'
+) {
+  const cacheName = extractCacheName(id, serverImport.source.value, moduleName);
+  // Use a per-source unique alias to avoid collisions when multiple .server.ts
+  // files contribute cache imports to the same consumer.
+  const aliasSuffix = moduleName.replace(/[^a-zA-Z0-9_$]/g, '_');
+  needsCacheImport.add(aliasSuffix);
+  stubs.push(
+    `const ${specifier.local.name} = __$createCache_${aliasSuffix}(${JSON.stringify(cacheName)});`
+  );
+}
+```
+
+You'll also need to declare `needsCacheImport` near the top of `transform`:
+
+```ts
+const needsCacheImport = new Set<string>();
+```
+
+And after the per-import loop completes, prepend any required `createCache` imports:
+
+```ts
+if (needsCacheImport.size > 0) {
+  const importDeclarations = [...needsCacheImport]
+    .map(
+      (suffix) =>
+        `import { createCache as __$createCache_${suffix} } from '@hono-preact/iso';`
+    )
+    .join('\n');
+  s.prepend(importDeclarations + '\n');
+}
+```
+
+- [ ] **Step 5: Add the unknown-specifier guard**
+
+Inside the specifier loop, after all the recognized branches, add a final `else`:
+
+```ts
+} else {
+  const importedName =
+    specifier.type === 'ImportSpecifier' &&
+    specifier.imported.type === 'Identifier'
+      ? specifier.imported.name
+      : specifier.type === 'ImportNamespaceSpecifier'
+      ? '* as ' + specifier.local.name
+      : '<unknown>';
+  throw new Error(
+    `${id}: \`${importedName}\` is not a recognized export from a *.server.* module. ` +
+    `Allowed: default, loader, cache, serverGuards, serverActions, actionGuards.`
+  );
+}
+```
+
+This converts the silent-drop bug from Critical #2 into a clear build-time error.
+
+- [ ] **Step 6: Run the unit tests to verify all pass**
+
+```bash
+pnpm vitest run packages/vite/src/__tests__/server-only-plugin.test.ts
+```
+
+Expected: ALL tests pass (existing + new).
+
+- [ ] **Step 7: Run the build-leak integration test**
+
+```bash
+pnpm vitest run packages/vite/src/__tests__/build-bundle-leak.test.ts
+```
+
+Expected: PASSES. The fixture's sentinel string no longer appears in the client bundle.
+
+If it still fails, debug:
+- Inspect `packages/vite/src/__tests__/fixtures/leak-test/dist/` to see which file has the sentinel.
+- Re-read the offending file's source — the leak might be from a path the plugin doesn't catch (e.g., a transitive `.server.ts` re-export).
+
+- [ ] **Step 8: Run the full repo test suite**
+
+```bash
+pnpm test
+```
+
+Expected: 182 + 8 (new specifier tests) + 1 (unknown-specifier test) + 1 (bundle leak) ≈ 192/192.
+
+- [ ] **Step 9: Build the iso, server, hono-preact, and vite packages**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+```
+
+Expected: clean builds across all four packages.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/vite/src/server-only.ts packages/vite/src/__tests__/server-only-plugin.test.ts
+git commit -m "feat(vite): stub loader and cache imports from .server.*, broaden import matching"
+```
+
+---
+
+## Task 4: Verify the real app no longer leaks and works end-to-end
+
+**Why:** The fixture proves the plugin works. Now confirm the real app (`apps/app`) — which the previous bad commits broke — actually works after the plugin fix.
+
+**Files:** None modified. This task is verification-only, but it MUST succeed before the branch is mergeable.
+
+- [ ] **Step 1: Build the real app**
+
+```bash
+pnpm --filter app build
+```
+
+Expected: clean.
+
+- [ ] **Step 2: Inspect the client bundle for `.server.ts` content**
+
+```bash
+# Look for known server-only strings that should NOT appear in client output.
+grep -r "Moana 2" apps/app/dist/static/ 2>/dev/null && echo "LEAK: TMDB seed found in client bundle" || echo "OK: TMDB seed not in client"
+grep -r "markWatched" apps/app/dist/static/ 2>/dev/null && echo "LEAK: markWatched fn in client" || echo "OK: markWatched not in client"
+grep -r "listWatched" apps/app/dist/static/ 2>/dev/null && echo "LEAK: listWatched fn in client" || echo "OK: listWatched not in client"
+```
+
+Expected: all three checks print "OK". If any print "LEAK", STOP and report — the plugin missed a code path.
+
+- [ ] **Step 3: Inspect the page chunk for the bare `moviesLoader` reference**
+
+```bash
+# The previous bug: useLoaderData(moviesLoader) referenced an undeclared identifier.
+# After the fix, moviesLoader should be declared as a local const in the page chunk.
+grep -l "useLoaderData" apps/app/dist/static/*.js | while read f; do
+  echo "=== $f ==="
+  # Look for the pattern: a `const moviesLoader =` declaration before its use.
+  grep -c "const.*[Ll]oader.*Symbol.for\|const.*[Ll]oader.*=" "$f" || echo "WARNING: no Loader const found"
+done
+```
+
+Expected: every file using `useLoaderData(...)` has a `const X = {Symbol.for...}` declaration above the use. If not, the plugin missed something specific to that page.
+
+- [ ] **Step 4: Dev-server smoke test all routes (manual end-to-end)**
+
+```bash
+pnpm dev > /tmp/dev.log 2>&1 &
+sleep 6
+for path in / /test /movies /movies/1241982 /watched /docs /docs/quick-start; do
+  echo "--- $path ---"
+  status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:5173$path")
+  bytes=$(curl -s "http://localhost:5173$path" | wc -c)
+  echo "  HTTP $status, $bytes bytes"
+done
+pkill -f "vite --force" 2>/dev/null
+```
+
+Expected: every route returns HTTP 200 with substantial content. If any return 500 or are very small (suggesting an error page), open that URL in a browser to see the error.
+
+- [ ] **Step 5: Browser smoke test (manual, the engineer running this should do it themselves)**
+
+Open `http://localhost:5173/movies` in a browser. Open the DevTools Console.
+
+- Click into a movie. Should navigate to `/movies/:id`.
+- Click "Mark watched". Should:
+  - Show optimistic ✓ watched immediately
+  - Fire ONE XHR to `/__actions`
+  - Fire ONE XHR to `/__loaders` (the auto-reload)
+  - NOT show any console errors
+  - NOT show a "Loading..." flash
+
+If the browser shows a `ReferenceError` or any "X is not defined" message in the console, the plugin still has a gap. Report which page and which identifier.
+
+- [ ] **Step 6: Run the full test suite once more (sanity)**
+
+```bash
+pnpm test
+```
+
+Expected: same count as Task 3 step 8 (all green).
+
+- [ ] **Step 7: No commit needed for this task** (verification only).
+
+---
+
+## Task 5: Final review pass
+
+**Files:** None modified. This is the same kind of holistic review the previous final reviewer did, performed before opening the PR.
+
+- [ ] **Step 1: Dispatch a fresh code-reviewer subagent (or run the review manually)** with focus on:
+  - Correctness of the new stubs (especially `Symbol.for` identity, RPC fetch shape)
+  - Whether the source-extraction helper handles edge cases (file not found, syntax errors, no `cache` export, non-literal arg)
+  - Whether the unknown-specifier error message is clear enough for a developer to understand the fix
+  - Whether the build-leak test is robust (would it pass even without the fix, by luck?)
+  - Any path the plugin still misses (re-exports, namespace imports, dynamic imports)
+
+- [ ] **Step 2: Address any Critical / Important findings before opening the PR.**
+
+- [ ] **Step 3: Final clean-state verification**
+
+```bash
+git status                    # clean
+pnpm test                     # all green
+pnpm --filter app build       # clean
+cd apps/app && npx tsc --noEmit  # clean
+```
+
+- [ ] **Step 4: Open the PR (or update the existing one)**
+
+If this branch already has a PR open against `feat/iso-v3-components` (or wherever), update its description with the bugs fixed and link this plan. If not, open it now.
+
+Suggested commit log shape (visible in PR):
+```
+b1fafd1 chore(app): drop unused imports left over from migration
+262d87e docs: rewrite for route-level loaders
+be2e217 refactor(app): migrate movie detail to route-level loader with custom Wrapper
+... (rest of the migration commits) ...
+NEW1     test(vite): add failing bundle-leak regression test for .server.ts content
+NEW2     feat(vite): stub loader and cache imports from .server.*, broaden import matching
+```
+
+---
+
+## Out of scope (NOT in this plan)
+
+- **Refactoring the per-import stub generation into a registry pattern** — current code uses an `if/else` chain per specifier. A registry-driven design would be cleaner, but it's a separate refactor. Don't blend it in.
+- **Source-extracting OTHER metadata** (e.g., loader options) — only `cache` name needs source extraction in this plan.
+- **Caching the source-parse result across multiple imports of the same `.server.ts`** — small perf win, not worth the complexity.
+- **Updating the existing user-facing docs MDX** — none of them describe the plugin internals; the user-facing API didn't change shape, only the build behavior.
+
+---
+
+## Self-review notes for the plan author (me)
+
+A reader of this plan should be able to:
+- Run Task 1 first to land the failing regression test (or batch with Task 3 if uncomfortable committing red).
+- Run Task 2 to write red unit tests that describe the fix.
+- Run Task 3 to make all the red tests green.
+- Run Task 4 to verify the real app works end-to-end.
+- Run Task 5 to do a holistic review and open the PR.
+
+Each task ends with a verifiable state. Task 3 is the largest (~100 lines of plugin code + new helper); the rest are lighter.
+
+The two critical bugs are addressed by:
+- Critical #1 (server-only leak): Task 3 step 2 (broaden `isServerImport`)
+- Critical #2 (silent specifier drop / `ReferenceError`): Task 3 step 3 (loader stub) + step 4 (cache stub) + step 5 (unknown-specifier guard)
+
+The integration test (Task 1) is the load-bearing regression guard for Critical #1. The unit tests (Task 2) cover Critical #2 directly. Together they would have caught both issues in the original migration.

--- a/packages/iso/src/__tests__/cache-registry.test.ts
+++ b/packages/iso/src/__tests__/cache-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { cacheRegistry } from '../cache-registry.js';
+import { createCache } from '../cache.js';
 
 beforeEach(() => {
   cacheRegistry.clear();
@@ -33,5 +34,27 @@ describe('cacheRegistry', () => {
     cacheRegistry.clear();
     cacheRegistry.invalidate('movies');
     expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('cacheRegistry.acquire', () => {
+  it('returns the same cache instance when called twice with the same name', () => {
+    const a = cacheRegistry.acquire('shared-name', () => createCache<number>('shared-name'));
+    const b = cacheRegistry.acquire('shared-name', () => createCache<number>('shared-name'));
+    expect(a).toBe(b);
+  });
+
+  it('returns different cache instances for different names', () => {
+    const a = cacheRegistry.acquire('name-a', () => createCache<number>('name-a'));
+    const b = cacheRegistry.acquire('name-b', () => createCache<number>('name-b'));
+    expect(a).not.toBe(b);
+  });
+
+  it('invalidating an acquired cache by name clears its store', () => {
+    const cache = cacheRegistry.acquire('inv-test', () => createCache<number>('inv-test'));
+    cache.set(42);
+    expect(cache.get()).toBe(42);
+    cacheRegistry.invalidate('inv-test');
+    expect(cache.get()).toBeNull();
   });
 });

--- a/packages/iso/src/__tests__/loader.test.tsx
+++ b/packages/iso/src/__tests__/loader.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act, cleanup, waitFor } from '@testing-library/preact';
 import { useState } from 'preact/hooks';
-import { LocationProvider } from 'preact-iso';
+import { LocationProvider, type RouteHook } from 'preact-iso';
 import { defineLoader } from '../define-loader.js';
 import { Loader } from '../loader.js';
 import { useLoaderData } from '../use-loader-data.js';
@@ -17,10 +17,9 @@ vi.mock('../preload.js', () => ({
 const loc = {
   path: '/test',
   url: 'http://localhost/test',
-  query: {},
-  params: {},
+  searchParams: {},
   pathParams: {},
-} as any;
+} as unknown as RouteHook;
 
 const originalEnv = env.current;
 beforeEach(() => {

--- a/packages/iso/src/__tests__/page.test.tsx
+++ b/packages/iso/src/__tests__/page.test.tsx
@@ -21,8 +21,7 @@ vi.mock('preact-iso', async (importOriginal) => {
 const loc = {
   path: '/test',
   url: 'http://localhost/test',
-  query: {},
-  params: {},
+  searchParams: {},
   pathParams: {},
 } as unknown as RouteHook;
 

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/preact';
+import { LocationProvider, type RouteHook } from 'preact-iso';
+import { defineLoader } from '../define-loader.js';
+import { wrapWithPage } from '../route.js';
+import { useLoaderData } from '../use-loader-data.js';
+import { env } from '../is-browser.js';
+
+vi.mock('../preload.js', () => ({
+  getPreloadedData: vi.fn(() => null),
+  deletePreloadedData: vi.fn(),
+}));
+
+const loc = {
+  path: '/x',
+  url: 'http://localhost/x',
+  query: {},
+  params: {},
+  pathParams: {},
+} as unknown as RouteHook;
+
+const originalEnv = env.current;
+beforeEach(() => {
+  env.current = 'browser';
+});
+afterEach(() => {
+  env.current = originalEnv;
+  cleanup();
+});
+
+describe('wrapWithPage', () => {
+  it('renders the component inside <Page> with no loader (no-data page)', async () => {
+    const Inner = () => <p data-testid="inner">hello</p>;
+    const Wrapped = wrapWithPage(Inner, {});
+    render(
+      <LocationProvider>
+        <Wrapped {...loc} />
+      </LocationProvider>
+    );
+    const el = await screen.findByTestId('inner');
+    expect(el).toHaveTextContent('hello');
+  });
+
+  it('renders the component with loader data via useLoaderData', async () => {
+    const fn = vi.fn(async () => ({ msg: 'ok' }));
+    const ref = defineLoader<{ msg: string }>(fn);
+    const Inner = () => {
+      const { msg } = useLoaderData(ref);
+      return <p data-testid="msg">{msg}</p>;
+    };
+    const Wrapped = wrapWithPage(Inner, { loader: ref });
+    render(
+      <LocationProvider>
+        <Wrapped {...loc} />
+      </LocationProvider>
+    );
+    const el = await screen.findByText('ok');
+    expect(el).toBeInTheDocument();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/preact';
+import { render, screen, cleanup, act } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
 import { LocationProvider, type RouteHook } from 'preact-iso';
 import { defineLoader } from '../define-loader.js';
 import { Route, Router, wrapWithPage } from '../route.js';
@@ -127,5 +128,66 @@ describe('<Route> rendered directly', () => {
     const Foo = () => <p data-testid="foo">foo</p>;
     const { container } = render(<Route path="/foo" component={Foo} />);
     expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('Route symbol marker', () => {
+  it('marks Route with a cross-realm-safe Symbol identity', () => {
+    const marker = Symbol.for('@hono-preact/iso/Route');
+    expect((Route as unknown as Record<symbol, unknown>)[marker]).toBe(true);
+  });
+});
+
+describe('<Router> re-render stability', () => {
+  it('does not remount the route component when Router re-renders', async () => {
+    let mountCount = 0;
+    const Counter = () => {
+      const [count, setCount] = useState(0);
+      if (count === 0 && mountCount === 0) mountCount++;
+      return (
+        <div>
+          <span data-testid="count">{count}</span>
+          <button data-testid="bump" onClick={() => setCount((c) => c + 1)}>
+            bump
+          </button>
+        </div>
+      );
+    };
+
+    // Wrap Router in a component that we can re-render externally
+    let triggerOuterRender!: () => void;
+    function Outer() {
+      const [, force] = useState(0);
+      triggerOuterRender = () => force((n) => n + 1);
+      return (
+        <Router>
+          <Route path="/x" component={Counter} />
+        </Router>
+      );
+    }
+
+    window.history.pushState({}, '', '/x');
+    render(
+      <LocationProvider>
+        <Outer />
+      </LocationProvider>
+    );
+
+    await screen.findByTestId('count');
+    // Bump the inner state to a non-zero value
+    await act(async () => {
+      screen.getByTestId('bump').click();
+      screen.getByTestId('bump').click();
+    });
+    expect(screen.getByTestId('count')).toHaveTextContent('2');
+
+    // Force the outer (and thus the Router) to re-render
+    await act(async () => {
+      triggerOuterRender();
+      triggerOuterRender();
+    });
+
+    // If the route component remounted, the count would reset to 0
+    expect(screen.getByTestId('count')).toHaveTextContent('2');
   });
 });

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -16,8 +16,7 @@ vi.mock('../preload.js', () => ({
 const loc = {
   path: '/x',
   url: 'http://localhost/x',
-  query: {},
-  params: {},
+  searchParams: {},
   pathParams: {},
 } as unknown as RouteHook;
 

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/preact';
 import { LocationProvider, type RouteHook } from 'preact-iso';
 import { defineLoader } from '../define-loader.js';
-import { wrapWithPage } from '../route.js';
+import { Route, Router, wrapWithPage } from '../route.js';
 import { useLoaderData } from '../use-loader-data.js';
 import { env } from '../is-browser.js';
 
@@ -23,6 +23,7 @@ const loc = {
 const originalEnv = env.current;
 beforeEach(() => {
   env.current = 'browser';
+  window.history.pushState({}, '', '/');
 });
 afterEach(() => {
   env.current = originalEnv;
@@ -58,5 +59,73 @@ describe('wrapWithPage', () => {
     const el = await screen.findByText('ok');
     expect(el).toBeInTheDocument();
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('<Router> + <Route>', () => {
+  it('renders the matched route wrapped in <Page> with loader data', async () => {
+    const fn = vi.fn(async () => ({ msg: 'foo-data' }));
+    const ref = defineLoader<{ msg: string }>(fn);
+    const Foo = () => {
+      const { msg } = useLoaderData(ref);
+      return <p data-testid="foo">{msg}</p>;
+    };
+
+    window.history.pushState({}, '', '/foo');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/foo" component={Foo} loader={ref} />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('foo');
+    expect(el).toHaveTextContent('foo-data');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes non-Route children through unchanged (e.g. default fallback)', async () => {
+    const Foo = () => <p data-testid="foo">foo</p>;
+    const Default = (_props: { default?: boolean }) => (
+      <p data-testid="default">not found</p>
+    );
+
+    window.history.pushState({}, '', '/nope');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/foo" component={Foo} />
+          <Default default />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('default');
+    expect(el).toHaveTextContent('not found');
+    expect(screen.queryByTestId('foo')).toBeNull();
+  });
+
+  it('renders nothing when no route path matches', async () => {
+    const Foo = () => <p data-testid="foo">foo</p>;
+
+    window.history.pushState({}, '', '/nope');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/foo" component={Foo} />
+        </Router>
+      </LocationProvider>
+    );
+
+    expect(screen.queryByTestId('foo')).toBeNull();
+  });
+});
+
+describe('<Route> rendered directly', () => {
+  it('returns null and renders nothing', () => {
+    const Foo = () => <p data-testid="foo">foo</p>;
+    const { container } = render(<Route path="/foo" component={Foo} />);
+    expect(container.innerHTML).toBe('');
   });
 });

--- a/packages/iso/src/cache-registry.ts
+++ b/packages/iso/src/cache-registry.ts
@@ -1,4 +1,8 @@
+import type { LoaderCache } from './cache.js';
+// Note: type-only import; no runtime dependency on cache.ts.
+
 const registry = new Map<string, () => void>();
+const acquired = new Map<string, unknown>();
 
 export const cacheRegistry = {
   register(name: string, invalidateFn: () => void): void {
@@ -7,7 +11,15 @@ export const cacheRegistry = {
   invalidate(name: string): void {
     registry.get(name)?.();
   },
+  acquire<T>(name: string, factory: () => LoaderCache<T>): LoaderCache<T> {
+    const existing = acquired.get(name) as LoaderCache<T> | undefined;
+    if (existing) return existing;
+    const fresh = factory();
+    acquired.set(name, fresh);
+    return fresh;
+  },
   clear(): void {
     registry.clear();
+    acquired.clear();
   },
 };

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -48,3 +48,10 @@ export type {
   UseOptimisticActionOptions,
   UseOptimisticActionResult,
 } from './optimistic-action.js';
+
+export { Route, Router, wrapWithPage } from './route.js';
+export type { RouteProps, RouterProps, PageConfig } from './route.js';
+
+// Convenience re-export so consumers don't need to import from preact-iso
+// alongside @hono-preact/iso.
+export { lazy } from 'preact-iso';

--- a/packages/iso/src/prefetch.ts
+++ b/packages/iso/src/prefetch.ts
@@ -8,7 +8,7 @@ export async function prefetch<T>(
   opts: { location?: RouteHook; cache?: LoaderCache<T> } = {}
 ): Promise<T> {
   const fakeLocation =
-    opts.location ?? ({ path: '', query: {} } as unknown as RouteHook);
+    opts.location ?? ({ path: '', searchParams: {}, pathParams: {} } as RouteHook);
   const cache = opts.cache ?? ref.cache;
   const result = await ref.fn({ location: fakeLocation });
   if (isBrowser()) cache?.set(result);

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -1,18 +1,8 @@
 import type { ComponentType, JSX } from 'preact';
 import type { RouteHook } from 'preact-iso';
-import type { LoaderCache } from './cache.js';
-import type { GuardFn } from './guard.js';
-import type { LoaderRef } from './define-loader.js';
-import { Page, type WrapperProps } from './page.js';
+import { Page, type PageProps } from './page.js';
 
-export type PageConfig<T> = {
-  loader?: LoaderRef<T>;
-  cache?: LoaderCache<T>;
-  serverGuards?: GuardFn[];
-  clientGuards?: GuardFn[];
-  fallback?: JSX.Element;
-  Wrapper?: ComponentType<WrapperProps>;
-};
+export type PageConfig<T> = Omit<PageProps<T>, 'location' | 'children'>;
 
 export function wrapWithPage<T>(
   Component: ComponentType,

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -1,5 +1,16 @@
-import type { ComponentType, JSX } from 'preact';
-import type { RouteHook } from 'preact-iso';
+import {
+  isValidElement,
+  toChildArray,
+  type ComponentChildren,
+  type ComponentType,
+  type JSX,
+  type VNode,
+} from 'preact';
+import {
+  Route as PreactIsoRoute,
+  Router as PreactIsoRouter,
+  type RouteHook,
+} from 'preact-iso';
 import { Page, type PageProps } from './page.js';
 
 export type PageConfig<T> = Omit<PageProps<T>, 'location' | 'children'>;
@@ -15,4 +26,60 @@ export function wrapWithPage<T>(
       </Page>
     );
   };
+}
+
+export type RouteProps<T> = PageConfig<T> & {
+  path: string;
+  component: ComponentType;
+};
+
+// Marker component. <Router> from this package replaces <Route> elements with
+// preact-iso <Route> elements whose `component` prop is wrapped in <Page>.
+// Rendering <Route> directly (outside our <Router>) is a programmer error;
+// we silently render nothing rather than throw.
+export function Route<T>(_props: RouteProps<T>): null {
+  return null;
+}
+Route.displayName = 'Route';
+
+function isOurRoute(node: unknown): node is VNode<RouteProps<unknown>> {
+  return (
+    isValidElement(node) &&
+    typeof node === 'object' &&
+    node !== null &&
+    (node as VNode).type === Route
+  );
+}
+
+// preact-iso doesn't export RouterProps from its public surface, so we mirror
+// the shape from `node_modules/preact-iso/src/router.d.ts` here.
+type PreactIsoRouterProps = {
+  onRouteChange?: (url: string) => void;
+  onLoadEnd?: (url: string) => void;
+  onLoadStart?: (url: string) => void;
+  children?: ComponentChildren;
+};
+
+export type RouterProps = Omit<PreactIsoRouterProps, 'children'> & {
+  children?: ComponentChildren;
+};
+
+export function Router({ children, ...rest }: RouterProps): JSX.Element {
+  const transformed = toChildArray(children).map((child) => {
+    if (!isOurRoute(child)) return child;
+    const { path, component, ...config } = child.props;
+    return (
+      <PreactIsoRoute
+        path={path}
+        component={wrapWithPage(component, config)}
+      />
+    );
+  });
+  // PreactIsoRouter's children type is NestedArray<VNode>; cast through unknown
+  // because toChildArray returns ComponentChild[].
+  return (
+    <PreactIsoRouter {...rest}>
+      {transformed as unknown as JSX.Element[]}
+    </PreactIsoRouter>
+  );
 }

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -37,17 +37,22 @@ export type RouteProps<T> = PageConfig<T> & {
 // preact-iso <Route> elements whose `component` prop is wrapped in <Page>.
 // Rendering <Route> directly (outside our <Router>) is a programmer error;
 // we silently render nothing rather than throw.
+
+// Using Symbol.for ensures the marker survives duplicate module copies (HMR,
+// pnpm phantom deps, etc.) because Symbol.for is realm-wide by key.
+const ROUTE_MARKER = Symbol.for('@hono-preact/iso/Route');
+
 export function Route<T>(_props: RouteProps<T>): null {
   return null;
 }
 Route.displayName = 'Route';
+(Route as unknown as Record<symbol, unknown>)[ROUTE_MARKER] = true;
 
 function isOurRoute(node: unknown): node is VNode<RouteProps<unknown>> {
   return (
     isValidElement(node) &&
-    typeof node === 'object' &&
-    node !== null &&
-    (node as VNode).type === Route
+    typeof node.type === 'function' &&
+    (node.type as unknown as Record<symbol, unknown>)[ROUTE_MARKER] === true
   );
 }
 

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -1,0 +1,28 @@
+import type { ComponentType, JSX } from 'preact';
+import type { RouteHook } from 'preact-iso';
+import type { LoaderCache } from './cache.js';
+import type { GuardFn } from './guard.js';
+import type { LoaderRef } from './define-loader.js';
+import { Page, type WrapperProps } from './page.js';
+
+export type PageConfig<T> = {
+  loader?: LoaderRef<T>;
+  cache?: LoaderCache<T>;
+  serverGuards?: GuardFn[];
+  clientGuards?: GuardFn[];
+  fallback?: JSX.Element;
+  Wrapper?: ComponentType<WrapperProps>;
+};
+
+export function wrapWithPage<T>(
+  Component: ComponentType,
+  config: PageConfig<T>
+): (location: RouteHook) => JSX.Element {
+  return function PageRouteHandler(location: RouteHook) {
+    return (
+      <Page {...config} location={location}>
+        <Component />
+      </Page>
+    );
+  };
+}

--- a/packages/server/src/__tests__/loaders-handler.test.ts
+++ b/packages/server/src/__tests__/loaders-handler.test.ts
@@ -16,7 +16,7 @@ function post(app: Hono, body: unknown) {
   });
 }
 
-const loc = { path: '/movies', pathParams: {}, query: {} };
+const loc = { path: '/movies', pathParams: {}, searchParams: {} };
 
 describe('loadersHandler', () => {
   it('calls the matching serverLoader with the location and returns JSON', async () => {
@@ -94,5 +94,22 @@ describe('loadersHandler', () => {
     });
     const res = await post(app, { module: 'movies', location: loc });
     expect(res.status).toBe(200);
+  });
+
+  it('propagates location.searchParams through to the loader', async () => {
+    const loaderFn = vi.fn().mockResolvedValue({ ok: true });
+    const app = makeApp({
+      './pages/movies.server.ts': { default: loaderFn },
+    });
+    const locWithParams = {
+      path: '/movies',
+      pathParams: {},
+      searchParams: { genre: 'action' },
+    };
+    const res = await post(app, { module: 'movies', location: locWithParams });
+    expect(res.status).toBe(200);
+    expect(loaderFn).toHaveBeenCalledWith({ location: locWithParams });
+    const callArg = loaderFn.mock.calls[0][0] as { location: { searchParams: Record<string, string> } };
+    expect(callArg.location.searchParams).toEqual({ genre: 'action' });
   });
 });

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -14,7 +14,7 @@ function moduleNameFromPath(filePath: string): string {
 type SerializedLocation = {
   path: string;
   pathParams: Record<string, string>;
-  query: Record<string, string>;
+  searchParams: Record<string, string>;
 };
 
 type LoaderFn = (props: { location: SerializedLocation }) => Promise<unknown>;

--- a/packages/vite/src/__tests__/build-bundle-leak.test.ts
+++ b/packages/vite/src/__tests__/build-bundle-leak.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { build } from 'vite';
+import { resolve } from 'node:path';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const fixtureDir = resolve(__dirname, 'fixtures/leak-test');
+
+function readAllFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = resolve(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...readAllFilesRecursive(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+describe('client bundle does not leak server-only sources', () => {
+  it('produces no chunk containing a sentinel from a *.server.ts file', async () => {
+    await build({
+      root: fixtureDir,
+      logLevel: 'error',
+      configFile: resolve(fixtureDir, 'vite.config.ts'),
+      build: {
+        outDir: resolve(fixtureDir, 'dist'),
+        emptyOutDir: true,
+      },
+    });
+
+    const distFiles = readAllFilesRecursive(resolve(fixtureDir, 'dist'));
+    const offending: string[] = [];
+    for (const f of distFiles) {
+      const content = readFileSync(f, 'utf8');
+      if (content.includes('sentinel-must-not-leak-XYZ123')) {
+        offending.push(f);
+      }
+    }
+    expect(
+      offending,
+      `Server-only sentinel found in: ${offending.join(', ')}`
+    ).toEqual([]);
+  }, 60_000);
+});

--- a/packages/vite/src/__tests__/fixtures/leak-test/client.tsx
+++ b/packages/vite/src/__tests__/fixtures/leak-test/client.tsx
@@ -1,0 +1,14 @@
+import { hydrate } from 'preact';
+import { LocationProvider } from 'preact-iso';
+
+import { Base } from './iso.js';
+
+const app = document.getElementById('app') as HTMLElement;
+
+export const App = () => (
+  <LocationProvider>
+    <Base />
+  </LocationProvider>
+);
+
+hydrate(<App />, app);

--- a/packages/vite/src/__tests__/fixtures/leak-test/index.html
+++ b/packages/vite/src/__tests__/fixtures/leak-test/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>leak-test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/client.tsx"></script>
+  </body>
+</html>

--- a/packages/vite/src/__tests__/fixtures/leak-test/iso.tsx
+++ b/packages/vite/src/__tests__/fixtures/leak-test/iso.tsx
@@ -1,0 +1,10 @@
+import { lazy, Route, Router } from '@hono-preact/iso';
+import { loader, cache } from './pages/foo.server.js';
+
+const Foo = lazy(() => import('./pages/foo.js'));
+
+export const Base = () => (
+  <Router>
+    <Route path="/foo" component={Foo} loader={loader} cache={cache} />
+  </Router>
+);

--- a/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts
+++ b/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts
@@ -1,0 +1,22 @@
+import { defineLoader, createCache, defineAction, type LoaderFn } from '@hono-preact/iso';
+
+// The sentinel is intentionally constructed at runtime (concatenating two
+// halves) so that Rollup/Terser cannot constant-fold it away during
+// tree-shaking. If the entire `.server.ts` module ends up in the client
+// bundle, this exact string MUST appear somewhere in the dist.
+const SECRET_HALF_A = 'sentinel-must-not-leak-';
+const SECRET_HALF_B = 'XYZ123';
+const SUPER_SECRET_DATABASE_URL = SECRET_HALF_A + SECRET_HALF_B;
+
+const serverLoader: LoaderFn<{ secret: string }> = async () => {
+  // returning the secret directly keeps tree-shakers from removing it
+  return { secret: SUPER_SECRET_DATABASE_URL };
+};
+export default serverLoader;
+
+export const loader = defineLoader<{ secret: string }>(serverLoader);
+export const cache = createCache<{ secret: string }>('foo');
+
+export const serverActions = {
+  noop: defineAction<void, { ok: boolean }>(async () => ({ ok: true })),
+};

--- a/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.tsx
+++ b/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.tsx
@@ -1,0 +1,7 @@
+import { useLoaderData } from '@hono-preact/iso';
+import { loader } from './foo.server.js';
+
+export default function Foo() {
+  const data = useLoaderData(loader);
+  return <p>{data.secret}</p>;
+}

--- a/packages/vite/src/__tests__/fixtures/leak-test/server.tsx
+++ b/packages/vite/src/__tests__/fixtures/leak-test/server.tsx
@@ -1,0 +1,6 @@
+// Minimal server entry so a full toolchain (if invoked) can resolve it.
+// The build-leak test only exercises the client transform, so this file
+// is intentionally trivial.
+import { Base } from './iso.js';
+export { Base };
+export default Base;

--- a/packages/vite/src/__tests__/fixtures/leak-test/vite.config.ts
+++ b/packages/vite/src/__tests__/fixtures/leak-test/vite.config.ts
@@ -1,0 +1,41 @@
+import preact from '@preact/preset-vite';
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import { serverOnlyPlugin } from '../../../index.js';
+
+// Minimal fixture vite config used by the build-bundle-leak test.
+//
+// We intentionally do NOT use the full `honoPreact` plugin here: it bundles
+// `@hono/vite-build/cloudflare-workers` and `@hono/vite-dev-server`, which
+// would force a Cloudflare Workers server build and a dev-server runtime.
+// The leak test only needs to verify the *client* transform output, so a
+// plain SPA build with `serverOnlyPlugin` is sufficient (and dramatically
+// faster + more reproducible).
+export default defineConfig({
+  // Resolve workspace packages to their TS sources so the fixture doesn't
+  // depend on a prior build step in this worktree.
+  resolve: {
+    alias: [
+      {
+        find: '@hono-preact/iso',
+        replacement: resolve(__dirname, '../../../../../iso/src/index.ts'),
+      },
+    ],
+    dedupe: ['preact', 'preact/compat', 'preact/hooks', 'preact-iso'],
+  },
+  plugins: [serverOnlyPlugin(), preact()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    minify: false,
+    sourcemap: false,
+    rollupOptions: {
+      input: resolve(__dirname, 'index.html'),
+      output: {
+        entryFileNames: 'static/client.js',
+        chunkFileNames: 'static/[name]-[hash].js',
+        assetFileNames: 'static/[name]-[hash].[ext]',
+      },
+    },
+  },
+});

--- a/packages/vite/src/__tests__/server-loader-validation-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-loader-validation-plugin.test.ts
@@ -127,6 +127,19 @@ describe('serverLoaderValidationPlugin', () => {
     expect(error).toBeNull();
   });
 
+  it('error message lists all allowed named exports including loader and cache', () => {
+    const code = [
+      'export const unauthorized = () => {};',
+      'export default async function serverLoader() { return {}; }',
+    ].join('\n');
+    const { error } = transform(code, 'movies.server.ts');
+    expect(error).toContain("'serverGuards'");
+    expect(error).toContain("'serverActions'");
+    expect(error).toContain("'actionGuards'");
+    expect(error).toContain("'loader'");
+    expect(error).toContain("'cache'");
+  });
+
   describe('allows loader and cache named exports', () => {
     it('does not reject "loader" named export', () => {
       const code = [

--- a/packages/vite/src/__tests__/server-loader-validation-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-loader-validation-plugin.test.ts
@@ -126,4 +126,24 @@ describe('serverLoaderValidationPlugin', () => {
     const { error } = transform(code, 'movies.server.ts');
     expect(error).toBeNull();
   });
+
+  describe('allows loader and cache named exports', () => {
+    it('does not reject "loader" named export', () => {
+      const code = [
+        'export default serverLoader;',
+        'export const loader = defineLoader(serverLoader);',
+      ].join('\n');
+      const { error } = transform(code, 'movies.server.ts');
+      expect(error).toBeNull();
+    });
+
+    it('does not reject "cache" named export', () => {
+      const code = [
+        "export default serverLoader;",
+        "export const cache = createCache('movies-list');",
+      ].join('\n');
+      const { error } = transform(code, 'movies.server.ts');
+      expect(error).toBeNull();
+    });
+  });
 });

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -238,3 +238,31 @@ describe('side-effect and type-only imports', () => {
     expect(result?.code).not.toContain('const Foo');
   });
 });
+
+describe('re-exports from .server.* are rejected', () => {
+  it('throws on `export { loader } from .server.*`', () => {
+    const code = `export { loader } from './movies.server.js';`;
+    expect(() => transform(code, '/src/aggregator.ts')).toThrow(
+      /re-export.*from.*\.server.*not supported/i
+    );
+  });
+
+  it('throws on `export { loader as moviesLoader } from .server.*`', () => {
+    const code = `export { loader as moviesLoader } from './movies.server.js';`;
+    expect(() => transform(code, '/src/aggregator.ts')).toThrow(
+      /re-export.*from.*\.server.*not supported/i
+    );
+  });
+
+  it('throws on `export * from .server.*`', () => {
+    const code = `export * from './movies.server.js';`;
+    expect(() => transform(code, '/src/aggregator.ts')).toThrow(
+      /re-export.*from.*\.server.*not supported/i
+    );
+  });
+
+  it('does not throw on regular `export * from` of a non-server module', () => {
+    const code = `export * from './utils.js';`;
+    expect(() => transform(code, '/src/aggregator.ts')).not.toThrow();
+  });
+});

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -150,7 +150,7 @@ describe('loader and cache specifiers', () => {
     // The fixture file isn't available here; the plugin should fall back to module name.
     const code = `import { cache } from './movies.server.js';`;
     const result = transform(code, '/src/iso.tsx');
-    expect(result?.code).toContain("import { createCache as");
+    expect(result?.code).toContain('createCache as');
     // Expect the fallback name (module name) since no fixture exists for source-extraction.
     // The plugin uses a unique alias (e.g. __$createCache_movies) to avoid collisions,
     // so match `createCache[_a-zA-Z0-9$]*("movies")` to allow either bare or aliased call sites.
@@ -202,6 +202,13 @@ describe('loader and cache specifiers', () => {
     expect(result).toBeDefined();
     expect(result?.code).not.toContain("import { cache }");
     expect(result?.code).toContain('const cache =');
+  });
+
+  it('emits cache stubs that go through cacheRegistry.acquire for identity', () => {
+    const code = `import { cache } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain('.acquire(');
+    expect(result?.code).toContain('cacheRegistry');
   });
 });
 

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -25,7 +25,7 @@ describe('serverOnlyPlugin', () => {
     expect(result?.code).toContain('"movies"');
     expect(result?.code).toContain('location.path');
     expect(result?.code).toContain('location.pathParams');
-    expect(result?.code).toContain('location.query');
+    expect(result?.code).toContain('location.searchParams');
     expect(result?.code).not.toContain('async () => ({})');
   });
 
@@ -243,6 +243,22 @@ describe('side-effect and type-only imports', () => {
     expect(result?.code).toContain("fetch('/__loaders'");
     // The type import should be skipped (no Foo declaration emitted).
     expect(result?.code).not.toContain('const Foo');
+  });
+});
+
+describe('loader RPC stub uses searchParams (not the deprecated query)', () => {
+  it('default import stub builds searchParams from location.searchParams', () => {
+    const code = `import serverLoader from './movies.server.js';`;
+    const result = transform(code, '/src/pages/movies.tsx');
+    expect(result?.code).toContain('searchParams: location.searchParams');
+    expect(result?.code).not.toContain('query: location.query');
+  });
+
+  it('loader named-import stub builds searchParams from location.searchParams', () => {
+    const code = `import { loader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain('searchParams: location.searchParams');
+    expect(result?.code).not.toContain('query: location.query');
   });
 });
 

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -136,3 +136,80 @@ describe('serverOnlyPlugin', () => {
     expect(result?.code).not.toContain('"some-other-page"');
   });
 });
+
+describe('loader and cache specifiers', () => {
+  it('replaces a `loader` named import with a client-side LoaderRef stub', () => {
+    const code = `import { loader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toMatch(/const loader = \{[\s\S]*__id: Symbol\.for\(['"]@hono-preact\/loader:movies['"]\)[\s\S]*fn:\s*async/);
+    expect(result?.code).toContain("fetch('/__loaders'");
+    expect(result?.code).toContain('"movies"');
+  });
+
+  it('replaces a `cache` named import with a createCache call using the source-file name', () => {
+    // The fixture file isn't available here; the plugin should fall back to module name.
+    const code = `import { cache } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain("import { createCache as");
+    // Expect the fallback name (module name) since no fixture exists for source-extraction.
+    // The plugin uses a unique alias (e.g. __$createCache_movies) to avoid collisions,
+    // so match `createCache[_a-zA-Z0-9$]*("movies")` to allow either bare or aliased call sites.
+    expect(result?.code).toMatch(/createCache[_a-zA-Z0-9$]*\(['"]movies['"]\)/);
+  });
+
+  it('handles `loader` aliased to a different local name', () => {
+    const code = `import { loader as moviesLoader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toMatch(/const moviesLoader = \{[\s\S]*Symbol\.for/);
+    expect(result?.code).toContain('"movies"');
+  });
+
+  it('handles `cache` aliased to a different local name', () => {
+    const code = `import { cache as moviesCache } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain('const moviesCache =');
+    expect(result?.code).toMatch(/createCache[_a-zA-Z0-9$]*\(['"]movies['"]\)/);
+  });
+
+  it('handles mixed loader + cache + serverActions in one import statement', () => {
+    const code = `import { loader, cache, serverActions } from './movies.server.js';`;
+    const result = transform(code, '/src/pages/movies.tsx');
+    expect(result?.code).toContain('const loader =');
+    expect(result?.code).toContain('const cache =');
+    expect(result?.code).toContain('const serverActions = new Proxy');
+  });
+
+  it('handles mixed default + loader in one import statement', () => {
+    const code = `import serverLoader, { loader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result?.code).toContain('const serverLoader =');
+    expect(result?.code).toContain('const loader =');
+  });
+
+  it('matches an import that has ONLY loader (no default, no actions, no guards)', () => {
+    // This is the bug from the route-level-loaders migration: imports with only
+    // `loader` were silently passed through.
+    const code = `import { loader } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result).toBeDefined();
+    expect(result?.code).not.toContain("import { loader }");
+    expect(result?.code).toContain('const loader =');
+  });
+
+  it('matches an import that has ONLY cache (no default, no actions, no guards)', () => {
+    const code = `import { cache } from './movies.server.js';`;
+    const result = transform(code, '/src/iso.tsx');
+    expect(result).toBeDefined();
+    expect(result?.code).not.toContain("import { cache }");
+    expect(result?.code).toContain('const cache =');
+  });
+});
+
+describe('unknown specifiers from .server.* imports', () => {
+  it('throws a clear error when an unknown named export is imported from .server.*', () => {
+    const code = `import { unknownExport } from './movies.server.js';`;
+    expect(() => transform(code, '/src/iso.tsx')).toThrow(
+      /unknownExport.*not a recognized.*server/i
+    );
+  });
+});

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -213,3 +213,28 @@ describe('unknown specifiers from .server.* imports', () => {
     );
   });
 });
+
+describe('side-effect and type-only imports', () => {
+  it('strips a side-effect-only .server.* import', () => {
+    const code = `import './x.server.js';\nconst foo = 1;`;
+    const result = transform(code, '/p.tsx');
+    expect(result?.code).not.toContain('.server');
+    expect(result?.code).toContain('const foo = 1');
+  });
+
+  it('leaves `import type { Foo } from .server.*` untouched (or stripped — either is safe since types are erased)', () => {
+    const code = `import type { Foo } from './x.server.js';\nconst foo = 1;`;
+    // Should NOT throw. The exact transform output is flexible — assert no throw.
+    expect(() => transform(code, '/p.tsx')).not.toThrow();
+  });
+
+  it('handles mixed `import { type Foo, default as loader } from .server.*`', () => {
+    const code = `import { type Foo, default as loader } from './x.server.js';`;
+    expect(() => transform(code, '/p.tsx')).not.toThrow();
+    const result = transform(code, '/p.tsx');
+    // The default import should still be stubbed.
+    expect(result?.code).toContain("fetch('/__loaders'");
+    // The type import should be skipped (no Foo declaration emitted).
+    expect(result?.code).not.toContain('const Foo');
+  });
+});

--- a/packages/vite/src/server-loader-validation.ts
+++ b/packages/vite/src/server-loader-validation.ts
@@ -2,6 +2,9 @@ import { parse } from '@babel/parser';
 import type { ExportNamedDeclaration } from '@babel/types';
 import type { Plugin } from 'vite';
 
+const ALLOWED_NAMED_EXPORTS = new Set(['serverGuards', 'serverActions', 'actionGuards', 'loader', 'cache']);
+const ALLOWED_NAMED_EXPORTS_LIST = [...ALLOWED_NAMED_EXPORTS].map((n) => `'${n}'`).join(', ');
+
 export function serverLoaderValidationPlugin(): Plugin {
   return {
     name: 'server-loader-validation',
@@ -50,14 +53,12 @@ export function serverLoaderValidationPlugin(): Plugin {
           }
         }
       }
-
-      const ALLOWED_NAMED_EXPORTS = new Set(['serverGuards', 'serverActions', 'actionGuards', 'loader', 'cache']);
       const disallowedExports = namedExports.filter(
         (n) => !ALLOWED_NAMED_EXPORTS.has(n)
       );
       if (disallowedExports.length > 0) {
         errors.push(
-          `${id}: .server files may only export 'serverGuards', 'serverActions', or 'actionGuards' as named exports (found: ${disallowedExports.join(', ')}). ` +
+          `${id}: .server files may only export ${ALLOWED_NAMED_EXPORTS_LIST} as named exports (found: ${disallowedExports.join(', ')}). ` +
             `Export the server loader as the default export only.`
         );
       }

--- a/packages/vite/src/server-loader-validation.ts
+++ b/packages/vite/src/server-loader-validation.ts
@@ -51,8 +51,9 @@ export function serverLoaderValidationPlugin(): Plugin {
         }
       }
 
+      const ALLOWED_NAMED_EXPORTS = new Set(['serverGuards', 'serverActions', 'actionGuards', 'loader', 'cache']);
       const disallowedExports = namedExports.filter(
-        (n) => n !== 'serverGuards' && n !== 'serverActions' && n !== 'actionGuards'
+        (n) => !ALLOWED_NAMED_EXPORTS.has(n)
       );
       if (disallowedExports.length > 0) {
         errors.push(

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -93,11 +93,36 @@ export function serverOnlyPlugin(): Plugin {
       const needsCacheImport = new Set<string>();
 
       for (const serverImport of [...serverImports].reverse()) {
+        // Type-only declarations (`import type { ... } from '...'`) are erased
+        // by Vite/esbuild; strip the entire declaration so it doesn't leak the
+        // .server.* module into the client bundle.
+        if ((serverImport as unknown as { importKind?: string }).importKind === 'type') {
+          s.overwrite(serverImport.start!, serverImport.end!, '');
+          continue;
+        }
+
         const moduleName = moduleNameFromSource(serverImport.source.value);
         const stubs: string[] = [];
+        let hasValueSpecifier = false;
 
         for (const specifier of serverImport.specifiers) {
-          if (specifier.type === 'ImportDefaultSpecifier') {
+          // Skip type-only specifiers in mixed imports (e.g.
+          // `import { type Foo, default as loader } from '...'`). These are
+          // erased by Vite/esbuild and must not trigger the unknown-specifier
+          // guard below.
+          if ((specifier as unknown as { importKind?: string }).importKind === 'type') {
+            continue;
+          }
+          hasValueSpecifier = true;
+          // Treat both `import X from '...'` (ImportDefaultSpecifier) and
+          // `import { default as X } from '...'` (ImportSpecifier with
+          // imported.name === 'default') as the default-loader case.
+          const isDefaultImport =
+            specifier.type === 'ImportDefaultSpecifier' ||
+            (specifier.type === 'ImportSpecifier' &&
+              specifier.imported.type === 'Identifier' &&
+              specifier.imported.name === 'default');
+          if (isDefaultImport) {
             stubs.push(
               `const ${specifier.local.name} = async ({ location }) => {\n` +
               `  const res = await fetch('/__loaders', {\n` +
@@ -179,6 +204,12 @@ export function serverOnlyPlugin(): Plugin {
 
         if (stubs.length > 0) {
           s.overwrite(serverImport.start!, serverImport.end!, stubs.join('\n'));
+        } else if (!hasValueSpecifier) {
+          // Side-effect-only import (`import './x.server.js';`) or a mixed
+          // import whose only specifiers were type-only. In either case there
+          // is nothing to stub and the original declaration would leak the
+          // .server.* module into the client bundle — strip it.
+          s.overwrite(serverImport.start!, serverImport.end!, '');
         }
       }
 

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -82,6 +82,23 @@ export function serverOnlyPlugin(): Plugin {
         errorRecovery: true,
       });
 
+      // Detect and reject re-exports from .server.* files. The plugin can't safely
+      // rewrite a re-export — synthesizing stubs and re-emitting them as exports is
+      // out of scope. Throw a clear error so the leak vector is closed at build time.
+      for (const node of ast.program.body) {
+        if (
+          (node.type === 'ExportNamedDeclaration' || node.type === 'ExportAllDeclaration') &&
+          node.source &&
+          /\.server(\.[jt]sx?)?$/.test(node.source.value)
+        ) {
+          throw new Error(
+            `${id}: re-export from '${node.source.value}' (a .server.* module) is not supported. ` +
+            `Import the named member directly instead, e.g. ` +
+            `\`import { loader } from '${node.source.value}';\``
+          );
+        }
+      }
+
       const isServerImport = (node: unknown): node is ImportDeclaration =>
         (node as ImportDeclaration).type === 'ImportDeclaration' &&
         /\.server(\.[jt]sx?)?$/.test((node as ImportDeclaration).source.value);

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -201,8 +201,10 @@ export function serverOnlyPlugin(): Plugin {
             // files contribute cache imports to the same consumer.
             const aliasSuffix = moduleName.replace(/[^a-zA-Z0-9_$]/g, '_');
             needsCacheImport.add(aliasSuffix);
+            // Route through cacheRegistry.acquire so that two consumers stubbing the
+            // same .server.* module share a single cache instance (name-as-identity).
             stubs.push(
-              `const ${specifier.local.name} = __$createCache_${aliasSuffix}(${JSON.stringify(cacheName)});`
+              `const ${specifier.local.name} = __$cacheRegistry_${aliasSuffix}.acquire(${JSON.stringify(cacheName)}, () => __$createCache_${aliasSuffix}(${JSON.stringify(cacheName)}));`
             );
           } else {
             const importedName =
@@ -234,7 +236,7 @@ export function serverOnlyPlugin(): Plugin {
         const importDeclarations = [...needsCacheImport]
           .map(
             (suffix) =>
-              `import { createCache as __$createCache_${suffix} } from '@hono-preact/iso';`
+              `import { cacheRegistry as __$cacheRegistry_${suffix}, createCache as __$createCache_${suffix} } from '@hono-preact/iso';`
           )
           .join('\n');
         s.prepend(importDeclarations + '\n');

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -145,7 +145,7 @@ export function serverOnlyPlugin(): Plugin {
               `  const res = await fetch('/__loaders', {\n` +
               `    method: 'POST',\n` +
               `    headers: { 'Content-Type': 'application/json' },\n` +
-              `    body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, query: location.query } }),\n` +
+              `    body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, searchParams: location.searchParams } }),\n` +
               `  });\n` +
               `  if (!res.ok) {\n` +
               `    const body = await res.json().catch(() => ({}));\n` +
@@ -181,7 +181,7 @@ export function serverOnlyPlugin(): Plugin {
               `    const res = await fetch('/__loaders', {\n` +
               `      method: 'POST',\n` +
               `      headers: { 'Content-Type': 'application/json' },\n` +
-              `      body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, query: location.query } }),\n` +
+              `      body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, searchParams: location.searchParams } }),\n` +
               `    });\n` +
               `    if (!res.ok) {\n` +
               `      const body = await res.json().catch(() => ({}));\n` +

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { parse } from '@babel/parser';
 import type { ImportDeclaration } from '@babel/types';
 import MagicString from 'magic-string';
@@ -8,6 +10,60 @@ function moduleNameFromSource(importSource: string): string {
     .split('/')
     .pop()!
     .replace(/\.server(\.[jt]sx?)?$/, '');
+}
+
+function extractCacheName(
+  importerPath: string,
+  importSource: string,
+  fallbackModuleName: string
+): string {
+  // Resolve the import source relative to the importer.
+  const importerDir = path.dirname(importerPath);
+  const baseResolved = path.resolve(importerDir, importSource);
+  // Try common TS/JS extensions.
+  const candidates = [
+    baseResolved,
+    baseResolved.replace(/\.js$/, '.ts'),
+    baseResolved.replace(/\.jsx$/, '.tsx'),
+    baseResolved.replace(/\.mjs$/, '.mts'),
+    baseResolved + '.ts',
+    baseResolved + '.tsx',
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      try {
+        const src = fs.readFileSync(candidate, 'utf8');
+        const ast = parse(src, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+          errorRecovery: true,
+        });
+        for (const node of ast.program.body) {
+          if (
+            node.type === 'ExportNamedDeclaration' &&
+            node.declaration?.type === 'VariableDeclaration'
+          ) {
+            for (const decl of node.declaration.declarations) {
+              if (
+                decl.id.type === 'Identifier' &&
+                decl.id.name === 'cache' &&
+                decl.init?.type === 'CallExpression' &&
+                decl.init.callee.type === 'Identifier' &&
+                decl.init.callee.name === 'createCache'
+              ) {
+                const arg = decl.init.arguments[0];
+                if (arg?.type === 'StringLiteral') return arg.value;
+              }
+            }
+          }
+        }
+      } catch {
+        // Source-parse failure — fall through to the fallback.
+      }
+      break; // file exists but no extractable name; don't keep trying extensions
+    }
+  }
+  return fallbackModuleName;
 }
 
 export function serverOnlyPlugin(): Plugin {
@@ -28,21 +84,13 @@ export function serverOnlyPlugin(): Plugin {
 
       const isServerImport = (node: unknown): node is ImportDeclaration =>
         (node as ImportDeclaration).type === 'ImportDeclaration' &&
-        /\.server(\.[jt]sx?)?$/.test((node as ImportDeclaration).source.value) &&
-        (node as ImportDeclaration).specifiers.some(
-          (s) =>
-            s.type === 'ImportDefaultSpecifier' ||
-            (s.type === 'ImportSpecifier' &&
-              s.imported.type === 'Identifier' &&
-              (s.imported.name === 'serverGuards' ||
-                s.imported.name === 'actionGuards' ||
-                s.imported.name === 'serverActions'))
-        );
+        /\.server(\.[jt]sx?)?$/.test((node as ImportDeclaration).source.value);
 
       const serverImports = ast.program.body.filter(isServerImport);
       if (serverImports.length === 0) return;
 
       const s = new MagicString(code);
+      const needsCacheImport = new Set<string>();
 
       for (const serverImport of [...serverImports].reverse()) {
         const moduleName = moduleNameFromSource(serverImport.source.value);
@@ -79,12 +127,69 @@ export function serverOnlyPlugin(): Plugin {
             stubs.push(
               `const ${specifier.local.name} = new Proxy({}, { get(_, action) { return { __module: ${JSON.stringify(moduleName)}, __action: String(action) }; } });`
             );
+          } else if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported.type === 'Identifier' &&
+            specifier.imported.name === 'loader'
+          ) {
+            stubs.push(
+              `const ${specifier.local.name} = {\n` +
+              `  __id: Symbol.for('@hono-preact/loader:${moduleName}'),\n` +
+              `  fn: async ({ location }) => {\n` +
+              `    const res = await fetch('/__loaders', {\n` +
+              `      method: 'POST',\n` +
+              `      headers: { 'Content-Type': 'application/json' },\n` +
+              `      body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, query: location.query } }),\n` +
+              `    });\n` +
+              `    if (!res.ok) {\n` +
+              `      const body = await res.json().catch(() => ({}));\n` +
+              `      throw new Error(body.error ?? \`Loader failed with status \${res.status}\`);\n` +
+              `    }\n` +
+              `    return res.json();\n` +
+              `  },\n` +
+              `};`
+            );
+          } else if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported.type === 'Identifier' &&
+            specifier.imported.name === 'cache'
+          ) {
+            const cacheName = extractCacheName(id, serverImport.source.value, moduleName);
+            // Use a per-source unique alias to avoid collisions when multiple .server.ts
+            // files contribute cache imports to the same consumer.
+            const aliasSuffix = moduleName.replace(/[^a-zA-Z0-9_$]/g, '_');
+            needsCacheImport.add(aliasSuffix);
+            stubs.push(
+              `const ${specifier.local.name} = __$createCache_${aliasSuffix}(${JSON.stringify(cacheName)});`
+            );
+          } else {
+            const importedName =
+              specifier.type === 'ImportSpecifier' &&
+              specifier.imported.type === 'Identifier'
+                ? specifier.imported.name
+                : specifier.type === 'ImportNamespaceSpecifier'
+                ? '* as ' + specifier.local.name
+                : '<unknown>';
+            throw new Error(
+              `${id}: \`${importedName}\` is not a recognized export from a *.server.* module. ` +
+              `Allowed: default, loader, cache, serverGuards, serverActions, actionGuards.`
+            );
           }
         }
 
         if (stubs.length > 0) {
           s.overwrite(serverImport.start!, serverImport.end!, stubs.join('\n'));
         }
+      }
+
+      if (needsCacheImport.size > 0) {
+        const importDeclarations = [...needsCacheImport]
+          .map(
+            (suffix) =>
+              `import { createCache as __$createCache_${suffix} } from '@hono-preact/iso';`
+          )
+          .join('\n');
+        s.prepend(importDeclarations + '\n');
       }
 
       return { code: s.toString(), map: s.generateMap({ hires: true }) };

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -8,5 +8,6 @@
     "noEmit": false,
     "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/__tests__/fixtures/**"]
 }


### PR DESCRIPTION
## Summary

Moves page-level config (loader, cache, guards, fallback, Wrapper) from inside page components to the route registration. Page files become pure components consuming \`useLoaderData(loader)\`. Loader refs and named caches live in the existing \`*.server.ts\` siblings as named exports.

The actual user-facing code goes from this (PR #3 surface):

```tsx
// pages/movies.tsx — owns wrapping, loader ref, cache
const moviesLoader = defineLoader<Data>(serverLoader);
const cache = createCache<Data>('movies-list');
const Movies = () => { /* useLoaderData(moviesLoader) */ };
export default function MoviesPage(location: RouteHook) {
  return <Page loader={moviesLoader} location={location} cache={cache}><Movies /></Page>;
}
```

To this:

```ts
// pages/movies.server.ts — exports loader and cache
export const loader = defineLoader<Data>(serverLoader);
export const cache = createCache<Data>('movies-list');
```
```tsx
// pages/movies.tsx — pure UI
export default function Movies() {
  const { movies } = useLoaderData(loader);
  return <ul>...</ul>;
}
```
```tsx
// iso.tsx — declarative route table
import { loader, cache } from './pages/movies.server.js';
<Route path=\"/movies\" component={Movies} loader={loader} cache={cache} />
```

## Why

Routes are now first-class. The framework knows the loader/guard graph at the route boundary without rendering the page component — the prerequisite for preload-on-hover, parallel loader+component fetch on navigation, and (eventually) filesystem-derived routing.

The whole class of \"duplicate XHR / Suspense flash\" bugs (PR #3 fixed one of these) becomes structurally impossible because the component never participates in fetch decisions.

## Architecture

### Iso package
- New \`<Route>\` (Symbol-marked, returns null) — marker component carrying \`path\`, \`component\`, and any \`PageConfig<T>\` (loader/cache/guards/fallback/Wrapper).
- New \`<Router>\` — walks its children with \`toChildArray\`, replaces our \`<Route>\` elements with preact-iso \`<Route>\` whose \`component\` is wrapped via \`wrapWithPage(Component, config)\`. Forwards all other Router props.
- \`PageConfig<T> = Omit<PageProps<T>, 'location' | 'children'>\` — derived to prevent drift.
- \`Symbol.for('@hono-preact/iso/Route')\` marker for cross-module-copy identity safety.
- \`cacheRegistry.acquire(name, factory)\` — name-as-identity for caches, mirroring how \`Symbol.for\` gives loaders shared identity.

### Vite plugin
- \`serverLoaderValidationPlugin\` allowlist extended: \`loader\`, \`cache\` are now valid named exports from \`*.server.*\`.
- \`serverOnlyPlugin\` extensively reworked:
  - Broadened \`isServerImport\` to match ANY \`*.server.*\` import (not only ones with known specifiers).
  - \`loader\` named import → emits a client-safe stub: \`{ __id: Symbol.for('@hono-preact/loader:moduleName'), fn: <RPC fetch> }\`.
  - \`cache\` named import → emits \`cacheRegistry.acquire(name, () => createCache(name))\`. Cache name is extracted by AST-parsing the source \`.server.ts\` for \`createCache(<literal>)\`, falling back to the module name.
  - Side-effect-only imports (\`import './x.server.js';\`) stripped (no leak).
  - Type-only imports (\`import type { Foo } from './x.server.js';\`) skipped (no false throw).
  - Re-exports (\`export { foo } from './x.server.js';\`) throw at build time with a clear error.
  - Unknown named specifiers throw with a clear error naming the offending export.
  - Loader RPC body now uses \`searchParams\` (matching \`RouteHook\`) instead of the obsolete \`query\` field. Server's \`SerializedLocation\` aligned. (Pre-existing latent bug fixed.)

### App
- All five page modules (\`home\`, \`test\`, \`movies\`, \`watched\`, \`movie\`) are now pure components.
- \`movie\` keeps its nested router (the detail page renders inside the movies list section — explicit decision to preserve current visual behavior).
- \`MovieWrapper\` (custom \`<article>\` Wrapper) lives inline in \`movies.tsx\` so it can be referenced from the nested route registration.

### Test infrastructure
- New build-level integration test (\`build-bundle-leak.test.ts\`) runs \`vite build\` programmatically against a fixture and greps the output for a sentinel string from a \`.server.ts\` file. **This test would have caught the original critical bugs** that per-task reviewers missed in the migration phase.
- The fixture's sentinel is built from runtime concatenation to defeat Rollup constant-folding (an early naïve fixture passed falsely because Rollup tree-shook the literal).

### Docs
All 9 user-facing MDX files rewritten to lead with the new \`<Route>\` / \`useLoaderData\` pattern. The previous \`<Page>\` API is mentioned only as the underlying composition primitive.

## Bug-finding chronology (worth noting)

The first \"all green\" version of this PR shipped with two **critical** bugs that all per-task reviewers missed:
1. \`.server.*\` modules leaking entire seed data and minified server functions into the client bundle.
2. \`useLoaderData(moviesLoader)\` silently referencing an undeclared identifier in built chunks (a \`ReferenceError\` waiting to happen on client navigation).

A holistic final-review subagent caught both by actually building the app and inspecting artifacts. The plugin work in this PR fixes both. The \`build-bundle-leak.test.ts\` integration test ensures regressions of this class will fail loudly going forward.

A second holistic review caught four more latent vectors (re-exports, type-only imports, side-effect imports, cache duplication). All four are now closed.

## What this does NOT do

These are explicit follow-ups, not in this PR:
- **Parallel loader+component fetch on navigation.** The architecture *enables* it but doesn't implement it. Currently the loader still fires after the lazy component mounts.
- **Preload-on-hover.** Same.
- **Filesystem-derived routes.** Manual \`<Route>\` registration in \`iso.tsx\` is transitional; eventually a Vite glob over \`pages/\` should derive the route table.

## Test plan

- [x] \`pnpm test\` — 207/207 passing (was 171 on PR #3; +36 new tests covering route registration, plugin transforms, leak prevention, cache identity)
- [x] \`pnpm --filter '@hono-preact/*' --filter hono-preact build\` — all four packages clean
- [x] \`pnpm --filter app build\` — clean
- [x] \`tsc --noEmit\` clean for \`apps/app\`
- [x] SSR check: \`/\`, \`/test\`, \`/movies\`, \`/movies/:id\`, \`/watched\`, \`/docs/*\` all return correct content
- [x] Custom \`<article>\` Wrapper preserved on movie detail
- [x] Loader RPC and Action RPC roundtrips return correct data
- [x] Bundle-leak forensics: \`grep -r \"Moana 2|markWatched(|listWatched(\" apps/app/dist/static/\` empty
- [x] Loader stub presence: \`Symbol.for('@hono-preact/loader:*')\` present in every page chunk that uses \`useLoaderData\`
- [ ] Manual browser smoke: optimistic toggle on \`/movies/:id\` — one XHR per click, no flicker, optimistic state survives reload

## Stack

This PR is stacked on \#3 (\`feat/iso-v3-components\`). Merge order: \#3 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)