### PR TITLE
fix(iso): post-merge follow-ups from feat/iso-v3-components

### DIFF
--- a/apps/app/src/iso.tsx
+++ b/apps/app/src/iso.tsx
@@ -12,7 +12,7 @@ const Movies = lazy(() => import('./pages/movies.js'));
 const Watched = lazy(() => import('./pages/watched.js'));
 
 // Each MDX file is lazy-loaded (code-split), consistent with the page pattern
-// above. Route paths are derived from filenames at module-evaluation time —
+// above. Route paths are derived from filenames at module-evaluation time;
 // the glob keys are statically analysable by Rollup so no dynamic import of
 // module contents is needed to know the path.
 const mdxModules = import.meta.glob('./pages/docs/*.mdx');
@@ -22,7 +22,7 @@ const mdxRoutes = Object.entries(mdxModules).map(([filePath, load]) => {
   // Wrap the MDX component in a single root element so the lazy Suspense
   // boundary contains one node. MDX compiles to a Fragment root (multiple
   // sibling nodes), which Preact cannot reconcile correctly during hydration
-  // when the component is inside a Suspense boundary — it appends instead of
+  // when the component is inside a Suspense boundary; it appends instead of
   // replacing, causing the content to appear twice.
   const Component = lazy(async () => {
     const [mod, { DocsLayout }] = await Promise.all([
@@ -44,14 +44,10 @@ function onRouteChange() {
 export const Base: FunctionComponent = () => {
   return (
     <Router onRouteChange={onRouteChange}>
-      {/* Migrated to route-level Page wrapping */}
       <Route path="/" component={Home} />
-      {/* Migrated to route-level Page wrapping */}
       <Route path="/test" component={Test} />
-      {/* Migrated to route-level Page wrapping */}
       <Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
       <Route path="/movies/*" component={Movies} loader={moviesLoader} cache={moviesCache} />
-      {/* Migrated to route-level Page wrapping */}
       <Route
         path="/watched"
         component={Watched}

--- a/apps/app/src/pages/docs/action-guards.mdx
+++ b/apps/app/src/pages/docs/action-guards.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Action Guards
 
 Action guards are middleware-style functions that run before a server action executes. Use them for authentication, authorization, rate limiting, or any cross-cutting concern that should halt execution before the action body runs.
@@ -53,7 +51,7 @@ import { defineActionGuard } from '@hono-preact/iso';
 
 const guard = defineActionGuard(async (ctx, next) => {
   // inspect ctx, then either throw or call next()
-  await next();
+  return next();
 });
 ```
 

--- a/apps/app/src/pages/docs/actions.mdx
+++ b/apps/app/src/pages/docs/actions.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Server Actions
 
 Pages often need to mutate data: adding a record, toggling a flag, deleting a row. Server actions let you define those mutations as typed functions in your `.server.ts` file and call them from the client with a single hook or form component. No manual `fetch` wiring, no API route plumbing.

--- a/apps/app/src/pages/docs/deployment.mdx
+++ b/apps/app/src/pages/docs/deployment.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Build & Deploy
 
 ## Development

--- a/apps/app/src/pages/docs/guards.mdx
+++ b/apps/app/src/pages/docs/guards.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Route Guards
 
 Pages sometimes need to be protected: requiring authentication, a specific role, or any other condition before rendering. Guards provide this as a middleware-style chain that runs before the page loader, on both the server (initial load) and the client (client-side navigation).
@@ -62,7 +60,7 @@ const serverLoader: LoaderFn<{ stats: Stats }> = async () => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ stats: Stats }>(serverLoader);
+export const loader = defineLoader<{ stats: Stats }>('admin', serverLoader);
 export const cache = createCache<{ stats: Stats }>();
 
 export const serverGuards = [
@@ -141,7 +139,7 @@ export const helper = () => {};
 export default serverLoader;
 
 // ✅ allowed
-export const loader = defineLoader(serverLoader);
+export const loader = defineLoader('admin', serverLoader);
 export const serverGuards = [...];
 export default serverLoader;
 ```

--- a/apps/app/src/pages/docs/index.mdx
+++ b/apps/app/src/pages/docs/index.mdx
@@ -8,7 +8,7 @@ Every route is a file pair: a `.tsx` page component and a `.server.ts` file that
 // movies.server.ts: runs only on the server
 const serverLoader = async () => ({ movies: await getMovies() });
 export default serverLoader;
-export const loader = defineLoader(serverLoader);
+export const loader = defineLoader('movies', serverLoader);
 
 // movies.tsx: the page component (pure, no wrappers)
 export default function Movies() {

--- a/apps/app/src/pages/docs/loaders.mdx
+++ b/apps/app/src/pages/docs/loaders.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Server Loaders
 
 Pages often need data. On the server, that data should come from a direct function call. In the browser during navigation, it goes through an RPC call to the server. Writing this branch manually is error-prone, so the loader system handles it automatically.
@@ -40,7 +38,7 @@ const serverLoader: LoaderFn<{ movies: MovieList }> = async () => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader);
 ```
 
 **`src/pages/movies.tsx`** is a pure component:
@@ -73,7 +71,7 @@ const Movies = lazy(() => import('./pages/movies.js'));
 <Route path="/movies" component={Movies} loader={moviesLoader} />
 ```
 
-`defineLoader(fn)` returns a typed reference (`LoaderRef<T>`). The `<Route loader={...}>` prop and the `useLoaderData(ref)` hook both consume that reference, so the data type flows through with no extra annotations.
+`defineLoader(name, fn)` returns a typed reference (`LoaderRef<T>`). The `name` argument is required, must be a non-empty string, and is used as a stable identity key (via `Symbol.for`) so that the SSR loader, the client RPC stub, and `useLoaderData` all agree on the same reference even when the module is loaded twice. The `<Route loader={...}>` prop and the `useLoaderData(ref)` hook both consume that reference, so the data type flows through with no extra annotations.
 
 ## Example: detail page (using route params)
 
@@ -91,7 +89,7 @@ const serverLoader: LoaderFn<{ movie: Movie }> = async ({ location }) => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movie: Movie }>(serverLoader);
+export const loader = defineLoader<{ movie: Movie }>('movie', serverLoader);
 ```
 
 ## Registering the loader endpoint
@@ -124,7 +122,7 @@ const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader);
 export const cache = createCache<{ movies: MovieList }>();
 ```
 

--- a/apps/app/src/pages/docs/loading-states.mdx
+++ b/apps/app/src/pages/docs/loading-states.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Loading States
 
 By default, a page renders nothing while its loader is fetching. Pass a `fallback` to `<Route>` to show a loading UI during client-side navigation.

--- a/apps/app/src/pages/docs/nav.ts
+++ b/apps/app/src/pages/docs/nav.ts
@@ -21,6 +21,7 @@ export const nav: NavSection[] = [
       { title: 'Server Loaders', route: '/docs/loaders' },
       { title: 'Loading States', route: '/docs/loading-states' },
       { title: 'Reloading Data', route: '/docs/reloading' },
+      { title: 'Prefetching', route: '/docs/prefetch' },
     ],
   },
   {

--- a/apps/app/src/pages/docs/optimistic-ui.mdx
+++ b/apps/app/src/pages/docs/optimistic-ui.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Optimistic UI Updates
 
 `useOptimistic` and `useOptimisticAction` let you show the result of a mutation in the UI before the server confirms it, then automatically reconcile when the server responds. They compose with the existing `useAction` hook with no changes to your loaders or actions.
@@ -130,3 +128,37 @@ const NotesForm = ({ defaultNotes }) => {
   );
 };
 ```
+
+## `<OptimisticOverlay>`
+
+`<OptimisticOverlay>` projects a list of pending actions onto the loader data that descendant components see via `useLoaderData`. Use it when a child component reads loader data and you want it to render against an optimistic projection without rewriting the child to take a prop.
+
+```tsx
+import { OptimisticOverlay, useLoaderData } from '@hono-preact/iso';
+import { moviesLoader } from './movies.server.js';
+
+const MovieList = () => {
+  const movies = useLoaderData(moviesLoader);
+  return <ul>{movies.map((m) => <li key={m.id}>{m.title}</li>)}</ul>;
+};
+
+const MoviesPage = ({ pendingAdds }) => (
+  <OptimisticOverlay
+    loader={moviesLoader}
+    reducer={(base, action) => [...base, action]}
+    pending={pendingAdds}
+  >
+    <MovieList />
+  </OptimisticOverlay>
+);
+```
+
+`<OptimisticOverlay>` must be inside a route or `<Page>` configured with the same `loader` it references; otherwise it throws.
+
+| Prop | Type | Description |
+|---|---|---|
+| `loader` | `LoaderRef<T>` | The loader whose data is being projected. Must match the surrounding route's loader. |
+| `reducer` | `(base: T, action: A) => T` | Folds each pending action into the base value. |
+| `pending` | `A[]` | Pending actions to project. Defaults to `[]`. |
+
+Prefer `useOptimistic` or `useOptimisticAction` when the optimistic state is local to the component that owns the mutation. Reach for `<OptimisticOverlay>` when the optimistic projection needs to flow through `useLoaderData` for descendants you don't want to thread props through.

--- a/apps/app/src/pages/docs/pages.mdx
+++ b/apps/app/src/pages/docs/pages.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Adding Pages
 
 There are two kinds of pages in this template: standard Preact pages and MDX content pages. Both are lazy-loaded (code-split) and registered as routes.
@@ -64,8 +62,6 @@ MDX pages in `src/pages/docs/` are auto-discovered. No changes to `iso.tsx` are 
 **Create `src/pages/docs/my-page.mdx`:**
 
 ```mdx
-[← docs](/docs)
-
 # My Page
 
 Content written in Markdown with optional JSX components.

--- a/apps/app/src/pages/docs/prefetch.mdx
+++ b/apps/app/src/pages/docs/prefetch.mdx
@@ -1,0 +1,45 @@
+# Prefetching Data
+
+`prefetch` runs a loader and fills its cache ahead of navigation, so the destination route renders immediately when the user arrives. Use it when you can predict the user's next move (hover on a link, scroll into view, idle after page load) and the loader is non-trivial.
+
+## Basic usage
+
+```ts
+import { prefetch } from '@hono-preact/iso';
+import { loader as movieLoader } from './pages/movie.server.js';
+
+// On link hover, kick off a fetch for /movies/42 so the route is ready when clicked.
+function onMovieLinkHover(id: number) {
+  prefetch(movieLoader, { url: `/movies/${id}`, route: '/movies/:id' });
+}
+```
+
+The result is written into the loader's cache (when one is configured) and the next navigation reads from cache instead of refetching.
+
+## Why pass `url` and `route`?
+
+Loaders receive a `RouteHook` location (`{ path, searchParams, pathParams }`). When your loader reads `location.pathParams.id` or `location.searchParams.q`, prefetching with no location would crash or return the wrong data. Pass the URL the user is about to navigate to, plus the route pattern, and `prefetch` derives a complete `RouteHook` for you:
+
+- `url` populates `path` (trailing slash stripped, root preserved) and `searchParams`.
+- `route` is the matching route pattern (e.g. `/movies/:id`); when present, `pathParams` is derived by matching `url` against it.
+
+If you don't read any of those fields, omit both arguments and `prefetch(loader)` still works.
+
+## Options
+
+| Option | Type | Description |
+|---|---|---|
+| `url` | `string` | Target URL or path. Drives `path` and `searchParams`. |
+| `route` | `string` | Route pattern (e.g. `/movies/:id`). Combined with `url` to derive `pathParams`. |
+| `location` | `RouteHook` | Escape hatch: pass a fully-formed `RouteHook` directly. Overrides `url`/`route`. |
+| `cache` | `LoaderCache<T>` | Override the cache the result is written to. Defaults to the cache attached to the loader. |
+
+## Common patterns
+
+**Hover prefetch** is the typical case: bind to `onMouseEnter` on a link and call `prefetch` with the destination URL.
+
+**Idle prefetch** is useful for the next-most-likely route. Call `prefetch` from a `requestIdleCallback` after the current page settles.
+
+**Programmatic prefetch** works anywhere: a router transition listener, a search-as-you-type debounce, an intersection observer for cards scrolling into view.
+
+`prefetch` is a no-op for cache hits if the underlying loader is wrapped in a cached path; treat it as a hint, not a guarantee.

--- a/apps/app/src/pages/docs/quick-start.mdx
+++ b/apps/app/src/pages/docs/quick-start.mdx
@@ -72,7 +72,7 @@ const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
+export const loader = defineLoader<{ movies: Movie[] }>('movies', serverLoader);
 ```
 
 Update `src/pages/movies.tsx` to a pure consumer of the loader data:
@@ -115,7 +115,7 @@ const Movies = lazy(() => import('./pages/movies.js'));
 
 Reload `http://localhost:5173/movies`. The list renders server-side on first load, with the data preloaded into the HTML. On client-side navigation away and back, the framework calls the loader over RPC. Same function, no manual wiring.
 
-`defineLoader(fn)` returns a typed reference. The `loader` prop on `<Route>` and the `useLoaderData(ref)` hook both take that reference, so the data type flows through without any explicit annotations on the consuming side.
+`defineLoader(name, fn)` returns a typed reference. The `name` is required and must match the user-chosen identifier on both sides (server module and client RPC stub), wired by `Symbol.for`. The `loader` prop on `<Route>` and the `useLoaderData(ref)` hook both take that reference, so the data type flows through without any explicit annotations on the consuming side.
 
 ## 3. Add a server action
 
@@ -141,7 +141,7 @@ const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
+export const loader = defineLoader<{ movies: Movie[] }>('movies', serverLoader);
 
 export const serverActions = {
   addMovie: defineAction<{ title: string }, { ok: boolean }>(

--- a/apps/app/src/pages/docs/reloading.mdx
+++ b/apps/app/src/pages/docs/reloading.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Reloading Data
 
 Sometimes you need to re-run the loader imperatively, for example after a user adds a record to a table. The `useReload` hook lets you do this from within a page component.
@@ -19,7 +17,7 @@ const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader);
 export const cache = createCache<{ movies: MovieList }>();
 ```
 
@@ -95,5 +93,5 @@ const { reload, reloading } = useReload();
 
 | Value | Type | Description |
 |---|---|---|
-| `reload` | `() => void` | Re-runs the `serverLoader`. No-op if a reload is already in progress. |
+| `reload` | `() => void` | Re-runs the `serverLoader`. If called while a fetch (initial load or a previous reload) is still in flight, the call is queued and runs once the in-flight fetch settles; concurrent calls coalesce into a single queued run. |
 | `reloading` | `boolean` | `true` while the loader is fetching, `false` otherwise. |

--- a/apps/app/src/pages/docs/render-page.mdx
+++ b/apps/app/src/pages/docs/render-page.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # renderPage
 
 `renderPage` is the SSR entry point exported from `@hono-preact/server`. It takes a Hono context and a root Preact node, prerenders it to HTML, injects head tags collected by [hoofd](https://github.com/nickvdyck/hoofd), and returns a full HTML response (including `<!doctype html>` and the `<html>` wrapper).

--- a/apps/app/src/pages/docs/structure.mdx
+++ b/apps/app/src/pages/docs/structure.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Project Structure
 
 ```
@@ -74,13 +72,13 @@ Renders the full HTML shell: `<head>`, `<body>`, the `#app` mount point, and the
 Isomorphic utilities shared between server and client (`packages/iso/`):
 
 - `route.tsx`: `<Route>` and `<Router>` components, the user-facing registration surface. `<Route>` accepts `path`, `component`, plus the page-level props `loader`, `cache`, `serverGuards`, `clientGuards`, `fallback`, `errorFallback`, and `Wrapper` (typed as `ComponentType<WrapperProps>`).
-- `page.tsx`: `<Page>` component and `WrapperProps` type. Composes the route boundary, guards, loader, and envelope into a single page wrapper (used internally by `<Route>`).
+- `page.tsx`: `<Page>` component and `WrapperProps` type. Composes the route boundary, guards, loader, and envelope into a single page wrapper (used internally by `<Route>`). `<Page>` accepts `loader`, `location`, `cache`, `serverGuards`, `clientGuards`, `fallback`, `errorFallback`, and `Wrapper` (typed as `ComponentType<WrapperProps>`).
 - `loader.tsx`: `<Loader>` component that fetches and caches loader data, plus the `useReload` provider context.
 - `define-loader.ts`: `defineLoader` factory and `LoaderFn<T>` / `LoaderRef<T>` types.
 - `use-loader-data.ts`: `useLoaderData(ref)` hook for typed access to loader data inside children.
-- `envelope.tsx`: `<Envelope>` (default page Wrapper) that emits the SSR `data-loader` attribute.
+- `envelope.tsx`: `<Envelope>` (default page Wrapper) that emits the SSR `data-loader` attribute. Accepts `as` (an intrinsic tag name or a `ComponentType<WrapperProps>`, defaults to `'section'`) and `children`.
 - `guards.tsx` / `guard.ts`: `<Guards>` component, `createGuard`, `runGuards`, guard types.
-- `cache.ts`: single-value in-memory cache (`createCache`) to avoid re-fetching on client-side navigation.
+- `cache.ts`: single-value in-memory cache (`createCache`) to avoid re-fetching on client-side navigation. On the server, storage is request-scoped via `AsyncLocalStorage` so concurrent requests do not leak data; `runRequestScope(fn)` from the same module wraps each render and loader/action call.
 - `reload-context.tsx`: `ReloadContext` and `useReload` hook.
 - `preload.ts`: reads loader data serialized into `data-loader` attributes on first hydration.
 

--- a/apps/app/src/pages/docs/vite-config.mdx
+++ b/apps/app/src/pages/docs/vite-config.mdx
@@ -1,5 +1,3 @@
-[← docs](/docs)
-
 # Vite Configuration
 
 The `@hono-preact/vite` package exports a `honoPreact()` plugin that configures Vite for the framework's two-pass build and dev server. Your `vite.config.ts` only needs to wire in the plugins that are specific to your application.

--- a/apps/app/src/pages/movie.server.ts
+++ b/apps/app/src/pages/movie.server.ts
@@ -24,7 +24,7 @@ const serverLoader: LoaderFn<{ movie: Movie | null; watched: WatchedRecord | nul
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>(serverLoader);
+export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>('movie', serverLoader);
 
 export const serverActions = {
   toggleWatched: defineAction<{ movieId: number; watched: boolean }, { ok: boolean }>(

--- a/apps/app/src/pages/movies.server.ts
+++ b/apps/app/src/pages/movies.server.ts
@@ -11,7 +11,7 @@ const serverLoader: LoaderFn<{ movies: MoviesData; watchedIds: number[] }> = asy
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>(serverLoader);
+export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>('movies', serverLoader);
 export const cache = createCache<{ movies: MoviesData; watchedIds: number[] }>('movies-list');
 
 export const serverActions = {

--- a/apps/app/src/pages/watched.server.ts
+++ b/apps/app/src/pages/watched.server.ts
@@ -34,7 +34,7 @@ const serverLoader: LoaderFn<{ entries: Entry[] }> = async () => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ entries: Entry[] }>(serverLoader);
+export const loader = defineLoader<{ entries: Entry[] }>('watched', serverLoader);
 export const cache = createCache<{ entries: Entry[] }>('watched');
 
 export const serverActions = {

--- a/packages/iso/src/__tests__/cache.test.ts
+++ b/packages/iso/src/__tests__/cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createCache } from '../cache.js';
+import { createCache, runRequestScope } from '../cache.js';
 import { cacheRegistry } from '../cache-registry.js';
+import { env } from '../is-browser.js';
 
 beforeEach(() => {
   cacheRegistry.clear();
@@ -71,5 +72,74 @@ describe('createCache', () => {
     createCache<{ val: number }>();
     cacheRegistry.invalidate('sentinel');
     expect(fn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createCache request-scoped storage on the server', () => {
+  it('does not leak cache writes between concurrent server requests', async () => {
+    const cache = createCache<{ user: string }>();
+    const previousEnv = env.current;
+    env.current = 'server';
+    try {
+      const observed: Array<{ before: { user: string } | null; after: { user: string } | null }> = [];
+
+      const handleRequest = async (user: string) => {
+        return runRequestScope(async () => {
+          const before = cache.get();
+          await Promise.resolve();
+          cache.set({ user });
+          await Promise.resolve();
+          const after = cache.get();
+          observed.push({ before, after });
+        });
+      };
+
+      await Promise.all([
+        handleRequest('alice'),
+        handleRequest('bob'),
+        handleRequest('carol'),
+      ]);
+
+      for (const o of observed) {
+        expect(o.before).toBeNull();
+      }
+      expect(observed.map((o) => o.after?.user).sort()).toEqual(['alice', 'bob', 'carol']);
+    } finally {
+      env.current = previousEnv;
+    }
+  });
+
+  it('cache.wrap() inside runRequestScope only sees its own request data', async () => {
+    const cache = createCache<{ id: number }>();
+    const previousEnv = env.current;
+    env.current = 'server';
+    try {
+      const handle = (id: number) =>
+        runRequestScope(async () => {
+          const wrapped = cache.wrap(async () => {
+            await Promise.resolve();
+            return { id };
+          });
+          const a = await wrapped({ location: {} as never });
+          const b = await wrapped({ location: {} as never });
+          return { a, b };
+        });
+
+      const [r1, r2, r3] = await Promise.all([handle(1), handle(2), handle(3)]);
+      expect(r1.a).toEqual({ id: 1 });
+      expect(r1.b).toEqual({ id: 1 });
+      expect(r2.a).toEqual({ id: 2 });
+      expect(r2.b).toEqual({ id: 2 });
+      expect(r3.a).toEqual({ id: 3 });
+      expect(r3.b).toEqual({ id: 3 });
+    } finally {
+      env.current = previousEnv;
+    }
+  });
+
+  it('falls back to module-scoped storage when no request scope is active (browser path)', () => {
+    const cache = createCache<{ val: number }>();
+    cache.set({ val: 7 });
+    expect(cache.get()).toEqual({ val: 7 });
   });
 });

--- a/packages/iso/src/__tests__/define-loader.test.ts
+++ b/packages/iso/src/__tests__/define-loader.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { defineLoader } from '../define-loader.js';
+
+describe('defineLoader', () => {
+  it('throws when called without a name argument', () => {
+    expect(() =>
+      // @ts-expect-error: name is required
+      defineLoader(async () => ({}))
+    ).toThrow(/name must be a non-empty string/);
+  });
+
+  it('throws when name is an empty string', () => {
+    expect(() => defineLoader('', async () => ({}))).toThrow(
+      /name must be a non-empty string/
+    );
+  });
+
+  it('keys __id with Symbol.for so two calls with the same name share identity', () => {
+    const a = defineLoader('movies', async () => ({}));
+    const b = defineLoader('movies', async () => ({}));
+    // Same name produces the same registered symbol, even across distinct
+    // defineLoader call sites. This protects useLoaderData(refId === ref.__id)
+    // when a consumer ends up importing two copies of the same .server.* module.
+    expect(a.__id).toBe(b.__id);
+    expect(typeof Symbol.keyFor(a.__id)).toBe('string');
+    expect(Symbol.keyFor(a.__id)).toBe('@hono-preact/loader:movies');
+  });
+
+  it('produces distinct __id for distinct names', () => {
+    const a = defineLoader('movies', async () => ({}));
+    const b = defineLoader('reviews', async () => ({}));
+    expect(a.__id).not.toBe(b.__id);
+  });
+
+  it('aligns with the SSR stub symbol shape (Symbol.for("@hono-preact/loader:<name>"))', () => {
+    const ref = defineLoader('movies', async () => ({}));
+    const stubSymbol = Symbol.for('@hono-preact/loader:movies');
+    // The stub fabricated by the server-only Vite plugin uses this exact key,
+    // so identity is stable across the user-authored module and the client stub.
+    expect(ref.__id).toBe(stubSymbol);
+  });
+});

--- a/packages/iso/src/__tests__/loader.test.tsx
+++ b/packages/iso/src/__tests__/loader.test.tsx
@@ -37,7 +37,7 @@ describe('v3 <Loader> stability', () => {
       callCount++;
       return Promise.resolve({ msg: `call ${callCount}` });
     });
-    const ref = defineLoader<{ msg: string }>(fn);
+    const ref = defineLoader<{ msg: string }>('refire-test', fn);
 
     function Child() {
       const { msg } = useLoaderData(ref);
@@ -86,7 +86,7 @@ describe('v3 <Loader> stability', () => {
             resolveReload = r;
           })
       );
-    const ref = defineLoader<{ msg: string }>(fn);
+    const ref = defineLoader<{ msg: string }>('preserve-state-test', fn);
 
     function Child() {
       const { msg } = useLoaderData(ref);
@@ -156,7 +156,7 @@ describe('v3 <Loader> stability', () => {
           resolve = r;
         })
     );
-    const ref = defineLoader<{ msg: string }>(fn);
+    const ref = defineLoader<{ msg: string }>('dup-xhr-test', fn);
 
     function Child() {
       const { msg } = useLoaderData(ref);
@@ -204,11 +204,76 @@ describe('v3 <Loader> stability', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it('queues reload() invoked before the initial fetch resolves', async () => {
+    let resolveInitial!: (v: { msg: string }) => void;
+    let resolveReload!: (v: { msg: string }) => void;
+    const fn = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ msg: string }>((r) => {
+            resolveInitial = r;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ msg: string }>((r) => {
+            resolveReload = r;
+          })
+      );
+    const ref = defineLoader<{ msg: string }>('search-test', fn);
+
+    function Fallback() {
+      const { reload } = useReload();
+      return (
+        <button data-testid="early-reload" onClick={reload}>
+          reload
+        </button>
+      );
+    }
+
+    function Child() {
+      const { msg } = useLoaderData(ref);
+      return <span data-testid="msg">{msg}</span>;
+    }
+
+    render(
+      <LocationProvider>
+        <Loader loader={ref} location={loc} fallback={<Fallback />}>
+          <Child />
+        </Loader>
+      </LocationProvider>
+    );
+
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      screen.getByTestId('early-reload').click();
+    });
+
+    // The reload should not have fired yet because the initial fetch is
+    // still pending. The click is queued, not dropped and not racing.
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveInitial({ msg: 'initial' });
+    });
+
+    // Once the initial settles, the queued reload fires.
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      resolveReload({ msg: 'reloaded' });
+    });
+
+    await screen.findByText('reloaded');
+  });
+
   it('refetches when searchParams change even though path is stable', async () => {
     const fn = vi.fn(({ location }: { location: RouteHook }) =>
       Promise.resolve({ q: location.searchParams.q ?? '' })
     );
-    const ref = defineLoader<{ q: string }>(fn);
+    const ref = defineLoader<{ q: string }>('search-q-test', fn);
 
     function Child() {
       const { q } = useLoaderData(ref);

--- a/packages/iso/src/__tests__/page.test.tsx
+++ b/packages/iso/src/__tests__/page.test.tsx
@@ -35,7 +35,7 @@ afterEach(() => {
   cleanup();
 });
 
-const emptyLoader = defineLoader<Record<string, never>>(async () => ({}));
+const emptyLoader = defineLoader<Record<string, never>>('empty-page-test', async () => ({}));
 
 describe('guard { render }', () => {
   it('renders the guard-supplied component instead of the page', async () => {
@@ -137,7 +137,7 @@ describe('Page without a loader', () => {
 
 describe('Page error boundary', () => {
   it('renders errorFallback when the loader rejects', async () => {
-    const failing = defineLoader<{ msg: string }>(async () => {
+    const failing = defineLoader<{ msg: string }>('failing-page-test', async () => {
       throw new Error('boom');
     });
 

--- a/packages/iso/src/__tests__/prefetch.test.ts
+++ b/packages/iso/src/__tests__/prefetch.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { defineLoader } from '../define-loader.js';
+import { prefetch } from '../prefetch.js';
+
+describe('prefetch', () => {
+  it('derives pathParams from url + route', async () => {
+    const ref = defineLoader('movie-by-id', async ({ location }) => {
+      return { id: location.pathParams.id };
+    });
+    const result = await prefetch(ref, { url: '/movies/42', route: '/movies/:id' });
+    expect(result).toEqual({ id: '42' });
+  });
+
+  it('derives searchParams from url query string', async () => {
+    const ref = defineLoader('search-by-q', async ({ location }) => {
+      return { q: location.searchParams.q };
+    });
+    const result = await prefetch(ref, { url: '/search?q=hi' });
+    expect(result).toEqual({ q: 'hi' });
+  });
+
+  it('derives a clean path (no trailing slash, leading slash preserved)', async () => {
+    const ref = defineLoader('path-echo', async ({ location }) => {
+      return { path: location.path };
+    });
+    expect(await prefetch(ref, { url: '/movies/' })).toEqual({ path: '/movies' });
+    expect(await prefetch(ref, { url: '/' })).toEqual({ path: '/' });
+    expect(await prefetch(ref, { url: '/movies/42?x=1' })).toEqual({ path: '/movies/42' });
+  });
+
+  it('back-compat: location overrides url/route derivation', async () => {
+    const ref = defineLoader('back-compat', async ({ location }) => {
+      return {
+        path: location.path,
+        id: location.pathParams.id,
+        q: location.searchParams.q,
+      };
+    });
+    const result = await prefetch(ref, {
+      url: '/should-be-ignored',
+      route: '/should-be-ignored/:id',
+      location: {
+        path: '/explicit',
+        pathParams: { id: 'X' },
+        searchParams: { q: 'Y' },
+      },
+    });
+    expect(result).toEqual({ path: '/explicit', id: 'X', q: 'Y' });
+  });
+
+  it('no-args call resolves with an empty but type-complete location', async () => {
+    const ref = defineLoader('empty-loc', async ({ location }) => {
+      return {
+        path: location.path,
+        pathParams: location.pathParams,
+        searchParams: location.searchParams,
+      };
+    });
+    const result = await prefetch(ref);
+    expect(result).toEqual({ path: '', pathParams: {}, searchParams: {} });
+  });
+});

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, act } from '@testing-library/preact';
+import { Fragment } from 'preact';
 import { useState } from 'preact/hooks';
 import { LocationProvider, type RouteHook } from 'preact-iso';
 import { defineLoader } from '../define-loader.js';
@@ -45,7 +46,7 @@ describe('wrapWithPage', () => {
 
   it('renders the component with loader data via useLoaderData', async () => {
     const fn = vi.fn(async () => ({ msg: 'ok' }));
-    const ref = defineLoader<{ msg: string }>(fn);
+    const ref = defineLoader<{ msg: string }>('wrap-with-page-test', fn);
     const Inner = () => {
       const { msg } = useLoaderData(ref);
       return <p data-testid="msg">{msg}</p>;
@@ -65,7 +66,7 @@ describe('wrapWithPage', () => {
 describe('<Router> + <Route>', () => {
   it('renders the matched route wrapped in <Page> with loader data', async () => {
     const fn = vi.fn(async () => ({ msg: 'foo-data' }));
-    const ref = defineLoader<{ msg: string }>(fn);
+    const ref = defineLoader<{ msg: string }>('router-route-test', fn);
     const Foo = () => {
       const { msg } = useLoaderData(ref);
       return <p data-testid="foo">{msg}</p>;
@@ -134,6 +135,86 @@ describe('Route symbol marker', () => {
   it('marks Route with a cross-realm-safe Symbol identity', () => {
     const marker = Symbol.for('@hono-preact/iso/Route');
     expect((Route as unknown as Record<symbol, unknown>)[marker]).toBe(true);
+  });
+});
+
+describe('<Router> Fragment recursion', () => {
+  it('matches a <Route> nested inside an explicit <Fragment>', async () => {
+    const Foo = () => <p data-testid="foo">foo-frag</p>;
+
+    window.history.pushState({}, '', '/foo');
+    render(
+      <LocationProvider>
+        <Router>
+          <Fragment>
+            <Route path="/foo" component={Foo} />
+          </Fragment>
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('foo');
+    expect(el).toHaveTextContent('foo-frag');
+  });
+
+  it('matches a <Route> nested inside a short-form <>...</> fragment', async () => {
+    const Foo = () => <p data-testid="foo">foo-short</p>;
+    const Bar = () => <p data-testid="bar">bar-short</p>;
+
+    window.history.pushState({}, '', '/bar');
+    render(
+      <LocationProvider>
+        <Router>
+          <>
+            <Route path="/foo" component={Foo} />
+            <Route path="/bar" component={Bar} />
+          </>
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('bar');
+    expect(el).toHaveTextContent('bar-short');
+    expect(screen.queryByTestId('foo')).toBeNull();
+  });
+
+  it('matches a <Route> nested inside a Fragment inside a Fragment', async () => {
+    const Foo = () => <p data-testid="foo">foo-deep</p>;
+
+    window.history.pushState({}, '', '/foo');
+    render(
+      <LocationProvider>
+        <Router>
+          <Fragment>
+            <>
+              <Fragment>
+                <Route path="/foo" component={Foo} />
+              </Fragment>
+            </>
+          </Fragment>
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('foo');
+    expect(el).toHaveTextContent('foo-deep');
+  });
+
+  it('still matches a conditional `cond && <Route />` (regression)', async () => {
+    const Foo = () => <p data-testid="foo">foo-cond</p>;
+    const enabled = true;
+
+    window.history.pushState({}, '', '/foo');
+    render(
+      <LocationProvider>
+        <Router>
+          {enabled && <Route path="/foo" component={Foo} />}
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('foo');
+    expect(el).toHaveTextContent('foo-cond');
   });
 });
 

--- a/packages/iso/src/cache.ts
+++ b/packages/iso/src/cache.ts
@@ -1,5 +1,6 @@
 import type { Loader } from './define-loader.js';
 import { cacheRegistry } from './cache-registry.js';
+import { isBrowser } from './is-browser.js';
 
 export interface LoaderCache<T> {
   get(): T | null;
@@ -9,29 +10,89 @@ export interface LoaderCache<T> {
   invalidate(): void;
 }
 
+type RequestStore = Map<symbol, unknown>;
+
+type ALSInstance = {
+  getStore(): RequestStore | undefined;
+  run<R>(store: RequestStore, fn: () => R): R;
+};
+
+// AsyncLocalStorage powers per-request isolation on the server. Available on
+// Node and on Cloudflare Workers with `nodejs_compat`. We skip the import in
+// a browser-like environment so client bundles don't try to resolve
+// `node:async_hooks`.
+let alsInstance: ALSInstance | null = null;
+const looksLikeBrowser =
+  typeof globalThis !== 'undefined' &&
+  typeof (globalThis as { window?: unknown }).window !== 'undefined' &&
+  typeof (globalThis as { document?: unknown }).document !== 'undefined';
+if (!looksLikeBrowser) {
+  try {
+    const moduleName = 'node:async_hooks';
+    const mod = (await import(/* @vite-ignore */ moduleName)) as {
+      AsyncLocalStorage: new () => ALSInstance;
+    };
+    alsInstance = new mod.AsyncLocalStorage();
+  } catch {
+    alsInstance = null;
+  }
+}
+
+function getRequestStore(): RequestStore | undefined {
+  return alsInstance?.getStore();
+}
+
+export function runRequestScope<R>(fn: () => R | Promise<R>): R | Promise<R> {
+  if (!alsInstance) return fn();
+  return alsInstance.run(new Map(), fn);
+}
+
 export function createCache<T>(name?: string): LoaderCache<T> {
-  let store: T | null = null;
+  const key = Symbol(name ?? 'cache');
+  let fallbackStore: T | null = null;
+
+  function read(): T | null {
+    if (!isBrowser()) {
+      const reqStore = getRequestStore();
+      if (reqStore) {
+        return (reqStore.get(key) as T | undefined) ?? null;
+      }
+    }
+    return fallbackStore;
+  }
+
+  function write(value: T | null): void {
+    if (!isBrowser()) {
+      const reqStore = getRequestStore();
+      if (reqStore) {
+        if (value === null) reqStore.delete(key);
+        else reqStore.set(key, value);
+        return;
+      }
+    }
+    fallbackStore = value;
+  }
+
   const cache: LoaderCache<T> = {
-    get: () => store,
-    set: (value) => {
-      store = value;
-    },
-    has: () => store !== null,
+    get: () => read(),
+    set: (value) => write(value),
+    has: () => read() !== null,
     wrap(loader) {
       return async (props) => {
-        if (store !== null) return store;
+        const existing = read();
+        if (existing !== null) return existing;
         const result = await loader(props);
-        store = result;
+        write(result);
         return result;
       };
     },
     invalidate() {
-      store = null;
+      write(null);
     },
   };
   if (name) {
     cacheRegistry.register(name, () => {
-      store = null;
+      write(null);
     });
   }
   return cache;

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -12,8 +12,20 @@ export interface LoaderRef<T> {
 }
 
 export function defineLoader<T>(
+  name: string,
   fn: Loader<T>,
   cache?: LoaderCache<T>
 ): LoaderRef<T> {
-  return { __id: Symbol('loader'), fn, cache };
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error(
+      'defineLoader(name, fn): name must be a non-empty string. ' +
+      "Pick a stable identifier matching the .server.* module basename, " +
+      "e.g. defineLoader('movies', serverLoader)."
+    );
+  }
+  return {
+    __id: Symbol.for(`@hono-preact/loader:${name}`),
+    fn,
+    cache,
+  };
 }

--- a/packages/iso/src/guards.tsx
+++ b/packages/iso/src/guards.tsx
@@ -12,20 +12,6 @@ import { isBrowser } from './is-browser.js';
 import wrapPromise from './wrap-promise.js';
 import { GuardResultContext } from './contexts.js';
 
-export function useGuards(
-  guards: GuardFn[],
-  location: RouteHook
-): GuardResult | null {
-  const prevPath = useRef(location.path);
-  const ref = useRef(wrapPromise(runGuards(guards, { location })));
-  if (prevPath.current !== location.path) {
-    prevPath.current = location.path;
-    ref.current = wrapPromise(runGuards(guards, { location }));
-  }
-  const result = ref.current.read();
-  return (result ?? null) as GuardResult | null;
-}
-
 export function useGuardResult(): GuardResult | null {
   return useContext(GuardResultContext);
 }

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -6,7 +6,6 @@ export { RouteBoundary } from './route-boundary.js';
 export {
   Guards,
   GuardGate,
-  useGuards,
   useGuardResult,
 } from './guards.js';
 export { defineLoader } from './define-loader.js';
@@ -25,7 +24,7 @@ export {
 } from './contexts.js';
 
 export { ReloadContext, useReload } from './reload-context.js';
-export { createCache } from './cache.js';
+export { createCache, runRequestScope } from './cache.js';
 export type { LoaderCache } from './cache.js';
 export { cacheRegistry } from './cache-registry.js';
 export { createGuard, runGuards, GuardRedirect } from './guard.js';

--- a/packages/iso/src/loader.tsx
+++ b/packages/iso/src/loader.tsx
@@ -69,8 +69,16 @@ function LoaderHost<T>({
   const locationRef = useRef(location);
   locationRef.current = location;
 
-  const reload = useCallback(() => {
-    if (reloading) return;
+  // True while either the initial Suspense fetch or an explicit reload is in
+  // flight. Tracked via a ref so reload() can read it without recapturing on
+  // every state change, and so the wrapPromise branch below can flip it
+  // during render without scheduling an extra setState.
+  const inFlightRef = useRef(false);
+  const queuedReloadRef = useRef(false);
+  const runReloadRef = useRef<() => void>(() => {});
+
+  const runReload = useCallback(() => {
+    inFlightRef.current = true;
     setReloading(true);
     setLoadError(null);
     fnRef
@@ -79,12 +87,28 @@ function LoaderHost<T>({
         if (isBrowser()) cache?.set(result);
         setOverrideData(result);
         setReloading(false);
+        inFlightRef.current = false;
+        if (queuedReloadRef.current) {
+          queuedReloadRef.current = false;
+          runReloadRef.current();
+        }
       })
       .catch((err: unknown) => {
         setLoadError(err instanceof Error ? err : new Error(String(err)));
         setReloading(false);
+        inFlightRef.current = false;
+        queuedReloadRef.current = false;
       });
-  }, [reloading, cache]);
+  }, [cache]);
+  runReloadRef.current = runReload;
+
+  const reload = useCallback(() => {
+    if (inFlightRef.current) {
+      queuedReloadRef.current = true;
+      return;
+    }
+    runReloadRef.current();
+  }, []);
 
   // Stable reader: only rebuilt when location or loader identity changes.
   // Without this, every re-render (e.g. from setReloading) would call
@@ -116,11 +140,26 @@ function LoaderHost<T>({
       const cached = cache.get()!;
       readerRef.current = { read: () => cached };
     } else {
+      inFlightRef.current = true;
+      const settle = () => {
+        inFlightRef.current = false;
+        if (queuedReloadRef.current) {
+          queuedReloadRef.current = false;
+          runReloadRef.current();
+        }
+      };
       readerRef.current = wrapPromise(
-        loaderRef.fn({ location }).then((r) => {
-          if (isBrowser()) cache?.set(r);
-          return r;
-        })
+        loaderRef
+          .fn({ location })
+          .then((r) => {
+            if (isBrowser()) cache?.set(r);
+            settle();
+            return r;
+          })
+          .catch((err: unknown) => {
+            settle();
+            throw err;
+          })
       );
     }
   }

--- a/packages/iso/src/optimistic-overlay.tsx
+++ b/packages/iso/src/optimistic-overlay.tsx
@@ -19,7 +19,7 @@ export function OptimisticOverlay<T, A>({
   const ctx = useContext(LoaderDataContext);
   if (!ctx || ctx.refId !== loader.__id)
     throw new Error(
-      '<OptimisticOverlay loader={x}> must be inside a <Loader loader={x}>'
+      '<OptimisticOverlay loader={x}> must be inside a route or <Page> configured with the same loader'
     );
 
   const base = ctx.data as T;

--- a/packages/iso/src/prefetch.ts
+++ b/packages/iso/src/prefetch.ts
@@ -1,16 +1,48 @@
 import type { RouteHook } from 'preact-iso';
+import { exec } from 'preact-iso';
 import type { LoaderCache } from './cache.js';
 import { isBrowser } from './is-browser.js';
 import type { LoaderRef } from './define-loader.js';
 
+export interface PrefetchOptions<T> {
+  url?: string;
+  route?: string;
+  location?: RouteHook;
+  cache?: LoaderCache<T>;
+}
+
+function buildLocation(opts: { url?: string; route?: string }): RouteHook {
+  if (!opts.url) {
+    return { path: '', searchParams: {}, pathParams: {} };
+  }
+
+  const parsed = new URL(opts.url, 'http://_');
+  let path = parsed.pathname;
+  if (path.length > 1 && path.endsWith('/')) path = path.slice(0, -1);
+
+  const searchParams: Record<string, string> = {};
+  parsed.searchParams.forEach((value, key) => {
+    searchParams[key] = value;
+  });
+
+  let pathParams: Record<string, string> = {};
+  if (opts.route) {
+    const matched = exec(path, opts.route, { path, query: searchParams, params: {} });
+    if (matched && matched.pathParams) {
+      pathParams = matched.pathParams as Record<string, string>;
+    }
+  }
+
+  return { path, searchParams, pathParams };
+}
+
 export async function prefetch<T>(
   ref: LoaderRef<T>,
-  opts: { location?: RouteHook; cache?: LoaderCache<T> } = {}
+  opts: PrefetchOptions<T> = {}
 ): Promise<T> {
-  const fakeLocation =
-    opts.location ?? ({ path: '', searchParams: {}, pathParams: {} } as RouteHook);
+  const location = opts.location ?? buildLocation({ url: opts.url, route: opts.route });
   const cache = opts.cache ?? ref.cache;
-  const result = await ref.fn({ location: fakeLocation });
+  const result = await ref.fn({ location });
   if (isBrowser()) cache?.set(result);
   return result;
 }

--- a/packages/iso/src/reload-context.tsx
+++ b/packages/iso/src/reload-context.tsx
@@ -14,6 +14,6 @@ export const ReloadContext = createContext<ReloadContextValue | undefined>(
 export function useReload(): ReloadContextValue {
   const ctx = useContext(ReloadContext);
   if (!ctx)
-    throw new Error('useReload must be called inside a <Page> with a loader');
+    throw new Error('useReload must be called inside a route or <Page> with a loader');
   return ctx;
 }

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -1,6 +1,8 @@
 import {
+  Fragment,
   isValidElement,
   toChildArray,
+  type ComponentChild,
   type ComponentChildren,
   type ComponentType,
   type JSX,
@@ -69,8 +71,25 @@ export type RouterProps = Omit<PreactIsoRouterProps, 'children'> & {
   children?: ComponentChildren;
 };
 
+function isFragmentNode(node: unknown): node is VNode<{ children?: ComponentChildren }> {
+  return isValidElement(node) && node.type === Fragment;
+}
+
+function flattenFragments(children: ComponentChildren): ComponentChild[] {
+  const out: ComponentChild[] = [];
+  for (const child of toChildArray(children)) {
+    if (isFragmentNode(child)) {
+      out.push(...flattenFragments(child.props.children));
+    } else {
+      out.push(child);
+    }
+  }
+  return out;
+}
+
+/** Routes one matching child path; recurses through nested Fragments, but not through other component wrappers. */
 export function Router({ children, ...rest }: RouterProps): JSX.Element {
-  const transformed = toChildArray(children).map((child) => {
+  const transformed = flattenFragments(children).map((child) => {
     if (!isOurRoute(child)) return child;
     const { path, component, ...config } = child.props;
     return (

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler } from 'hono';
-import { ActionGuardError, type ActionGuardFn, type ActionGuardContext } from '@hono-preact/iso';
+import { ActionGuardError, runRequestScope, type ActionGuardFn, type ActionGuardContext } from '@hono-preact/iso';
 
 type GlobModule = {
   serverActions?: Record<string, unknown>;
@@ -139,9 +139,8 @@ export function actionsHandler(glob: LazyGlob | EagerGlob): MiddlewareHandler {
     }
 
     try {
-      const result = await (fn as (ctx: unknown, payload: unknown) => Promise<unknown>)(
-        c,
-        payload
+      const result = await runRequestScope(() =>
+        (fn as (ctx: unknown, payload: unknown) => Promise<unknown>)(c, payload)
       );
       if (result instanceof ReadableStream) {
         return new Response(result as ReadableStream<Uint8Array>, {

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareHandler } from 'hono';
+import { runRequestScope } from '@hono-preact/iso';
 
 type GlobModule = { default?: unknown; [key: string]: unknown };
 type LazyGlob = Record<string, () => Promise<unknown>>;
@@ -72,7 +73,9 @@ export function loadersHandler(glob: LazyGlob | EagerGlob): MiddlewareHandler {
     }
 
     try {
-      const result = await loader({ location: location as SerializedLocation });
+      const result = await runRequestScope(() =>
+        loader({ location: location as SerializedLocation })
+      );
       return c.json(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/server/src/render.tsx
+++ b/packages/server/src/render.tsx
@@ -2,7 +2,7 @@ import type { Context } from 'hono';
 import type { VNode } from 'preact';
 import { createDispatcher, HoofdProvider } from 'hoofd/preact';
 import { prerender } from 'preact-iso/prerender';
-import { GuardRedirect, env } from '@hono-preact/iso';
+import { GuardRedirect, env, runRequestScope } from '@hono-preact/iso';
 
 function escapeHtml(str: string): string {
   return str
@@ -32,8 +32,8 @@ export async function renderPage(
 
   let html: string;
   try {
-    ({ html } = await prerender(
-      <HoofdProvider value={dispatcher}>{node}</HoofdProvider>
+    ({ html } = await runRequestScope(() =>
+      prerender(<HoofdProvider value={dispatcher}>{node}</HoofdProvider>)
     ));
   } catch (e: unknown) {
     if (e instanceof GuardRedirect) return c.redirect(e.location);

--- a/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts
+++ b/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts
@@ -14,7 +14,7 @@ const serverLoader: LoaderFn<{ secret: string }> = async () => {
 };
 export default serverLoader;
 
-export const loader = defineLoader<{ secret: string }>(serverLoader);
+export const loader = defineLoader<{ secret: string }>('foo', serverLoader);
 export const cache = createCache<{ secret: string }>('foo');
 
 export const serverActions = {

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -289,3 +289,66 @@ describe('re-exports from .server.* are rejected', () => {
     expect(() => transform(code, '/src/aggregator.ts')).not.toThrow();
   });
 });
+
+describe('cache alias suffix is collision-free', () => {
+  it('produces distinct cache aliases for module sources that sanitize to the same identifier', () => {
+    // Before the hash-based suffix, a sanitizer of /[^a-zA-Z0-9_$]/g -> '_'
+    // collapsed both "foo-bar" and "foo_bar" to the same alias and broke
+    // multi-import cases that resolved to either.
+    const code = [
+      `import { cache as a } from './foo-bar.server.js';`,
+      `import { cache as b } from './foo_bar.server.js';`,
+    ].join('\n');
+    const result = transform(code, '/src/iso.tsx');
+    expect(result).toBeDefined();
+    // Two distinct cacheRegistry alias bindings should be emitted.
+    const matches = result!.code.match(/__\$cacheRegistry_[a-zA-Z0-9$_]+/g) ?? [];
+    const unique = new Set(matches);
+    expect(unique.size).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('loader RPC stub key alignment', () => {
+  it('default and loader-named stubs share the same fetch envelope (refactored helper)', () => {
+    const code = [
+      `import serverLoader from './movies.server.js';`,
+      `import { loader } from './movies.server.js';`,
+    ].join('\n');
+    const result = transform(code, '/src/iso.tsx');
+    expect(result).toBeDefined();
+    // Both stubs include the same module RPC body shape.
+    const fetchOccurrences =
+      (result!.code.match(/fetch\('\/__loaders'/g) ?? []).length;
+    expect(fetchOccurrences).toBe(2);
+    // Same module string is referenced from both stubs.
+    const moduleOccurrences =
+      (result!.code.match(/module:\s*"movies"/g) ?? []).length;
+    expect(moduleOccurrences).toBe(2);
+  });
+});
+
+describe('loader stub Symbol.for keying matches user-provided name', () => {
+  it("extracts the name argument from defineLoader('foo', ...) in the source file", () => {
+    // Use the fixture .server.ts which has `defineLoader<...>('foo', serverLoader)`.
+    // The plugin should statically extract 'foo' and key the stub on it,
+    // even if the module filename happened to differ from the chosen name.
+    const code = `import { loader } from './pages/foo.server.js';`;
+    const importerPath =
+      '/Users/stevenbeshensky/Documents/repos/hono-preact/packages/vite/src/__tests__/fixtures/leak-test/iso.tsx';
+    const result = transform(code, importerPath);
+    expect(result).toBeDefined();
+    expect(result?.code).toContain(
+      "__id: Symbol.for('@hono-preact/loader:foo')"
+    );
+  });
+
+  it('falls back to module basename when the source file is unreachable', () => {
+    const code = `import { loader } from './nope.server.js';`;
+    const result = transform(code, '/no/such/path/iso.tsx');
+    expect(result).toBeDefined();
+    // Falls back to the module basename derived from the import source.
+    expect(result?.code).toContain(
+      "__id: Symbol.for('@hono-preact/loader:nope')"
+    );
+  });
+});

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import { parse } from '@babel/parser';
 import type { ImportDeclaration } from '@babel/types';
 import MagicString from 'magic-string';
@@ -12,15 +13,13 @@ function moduleNameFromSource(importSource: string): string {
     .replace(/\.server(\.[jt]sx?)?$/, '');
 }
 
-function extractCacheName(
-  importerPath: string,
-  importSource: string,
-  fallbackModuleName: string
-): string {
-  // Resolve the import source relative to the importer.
+function hashSuffix(input: string): string {
+  return crypto.createHash('sha1').update(input).digest('hex').slice(0, 8);
+}
+
+function readSource(importerPath: string, importSource: string): string | null {
   const importerDir = path.dirname(importerPath);
   const baseResolved = path.resolve(importerDir, importSource);
-  // Try common TS/JS extensions.
   const candidates = [
     baseResolved,
     baseResolved.replace(/\.js$/, '.ts'),
@@ -32,38 +31,92 @@ function extractCacheName(
   for (const candidate of candidates) {
     if (fs.existsSync(candidate)) {
       try {
-        const src = fs.readFileSync(candidate, 'utf8');
-        const ast = parse(src, {
-          sourceType: 'module',
-          plugins: ['typescript', 'jsx'],
-          errorRecovery: true,
-        });
-        for (const node of ast.program.body) {
-          if (
-            node.type === 'ExportNamedDeclaration' &&
-            node.declaration?.type === 'VariableDeclaration'
-          ) {
-            for (const decl of node.declaration.declarations) {
-              if (
-                decl.id.type === 'Identifier' &&
-                decl.id.name === 'cache' &&
-                decl.init?.type === 'CallExpression' &&
-                decl.init.callee.type === 'Identifier' &&
-                decl.init.callee.name === 'createCache'
-              ) {
-                const arg = decl.init.arguments[0];
-                if (arg?.type === 'StringLiteral') return arg.value;
-              }
-            }
-          }
-        }
+        return fs.readFileSync(candidate, 'utf8');
       } catch {
-        // Source-parse failure — fall through to the fallback.
+        return null;
       }
-      break; // file exists but no extractable name; don't keep trying extensions
     }
   }
-  return fallbackModuleName;
+  return null;
+}
+
+function extractStringArgFromVarDecl(
+  src: string,
+  exportName: string,
+  factoryName: string,
+  argIndex: number
+): string | null {
+  try {
+    const ast = parse(src, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+      errorRecovery: true,
+    });
+    for (const node of ast.program.body) {
+      if (
+        node.type === 'ExportNamedDeclaration' &&
+        node.declaration?.type === 'VariableDeclaration'
+      ) {
+        for (const decl of node.declaration.declarations) {
+          if (
+            decl.id.type === 'Identifier' &&
+            decl.id.name === exportName &&
+            decl.init?.type === 'CallExpression' &&
+            decl.init.callee.type === 'Identifier' &&
+            decl.init.callee.name === factoryName
+          ) {
+            const arg = decl.init.arguments[argIndex];
+            if (arg?.type === 'StringLiteral') return arg.value;
+          }
+        }
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function extractCacheName(
+  importerPath: string,
+  importSource: string,
+  fallbackModuleName: string
+): string {
+  const src = readSource(importerPath, importSource);
+  if (src === null) return fallbackModuleName;
+  return (
+    extractStringArgFromVarDecl(src, 'cache', 'createCache', 0) ?? fallbackModuleName
+  );
+}
+
+function extractLoaderName(
+  importerPath: string,
+  importSource: string,
+  fallbackModuleName: string
+): string {
+  const src = readSource(importerPath, importSource);
+  if (src === null) return fallbackModuleName;
+  return (
+    extractStringArgFromVarDecl(src, 'loader', 'defineLoader', 0) ?? fallbackModuleName
+  );
+}
+
+function loaderFetchArrow(moduleName: string, indent: string): string {
+  const i = indent;
+  return (
+    `async ({ location }) => {\n` +
+    `${i}  const res = await fetch('/__loaders', {\n` +
+    `${i}    method: 'POST',\n` +
+    `${i}    headers: { 'Content-Type': 'application/json' },\n` +
+    `${i}    body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, searchParams: location.searchParams } }),\n` +
+    `${i}  });\n` +
+    `${i}  if (!res.ok) {\n` +
+    `${i}    const body = await res.json().catch(() => ({}));\n` +
+    `${i}    throw new Error(body.error ?? \`Loader failed with status \${res.status}\`);\n` +
+    `${i}  }\n` +
+    `${i}  return res.json();\n` +
+    `${i}}`
+  );
 }
 
 export function serverOnlyPlugin(): Plugin {
@@ -82,9 +135,6 @@ export function serverOnlyPlugin(): Plugin {
         errorRecovery: true,
       });
 
-      // Detect and reject re-exports from .server.* files. The plugin can't safely
-      // rewrite a re-export — synthesizing stubs and re-emitting them as exports is
-      // out of scope. Throw a clear error so the leak vector is closed at build time.
       for (const node of ast.program.body) {
         if (
           (node.type === 'ExportNamedDeclaration' || node.type === 'ExportAllDeclaration') &&
@@ -110,9 +160,6 @@ export function serverOnlyPlugin(): Plugin {
       const needsCacheImport = new Set<string>();
 
       for (const serverImport of [...serverImports].reverse()) {
-        // Type-only declarations (`import type { ... } from '...'`) are erased
-        // by Vite/esbuild; strip the entire declaration so it doesn't leak the
-        // .server.* module into the client bundle.
         if ((serverImport as unknown as { importKind?: string }).importKind === 'type') {
           s.overwrite(serverImport.start!, serverImport.end!, '');
           continue;
@@ -123,17 +170,10 @@ export function serverOnlyPlugin(): Plugin {
         let hasValueSpecifier = false;
 
         for (const specifier of serverImport.specifiers) {
-          // Skip type-only specifiers in mixed imports (e.g.
-          // `import { type Foo, default as loader } from '...'`). These are
-          // erased by Vite/esbuild and must not trigger the unknown-specifier
-          // guard below.
           if ((specifier as unknown as { importKind?: string }).importKind === 'type') {
             continue;
           }
           hasValueSpecifier = true;
-          // Treat both `import X from '...'` (ImportDefaultSpecifier) and
-          // `import { default as X } from '...'` (ImportSpecifier with
-          // imported.name === 'default') as the default-loader case.
           const isDefaultImport =
             specifier.type === 'ImportDefaultSpecifier' ||
             (specifier.type === 'ImportSpecifier' &&
@@ -141,18 +181,7 @@ export function serverOnlyPlugin(): Plugin {
               specifier.imported.name === 'default');
           if (isDefaultImport) {
             stubs.push(
-              `const ${specifier.local.name} = async ({ location }) => {\n` +
-              `  const res = await fetch('/__loaders', {\n` +
-              `    method: 'POST',\n` +
-              `    headers: { 'Content-Type': 'application/json' },\n` +
-              `    body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, searchParams: location.searchParams } }),\n` +
-              `  });\n` +
-              `  if (!res.ok) {\n` +
-              `    const body = await res.json().catch(() => ({}));\n` +
-              `    throw new Error(body.error ?? \`Loader failed with status \${res.status}\`);\n` +
-              `  }\n` +
-              `  return res.json();\n` +
-              `};`
+              `const ${specifier.local.name} = ${loaderFetchArrow(moduleName, '')};`
             );
           } else if (
             specifier.type === 'ImportSpecifier' &&
@@ -174,21 +203,11 @@ export function serverOnlyPlugin(): Plugin {
             specifier.imported.type === 'Identifier' &&
             specifier.imported.name === 'loader'
           ) {
+            const loaderName = extractLoaderName(id, serverImport.source.value, moduleName);
             stubs.push(
               `const ${specifier.local.name} = {\n` +
-              `  __id: Symbol.for('@hono-preact/loader:${moduleName}'),\n` +
-              `  fn: async ({ location }) => {\n` +
-              `    const res = await fetch('/__loaders', {\n` +
-              `      method: 'POST',\n` +
-              `      headers: { 'Content-Type': 'application/json' },\n` +
-              `      body: JSON.stringify({ module: ${JSON.stringify(moduleName)}, location: { path: location.path, pathParams: location.pathParams, searchParams: location.searchParams } }),\n` +
-              `    });\n` +
-              `    if (!res.ok) {\n` +
-              `      const body = await res.json().catch(() => ({}));\n` +
-              `      throw new Error(body.error ?? \`Loader failed with status \${res.status}\`);\n` +
-              `    }\n` +
-              `    return res.json();\n` +
-              `  },\n` +
+              `  __id: Symbol.for('@hono-preact/loader:${loaderName}'),\n` +
+              `  fn: ${loaderFetchArrow(moduleName, '  ')},\n` +
               `};`
             );
           } else if (
@@ -197,12 +216,8 @@ export function serverOnlyPlugin(): Plugin {
             specifier.imported.name === 'cache'
           ) {
             const cacheName = extractCacheName(id, serverImport.source.value, moduleName);
-            // Use a per-source unique alias to avoid collisions when multiple .server.ts
-            // files contribute cache imports to the same consumer.
-            const aliasSuffix = moduleName.replace(/[^a-zA-Z0-9_$]/g, '_');
+            const aliasSuffix = hashSuffix(serverImport.source.value);
             needsCacheImport.add(aliasSuffix);
-            // Route through cacheRegistry.acquire so that two consumers stubbing the
-            // same .server.* module share a single cache instance (name-as-identity).
             stubs.push(
               `const ${specifier.local.name} = __$cacheRegistry_${aliasSuffix}.acquire(${JSON.stringify(cacheName)}, () => __$createCache_${aliasSuffix}(${JSON.stringify(cacheName)}));`
             );
@@ -224,10 +239,6 @@ export function serverOnlyPlugin(): Plugin {
         if (stubs.length > 0) {
           s.overwrite(serverImport.start!, serverImport.end!, stubs.join('\n'));
         } else if (!hasValueSpecifier) {
-          // Side-effect-only import (`import './x.server.js';`) or a mixed
-          // import whose only specifiers were type-only. In either case there
-          // is nothing to stub and the original declaration would leak the
-          // .server.* module into the client bundle — strip it.
           s.overwrite(serverImport.start!, serverImport.end!, '');
         }
       }


### PR DESCRIPTION
## Summary

Clears the post-merge backlog from feat/iso-v3-components in one batch. Each item below corresponds to an entry in the deferred review notes from PR #3.

## Correctness fixes

- **Server cache request-scoping** (`packages/iso/src/cache.ts`, `packages/server/src/*`). Module-scope `let store` was process-global, so concurrent SSR requests could leak data via `cache.wrap()`. Now keyed in an `AsyncLocalStorage` request scope established by the render, loaders-handler, and actions-handler entry points. Browser path is unchanged. New `runRequestScope` helper exported. +3 tests.
- **Reload race during initial load** (`packages/iso/src/loader.tsx`). `reload()` clicks during the first Suspense fetch were silently dropped; they now queue and drain when the in-flight read settles. Concurrent reload-during-reload coalesces into a single queued run. Public hook surface unchanged. +1 test. `reloading.mdx` updated.
- **defineLoader symbol identity** (`packages/iso/src/define-loader.ts`, `packages/vite/src/server-only.ts`). The hook side used `Symbol('loader')` (fresh per call) while the SSR stub used `Symbol.for(...)`, so re-exports could break `useLoaderData`'s strict-equal `refId` check. `defineLoader(name, fn)` is now required; both sides key on `Symbol.for('@hono-preact/loader:${name}')`. The vite plugin extracts `name` via static AST analysis to match. +5+3 tests.
- **prefetch fake-location** (`packages/iso/src/prefetch.ts`). The fake `RouteHook` had empty `path`/`searchParams`/`pathParams`, so loaders reading those fields crashed. New options shape `{ url?, route?, location?, cache? }` derives a complete `RouteHook` from a URL and a route pattern via `preact-iso`'s `exec`. Back-compat: passing `location` directly still wins, and `prefetch(loader)` no-args still works. +5 tests.

## Ergonomics

- **`<Router>` Fragment children** (`packages/iso/src/route.tsx`). Routes nested in `<Fragment>` (or `<>...</>`) were silently dropped. New `flattenFragments` helper recurses fully through nested fragments. Non-Fragment wrappers are still not recursed into; documented on the `Router` JSDoc. +4 tests.
- **Dead `useGuards` removed** (`packages/iso/src/guards.tsx`, `index.ts`). The component-flavor `Guards` is the only used form.
- **Clearer error messages** in `useReload` and `<OptimisticOverlay>` now mention "route or `<Page>`" (Page is optional given Route).
- **`server-only.ts` cleanup**. Duplicate fetch-template strings extracted to a single helper. Alias suffix collisions (`foo-bar` vs `foo_bar`) fixed via sha1 hash of the import source.
- **`apps/app/src/iso.tsx`** scaffolding comments removed; em-dashes in remaining comments swapped for commas.

## Docs

- New page: `prefetch.mdx` (added to nav under Data section).
- New section in `optimistic-ui.mdx` documenting `<OptimisticOverlay>`.
- `defineLoader(name, fn)` signature reflected in loaders, quick-start, index, guards, and reloading pages.
- `<Page>` and `<Envelope>` prop lists expanded in structure.mdx.
- `[back to docs]` backlinks removed from all 12 pages, per the add-docs-page skill.
- `action-guards.mdx` `await next()` aligned to `return next()` for prose consistency with actions.mdx.

## Deferred (separate task)

- `apps/app/src/iso.tsx:6-7` import code-split move for loader/cache. Pulling them into the `lazy()` chunks needs `<Route>` to accept a deferred loader/cache; that is a real API change rather than a tidy-up, so kept out of this PR.

## Test plan

- [x] `pnpm test` passes (211 to 233, +22)
- [x] `pnpm --filter @hono-preact/iso build` typecheck clean
- [x] `pnpm --filter @hono-preact/vite build` typecheck clean
- [x] `pnpm build` (full monorepo) succeeds
- [ ] Smoke-test the docs site routes for `/docs/prefetch` and the new OptimisticOverlay section render correctly
- [ ] Smoke-test a real `prefetch(loader, { url, route })` call against a loader that reads `pathParams`
- [ ] Smoke-test SSR concurrency: two interleaved requests do not see each other's cache writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)