### PR TITLE
feat(iso): page-owned route bindings via definePage

### DIFF
--- a/apps/app/src/iso.tsx
+++ b/apps/app/src/iso.tsx
@@ -3,8 +3,6 @@ import { flushSync } from 'preact/compat';
 import { lazy, Route, Router } from '@hono-preact/iso';
 import { Route as IsoRoute } from 'preact-iso';
 import NotFound from './pages/not-found.js';
-import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
-import { loader as watchedLoader, cache as watchedCache } from './pages/watched.server.js';
 
 const Home = lazy(() => import('./pages/home.js'));
 const Test = lazy(() => import('./pages/test.js'));
@@ -46,13 +44,11 @@ export const Base: FunctionComponent = () => {
     <Router onRouteChange={onRouteChange}>
       <Route path="/" component={Home} />
       <Route path="/test" component={Test} />
-      <Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
-      <Route path="/movies/*" component={Movies} loader={moviesLoader} cache={moviesCache} />
+      <Route path="/movies" component={Movies} />
+      <Route path="/movies/*" component={Movies} />
       <Route
         path="/watched"
         component={Watched}
-        loader={watchedLoader}
-        cache={watchedCache}
         fallback={<p class="p-1">Loading watched list…</p>}
       />
       {mdxRoutes.map(({ route, Component }) => (

--- a/apps/app/src/pages/docs/actions.mdx
+++ b/apps/app/src/pages/docs/actions.mdx
@@ -61,7 +61,7 @@ import { useAction, useLoaderData } from '@hono-preact/iso';
 import { loader, serverActions } from './movies.server.js';
 
 const Movies = () => {
-  const { movies } = useLoaderData(loader);
+  const { movies } = useLoaderData<typeof loader>();
   const { mutate, pending, error } = useAction(serverActions.addMovie, {
     invalidate: 'auto',
     onSuccess: (data) => console.log('added', data),
@@ -128,7 +128,7 @@ FormData values are collected with `Object.fromEntries(new FormData(form))`. Str
 Use `onMutate` to update local state before the request fires, and `onError` to roll it back:
 
 ```tsx
-const { movies } = useLoaderData(loader);
+const { movies } = useLoaderData<typeof loader>();
 const [items, setItems] = useState(movies.results);
 
 const { mutate } = useAction(serverActions.addMovie, {

--- a/apps/app/src/pages/docs/guards.mdx
+++ b/apps/app/src/pages/docs/guards.mdx
@@ -11,7 +11,7 @@ Like loaders, guards are split by environment:
 - `serverGuards`: exported from `*.server.ts`, run during SSR, tree-shaken from the browser bundle
 - `clientGuards`: defined in the page file (or any browser-safe module), run during client-side navigation
 
-Both are passed to the route at registration time via `<Route serverGuards={...} clientGuards={...}>`.
+Both are passed to the route at registration time via `<Route serverGuards={...} clientGuards={...}>`. Loaders, caches, and `Wrapper` move into `definePage` on the page component, but guards remain `<Route>`-level props because they often differ per mount point (the same component can be guarded differently behind two paths).
 
 ## API
 
@@ -73,19 +73,19 @@ export const serverGuards = [
 ];
 ```
 
-**`src/pages/admin.tsx`** is a pure component:
+**`src/pages/admin.tsx`** is a pure component, with bindings attached via `definePage`:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import { useLoaderData } from '@hono-preact/iso';
-import { loader } from './admin.server.js';
+import { definePage, useLoaderData } from '@hono-preact/iso';
+import { loader, cache } from './admin.server.js';
 
 const Admin: FunctionComponent = () => {
-  const { stats } = useLoaderData(loader);
+  const { stats } = useLoaderData<typeof loader>();
   return <section>...</section>;
 };
 
-export default Admin;
+export default definePage(Admin, { loader, cache });
 ```
 
 **`src/pages/admin.guards.ts`** holds client guards in a browser-safe module:
@@ -104,15 +104,11 @@ export const clientGuards = [
 ];
 ```
 
-**`src/iso.tsx`** wires the loader, cache, and both guard chains into the route:
+**`src/iso.tsx`** wires both guard chains into the route. The loader and cache live on the page component (via `definePage`) and don't need to be re-imported here:
 
 ```tsx
 import { lazy, Route } from '@hono-preact/iso';
-import {
-  loader as adminLoader,
-  cache as adminCache,
-  serverGuards,
-} from './pages/admin.server.js';
+import { serverGuards } from './pages/admin.server.js';
 import { clientGuards } from './pages/admin.guards.js';
 
 const Admin = lazy(() => import('./pages/admin.js'));
@@ -120,8 +116,6 @@ const Admin = lazy(() => import('./pages/admin.js'));
 <Route
   path="/admin"
   component={Admin}
-  loader={adminLoader}
-  cache={adminCache}
   serverGuards={serverGuards}
   clientGuards={clientGuards}
 />

--- a/apps/app/src/pages/docs/index.mdx
+++ b/apps/app/src/pages/docs/index.mdx
@@ -10,15 +10,18 @@ const serverLoader = async () => ({ movies: await getMovies() });
 export default serverLoader;
 export const loader = defineLoader('movies', serverLoader);
 
-// movies.tsx: the page component (pure, no wrappers)
-export default function Movies() {
-  const { movies } = useLoaderData(loader);
+// movies.tsx: the page component, with bindings attached via definePage
+import { definePage, useLoaderData } from '@hono-preact/iso';
+import { loader } from './movies.server.js';
+
+function Movies() {
+  const { movies } = useLoaderData<typeof loader>();
   return <ul>{movies.map((m) => <li key={m.id}>{m.title}</li>)}</ul>;
 }
+export default definePage(Movies, { loader });
 
-// iso.tsx: the route ties them together
-import { loader as moviesLoader } from './pages/movies.server.js';
-<Route path="/movies" component={Movies} loader={moviesLoader} />
+// iso.tsx: routes deal only in paths and component refs
+<Route path="/movies" component={Movies} />
 ```
 
 On the first request, the server runs the loader directly and preloads the result into the HTML. On hydration, the client reads from that preloaded data. On client-side navigation, the framework calls the loader over RPC. Same loader, three environments, zero config.

--- a/apps/app/src/pages/docs/loaders.mdx
+++ b/apps/app/src/pages/docs/loaders.mdx
@@ -7,9 +7,9 @@ Pages often need data. On the server, that data should come from a direct functi
 A page is a file pair:
 
 - `movies.server.ts`: the server loader (default export) plus its `defineLoader` reference (named export). Never reaches the browser bundle.
-- `movies.tsx`: a pure component that consumes the loader data via `useLoaderData(loader)`.
+- `movies.tsx`: a pure component that consumes the loader data via `useLoaderData<typeof loader>()` and is exported through `definePage(Component, { loader })`.
 
-The two are bound together at the route registration in `iso.tsx`, which passes the loader reference to `<Route loader={...}>`.
+`definePage` attaches the loader (and optional `cache`, `Wrapper`) to the page component itself. The `<Route>` in `iso.tsx` only maps a path to a component; it discovers the bindings by reading them off the component.
 
 **At runtime:**
 1. **SSR:** `serverLoader` runs directly during `prerender`. Its return value is JSON-serialized into a `data-loader` attribute on the page's wrapper element.
@@ -41,15 +41,15 @@ export default serverLoader;
 export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader);
 ```
 
-**`src/pages/movies.tsx`** is a pure component:
+**`src/pages/movies.tsx`** is a pure component, with `definePage` attaching the loader binding:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import { useLoaderData } from '@hono-preact/iso';
+import { definePage, useLoaderData } from '@hono-preact/iso';
 import { loader } from './movies.server.js';
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(loader);
+  const { movies } = useLoaderData<typeof loader>();
   return (
     <ul>
       {movies.results.map((m) => <li key={m.id}>{m.title}</li>)}
@@ -57,21 +57,20 @@ const Movies: FunctionComponent = () => {
   );
 };
 
-export default Movies;
+export default definePage(Movies, { loader });
 ```
 
-**`src/iso.tsx`** ties the loader to the route at registration:
+**`src/iso.tsx`** maps the path to the component; it does not import the loader:
 
 ```tsx
 import { lazy, Route } from '@hono-preact/iso';
-import { loader as moviesLoader } from './pages/movies.server.js';
 
 const Movies = lazy(() => import('./pages/movies.js'));
 
-<Route path="/movies" component={Movies} loader={moviesLoader} />
+<Route path="/movies" component={Movies} />
 ```
 
-`defineLoader(name, fn)` returns a typed reference (`LoaderRef<T>`). The `name` argument is required, must be a non-empty string, and is used as a stable identity key (via `Symbol.for`) so that the SSR loader, the client RPC stub, and `useLoaderData` all agree on the same reference even when the module is loaded twice. The `<Route loader={...}>` prop and the `useLoaderData(ref)` hook both consume that reference, so the data type flows through with no extra annotations.
+`defineLoader(name, fn)` returns a typed reference (`LoaderRef<T>`). The `name` argument is required, must be a non-empty string, and is used as a stable identity key (via `Symbol.for`) so that the SSR loader, the client RPC stub, and `useLoaderData` all agree on the same reference even when the module is loaded twice. `definePage(Component, { loader })` stamps that reference onto the page component so the route runtime can pick it up. `useLoaderData<typeof loader>()` is a type-only consumer: the generic narrows the return type to the loader's return shape without dragging the loader ref in as a runtime value.
 
 ## Example: detail page (using route params)
 
@@ -110,7 +109,7 @@ app
 
 ## Caching navigation results
 
-Export a `cache` from the `.server.ts` file alongside the loader, then pass it to the route so repeated navigations to the same page don't re-fetch:
+Export a `cache` from the `.server.ts` file alongside the loader, then pass it to `definePage` so repeated navigations to the same page don't re-fetch:
 
 ```ts
 // src/pages/movies.server.ts
@@ -127,16 +126,80 @@ export const cache = createCache<{ movies: MovieList }>();
 ```
 
 ```tsx
+// src/pages/movies.tsx
+import { definePage, useLoaderData } from '@hono-preact/iso';
+import { loader, cache } from './movies.server.js';
+
+function Movies() {
+  const { movies } = useLoaderData<typeof loader>();
+  return <ul>{movies.results.map((m) => <li key={m.id}>{m.title}</li>)}</ul>;
+}
+
+export default definePage(Movies, { loader, cache });
+```
+
+```tsx
 // src/iso.tsx
 import { lazy, Route } from '@hono-preact/iso';
-import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
 
 const Movies = lazy(() => import('./pages/movies.js'));
 
-<Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
+<Route path="/movies" component={Movies} />
 ```
 
 On a cache hit, the RPC call is skipped entirely. After a successful fetch the result is stored in the cache for the session.
+
+## Page bindings with `definePage`
+
+Per-page concerns (loader, cache, Wrapper) live with the page component, not with the route declaration that mounts it. `definePage` attaches them to the component:
+
+```tsx
+import { definePage } from '@hono-preact/iso';
+
+export default definePage(Component, { loader, cache, Wrapper });
+```
+
+`definePage(Component, bindings)` returns the same component reference, with the bindings stamped onto it via a well-known symbol. At route time, `<Route>` reads those bindings off the component to coordinate SSR preload, hydration, and client-side fetching. From the consumer's perspective the export is still just the page component.
+
+A page with no loader simply skips `definePage`. `<Route>` treats the absence of bindings as "no loader", and the component renders directly:
+
+```tsx
+// src/pages/home.tsx
+const Home = () => <main>Welcome.</main>;
+export default Home;
+```
+
+```tsx
+// src/iso.tsx
+<Route path="/" component={Home} />
+```
+
+A `Wrapper` binding wraps the page in a custom element while keeping the SSR `data-loader` plumbing. This was previously a `<Route Wrapper>` prop:
+
+```tsx
+// src/pages/movie.tsx
+import { definePage, type WrapperProps } from '@hono-preact/iso';
+import { loader } from './movie.server.js';
+
+function MovieWrapper(props: WrapperProps) {
+  return <article {...props} />;
+}
+
+function MovieDetail() {
+  /* ... */
+}
+
+export default definePage(MovieDetail, { loader, Wrapper: MovieWrapper });
+```
+
+```tsx
+// src/iso.tsx
+<Route path="/movies/:id" component={Movie} />
+```
+
+`useLoaderData<typeof loader>()` is the consumer side. Importing `loader` purely as a type from the `.server.ts` file gives narrowing without a runtime reference; the call itself takes no arguments.
+
+For nested routers, the bindings always live with the page being mounted. A nested `<Route path="/:id" component={Movie} />` inside a `Movies` page no longer plumbs `loader=` or `Wrapper=` to that route; those move into `movie.tsx`'s `definePage` call.
 
 ## Named caches
 

--- a/apps/app/src/pages/docs/optimistic-ui.mdx
+++ b/apps/app/src/pages/docs/optimistic-ui.mdx
@@ -135,10 +135,10 @@ const NotesForm = ({ defaultNotes }) => {
 
 ```tsx
 import { OptimisticOverlay, useLoaderData } from '@hono-preact/iso';
-import { moviesLoader } from './movies.server.js';
+import { loader as moviesLoader } from './movies.server.js';
 
 const MovieList = () => {
-  const movies = useLoaderData(moviesLoader);
+  const movies = useLoaderData<typeof moviesLoader>();
   return <ul>{movies.map((m) => <li key={m.id}>{m.title}</li>)}</ul>;
 };
 

--- a/apps/app/src/pages/docs/pages.mdx
+++ b/apps/app/src/pages/docs/pages.mdx
@@ -4,7 +4,7 @@ There are two kinds of pages in this template: standard Preact pages and MDX con
 
 ## Standard Preact pages
 
-A standard page is a pure component plus a `<Route>` registration. Loaders, caches, and guards live in the sibling `.server.ts` file and are wired in at the route. The page itself imports only what it consumes.
+A standard page is a pure component plus a `<Route>` registration. Loaders, caches, and Wrappers live in the sibling `.server.ts` file (or in the page file for `Wrapper`) and are bound to the page component via `definePage`. Guards stay at the `<Route>` level. The page itself imports only what it consumes.
 
 ### Step 1: Create `src/pages/about.tsx`
 
@@ -34,15 +34,28 @@ const About = lazy(() => import('./pages/about.js'));
 <Route path="/about" component={About} />
 ```
 
-`<Route>` from `@hono-preact/iso` is the registration surface. It hosts the Suspense boundary, runs guards, and (when a `loader` prop is supplied) coordinates SSR preload, hydration, and client-side fetching. For pages with data, import the loader from the `.server.ts` sibling and pass it through:
+`<Route>` from `@hono-preact/iso` is the registration surface. It hosts the Suspense boundary, runs guards, and (when the page is bound to a loader via `definePage`) coordinates SSR preload, hydration, and client-side fetching. For pages with data, import the loader inside the `.tsx` file and attach it via `definePage`:
 
 ```tsx
+// src/pages/about.tsx
+import { definePage, useLoaderData } from '@hono-preact/iso';
+import { loader } from './about.server.js';
+
+function About() {
+  const data = useLoaderData<typeof loader>();
+  return <section>{/* ... */}</section>;
+}
+
+export default definePage(About, { loader });
+```
+
+```tsx
+// src/iso.tsx
 import { lazy, Route } from '@hono-preact/iso';
-import { loader as aboutLoader } from './pages/about.server.js';
 
 const About = lazy(() => import('./pages/about.js'));
 
-<Route path="/about" component={About} loader={aboutLoader} />
+<Route path="/about" component={About} />
 ```
 
 ### Step 3: Link to it

--- a/apps/app/src/pages/docs/quick-start.mdx
+++ b/apps/app/src/pages/docs/quick-start.mdx
@@ -48,7 +48,7 @@ const Movies = lazy(() => import('./pages/movies.js'));
 
 Open `http://localhost:5173/movies`. You should see "Movies".
 
-> `<Route>` from `@hono-preact/iso` is the registration surface. It wires the component into the loader/preload, guard, and Suspense system. For a page with no data, `loader` is omitted and the component renders directly.
+> `<Route>` from `@hono-preact/iso` is the registration surface. It maps a path to a component. Per-page concerns (loader, cache, Wrapper) are attached to the page component itself via `definePage`; pages without bindings render directly.
 
 ## 2. Add a server loader
 
@@ -75,15 +75,15 @@ export default serverLoader;
 export const loader = defineLoader<{ movies: Movie[] }>('movies', serverLoader);
 ```
 
-Update `src/pages/movies.tsx` to a pure consumer of the loader data:
+Update `src/pages/movies.tsx` to a pure consumer of the loader data, and bind the loader to the page with `definePage`:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import { useLoaderData } from '@hono-preact/iso';
+import { definePage, useLoaderData } from '@hono-preact/iso';
 import { loader } from './movies.server.js';
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(loader);
+  const { movies } = useLoaderData<typeof loader>();
   return (
     <main>
       <h1>Movies</h1>
@@ -98,24 +98,23 @@ const Movies: FunctionComponent = () => {
 
 Movies.displayName = 'Movies';
 
-export default Movies;
+export default definePage(Movies, { loader });
 ```
 
-Wire the loader into the route in `src/iso.tsx`:
+The `<Route>` registration in `src/iso.tsx` does not change; it still just maps the path to the component:
 
 ```tsx
 import { lazy, Route } from '@hono-preact/iso';
-import { loader as moviesLoader } from './pages/movies.server.js';
 
 const Movies = lazy(() => import('./pages/movies.js'));
 
 // inside <Router>:
-<Route path="/movies" component={Movies} loader={moviesLoader} />
+<Route path="/movies" component={Movies} />
 ```
 
 Reload `http://localhost:5173/movies`. The list renders server-side on first load, with the data preloaded into the HTML. On client-side navigation away and back, the framework calls the loader over RPC. Same function, no manual wiring.
 
-`defineLoader(name, fn)` returns a typed reference. The `name` is required and must match the user-chosen identifier on both sides (server module and client RPC stub), wired by `Symbol.for`. The `loader` prop on `<Route>` and the `useLoaderData(ref)` hook both take that reference, so the data type flows through without any explicit annotations on the consuming side.
+`defineLoader(name, fn)` returns a typed reference. The `name` is required and must match the user-chosen identifier on both sides (server module and client RPC stub), wired by `Symbol.for`. `definePage(Component, { loader })` attaches the loader to the page component so the route can find it. `useLoaderData<typeof loader>()` is argument-free; the type-only generic narrows the return type without pulling the loader ref in as a runtime value.
 
 ## 3. Add a server action
 
@@ -157,7 +156,7 @@ Update `src/pages/movies.tsx` to add the form:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import { Form, useAction, useLoaderData } from '@hono-preact/iso';
+import { definePage, Form, useAction, useLoaderData } from '@hono-preact/iso';
 import { loader, serverActions } from './movies.server.js';
 
 const AddMovieForm: FunctionComponent = () => {
@@ -171,7 +170,7 @@ const AddMovieForm: FunctionComponent = () => {
 };
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(loader);
+  const { movies } = useLoaderData<typeof loader>();
   return (
     <main>
       <h1>Movies</h1>
@@ -187,7 +186,7 @@ const Movies: FunctionComponent = () => {
 
 Movies.displayName = 'Movies';
 
-export default Movies;
+export default definePage(Movies, { loader });
 ```
 
 The `<Route>` registration in `iso.tsx` doesn't change. Actions don't need any route-level wiring.

--- a/apps/app/src/pages/docs/reloading.mdx
+++ b/apps/app/src/pages/docs/reloading.mdx
@@ -21,15 +21,15 @@ export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader
 export const cache = createCache<{ movies: MovieList }>();
 ```
 
-**`src/pages/movies.tsx`** is a pure component using `useReload`:
+**`src/pages/movies.tsx`** is a pure component using `useReload`, with bindings attached via `definePage`:
 
 ```tsx
 import type { FunctionComponent } from 'preact';
-import { useLoaderData, useReload } from '@hono-preact/iso';
-import { loader } from './movies.server.js';
+import { definePage, useLoaderData, useReload } from '@hono-preact/iso';
+import { loader, cache } from './movies.server.js';
 
 const Movies: FunctionComponent = () => {
-  const { movies } = useLoaderData(loader);
+  const { movies } = useLoaderData<typeof loader>();
   const { reload, reloading } = useReload();
 
   const handleAdd = async () => {
@@ -49,21 +49,20 @@ const Movies: FunctionComponent = () => {
   );
 };
 
-export default Movies;
+export default definePage(Movies, { loader, cache });
 ```
 
-**`src/iso.tsx`** registers the route with the loader:
+**`src/iso.tsx`** maps the path to the component; the bindings live with the page:
 
 ```tsx
 import { lazy, Route } from '@hono-preact/iso';
-import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
 
 const Movies = lazy(() => import('./pages/movies.js'));
 
-<Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
+<Route path="/movies" component={Movies} />
 ```
 
-`useReload` must be called inside a component rendered by a `<Route>` that has a `loader` prop. Calling it elsewhere throws an error.
+`useReload` must be called inside a component whose page has a loader binding (via `definePage(..., { loader })`). Calling it elsewhere throws an error.
 
 ## Background refresh
 

--- a/apps/app/src/pages/docs/structure.mdx
+++ b/apps/app/src/pages/docs/structure.mdx
@@ -48,16 +48,15 @@ hydrate(<App />, document.getElementById('app'));
 
 ### `apps/app/src/iso.tsx`
 
-The shared component tree used by both the server (via `Layout`) and the client (via hydration). Defines the `<Router>` from `@hono-preact/iso` with all routes. Each `<Route>` registers a lazy-loaded page component and (optionally) imports its sibling `.server.ts` loader, cache, and guards.
+The shared component tree used by both the server (via `Layout`) and the client (via hydration). Defines the `<Router>` from `@hono-preact/iso` with all routes. Each `<Route>` registers a lazy-loaded page component by path. Loader, cache, and Wrapper bindings live with the page component itself (via `definePage` in the `.tsx` file); guards stay on `<Route>` because they often differ per mount point.
 
 ```tsx
 import { lazy, Route, Router } from '@hono-preact/iso';
-import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
 
 const Movies = lazy(() => import('./pages/movies.js'));
 
 <Router>
-  <Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
+  <Route path="/movies" component={Movies} />
 </Router>
 ```
 
@@ -71,11 +70,12 @@ Renders the full HTML shell: `<head>`, `<body>`, the `#app` mount point, and the
 
 Isomorphic utilities shared between server and client (`packages/iso/`):
 
-- `route.tsx`: `<Route>` and `<Router>` components, the user-facing registration surface. `<Route>` accepts `path`, `component`, plus the page-level props `loader`, `cache`, `serverGuards`, `clientGuards`, `fallback`, `errorFallback`, and `Wrapper` (typed as `ComponentType<WrapperProps>`).
+- `route.tsx`: `<Route>` and `<Router>` components, the user-facing registration surface. `<Route>` accepts `path`, `component`, plus the route-level props `serverGuards`, `clientGuards`, `fallback`, and `errorFallback`. Page-level bindings (`loader`, `cache`, `Wrapper`) come from the component itself via `definePage`.
+- `define-page.ts`: `definePage(Component, { loader, cache, Wrapper })` factory that stamps page bindings onto a component via a well-known symbol; `<Route>` reads them at mount time.
 - `page.tsx`: `<Page>` component and `WrapperProps` type. Composes the route boundary, guards, loader, and envelope into a single page wrapper (used internally by `<Route>`). `<Page>` accepts `loader`, `location`, `cache`, `serverGuards`, `clientGuards`, `fallback`, `errorFallback`, and `Wrapper` (typed as `ComponentType<WrapperProps>`).
 - `loader.tsx`: `<Loader>` component that fetches and caches loader data, plus the `useReload` provider context.
 - `define-loader.ts`: `defineLoader` factory and `LoaderFn<T>` / `LoaderRef<T>` types.
-- `use-loader-data.ts`: `useLoaderData(ref)` hook for typed access to loader data inside children.
+- `use-loader-data.ts`: `useLoaderData<typeof loader>()` hook for typed access to loader data inside children. The loader is supplied as a type-only generic, not as a runtime argument.
 - `envelope.tsx`: `<Envelope>` (default page Wrapper) that emits the SSR `data-loader` attribute. Accepts `as` (an intrinsic tag name or a `ComponentType<WrapperProps>`, defaults to `'section'`) and `children`.
 - `guards.tsx` / `guard.ts`: `<Guards>` component, `createGuard`, `runGuards`, guard types.
 - `cache.ts`: single-value in-memory cache (`createCache`) to avoid re-fetching on client-side navigation. On the server, storage is request-scoped via `AsyncLocalStorage` so concurrent requests do not leak data; `runRequestScope(fn)` from the same module wraps each render and loader/action call.

--- a/apps/app/src/pages/movie.tsx
+++ b/apps/app/src/pages/movie.tsx
@@ -1,14 +1,20 @@
 // apps/app/src/pages/movie.tsx
 import {
   cacheRegistry,
+  definePage,
   Form,
   useAction,
   useLoaderData,
   useOptimisticAction,
   useReload,
+  type WrapperProps,
 } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
-import { loader as movieLoader, serverActions } from './movie.server.js';
+import { loader, serverActions } from './movie.server.js';
+
+function MovieWrapper(props: WrapperProps) {
+  return <article {...props} />;
+}
 
 const NotesForm: FunctionComponent<{
   movieIdStr: string;
@@ -59,7 +65,7 @@ const PhotoForm: FunctionComponent<{ movieIdStr: string }> = ({ movieIdStr }) =>
 };
 
 const MovieDetail: FunctionComponent = () => {
-  const { movie, watched } = useLoaderData(movieLoader);
+  const { movie, watched } = useLoaderData<typeof loader>();
   if (!movie) return <p>Movie not found.</p>;
 
   const isWatched = !!watched && watched.watchedAt > 0;
@@ -140,4 +146,4 @@ const MovieDetail: FunctionComponent = () => {
 };
 MovieDetail.displayName = 'MovieDetail';
 
-export default MovieDetail;
+export default definePage(MovieDetail, { loader, Wrapper: MovieWrapper });

--- a/apps/app/src/pages/movies.tsx
+++ b/apps/app/src/pages/movies.tsx
@@ -1,27 +1,22 @@
 // apps/app/src/pages/movies.tsx
 import {
   cacheRegistry,
+  definePage,
   lazy,
   Route,
   Router,
   useLoaderData,
   useOptimisticAction,
-  type WrapperProps,
 } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
 import type { MovieSummary } from '@/server/data/movies.js';
-import { loader as movieLoader } from './movie.server.js';
-import { loader as moviesLoader, serverActions } from './movies.server.js';
+import { loader, cache, serverActions } from './movies.server.js';
 import Noop from './noop.js';
 
 const Movie = lazy(() => import('./movie.js'));
 
-function MovieWrapper(props: WrapperProps) {
-  return <article {...props} />;
-}
-
 const Movies: FunctionComponent = () => {
-  const { movies, watchedIds } = useLoaderData(moviesLoader);
+  const { movies, watchedIds } = useLoaderData<typeof loader>();
 
   const { mutate, value: optimisticWatchedIds } = useOptimisticAction(
     serverActions.toggleWatched,
@@ -68,7 +63,7 @@ const Movies: FunctionComponent = () => {
         ))}
       </ul>
       <Router>
-        <Route path="/:id" component={Movie} loader={movieLoader} Wrapper={MovieWrapper} />
+        <Route path="/:id" component={Movie} />
         <Noop />
       </Router>
     </section>
@@ -76,4 +71,4 @@ const Movies: FunctionComponent = () => {
 };
 Movies.displayName = 'Movies';
 
-export default Movies;
+export default definePage(Movies, { loader, cache });

--- a/apps/app/src/pages/watched.tsx
+++ b/apps/app/src/pages/watched.tsx
@@ -1,19 +1,17 @@
 // apps/app/src/pages/watched.tsx
 import {
   cacheRegistry,
+  definePage,
   useAction,
   useLoaderData,
   useReload,
 } from '@hono-preact/iso';
 import type { FunctionComponent } from 'preact';
 import { useState } from 'preact/hooks';
-import {
-  serverActions,
-  loader as watchedLoader,
-} from './watched.server.js';
+import { cache, loader, serverActions } from './watched.server.js';
 
 const WatchedPage: FunctionComponent = () => {
-  const { entries } = useLoaderData(watchedLoader);
+  const { entries } = useLoaderData<typeof loader>();
   const [progress, setProgress] = useState<{ count: number; total: number } | null>(null);
 
   const reload = useReload();
@@ -106,4 +104,4 @@ const WatchedPage: FunctionComponent = () => {
 };
 WatchedPage.displayName = 'WatchedPage';
 
-export default WatchedPage;
+export default definePage(WatchedPage, { loader, cache });

--- a/apps/app/wrangler.jsonc
+++ b/apps/app/wrangler.jsonc
@@ -6,6 +6,7 @@
     "directory": "./dist",
   },
   "compatibility_flags": ["nodejs_compat"],
+  "preview_urls": true,
   "routes": [
     {
       "pattern": "framework.sbesh.com",

--- a/docs/superpowers/plans/2026-04-30-define-page.md
+++ b/docs/superpowers/plans/2026-04-30-define-page.md
@@ -1,0 +1,1318 @@
+# `definePage`: Page-Owned Route Bindings — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move per-page bindings (loader, cache, Wrapper) from `<Route>` props in `iso.tsx` onto the page component itself via a new `definePage` helper. `iso.tsx` becomes paths + lazy refs only; `useLoaderData` becomes argument-free.
+
+**Architecture:** Add `definePage` to `@hono-preact/iso`, which mutates a component to attach a `PAGE_BINDINGS` symbol. Wrap preact-iso's `lazy()` to expose the resolved default export. `<Route>` drops `loader`/`cache`/`Wrapper` props; `wrapWithPage` reads them from `PAGE_BINDINGS` (suspending on lazy resolution if needed) and passes them to the existing `<Page>` primitive.
+
+**Tech Stack:** TypeScript, Preact, preact-iso (`lazy`/`Router`/`Route`), Vitest, happy-dom, @testing-library/preact.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-define-page-design.md`
+
+---
+
+## Pre-flight context for the executing engineer
+
+- This work is on top of `main` after PR #4 (`feat/iso-route-level-loaders`) merged. Recommend a fresh branch like `feat/define-page`.
+- Read these files to understand the surfaces you'll touch:
+  - `packages/iso/src/route.tsx` — current `<Route>`/`<Router>`/`wrapWithPage`
+  - `packages/iso/src/page.tsx` — the `<Page>` primitive (NOT changing — it stays as-is)
+  - `packages/iso/src/loader.tsx` — `<Loader>` provides `LoaderDataContext`
+  - `packages/iso/src/contexts.ts` — `LoaderDataContext` shape
+  - `packages/iso/src/use-loader-data.ts` — runtime ref check (going away)
+  - `packages/iso/src/define-loader.ts` — `LoaderRef<T>` (unchanged; `defineLoader('name', fn)` API stays)
+  - `packages/iso/src/index.ts` — public export surface
+  - `packages/iso/src/__tests__/route.test.tsx`, `loader.test.tsx`, `page.test.tsx` — existing test patterns
+  - `apps/app/src/iso.tsx` — central route table
+  - `apps/app/src/pages/movies.tsx`, `movie.tsx`, `watched.tsx` — pages with loaders
+  - `apps/app/src/pages/movies.tsx` (nested `<Router>` for `/movies/:id`)
+- Run `pnpm test` from repo root — confirm all tests pass before starting (the spec assumes this).
+- Run `pnpm --filter app build` — confirm clean.
+
+This is a coordinated, breaking refactor of `<Route>` props and `useLoaderData`. There is **no parallel-old-and-new API window** — pages and tests migrate in the same branch. Plan that into your commit cadence: tests for the new shape may break tests for the old shape mid-task; that's expected.
+
+---
+
+## File Structure
+
+### New files
+- `packages/iso/src/define-page.ts` — `definePage` helper, `PAGE_BINDINGS` symbol, types
+- `packages/iso/src/__tests__/define-page.test.ts` — unit tests for `definePage`
+- `packages/iso/src/lazy.ts` — wrapper around `preact-iso/lazy` exposing resolved default
+- `packages/iso/src/__tests__/lazy.test.tsx` — unit tests for the wrapper
+
+### Modified files
+- `packages/iso/src/index.ts` — add new exports, switch `lazy` re-export source
+- `packages/iso/src/route.tsx` — `<Route>` props slim down; `wrapWithPage` reads `PAGE_BINDINGS`
+- `packages/iso/src/contexts.ts` — drop `refId` from `LoaderDataContext`
+- `packages/iso/src/loader.tsx` — pass only `{ data }` into `LoaderDataContext`
+- `packages/iso/src/use-loader-data.ts` — argument-free signature with conditional generic
+- `packages/iso/src/__tests__/route.test.tsx` — migrate test patterns
+- `packages/iso/src/__tests__/loader.test.tsx` — migrate `useLoaderData(ref)` → `useLoaderData<typeof ref>()`
+- `packages/iso/src/__tests__/define-loader.test.ts` — drop comments referencing the dead `refId === ref.__id` check
+- `apps/app/src/iso.tsx` — drop server imports, drop loader/cache/Wrapper props
+- `apps/app/src/pages/movies.tsx` — `definePage`, drop nested `Wrapper` prop, `useLoaderData<typeof loader>()`
+- `apps/app/src/pages/movie.tsx` — `definePage` with `Wrapper`, `useLoaderData<typeof loader>()`
+- `apps/app/src/pages/watched.tsx` — `definePage`, `useLoaderData<typeof loader>()`
+- `apps/app/src/pages/docs/*.mdx` — update examples to new API
+
+### Files NOT touched
+- `packages/iso/src/page.tsx` — `<Page>` is the internal primitive; its props stay (loader, cache, Wrapper); only the *source* of those values changes upstream.
+- `packages/iso/src/define-loader.ts` — `defineLoader('name', fn)` signature unchanged.
+- `packages/iso/src/cache.ts` and `cache-registry.ts` — unchanged.
+- `packages/iso/src/prefetch.ts` — operates on `LoaderRef` directly; unaffected.
+- `packages/server/**` — server-side loader dispatch is unchanged (still keys off the `module` field of the RPC body and reads the default export).
+- `packages/vite/**` — `serverOnlyPlugin` already handles `loader`/`cache`/`serverActions` specifiers; no new specifiers introduced.
+
+---
+
+## Task 1: Add `definePage` helper
+
+**Why:** This is the smallest, most isolated piece — no other tasks depend on shape changes, so getting it landed first gives a stable target. Pure unit-testable function plus types.
+
+**Files:**
+- Create: `packages/iso/src/define-page.ts`
+- Create: `packages/iso/src/__tests__/define-page.test.ts`
+- Modify: `packages/iso/src/index.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `packages/iso/src/__tests__/define-page.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { definePage, PAGE_BINDINGS, type PageComponent } from '../define-page.js';
+import { defineLoader } from '../define-loader.js';
+import { createCache } from '../cache.js';
+
+describe('definePage', () => {
+  it('attaches bindings under the realm-wide PAGE_BINDINGS symbol', () => {
+    const fn = async () => ({ msg: 'ok' });
+    const loader = defineLoader<{ msg: string }>('define-page-test-1', fn);
+    const cache = createCache<{ msg: string }>('define-page-test-1');
+    const Inner = () => null;
+
+    const Wrapped = definePage(Inner, { loader, cache });
+
+    expect(Wrapped).toBe(Inner);
+    expect((Wrapped as PageComponent<{ msg: string }>)[PAGE_BINDINGS]).toEqual({
+      loader,
+      cache,
+    });
+  });
+
+  it('uses Symbol.for for cross-module identity', () => {
+    expect(PAGE_BINDINGS).toBe(Symbol.for('@hono-preact/iso/page-bindings'));
+  });
+
+  it('returns the same component reference (no wrapper)', () => {
+    const Inner = () => null;
+    const Wrapped = definePage(Inner);
+    expect(Wrapped).toBe(Inner);
+  });
+
+  it('treats omitted bindings as no-op (no symbol attached)', () => {
+    const Inner = () => null;
+    definePage(Inner);
+    expect((Inner as PageComponent<unknown>)[PAGE_BINDINGS]).toBeUndefined();
+  });
+
+  it('replaces previously-attached bindings if called twice on the same component', () => {
+    const fn1 = async () => ({ a: 1 });
+    const fn2 = async () => ({ b: 2 });
+    const loader1 = defineLoader('define-page-test-replace-1', fn1);
+    const loader2 = defineLoader('define-page-test-replace-2', fn2);
+    const Inner = () => null;
+
+    definePage(Inner, { loader: loader1 });
+    definePage(Inner, { loader: loader2 });
+
+    expect((Inner as PageComponent<unknown>)[PAGE_BINDINGS]).toEqual({
+      loader: loader2,
+    });
+  });
+
+  it('accepts a Wrapper component in bindings', () => {
+    const Inner = () => null;
+    const Wrapper = (props: { children: unknown }) =>
+      props.children as never;
+
+    const Wrapped = definePage(Inner, { Wrapper });
+
+    expect((Wrapped as PageComponent<unknown>)[PAGE_BINDINGS]).toEqual({
+      Wrapper,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm vitest run packages/iso/src/__tests__/define-page.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../define-page.js'`.
+
+- [ ] **Step 3: Implement `define-page.ts`**
+
+Create `packages/iso/src/define-page.ts`:
+
+```ts
+import type { ComponentType } from 'preact';
+import type { LoaderRef } from './define-loader.js';
+import type { LoaderCache } from './cache.js';
+import type { WrapperProps } from './page.js';
+
+export type PageBindings<T> = {
+  loader?: LoaderRef<T>;
+  cache?: LoaderCache<T>;
+  Wrapper?: ComponentType<WrapperProps>;
+};
+
+// Symbol.for so duplicate module copies (HMR, pnpm phantom deps) still match.
+export const PAGE_BINDINGS = Symbol.for('@hono-preact/iso/page-bindings');
+
+export type PageComponent<T> = ComponentType & {
+  [PAGE_BINDINGS]?: PageBindings<T>;
+};
+
+export function definePage<T>(
+  Component: ComponentType,
+  bindings?: PageBindings<T>
+): PageComponent<T> {
+  if (bindings) {
+    (Component as PageComponent<T>)[PAGE_BINDINGS] = bindings;
+  }
+  return Component as PageComponent<T>;
+}
+```
+
+- [ ] **Step 4: Export from package root**
+
+Modify `packages/iso/src/index.ts` — add after the `defineLoader` export block:
+
+```ts
+export { definePage, PAGE_BINDINGS } from './define-page.js';
+export type { PageBindings, PageComponent } from './define-page.js';
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+pnpm vitest run packages/iso/src/__tests__/define-page.test.ts
+```
+
+Expected: 6 passing.
+
+- [ ] **Step 6: Run the full iso test suite to verify nothing broke**
+
+```bash
+pnpm vitest run packages/iso
+```
+
+Expected: all green (existing tests + 6 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/iso/src/define-page.ts packages/iso/src/__tests__/define-page.test.ts packages/iso/src/index.ts
+git commit -m "feat(iso): add definePage helper for page-owned route bindings"
+```
+
+---
+
+## Task 2: Wrap `lazy()` to expose resolved default export
+
+**Why:** `<Route>` needs to read `PAGE_BINDINGS` off the resolved component, but preact-iso's `lazy` keeps the resolved value in a closure with no public accessor. We wrap it so `wrapWithPage` can synchronously check whether the module has resolved, suspend on the import promise if not, and read the default export's `[PAGE_BINDINGS]` once it has.
+
+**Files:**
+- Create: `packages/iso/src/lazy.ts`
+- Create: `packages/iso/src/__tests__/lazy.test.tsx`
+- Modify: `packages/iso/src/index.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `packages/iso/src/__tests__/lazy.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { lazy } from '../lazy.js';
+
+describe('lazy() wrapper', () => {
+  it('returns a component with preload() that resolves to the module', async () => {
+    const Mod = { default: () => null, marker: 'movies-mod' };
+    const Lazy = lazy(async () => Mod);
+    const m = await Lazy.preload();
+    expect(m).toBe(Mod);
+  });
+
+  it('returns null from getResolvedDefault before preload', () => {
+    const Lazy = lazy(async () => ({ default: () => null }));
+    expect(Lazy.getResolvedDefault()).toBeNull();
+  });
+
+  it('returns the resolved default after preload completes', async () => {
+    const Inner = () => null;
+    const Lazy = lazy(async () => ({ default: Inner }));
+    await Lazy.preload();
+    expect(Lazy.getResolvedDefault()).toBe(Inner);
+  });
+
+  it('also handles modules whose export is the component itself (no default key)', async () => {
+    // preact-iso's lazy supports `m.default || m` — preserve that behavior.
+    const Inner = () => null;
+    const Lazy = lazy(async () => Inner as unknown as { default: typeof Inner });
+    await Lazy.preload();
+    expect(Lazy.getResolvedDefault()).toBe(Inner);
+  });
+
+  it('preload() returns the same promise on repeated calls', () => {
+    const Lazy = lazy(async () => ({ default: () => null }));
+    const p1 = Lazy.preload();
+    const p2 = Lazy.preload();
+    expect(p1).toBe(p2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm vitest run packages/iso/src/__tests__/lazy.test.tsx
+```
+
+Expected: FAIL — `Cannot find module '../lazy.js'`.
+
+- [ ] **Step 3: Implement `lazy.ts`**
+
+Create `packages/iso/src/lazy.ts`:
+
+```ts
+import type { ComponentType } from 'preact';
+import { lazy as preactIsoLazy } from 'preact-iso';
+
+export interface LazyComponent<P = {}> extends ComponentType<P> {
+  preload: () => Promise<unknown>;
+  getResolvedDefault: () => ComponentType | null;
+}
+
+type ModuleLike = { default?: ComponentType } | ComponentType;
+
+export function lazy<P = {}>(
+  load: () => Promise<ModuleLike>
+): LazyComponent<P> {
+  let resolved: ComponentType | null = null;
+  let modulePromise: Promise<ModuleLike> | null = null;
+
+  // Single source of truth for the import. Side-effect: also caches the
+  // resolved default. Returns the original module-like value so callers of
+  // preload() see what `load()` actually returned.
+  const ensure = (): Promise<ModuleLike> => {
+    if (!modulePromise) {
+      modulePromise = load().then((m) => {
+        const c =
+          (m && (m as { default?: ComponentType }).default) ??
+          (m as ComponentType);
+        resolved = c;
+        return m;
+      });
+    }
+    return modulePromise;
+  };
+
+  // Hand preact-iso's lazy a stable factory that adapts the module to the
+  // {default: Component} shape it expects. This shares `ensure`'s cache, so
+  // the underlying load() runs at most once across our preload() callers and
+  // preact-iso's own first-render preload.
+  const Inner = preactIsoLazy(() =>
+    ensure().then((m) => ({
+      default:
+        (m as { default?: ComponentType }).default ??
+        (m as unknown as ComponentType),
+    }))
+  ) as unknown as LazyComponent<P>;
+
+  Inner.preload = ensure;
+  Inner.getResolvedDefault = () => resolved;
+
+  return Inner;
+}
+```
+
+> **Note on double-suspend:** when `wrapWithPage` throws `lazyish.preload()` to wait for the module, then renders `<Component />`, preact-iso's internal lazy state may suspend a second time on its own first render. Both suspends share the same cached module promise, so the second resolves on the next microtask — visible as a single Suspense fallback, not two flashes. Accepted as the cost of layering on top of preact-iso's lazy rather than rolling a new one.
+
+- [ ] **Step 4: Switch the package's `lazy` export to use the wrapper**
+
+Modify `packages/iso/src/index.ts`:
+
+Replace:
+```ts
+// Convenience re-export so consumers don't need to import from preact-iso
+// alongside @hono-preact/iso.
+export { lazy } from 'preact-iso';
+```
+
+with:
+```ts
+// Wrapped lazy that exposes the resolved default for binding lookup. API is
+// otherwise identical to preact-iso's lazy.
+export { lazy } from './lazy.js';
+export type { LazyComponent } from './lazy.js';
+```
+
+- [ ] **Step 5: Run the lazy tests**
+
+```bash
+pnpm vitest run packages/iso/src/__tests__/lazy.test.tsx
+```
+
+Expected: 5 passing.
+
+- [ ] **Step 6: Run the full iso test suite**
+
+```bash
+pnpm vitest run packages/iso
+```
+
+Expected: all green. The change to `lazy`'s export source should be transparent for consumers — preact-iso's component behavior is preserved.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/iso/src/lazy.ts packages/iso/src/__tests__/lazy.test.tsx packages/iso/src/index.ts
+git commit -m "feat(iso): wrap lazy() to expose resolved default for page-binding lookup"
+```
+
+---
+
+## Task 3: Drop `refId` from `LoaderDataContext`; make `useLoaderData()` argument-free
+
+**Why:** The page no longer imports the loader ref, so the runtime ref-identity check has nothing to verify against. Drop it before changing `<Route>` so the type changes propagate cleanly. This task is independent of the route-binding changes and gives us a clean checkpoint.
+
+**Files:**
+- Modify: `packages/iso/src/contexts.ts`
+- Modify: `packages/iso/src/loader.tsx`
+- Modify: `packages/iso/src/use-loader-data.ts`
+- Modify: `packages/iso/src/__tests__/loader.test.tsx`
+- Modify: `packages/iso/src/__tests__/define-loader.test.ts` (comments only)
+
+- [ ] **Step 1: Update `LoaderDataContext` shape**
+
+Modify `packages/iso/src/contexts.ts`:
+
+Replace:
+```ts
+export const LoaderDataContext = createContext<{
+  refId: symbol;
+  data: unknown;
+} | null>(null);
+```
+
+with:
+```ts
+export const LoaderDataContext = createContext<{
+  data: unknown;
+} | null>(null);
+```
+
+- [ ] **Step 2: Update `<Loader>`'s context provider in `loader.tsx`**
+
+Modify `packages/iso/src/loader.tsx`:
+
+In `DataReader`, replace:
+```tsx
+return (
+  <LoaderDataContext.Provider value={{ refId, data }}>
+    {children}
+  </LoaderDataContext.Provider>
+);
+```
+
+with:
+```tsx
+return (
+  <LoaderDataContext.Provider value={{ data }}>
+    {children}
+  </LoaderDataContext.Provider>
+);
+```
+
+Also remove `refId` from `DataReaderProps`:
+
+```tsx
+type DataReaderProps<T> = {
+  reader: { read: () => T };
+  overrideData?: T;
+  children: ComponentChildren;
+};
+
+function DataReader<T>({
+  reader,
+  overrideData,
+  children,
+}: DataReaderProps<T>) {
+  const data = overrideData !== undefined ? overrideData : reader.read();
+  return (
+    <LoaderDataContext.Provider value={{ data }}>
+      {children}
+    </LoaderDataContext.Provider>
+  );
+}
+```
+
+And in `LoaderHost`, remove `refId={loaderRef.__id}` from the `<DataReader>` invocation:
+
+```tsx
+<DataReader
+  reader={readerRef.current}
+  overrideData={overrideData}
+>
+  {children}
+</DataReader>
+```
+
+- [ ] **Step 3: Rewrite `use-loader-data.ts`**
+
+Replace the contents of `packages/iso/src/use-loader-data.ts`:
+
+```ts
+import { useContext } from 'preact/hooks';
+import { LoaderDataContext } from './contexts.js';
+import type { LoaderRef } from './define-loader.js';
+
+export function useLoaderData<L>(): L extends LoaderRef<infer T> ? T : L {
+  const ctx = useContext(LoaderDataContext);
+  if (!ctx) {
+    throw new Error(
+      'useLoaderData must be called inside a route page that has a loader.'
+    );
+  }
+  return ctx.data as never;
+}
+```
+
+- [ ] **Step 4: Migrate the loader tests to the new signature**
+
+Modify `packages/iso/src/__tests__/loader.test.tsx`. Every call site of `useLoaderData(ref)` must change to `useLoaderData<typeof ref>()`. Use `replace_all` semantics — there are five call sites in this file (lines 43, 65, 102, 145, 170 in the previous shape).
+
+For each occurrence, replace:
+```tsx
+const { msg } = useLoaderData(ref);
+```
+with:
+```tsx
+const { msg } = useLoaderData<typeof ref>();
+```
+
+And likewise for `const { q } = useLoaderData(ref);` → `const { q } = useLoaderData<typeof ref>();`.
+
+- [ ] **Step 5: Update `define-loader.test.ts` comments**
+
+Modify `packages/iso/src/__tests__/define-loader.test.ts`. Find any reference to `useLoaderData(refId === ref.__id)` or the runtime ref-identity check in comments and either delete the comment or rephrase it. The runtime check no longer exists.
+
+```bash
+grep -n "refId\|ref\.__id" packages/iso/src/__tests__/define-loader.test.ts
+```
+
+Update each match. If a test asserts on `__id` matching that's still meaningful (the symbol-identity is used for prefetch keying), leave it. Only the "useLoaderData verifies refId" comments are stale.
+
+- [ ] **Step 6: Run the loader and define-loader tests**
+
+```bash
+pnpm vitest run packages/iso/src/__tests__/loader.test.tsx packages/iso/src/__tests__/define-loader.test.ts
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Run the full iso suite**
+
+```bash
+pnpm vitest run packages/iso
+```
+
+Expected: `route.test.tsx` may still pass (its `useLoaderData(ref)` calls work because TS doesn't complain about an unused argument — it's just ignored at runtime now). If `route.test.tsx` fails on a type mismatch, that's fine; it'll be migrated in Task 4. If runtime tests fail, fix before continuing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/iso/src/contexts.ts packages/iso/src/loader.tsx packages/iso/src/use-loader-data.ts packages/iso/src/__tests__/loader.test.tsx packages/iso/src/__tests__/define-loader.test.ts
+git commit -m "refactor(iso): drop refId from LoaderDataContext; useLoaderData() is argument-free"
+```
+
+---
+
+## Task 4: Slim `<Route>` props; `wrapWithPage` reads `PAGE_BINDINGS`
+
+**Why:** This is the load-bearing change. After this task, `<Route>` no longer accepts `loader`/`cache`/`Wrapper`, and `wrapWithPage` resolves them from the component's `PAGE_BINDINGS` (suspending on lazy if needed). Tests for the new shape go in first; existing tests are migrated as part of this task.
+
+**Files:**
+- Modify: `packages/iso/src/route.tsx`
+- Modify: `packages/iso/src/__tests__/route.test.tsx`
+
+- [ ] **Step 1: Read `route.tsx` end-to-end again**
+
+Refresh on the current `wrapWithPage` and `<Router>`'s child-walking logic. Note the `ROUTE_MARKER` symbol pattern.
+
+- [ ] **Step 2: Add a failing integration test for `<Route>` with a `definePage`'d component**
+
+Append to `packages/iso/src/__tests__/route.test.tsx`, at the end of the existing `describe('<Router> + <Route>')` block, a new test:
+
+```tsx
+  it('reads loader/cache/Wrapper from PAGE_BINDINGS on the component', async () => {
+    const fn = vi.fn(async () => ({ msg: 'page-data' }));
+    const ref = defineLoader<{ msg: string }>('page-bindings-test', fn);
+
+    const Inner = () => {
+      const { msg } = useLoaderData<typeof ref>();
+      return <p data-testid="page">{msg}</p>;
+    };
+    const Wrapped = definePage(Inner, { loader: ref });
+
+    window.history.pushState({}, '', '/page');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/page" component={Wrapped} />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('page');
+    expect(el).toHaveTextContent('page-data');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads PAGE_BINDINGS off a lazy component once resolved', async () => {
+    const fn = vi.fn(async () => ({ msg: 'lazy-data' }));
+    const ref = defineLoader<{ msg: string }>('page-bindings-lazy-test', fn);
+
+    const Inner = () => {
+      const { msg } = useLoaderData<typeof ref>();
+      return <p data-testid="lazy-page">{msg}</p>;
+    };
+    const Wrapped = definePage(Inner, { loader: ref });
+    const Lazy = lazy(async () => ({ default: Wrapped }));
+
+    window.history.pushState({}, '', '/lazy');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/lazy" component={Lazy} />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('lazy-page');
+    expect(el).toHaveTextContent('lazy-data');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a component with no PAGE_BINDINGS without a loader (no-data page)', async () => {
+    const Inner = () => <p data-testid="bare">no-data</p>;
+
+    window.history.pushState({}, '', '/bare');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/bare" component={Inner} />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('bare');
+    expect(el).toHaveTextContent('no-data');
+  });
+```
+
+Add the new imports at the top of the file (alongside existing ones):
+
+```tsx
+import { definePage } from '../define-page.js';
+import { lazy } from '../lazy.js';
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+```bash
+pnpm vitest run packages/iso/src/__tests__/route.test.tsx -t "PAGE_BINDINGS"
+pnpm vitest run packages/iso/src/__tests__/route.test.tsx -t "no PAGE_BINDINGS"
+```
+
+Expected: tests fail. The current `<Route>` ignores PAGE_BINDINGS; `Movies` will render but `useLoaderData` will throw because no `<Loader>` mounted.
+
+- [ ] **Step 4: Update `RouteProps` type and `wrapWithPage` to read bindings**
+
+Modify `packages/iso/src/route.tsx` — full replacement:
+
+```tsx
+import {
+  isValidElement,
+  toChildArray,
+  type ComponentChildren,
+  type ComponentType,
+  type JSX,
+  type VNode,
+} from 'preact';
+import {
+  Route as PreactIsoRoute,
+  Router as PreactIsoRouter,
+  type RouteHook,
+} from 'preact-iso';
+import { Page, type PageProps } from './page.js';
+import { PAGE_BINDINGS, type PageComponent } from './define-page.js';
+import type { LazyComponent } from './lazy.js';
+
+// Route-level config — these stay on <Route>. Page-level (loader, cache,
+// Wrapper) come from the component's PAGE_BINDINGS.
+export type RouteConfig = Pick<
+  PageProps<unknown>,
+  'fallback' | 'errorFallback' | 'serverGuards' | 'clientGuards'
+>;
+
+export type RouteProps = RouteConfig & {
+  path: string;
+  component: ComponentType;
+};
+
+// Kept for back-compat consumers and tests.
+export type PageConfig = RouteConfig;
+
+function readBindings(component: ComponentType) {
+  // Lazy component path: if not yet resolved, throw the preload promise so
+  // Suspense can wait. Once resolved, read PAGE_BINDINGS off the resolved
+  // default. Eager components carry PAGE_BINDINGS directly on themselves.
+  const lazyish = component as LazyComponent;
+  if (typeof lazyish.preload === 'function' && typeof lazyish.getResolvedDefault === 'function') {
+    const resolved = lazyish.getResolvedDefault();
+    if (!resolved) throw lazyish.preload();
+    return (resolved as PageComponent<unknown>)[PAGE_BINDINGS];
+  }
+  return (component as PageComponent<unknown>)[PAGE_BINDINGS];
+}
+
+export function wrapWithPage(
+  Component: ComponentType,
+  config: RouteConfig
+): (location: RouteHook) => JSX.Element {
+  return function PageRouteHandler(location: RouteHook) {
+    const bindings = readBindings(Component);
+    return (
+      <Page
+        loader={bindings?.loader}
+        cache={bindings?.cache}
+        Wrapper={bindings?.Wrapper}
+        fallback={config.fallback}
+        errorFallback={config.errorFallback}
+        serverGuards={config.serverGuards}
+        clientGuards={config.clientGuards}
+        location={location}
+      >
+        <Component />
+      </Page>
+    );
+  };
+}
+
+const ROUTE_MARKER = Symbol.for('@hono-preact/iso/Route');
+
+export function Route(_props: RouteProps): null {
+  return null;
+}
+Route.displayName = 'Route';
+(Route as unknown as Record<symbol, unknown>)[ROUTE_MARKER] = true;
+
+function isOurRoute(node: unknown): node is VNode<RouteProps> {
+  return (
+    isValidElement(node) &&
+    typeof node.type === 'function' &&
+    (node.type as unknown as Record<symbol, unknown>)[ROUTE_MARKER] === true
+  );
+}
+
+type PreactIsoRouterProps = {
+  onRouteChange?: (url: string) => void;
+  onLoadEnd?: (url: string) => void;
+  onLoadStart?: (url: string) => void;
+  children?: ComponentChildren;
+};
+
+export type RouterProps = Omit<PreactIsoRouterProps, 'children'> & {
+  children?: ComponentChildren;
+};
+
+export function Router({ children, ...rest }: RouterProps): JSX.Element {
+  const transformed = toChildArray(children).map((child) => {
+    if (!isOurRoute(child)) return child;
+    const { path, component, ...config } = child.props;
+    return (
+      <PreactIsoRoute
+        path={path}
+        component={wrapWithPage(component, config)}
+      />
+    );
+  });
+  return (
+    <PreactIsoRouter {...rest}>
+      {transformed as unknown as JSX.Element[]}
+    </PreactIsoRouter>
+  );
+}
+```
+
+> **Note on Fragment recursion:** the existing `Router` does *not* explicitly recurse into Fragment children — that flattening is already handled by `toChildArray`. The four "Fragment recursion" tests in `route.test.tsx` should continue to pass without further work because `toChildArray` flattens `<Fragment>` and `<>...</>` children into a flat list.
+
+- [ ] **Step 5: Migrate the existing `wrapWithPage` and `<Router> + <Route>` tests**
+
+The previous test at line 47 is:
+```tsx
+it('renders the component with loader data via useLoaderData', async () => {
+  const fn = vi.fn(async () => ({ msg: 'ok' }));
+  const ref = defineLoader<{ msg: string }>('wrap-with-page-test', fn);
+  const Inner = () => {
+    const { msg } = useLoaderData(ref);
+    return <p data-testid="msg">{msg}</p>;
+  };
+  const Wrapped = wrapWithPage(Inner, { loader: ref });
+  // ...
+});
+```
+
+Replace with:
+```tsx
+it('renders the component with loader data via useLoaderData', async () => {
+  const fn = vi.fn(async () => ({ msg: 'ok' }));
+  const ref = defineLoader<{ msg: string }>('wrap-with-page-test', fn);
+  const Inner = () => {
+    const { msg } = useLoaderData<typeof ref>();
+    return <p data-testid="msg">{msg}</p>;
+  };
+  const Page = definePage(Inner, { loader: ref });
+  const Wrapped = wrapWithPage(Page, {});
+  render(
+    <LocationProvider>
+      <Wrapped {...loc} />
+    </LocationProvider>
+  );
+  const el = await screen.findByText('ok');
+  expect(el).toBeInTheDocument();
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+```
+
+The previous test at line 67:
+```tsx
+it('renders the matched route wrapped in <Page> with loader data', async () => {
+  // ...
+  <Route path="/foo" component={Foo} loader={ref} />
+  // ...
+});
+```
+
+Replace with:
+```tsx
+it('renders the matched route wrapped in <Page> with loader data', async () => {
+  const fn = vi.fn(async () => ({ msg: 'foo-data' }));
+  const ref = defineLoader<{ msg: string }>('router-route-test', fn);
+  const Foo = () => {
+    const { msg } = useLoaderData<typeof ref>();
+    return <p data-testid="foo">{msg}</p>;
+  };
+  const Page = definePage(Foo, { loader: ref });
+
+  window.history.pushState({}, '', '/foo');
+  render(
+    <LocationProvider>
+      <Router>
+        <Route path="/foo" component={Page} />
+      </Router>
+    </LocationProvider>
+  );
+
+  const el = await screen.findByTestId('foo');
+  expect(el).toHaveTextContent('foo-data');
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+```
+
+(Other tests in this file that do not pass a `loader` prop need no change.)
+
+- [ ] **Step 6: Run the route tests**
+
+```bash
+pnpm vitest run packages/iso/src/__tests__/route.test.tsx
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Run the full iso suite**
+
+```bash
+pnpm vitest run packages/iso
+```
+
+Expected: all green. If `page.test.tsx` fails (it shouldn't — `<Page>`'s API didn't change), fix the test rather than reverting the production change.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/iso/src/route.tsx packages/iso/src/__tests__/route.test.tsx
+git commit -m "feat(iso): <Route> reads loader/cache/Wrapper from PAGE_BINDINGS via wrapWithPage"
+```
+
+---
+
+## Task 5: Migrate `apps/app` pages and `iso.tsx`
+
+**Why:** Activate the new shape end-to-end in the consumer app. After this task, `apps/app/src/iso.tsx` no longer imports anything from a `*.server.ts` file.
+
+**Files:**
+- Modify: `apps/app/src/pages/movies.tsx`
+- Modify: `apps/app/src/pages/movie.tsx`
+- Modify: `apps/app/src/pages/watched.tsx`
+- Modify: `apps/app/src/iso.tsx`
+
+- [ ] **Step 1: Update `apps/app/src/pages/movies.tsx`**
+
+Top of file (imports) — add `definePage` to the iso import; the `loader as moviesLoader` import is renamed to `loader` since we no longer need to disambiguate against the inner Movie loader (we no longer pass it through Route). The `loader` and `cache` value-imports stay (they're used in the `definePage` call):
+
+Replace:
+```tsx
+import {
+  cacheRegistry,
+  lazy,
+  Route,
+  Router,
+  useLoaderData,
+  useOptimisticAction,
+  type WrapperProps,
+} from '@hono-preact/iso';
+import type { FunctionComponent } from 'preact';
+import type { MovieSummary } from '@/server/data/movies.js';
+import { loader as movieLoader } from './movie.server.js';
+import { loader as moviesLoader, serverActions } from './movies.server.js';
+import Noop from './noop.js';
+```
+
+with:
+```tsx
+import {
+  cacheRegistry,
+  definePage,
+  lazy,
+  Route,
+  Router,
+  useLoaderData,
+  useOptimisticAction,
+} from '@hono-preact/iso';
+import type { FunctionComponent } from 'preact';
+import type { MovieSummary } from '@/server/data/movies.js';
+import { loader, cache, serverActions } from './movies.server.js';
+import Noop from './noop.js';
+```
+
+Then remove the `MovieWrapper` component declaration and its usage in the nested `<Route>` (the wrapper moves to `movie.tsx` in the next step):
+
+Remove:
+```tsx
+function MovieWrapper(props: WrapperProps) {
+  return <article {...props} />;
+}
+```
+
+Update `useLoaderData` call:
+
+Replace:
+```tsx
+const { movies, watchedIds } = useLoaderData(moviesLoader);
+```
+
+with:
+```tsx
+const { movies, watchedIds } = useLoaderData<typeof loader>();
+```
+
+Update the nested `<Router>` block — the inner `<Route>` no longer takes `loader`/`Wrapper` props:
+
+Replace:
+```tsx
+<Router>
+  <Route path="/:id" component={Movie} loader={movieLoader} Wrapper={MovieWrapper} />
+  <Noop />
+</Router>
+```
+
+with:
+```tsx
+<Router>
+  <Route path="/:id" component={Movie} />
+  <Noop />
+</Router>
+```
+
+Replace the default export:
+
+```tsx
+export default Movies;
+```
+
+with:
+
+```tsx
+export default definePage(Movies, { loader, cache });
+```
+
+- [ ] **Step 2: Update `apps/app/src/pages/movie.tsx`**
+
+Top of file — add `definePage` and `cache`-imports (movie has only `loader`, no `cache` in `movie.server.ts`; verify):
+
+```bash
+grep "export const cache" apps/app/src/pages/movie.server.ts
+```
+
+If no `cache` export exists, omit it from the bindings. Otherwise, include it.
+
+Add the `MovieWrapper` declaration that previously lived in `movies.tsx`:
+
+```tsx
+import {
+  cacheRegistry,
+  definePage,
+  Form,
+  useAction,
+  useLoaderData,
+  useOptimisticAction,
+  useReload,
+  type WrapperProps,
+} from '@hono-preact/iso';
+import type { ComponentType, FunctionComponent } from 'preact';
+import { loader, serverActions } from './movie.server.js';
+
+function MovieWrapper(props: WrapperProps) {
+  return <article {...props} />;
+}
+```
+
+Update `useLoaderData`:
+
+Replace:
+```tsx
+const { movie, watched } = useLoaderData(movieLoader);
+```
+
+with:
+```tsx
+const { movie, watched } = useLoaderData<typeof loader>();
+```
+
+Replace the default export:
+
+```tsx
+export default MovieDetail;
+```
+
+with:
+
+```tsx
+export default definePage(MovieDetail, { loader, Wrapper: MovieWrapper });
+```
+
+(Remove the `import { loader as movieLoader }` rename if present — use `loader` directly.)
+
+- [ ] **Step 3: Update `apps/app/src/pages/watched.tsx`**
+
+Top of file — add `definePage`, drop the `as`-rename:
+
+Replace:
+```tsx
+import {
+  cacheRegistry,
+  useAction,
+  useLoaderData,
+  useReload,
+} from '@hono-preact/iso';
+import type { FunctionComponent } from 'preact';
+import { useState } from 'preact/hooks';
+import {
+  serverActions,
+  loader as watchedLoader,
+} from './watched.server.js';
+```
+
+with:
+```tsx
+import {
+  cacheRegistry,
+  definePage,
+  useAction,
+  useLoaderData,
+  useReload,
+} from '@hono-preact/iso';
+import type { FunctionComponent } from 'preact';
+import { useState } from 'preact/hooks';
+import { cache, loader, serverActions } from './watched.server.js';
+```
+
+Update `useLoaderData`:
+
+Replace:
+```tsx
+const { entries } = useLoaderData(watchedLoader);
+```
+
+with:
+```tsx
+const { entries } = useLoaderData<typeof loader>();
+```
+
+Replace the default export:
+
+```tsx
+export default WatchedPage;
+```
+
+with:
+
+```tsx
+export default definePage(WatchedPage, { loader, cache });
+```
+
+- [ ] **Step 4: Update `apps/app/src/iso.tsx`**
+
+Replace contents of the central route table — drop all `.server.js` imports and all `loader=`/`cache=` props. Keep `fallback` props (route-level).
+
+Full new contents of `apps/app/src/iso.tsx`:
+
+```tsx
+import type { ComponentType, FunctionComponent } from 'preact';
+import { flushSync } from 'preact/compat';
+import { lazy, Route, Router } from '@hono-preact/iso';
+import { Route as IsoRoute } from 'preact-iso';
+import NotFound from './pages/not-found.js';
+
+const Home = lazy(() => import('./pages/home.js'));
+const Test = lazy(() => import('./pages/test.js'));
+const Movies = lazy(() => import('./pages/movies.js'));
+const Watched = lazy(() => import('./pages/watched.js'));
+
+const mdxModules = import.meta.glob('./pages/docs/*.mdx');
+const mdxRoutes = Object.entries(mdxModules).map(([filePath, load]) => {
+  const route = ('/docs' + filePath.replace('./pages/docs', '').replace('.mdx', ''))
+    .replace(/\/index$/, '') || '/docs';
+  const Component = lazy(async () => {
+    const [mod, { DocsLayout }] = await Promise.all([
+      (load as () => Promise<{ default: ComponentType }>)(),
+      import('./components/DocsLayout.js'),
+    ]);
+    const MDX = mod.default;
+    const Wrapped: ComponentType = (props) => <DocsLayout><MDX {...props} /></DocsLayout>;
+    return { default: Wrapped };
+  });
+  return { route, Component };
+});
+
+function onRouteChange() {
+  if (!document.startViewTransition) return;
+  document.startViewTransition(() => flushSync(() => {}));
+}
+
+export const Base: FunctionComponent = () => {
+  return (
+    <Router onRouteChange={onRouteChange}>
+      <Route path="/" component={Home} />
+      <Route path="/test" component={Test} />
+      <Route path="/movies" component={Movies} />
+      <Route path="/movies/*" component={Movies} />
+      <Route
+        path="/watched"
+        component={Watched}
+        fallback={<p class="p-1">Loading watched list…</p>}
+      />
+      {mdxRoutes.map(({ route, Component }) => (
+        <IsoRoute path={route} component={Component} />
+      ))}
+      <NotFound />
+    </Router>
+  );
+};
+```
+
+- [ ] **Step 5: Build and TypeScript-check the app**
+
+```bash
+pnpm --filter app build
+```
+
+Expected: clean build. If the build fails for unused-import reasons (e.g., a leftover `WrapperProps` import), drop the import.
+
+```bash
+cd apps/app && npx tsc --noEmit && cd -
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Run the full repo test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all green. The iso package tests pass from previous tasks; the app build is clean.
+
+- [ ] **Step 7: Dev-server smoke test**
+
+```bash
+pnpm dev > /tmp/dev.log 2>&1 &
+sleep 6
+for path in / /test /movies /movies/1241982 /watched /docs /docs/quick-start; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:5173$path")
+  bytes=$(curl -s "http://localhost:5173$path" | wc -c)
+  echo "$path → HTTP $status, $bytes bytes"
+done
+pkill -f "vite --force" 2>/dev/null || true
+```
+
+Expected: every route returns HTTP 200 with substantial content (>1 KB).
+
+- [ ] **Step 8: Manual browser smoke test**
+
+Open `http://localhost:5173/movies`, then click into a movie, click "Mark watched", click "Refresh." DevTools console must be free of `ReferenceError`, `useLoaderData must be called inside…` errors, and 500s.
+
+Specifically verify:
+- Initial load — page renders with movies list.
+- Click a movie → /movies/:id loads, MovieWrapper's `<article>` element wraps the page (inspect DOM).
+- "Mark watched" optimistic update fires + reload completes without console error.
+- Navigate to /watched — page renders with entries; bulk-import streaming still works.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/app/src/pages/movies.tsx apps/app/src/pages/movie.tsx apps/app/src/pages/watched.tsx apps/app/src/iso.tsx
+git commit -m "refactor(app): migrate pages to definePage, drop .server.* imports from iso.tsx"
+```
+
+---
+
+## Task 6: Update docs MDX
+
+**Why:** The MDX docs in `apps/app/src/pages/docs/*.mdx` describe the old `useLoaderData(ref)` and `<Route loader={...}>` patterns. After Task 5 these are wrong.
+
+**Files:**
+- Modify: each MDX file in `apps/app/src/pages/docs/` that mentions `useLoaderData(` or `<Route` with a `loader=` prop.
+
+- [ ] **Step 1: Find every doc reference to the old patterns**
+
+```bash
+grep -rln "useLoaderData(" apps/app/src/pages/docs/
+grep -rln "loader=" apps/app/src/pages/docs/
+grep -rln "Wrapper=" apps/app/src/pages/docs/
+```
+
+The expected hit list (from initial exploration) includes: `index.mdx`, `quick-start.mdx`, `loaders.mdx`, `actions.mdx`, `optimistic-ui.mdx`, `reloading.mdx`, `guards.mdx`, `structure.mdx`.
+
+- [ ] **Step 2: Update each file's code samples**
+
+For every code block:
+- `useLoaderData(loaderRef)` → `useLoaderData<typeof loaderRef>()` (with a comment explaining the type-only style if it aids comprehension)
+- `<Route ... loader={x}>` → `<Route ... component={x}>` and a sibling sample showing `definePage(Component, { loader, cache })`
+- `<Route ... Wrapper={x}>` → fold into `definePage`
+
+Also update prose text where it describes the API. Aim for accuracy over surgical minimalism — if a paragraph discusses the old refId check, rewrite it; do not leave stale guidance.
+
+Add a short section to `loaders.mdx` (or wherever route-level concepts are introduced) titled "Page bindings with `definePage`" that documents:
+- `definePage(Component, { loader, cache, Wrapper })`
+- bindings live with the page, not with `<Route>`
+- argument-free `useLoaderData<typeof loader>()` pattern
+- nested routers: bindings always live with the page being mounted
+
+Cross-check the resulting MDX renders by running `pnpm dev` and visiting `/docs/loaders` etc. (already covered by Task 5 step 7).
+
+- [ ] **Step 3: Run the test suite once more**
+
+```bash
+pnpm test
+```
+
+Expected: green.
+
+- [ ] **Step 4: Build the app**
+
+```bash
+pnpm --filter app build
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/app/src/pages/docs/
+git commit -m "docs: update for definePage and argument-free useLoaderData"
+```
+
+---
+
+## Task 7: Final verification
+
+**Why:** The same kind of holistic check the previous reviewer did before merging. No code changes — verification only.
+
+- [ ] **Step 1: Clean working tree + full test run**
+
+```bash
+git status                            # clean
+pnpm test                             # all green
+pnpm --filter app build               # clean
+cd apps/app && npx tsc --noEmit && cd -  # clean
+```
+
+- [ ] **Step 2: Inspect client bundles for `.server.ts` content (no leak regression)**
+
+The `serverOnlyPlugin` should still strip every `.server.*` import from client bundles. Quick sanity:
+
+```bash
+grep -r "Moana 2" apps/app/dist/static/ 2>/dev/null && echo "LEAK" || echo "OK: TMDB seed not in client"
+grep -r "markWatched" apps/app/dist/static/ 2>/dev/null && echo "LEAK" || echo "OK: markWatched not in client"
+grep -r "listWatched" apps/app/dist/static/ 2>/dev/null && echo "LEAK" || echo "OK: listWatched not in client"
+```
+
+Expected: all "OK".
+
+- [ ] **Step 3: Inspect a page chunk for `definePage`**
+
+```bash
+grep -l "PAGE_BINDINGS\|@hono-preact/iso/page-bindings" apps/app/dist/static/*.js | head -5
+```
+
+Expected: at least one file matches — the page chunks should reference the symbol by realm key.
+
+- [ ] **Step 4: Manual smoke test in a real browser**
+
+Open `http://localhost:5173/` after `pnpm dev`. Click through:
+- `/` (Home) — renders, no loader
+- `/movies` — list loads, "Mark watched" works
+- `/movies/:id` — detail page, MovieWrapper `<article>` is in the DOM, notes form submits, photo upload works
+- `/watched` — list, bulk-import streaming progresses
+- `/docs/loaders` — doc page renders the new examples
+
+DevTools console must be free of any `useLoaderData` errors or `ReferenceError`s.
+
+- [ ] **Step 5: Open the PR**
+
+Suggested title: `feat(iso): page-owned route bindings via definePage`
+
+Body should link the spec at `docs/superpowers/specs/2026-04-30-define-page-design.md` and summarize the breaking-change shape:
+- `<Route>` no longer accepts `loader`/`cache`/`Wrapper` props (call sites migrate to `definePage`).
+- `useLoaderData(ref)` → `useLoaderData<typeof ref>()` (argument-free).
+- `lazy()` is now exported from `@hono-preact/iso`'s own wrapper (still re-exports preact-iso behavior for component rendering).
+
+---
+
+## Out of scope (NOT in this plan)
+
+- **Generated route types** for `useLoaderData()` to infer without `<typeof loader>`. Spec explicitly defers; revisit when the migration has soaked.
+- **Auto-pairing of `.tsx` and `.server.ts` files** via Vite. Rejected during brainstorming.
+- **Nested-router cleanup** (the duplicate `<Route path="/movies">` and `<Route path="/movies/*">` declarations). Separate concern.
+- **Migrating `serverGuards`/`clientGuards`/`actionGuards` into `definePage`.** They could plausibly move; deferred.
+- **Backward-compat shim** for `<Route loader={x}>`. Single-commit cutover; no compat layer.

--- a/docs/superpowers/specs/2026-04-30-define-page-design.md
+++ b/docs/superpowers/specs/2026-04-30-define-page-design.md
@@ -1,0 +1,276 @@
+# `definePage`: Page-Owned Route Bindings
+
+**Date:** 2026-04-30
+**Status:** Draft
+
+## Problem
+
+`iso.tsx` grows linearly with the route count, and each new page costs three lines of central-registry boilerplate:
+
+```tsx
+import { loader as moviesLoader, cache as moviesCache } from './pages/movies.server.js';
+const Movies = lazy(() => import('./pages/movies.js'));
+<Route path="/movies" component={Movies} loader={moviesLoader} cache={moviesCache} />
+```
+
+The friction is concrete:
+
+- A named import per `.server.ts`, with `as`-rename to avoid identifier collisions across pages.
+- `loader=`/`cache=`/`Wrapper=` props plumbed through `<Route>` per route declaration.
+- The `.server.ts` file is referenced from two places (the page component for actions, and `iso.tsx` for the loader/cache binding) — duplicated knowledge of which page goes with which server file.
+
+The page component file is also impure: it must import the loader as a runtime value (`useLoaderData(loader)`) so that `<Route>` and the page agree on which loader is in scope.
+
+We want the route table in `iso.tsx` to deal in *paths and components only*, the page file to *own its data and rendering bindings*, and the page component itself to be *purely presentational* — no runtime imports of the loader ref.
+
+We are explicitly **not** moving to file-based routing. The path table stays declarative and central in `iso.tsx`.
+
+## Goal
+
+A single helper, `definePage`, lets a page module bind its loader/cache/Wrapper directly to the component it exports as default. `<Route>` introspects the resolved component for these bindings; `iso.tsx` no longer imports anything from `*.server.ts` files.
+
+`useLoaderData()` becomes argument-free and reads from the nearest loader context. Type narrowing comes from a type-only import: `useLoaderData<typeof loader>()`.
+
+The two-stage suspense (lazy chunk first, then loader RPC) is accepted as the cost of co-locating the binding with the component. Prefetch-on-hover (already supported by the framework) is the mitigation that makes the cold-navigation latency acceptable in practice.
+
+## Target Shape
+
+```ts
+// movies.server.ts — server-only module (Vite plugin stubs to RPC on client)
+const serverLoader = async () => ({ movies: await getMovies() });
+export default serverLoader;
+
+export const loader = defineLoader('movies', serverLoader);
+export const cache = createCache('movies');
+export const serverActions = { /* unchanged */ };
+```
+
+```tsx
+// movies.tsx — pure component, owns its bindings via the default export
+import { definePage, useLoaderData } from '@hono-preact/iso';
+import { loader, cache } from './movies.server.js';
+
+function Movies() {
+  const { movies } = useLoaderData<typeof loader>();
+  return <ul>{movies.map((m) => <li key={m.id}>{m.title}</li>)}</ul>;
+}
+
+export default definePage(Movies, { loader, cache });
+```
+
+```tsx
+// movies.tsx — variant with a custom Wrapper
+import { definePage } from '@hono-preact/iso';
+import { loader, cache } from './movie.server.js';
+
+function Movie() { /* ... */ }
+function MovieWrapper(props) { return <article {...props} />; }
+
+export default definePage(Movie, { loader, cache, Wrapper: MovieWrapper });
+```
+
+```tsx
+// iso.tsx — paths and lazy component refs only
+import { lazy, Route, Router } from '@hono-preact/iso';
+import NotFound from './pages/not-found.js';
+
+const Home = lazy(() => import('./pages/home.js'));
+const Movies = lazy(() => import('./pages/movies.js'));
+const Watched = lazy(() => import('./pages/watched.js'));
+
+export const Base = () => (
+  <Router>
+    <Route path="/" component={Home} />
+    <Route path="/movies" component={Movies} />
+    <Route path="/movies/*" component={Movies} />
+    <Route
+      path="/watched"
+      component={Watched}
+      fallback={<p class="p-1">Loading watched list…</p>}
+    />
+    {/* mdx routes omitted — unchanged */}
+    <NotFound />
+  </Router>
+);
+```
+
+## Components
+
+### 1. `definePage` helper (new)
+
+**File:** `packages/iso/src/define-page.ts`
+**Export:** added to `packages/iso/src/index.ts`
+
+```ts
+import type { ComponentType } from 'preact';
+import type { LoaderRef } from './define-loader.js';
+import type { LoaderCache } from './cache.js';
+import type { WrapperProps } from './page.js';
+
+export type PageBindings<T> = {
+  loader?: LoaderRef<T>;
+  cache?: LoaderCache<T>;
+  Wrapper?: ComponentType<WrapperProps>;
+};
+
+export const PAGE_BINDINGS = Symbol.for('@hono-preact/iso/page-bindings');
+
+export type PageComponent<T> = ComponentType & {
+  [PAGE_BINDINGS]?: PageBindings<T>;
+};
+
+export function definePage<T>(
+  Component: ComponentType,
+  bindings?: PageBindings<T>
+): PageComponent<T> {
+  if (bindings) {
+    (Component as PageComponent<T>)[PAGE_BINDINGS] = bindings;
+  }
+  return Component as PageComponent<T>;
+}
+```
+
+`definePage` *mutates* the passed component to attach the bindings under a realm-wide symbol (`Symbol.for(...)`) so duplicate module copies (HMR, pnpm phantom deps) still match. The function returns the same component reference — there is no wrapper, no extra render layer.
+
+Pages with no bindings (`Home`, `Test`, `NotFound`) **do not call `definePage`** at all. The framework treats absence of `[PAGE_BINDINGS]` as "no loader, no cache, default Wrapper." This avoids paying a function call for nothing.
+
+### 2. `<Route>` introspection (changed)
+
+**File:** `packages/iso/src/route.tsx`
+
+`<Route>` keeps its current marker-component shape and still drops `loader`/`cache`/`Wrapper` from its prop surface — those move to `definePage`. The Route prop surface becomes:
+
+```ts
+export type RouteProps = {
+  path: string;
+  component: ComponentType;
+  fallback?: JSX.Element;             // route-level — kept on Route, not on page
+  errorFallback?: PageProps['errorFallback'];  // route-level
+  serverGuards?: GuardFn[];           // unchanged
+  clientGuards?: GuardFn[];           // unchanged
+};
+```
+
+`<Router>`'s transform of `<Route>` children no longer reads `loader`/`cache`/`Wrapper` from `<Route>` props. Instead, `wrapWithPage` produces a route handler that:
+
+1. Resolves the lazy component (suspends while the chunk loads — this is the existing preact-iso `lazy` behavior).
+2. Reads `[PAGE_BINDINGS]` off the resolved component.
+3. Renders `<Page loader={bindings.loader} cache={bindings.cache} Wrapper={bindings.Wrapper} fallback={routeFallback} ...>`.
+
+Since `lazy()` only exposes the resolved value mid-render (via Suspense), the practical implementation is a small `<PageBoundary>` component that does the lookup at render time after `<Component />` has resolved. The implementation may extend or wrap `lazy()` to expose a thenable for the bindings; the choice is left to the implementation plan.
+
+For non-lazy components, `[PAGE_BINDINGS]` is readable synchronously and the lookup is a no-op cost.
+
+`fallback` stays on `<Route>` because the same component can be mounted at two paths with different fallbacks (e.g. `/movies` and `/movies/*`) and a page-level fallback would force them to coincide.
+
+### 3. `useLoaderData()` argument-free (changed)
+
+**File:** `packages/iso/src/use-loader-data.ts`
+
+```ts
+import { useContext } from 'preact/hooks';
+import { LoaderDataContext } from './contexts.js';
+import type { LoaderRef } from './define-loader.js';
+
+export function useLoaderData<L>(): L extends LoaderRef<infer T> ? T : L {
+  const ctx = useContext(LoaderDataContext);
+  if (!ctx) {
+    throw new Error('useLoaderData must be called inside a <Loader> (i.e. a route page with a loader)');
+  }
+  return ctx.data as never;
+}
+```
+
+The runtime ref-identity check (`ctx.refId !== ref.__id`) is removed. The hook reads the nearest loader context's data and returns it. Callers narrow the type with `useLoaderData<typeof loader>()` using a type-only import — `L` resolves to `LoaderRef<T>`, the conditional unwraps `T`. If a caller passes a non-`LoaderRef` type (`useLoaderData<MyData>()`), `L` is returned as-is — so hand-written data types work too.
+
+The dropped runtime check is a small safety regression, accepted: the practical case it caught (using the wrong ref) is rare, and the type system catches the same class of bug at compile time.
+
+### 4. `LoaderDataContext.refId` (removed)
+
+**File:** `packages/iso/src/contexts.ts`, `packages/iso/src/loader.tsx`
+
+Today `LoaderDataContext` carries `{ refId, data }` so `useLoaderData(ref)` can verify the ref matches the data. With ref-free `useLoaderData()`, `refId` is unused. Drop it from the context shape; `<Loader>` only provides `{ data }`. This is purely internal — no public API change beyond `useLoaderData`.
+
+### 5. Vite plugin: no change
+
+**File:** `packages/vite/src/server-only.ts`
+
+The plugin already stubs `loader`, `cache`, and `serverActions` named imports from `*.server.*`. No new specifiers are introduced by this design. `definePage` lives in `@hono-preact/iso` (a regular client package), so the page file imports it as a normal value.
+
+### 6. Server / SSR behavior: no change
+
+**Files:** `packages/server/src/loaders-handler.ts`, `packages/server/src/render.tsx`
+
+Server-side loader dispatch still keys off the `module` field in the RPC body and reads the default export of the matched `.server.ts`. `definePage` is a client-side concern that attaches metadata to a *component* — it does not interact with the server's module map.
+
+During SSR, `<Route>` introspection works identically to client-side: the resolved page component is walked for `[PAGE_BINDINGS]` and the loader is invoked directly (not via RPC) before render.
+
+### 7. Nested routers
+
+Nested `<Router>` blocks (e.g. the inner `<Router>` inside `movies.tsx` that mounts `/movies/:id`) are unaffected. `<Router>` and `<Route>` keep their semantics; only the source of bindings changes. A nested route declaration goes from:
+
+```tsx
+// today, inside movies.tsx
+const Movie = lazy(() => import('./movie.js'));
+function MovieWrapper(props) { return <article {...props} />; }
+
+<Router>
+  <Route path="/:id" component={Movie} loader={movieLoader} Wrapper={MovieWrapper} />
+  <Noop />
+</Router>
+```
+
+to:
+
+```tsx
+// after, inside movies.tsx
+const Movie = lazy(() => import('./movie.js'));
+
+<Router>
+  <Route path="/:id" component={Movie} />
+  <Noop />
+</Router>
+```
+
+`MovieWrapper` and the loader/cache bindings move into `movie.tsx`'s `definePage` call. This is a coherence win independent of the convenience: `MovieWrapper` describes how the Movie page wraps *itself* — it was always page-internal, and today's arrangement leaks that concern into whichever parent happens to mount it.
+
+Two- and three-level nesting follow the same pattern; bindings always live with the page being mounted, never with the route declaration that mounts it.
+
+### 8. App migration
+
+**Files:** every `apps/app/src/pages/*.tsx` that currently calls `useLoaderData(loaderRef)`, plus `apps/app/src/iso.tsx`.
+
+Per page:
+- Import `definePage` from `@hono-preact/iso`.
+- Replace the bare `export default Movies` with `export default definePage(Movies, { loader, cache });` (and `Wrapper` where applicable).
+- Convert `useLoaderData(loaderRef)` to `useLoaderData<typeof loader>()`. The value-imports of `loader`/`cache` remain for the `definePage` call; the page no longer needs to thread the ref through `useLoaderData`.
+
+Pages with no loader (`home.tsx`, `test.tsx`, `not-found.tsx`) need no changes.
+
+In `iso.tsx`:
+- Drop every `import { loader as ..., cache as ... } from './pages/*.server.js'`.
+- Drop every `loader=`/`cache=`/`Wrapper=` prop on `<Route>`.
+
+Movie detail page (`movie.tsx`) currently passes `Wrapper={MovieWrapper}` from `movies.tsx`'s nested `<Router>`. The `Wrapper` moves into `movie.tsx`'s `definePage` call.
+
+## Trade-offs Accepted
+
+1. **Lazy chunk fetch precedes loader RPC.** Total navigation work is now `chunk + loader` instead of `max(chunk, loader)`. Mitigated by prefetch-on-hover. Conventional for any framework that co-locates data needs with components (Astro, RSC).
+
+2. **Lost runtime ref-identity check in `useLoaderData`.** The check today catches "you passed the wrong loader ref to `useLoaderData`." With argument-free `useLoaderData`, the type system replaces the runtime check. Low impact.
+
+3. **`definePage` mutates its argument.** Attaching the bindings symbol to the component itself avoids a wrapper component (no extra render layer) but does mean the function has a side-effect on its input. Documented as part of the API. Calling `definePage(Component)` more than once is idempotent (same bindings overwritten); calling it on the same component with different bindings would replace them — practical risk is negligible since each component is defined and bound in one file.
+
+## Out of Scope
+
+- **Generated route types.** Per-route type augmentation (so `useLoaderData()` infers without `<typeof loader>`) is deferred. The user is movable on this for future work, but it requires codegen machinery that is heavier than the gain.
+- **`fallback` migration into `definePage`.** Considered and rejected — same component at two paths can want different fallbacks. Stays on `<Route>`.
+- **Auto-pairing of `.tsx`/`.server.ts` files via Vite.** Considered as a way to elide the `import { loader, cache }` line in the page file. Rejected as filesystem-pair magic adjacent to file-based routing, which the user has chosen to avoid.
+- **Eliminating the duplicate `<Route path="/movies">` and `<Route path="/movies/*">` declarations.** A real nested-router pattern (`<Route path="/movies"><Route path=":id" .../></Route>`) is a separate concern from page-binding ownership and would warrant its own design.
+- **`serverGuards`/`clientGuards`/`actionGuards` migration into `definePage`.** They could plausibly move; deferred to a follow-up if the pattern proves out.
+- **Backward compatibility shim.** `<Route loader={x} cache={y}>` props are removed in this change; pages migrate in the same commit. There is no parallel-old-and-new API window.
+
+## Open Implementation Questions (for the plan, not this spec)
+
+- Exact mechanism for reading `[PAGE_BINDINGS]` off a lazy component — extend `lazy()`, wrap it, or peek at the resolved value during the `<PageBoundary>` render. The implementer chooses.
+- Whether to preserve a development-mode warning when a `<Route>` references a component without `[PAGE_BINDINGS]` *and* without an explicit "this page has no loader" marker. Probably no — absence is unambiguous and warning would be noise for `Home`/`Test`/`NotFound`.

--- a/packages/iso/src/__tests__/define-loader.test.ts
+++ b/packages/iso/src/__tests__/define-loader.test.ts
@@ -19,8 +19,8 @@ describe('defineLoader', () => {
     const a = defineLoader('movies', async () => ({}));
     const b = defineLoader('movies', async () => ({}));
     // Same name produces the same registered symbol, even across distinct
-    // defineLoader call sites. This protects useLoaderData(refId === ref.__id)
-    // when a consumer ends up importing two copies of the same .server.* module.
+    // defineLoader call sites. This ensures stable loader identity for prefetch
+    // and cache keying when a consumer imports two copies of the same .server.* module.
     expect(a.__id).toBe(b.__id);
     expect(typeof Symbol.keyFor(a.__id)).toBe('string');
     expect(Symbol.keyFor(a.__id)).toBe('@hono-preact/loader:movies');

--- a/packages/iso/src/__tests__/define-page.test.ts
+++ b/packages/iso/src/__tests__/define-page.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { definePage, PAGE_BINDINGS, type PageComponent } from '../define-page.js';
+import { defineLoader } from '../define-loader.js';
+import { createCache } from '../cache.js';
+
+describe('definePage', () => {
+  it('attaches bindings under the realm-wide PAGE_BINDINGS symbol', () => {
+    const fn = async () => ({ msg: 'ok' });
+    const loader = defineLoader<{ msg: string }>('define-page-test-1', fn);
+    const cache = createCache<{ msg: string }>('define-page-test-1');
+    const Inner = () => null;
+
+    const Wrapped = definePage(Inner, { loader, cache });
+
+    expect(Wrapped).toBe(Inner);
+    expect((Wrapped as PageComponent<{ msg: string }>)[PAGE_BINDINGS]).toEqual({
+      loader,
+      cache,
+    });
+  });
+
+  it('uses Symbol.for for cross-module identity', () => {
+    expect(PAGE_BINDINGS).toBe(Symbol.for('@hono-preact/iso/page-bindings'));
+  });
+
+  it('returns the same component reference (no wrapper)', () => {
+    const Inner = () => null;
+    const Wrapped = definePage(Inner);
+    expect(Wrapped).toBe(Inner);
+  });
+
+  it('treats omitted bindings as no-op (no symbol attached)', () => {
+    const Inner = () => null;
+    definePage(Inner);
+    expect((Inner as PageComponent<unknown>)[PAGE_BINDINGS]).toBeUndefined();
+  });
+
+  it('replaces previously-attached bindings if called twice on the same component', () => {
+    const fn1 = async () => ({ a: 1 });
+    const fn2 = async () => ({ b: 2 });
+    const loader1 = defineLoader('define-page-test-replace-1', fn1);
+    const loader2 = defineLoader('define-page-test-replace-2', fn2);
+    const Inner = () => null;
+
+    definePage(Inner, { loader: loader1 });
+    definePage(Inner, { loader: loader2 });
+
+    expect((Inner as PageComponent<unknown>)[PAGE_BINDINGS]).toEqual({
+      loader: loader2,
+    });
+  });
+
+  it('accepts a Wrapper component in bindings', () => {
+    const Inner = () => null;
+    const Wrapper = (props: { children: unknown }) =>
+      props.children as never;
+
+    const Wrapped = definePage(Inner, { Wrapper });
+
+    expect((Wrapped as PageComponent<unknown>)[PAGE_BINDINGS]).toEqual({
+      Wrapper,
+    });
+  });
+});

--- a/packages/iso/src/__tests__/envelope.test.tsx
+++ b/packages/iso/src/__tests__/envelope.test.tsx
@@ -16,10 +16,9 @@ afterEach(() => {
 
 describe('<Envelope> data-loader serialization', () => {
   it('serializes undefined data as null (not the literal "undefined")', () => {
-    const refId = Symbol('test');
     const { container } = render(
       <LoaderIdContext.Provider value="loader-1">
-        <LoaderDataContext.Provider value={{ refId, data: undefined }}>
+        <LoaderDataContext.Provider value={{ data: undefined }}>
           <Envelope>
             <span>child</span>
           </Envelope>
@@ -31,10 +30,9 @@ describe('<Envelope> data-loader serialization', () => {
   });
 
   it('serializes regular data as JSON', () => {
-    const refId = Symbol('test');
     const { container } = render(
       <LoaderIdContext.Provider value="loader-2">
-        <LoaderDataContext.Provider value={{ refId, data: { msg: 'hi' } }}>
+        <LoaderDataContext.Provider value={{ data: { msg: 'hi' } }}>
           <Envelope>
             <span>child</span>
           </Envelope>

--- a/packages/iso/src/__tests__/lazy.test.tsx
+++ b/packages/iso/src/__tests__/lazy.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { lazy } from '../lazy.js';
+
+describe('lazy() wrapper', () => {
+  it('returns a component with preload() that resolves to the module', async () => {
+    const Mod = { default: () => null, marker: 'movies-mod' };
+    const Lazy = lazy(async () => Mod);
+    const m = await Lazy.preload();
+    expect(m).toBe(Mod);
+  });
+
+  it('returns null from getResolvedDefault before preload', () => {
+    const Lazy = lazy(async () => ({ default: () => null }));
+    expect(Lazy.getResolvedDefault()).toBeNull();
+  });
+
+  it('returns the resolved default after preload completes', async () => {
+    const Inner = () => null;
+    const Lazy = lazy(async () => ({ default: Inner }));
+    await Lazy.preload();
+    expect(Lazy.getResolvedDefault()).toBe(Inner);
+  });
+
+  it('also handles modules whose export is the component itself (no default key)', async () => {
+    // preact-iso's lazy supports `m.default || m` — preserve that behavior.
+    const Inner = () => null;
+    const Lazy = lazy(async () => Inner as unknown as { default: typeof Inner });
+    await Lazy.preload();
+    expect(Lazy.getResolvedDefault()).toBe(Inner);
+  });
+
+  it('preload() returns the same promise on repeated calls', () => {
+    const Lazy = lazy(async () => ({ default: () => null }));
+    const p1 = Lazy.preload();
+    const p2 = Lazy.preload();
+    expect(p1).toBe(p2);
+  });
+});

--- a/packages/iso/src/__tests__/loader.test.tsx
+++ b/packages/iso/src/__tests__/loader.test.tsx
@@ -40,7 +40,7 @@ describe('v3 <Loader> stability', () => {
     const ref = defineLoader<{ msg: string }>('refire-test', fn);
 
     function Child() {
-      const { msg } = useLoaderData(ref);
+      const { msg } = useLoaderData<typeof ref>();
       const { reload } = useReload();
       return (
         <div>
@@ -89,7 +89,7 @@ describe('v3 <Loader> stability', () => {
     const ref = defineLoader<{ msg: string }>('preserve-state-test', fn);
 
     function Child() {
-      const { msg } = useLoaderData(ref);
+      const { msg } = useLoaderData<typeof ref>();
       const { reload } = useReload();
       const [count, setCount] = useState(0);
       return (
@@ -159,7 +159,7 @@ describe('v3 <Loader> stability', () => {
     const ref = defineLoader<{ msg: string }>('dup-xhr-test', fn);
 
     function Child() {
-      const { msg } = useLoaderData(ref);
+      const { msg } = useLoaderData<typeof ref>();
       return <span data-testid="msg">{msg}</span>;
     }
 
@@ -233,7 +233,7 @@ describe('v3 <Loader> stability', () => {
     }
 
     function Child() {
-      const { msg } = useLoaderData(ref);
+      const { msg } = useLoaderData<typeof ref>();
       return <span data-testid="msg">{msg}</span>;
     }
 
@@ -276,7 +276,7 @@ describe('v3 <Loader> stability', () => {
     const ref = defineLoader<{ q: string }>('search-q-test', fn);
 
     function Child() {
-      const { q } = useLoaderData(ref);
+      const { q } = useLoaderData<typeof ref>();
       return <span data-testid="q">{q || '(empty)'}</span>;
     }
 

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -8,6 +8,8 @@ import { defineLoader } from '../define-loader.js';
 import { Route, Router, wrapWithPage } from '../route.js';
 import { useLoaderData } from '../use-loader-data.js';
 import { env } from '../is-browser.js';
+import { definePage } from '../define-page.js';
+import { lazy } from '../lazy.js';
 
 vi.mock('../preload.js', () => ({
   getPreloadedData: vi.fn(() => null),
@@ -48,10 +50,11 @@ describe('wrapWithPage', () => {
     const fn = vi.fn(async () => ({ msg: 'ok' }));
     const ref = defineLoader<{ msg: string }>('wrap-with-page-test', fn);
     const Inner = () => {
-      const { msg } = useLoaderData(ref);
+      const { msg } = useLoaderData<typeof ref>();
       return <p data-testid="msg">{msg}</p>;
     };
-    const Wrapped = wrapWithPage(Inner, { loader: ref });
+    const Page = definePage(Inner, { loader: ref });
+    const Wrapped = wrapWithPage(Page, {});
     render(
       <LocationProvider>
         <Wrapped {...loc} />
@@ -68,15 +71,16 @@ describe('<Router> + <Route>', () => {
     const fn = vi.fn(async () => ({ msg: 'foo-data' }));
     const ref = defineLoader<{ msg: string }>('router-route-test', fn);
     const Foo = () => {
-      const { msg } = useLoaderData(ref);
+      const { msg } = useLoaderData<typeof ref>();
       return <p data-testid="foo">{msg}</p>;
     };
+    const Page = definePage(Foo, { loader: ref });
 
     window.history.pushState({}, '', '/foo');
     render(
       <LocationProvider>
         <Router>
-          <Route path="/foo" component={Foo} loader={ref} />
+          <Route path="/foo" component={Page} />
         </Router>
       </LocationProvider>
     );
@@ -120,6 +124,71 @@ describe('<Router> + <Route>', () => {
     );
 
     expect(screen.queryByTestId('foo')).toBeNull();
+  });
+
+  it('reads loader/cache/Wrapper from PAGE_BINDINGS on the component', async () => {
+    const fn = vi.fn(async () => ({ msg: 'page-data' }));
+    const ref = defineLoader<{ msg: string }>('page-bindings-test', fn);
+
+    const Inner = () => {
+      const { msg } = useLoaderData<typeof ref>();
+      return <p data-testid="page">{msg}</p>;
+    };
+    const Wrapped = definePage(Inner, { loader: ref });
+
+    window.history.pushState({}, '', '/page');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/page" component={Wrapped} />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('page');
+    expect(el).toHaveTextContent('page-data');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads PAGE_BINDINGS off a lazy component once resolved', async () => {
+    const fn = vi.fn(async () => ({ msg: 'lazy-data' }));
+    const ref = defineLoader<{ msg: string }>('page-bindings-lazy-test', fn);
+
+    const Inner = () => {
+      const { msg } = useLoaderData<typeof ref>();
+      return <p data-testid="lazy-page">{msg}</p>;
+    };
+    const Wrapped = definePage(Inner, { loader: ref });
+    const Lazy = lazy(async () => ({ default: Wrapped }));
+
+    window.history.pushState({}, '', '/lazy');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/lazy" component={Lazy} />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('lazy-page');
+    expect(el).toHaveTextContent('lazy-data');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a component with no PAGE_BINDINGS without a loader (no-data page)', async () => {
+    const Inner = () => <p data-testid="bare">no-data</p>;
+
+    window.history.pushState({}, '', '/bare');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/bare" component={Inner} />
+        </Router>
+      </LocationProvider>
+    );
+
+    const el = await screen.findByTestId('bare');
+    expect(el).toHaveTextContent('no-data');
   });
 });
 

--- a/packages/iso/src/contexts.ts
+++ b/packages/iso/src/contexts.ts
@@ -4,7 +4,6 @@ import type { GuardResult } from './guard.js';
 export const LoaderIdContext = createContext<string | null>(null);
 
 export const LoaderDataContext = createContext<{
-  refId: symbol;
   data: unknown;
 } | null>(null);
 

--- a/packages/iso/src/define-page.ts
+++ b/packages/iso/src/define-page.ts
@@ -1,0 +1,27 @@
+import type { ComponentType } from 'preact';
+import type { LoaderRef } from './define-loader.js';
+import type { LoaderCache } from './cache.js';
+import type { WrapperProps } from './page.js';
+
+export type PageBindings<T> = {
+  loader?: LoaderRef<T>;
+  cache?: LoaderCache<T>;
+  Wrapper?: ComponentType<WrapperProps>;
+};
+
+// Symbol.for so duplicate module copies (HMR, pnpm phantom deps) still match.
+export const PAGE_BINDINGS = Symbol.for('@hono-preact/iso/page-bindings');
+
+export type PageComponent<T> = ComponentType & {
+  [PAGE_BINDINGS]?: PageBindings<T>;
+};
+
+export function definePage<T>(
+  Component: ComponentType,
+  bindings?: PageBindings<T>
+): PageComponent<T> {
+  if (bindings) {
+    (Component as PageComponent<T>)[PAGE_BINDINGS] = bindings;
+  }
+  return Component as PageComponent<T>;
+}

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -14,6 +14,8 @@ export type {
   LoaderCtx,
   Loader as LoaderFn,
 } from './define-loader.js';
+export { definePage, PAGE_BINDINGS } from './define-page.js';
+export type { PageBindings, PageComponent } from './define-page.js';
 export { useLoaderData } from './use-loader-data.js';
 export { OptimisticOverlay } from './optimistic-overlay.js';
 export { prefetch } from './prefetch.js';
@@ -49,8 +51,9 @@ export type {
 } from './optimistic-action.js';
 
 export { Route, Router, wrapWithPage } from './route.js';
-export type { RouteProps, RouterProps, PageConfig } from './route.js';
+export type { RouteProps, RouterProps, RouteConfig, PageConfig } from './route.js';
 
-// Convenience re-export so consumers don't need to import from preact-iso
-// alongside @hono-preact/iso.
-export { lazy } from 'preact-iso';
+// Wrapped lazy that exposes the resolved default for binding lookup. API is
+// otherwise identical to preact-iso's lazy.
+export { lazy } from './lazy.js';
+export type { LazyComponent } from './lazy.js';

--- a/packages/iso/src/lazy.ts
+++ b/packages/iso/src/lazy.ts
@@ -1,0 +1,49 @@
+import type { ComponentType } from 'preact';
+import { lazy as preactIsoLazy } from 'preact-iso';
+
+export type LazyComponent<P = {}> = ComponentType<P> & {
+  preload: () => Promise<unknown>;
+  getResolvedDefault: () => ComponentType | null;
+};
+
+type ModuleLike = { default?: ComponentType } | ComponentType;
+
+export function lazy<P = {}>(
+  load: () => Promise<ModuleLike>
+): LazyComponent<P> {
+  let resolved: ComponentType | null = null;
+  let modulePromise: Promise<ModuleLike> | null = null;
+
+  // Single source of truth for the import. Side-effect: also caches the
+  // resolved default. Returns the original module-like value so callers of
+  // preload() see what `load()` actually returned.
+  const ensure = (): Promise<ModuleLike> => {
+    if (!modulePromise) {
+      modulePromise = load().then((m) => {
+        const c =
+          (m && (m as { default?: ComponentType }).default) ??
+          (m as ComponentType);
+        resolved = c;
+        return m;
+      });
+    }
+    return modulePromise;
+  };
+
+  // Hand preact-iso's lazy a stable factory that adapts the module to the
+  // {default: Component} shape it expects. This shares `ensure`'s cache, so
+  // the underlying load() runs at most once across our preload() callers and
+  // preact-iso's own first-render preload.
+  const Inner = preactIsoLazy(() =>
+    ensure().then((m) => ({
+      default:
+        (m as { default?: ComponentType }).default ??
+        (m as unknown as ComponentType),
+    }))
+  ) as unknown as LazyComponent<P>;
+
+  Inner.preload = ensure;
+  Inner.getResolvedDefault = () => resolved;
+
+  return Inner;
+}

--- a/packages/iso/src/loader.tsx
+++ b/packages/iso/src/loader.tsx
@@ -168,7 +168,6 @@ function LoaderHost<T>({
     <ReloadContext.Provider value={{ reload, reloading, error: loadError }}>
       <Suspense fallback={fallback}>
         <DataReader
-          refId={loaderRef.__id}
           reader={readerRef.current}
           overrideData={overrideData}
         >
@@ -180,21 +179,19 @@ function LoaderHost<T>({
 }
 
 type DataReaderProps<T> = {
-  refId: symbol;
   reader: { read: () => T };
   overrideData?: T;
   children: ComponentChildren;
 };
 
 function DataReader<T>({
-  refId,
   reader,
   overrideData,
   children,
 }: DataReaderProps<T>) {
   const data = overrideData !== undefined ? overrideData : reader.read();
   return (
-    <LoaderDataContext.Provider value={{ refId, data }}>
+    <LoaderDataContext.Provider value={{ data }}>
       {children}
     </LoaderDataContext.Provider>
   );

--- a/packages/iso/src/optimistic-overlay.tsx
+++ b/packages/iso/src/optimistic-overlay.tsx
@@ -4,6 +4,9 @@ import { LoaderDataContext } from './contexts.js';
 import type { LoaderRef } from './define-loader.js';
 
 type OverlayProps<T, A> = {
+  // `loader` binds the overlay's data type `T`. It is not read at runtime;
+  // the overlay reads from the nearest LoaderDataContext provided by <Page>.
+  // Pass the same loader ref the page was configured with so `T` matches.
   loader: LoaderRef<T>;
   reducer: (base: T, action: A) => T;
   pending?: A[];
@@ -11,15 +14,14 @@ type OverlayProps<T, A> = {
 };
 
 export function OptimisticOverlay<T, A>({
-  loader,
   reducer,
   pending = [],
   children,
 }: OverlayProps<T, A>) {
   const ctx = useContext(LoaderDataContext);
-  if (!ctx || ctx.refId !== loader.__id)
+  if (!ctx)
     throw new Error(
-      '<OptimisticOverlay loader={x}> must be inside a route or <Page> configured with the same loader'
+      '<OptimisticOverlay> must be inside a route page that has a loader'
     );
 
   const base = ctx.data as T;
@@ -29,7 +31,7 @@ export function OptimisticOverlay<T, A>({
   );
 
   return (
-    <LoaderDataContext.Provider value={{ refId: loader.__id, data: projected }}>
+    <LoaderDataContext.Provider value={{ data: projected }}>
       {children}
     </LoaderDataContext.Provider>
   );

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -8,32 +8,115 @@ import {
   type JSX,
   type VNode,
 } from 'preact';
+import { useRef, useState } from 'preact/hooks';
 import {
   Route as PreactIsoRoute,
   Router as PreactIsoRouter,
   type RouteHook,
 } from 'preact-iso';
 import { Page, type PageProps } from './page.js';
+import { PAGE_BINDINGS, type PageComponent } from './define-page.js';
+import type { LazyComponent } from './lazy.js';
 
-export type PageConfig<T> = Omit<PageProps<T>, 'location' | 'children'>;
+// Route-level config — these stay on <Route>. Page-level (loader, cache,
+// Wrapper) come from the component's PAGE_BINDINGS.
+export type RouteConfig = Pick<
+  PageProps<unknown>,
+  'fallback' | 'errorFallback' | 'serverGuards' | 'clientGuards'
+>;
 
-export function wrapWithPage<T>(
-  Component: ComponentType,
-  config: PageConfig<T>
-): (location: RouteHook) => JSX.Element {
-  return function PageRouteHandler(location: RouteHook) {
-    return (
-      <Page {...config} location={location}>
-        <Component />
-      </Page>
-    );
-  };
-}
-
-export type RouteProps<T> = PageConfig<T> & {
+export type RouteProps = RouteConfig & {
   path: string;
   component: ComponentType;
 };
+
+// Kept for back-compat consumers and tests.
+export type PageConfig = RouteConfig;
+
+function isLazyComponent(component: ComponentType): component is LazyComponent {
+  const lazyish = component as LazyComponent;
+  return (
+    typeof lazyish.preload === 'function' &&
+    typeof lazyish.getResolvedDefault === 'function'
+  );
+}
+
+function readBindings(component: ComponentType) {
+  // Eager components carry PAGE_BINDINGS directly. Lazy components carry it
+  // on their resolved default; callers must check isLazyComponent first and
+  // ensure the lazy is resolved before reading.
+  if (isLazyComponent(component)) {
+    const resolved = component.getResolvedDefault();
+    return resolved
+      ? (resolved as PageComponent<unknown>)[PAGE_BINDINGS]
+      : undefined;
+  }
+  return (component as PageComponent<unknown>)[PAGE_BINDINGS];
+}
+
+// PageBoundary reads PAGE_BINDINGS at render time. For a lazy component it
+// kicks off preload() and self-suspends with its own state-update on resolve,
+// mirroring preact-iso's LazyComponent pattern (so we don't depend on a
+// parent <Suspense>/Router re-render to recover from the throw). Once the
+// lazy is resolved, the resolved default is introspected for bindings and
+// <Page> mounts with them.
+type PageBoundaryProps = {
+  Component: ComponentType;
+  config: RouteConfig;
+  location: RouteHook;
+};
+
+function PageBoundary({ Component, config, location }: PageBoundaryProps) {
+  // The state-update closure mirrors preact-iso's lazy.js — gives us a
+  // re-render trigger that's local to this component instance.
+  const [, update] = useState(0);
+  const tracked = useRef<Promise<unknown> | null>(null);
+
+  if (isLazyComponent(Component)) {
+    const resolved = Component.getResolvedDefault();
+    if (!resolved) {
+      const p = Component.preload();
+      if (tracked.current !== p) {
+        tracked.current = p;
+        // Both arms re-render so the throw on the next render either succeeds
+        // (resolved) or re-fires through Suspense to a parent error boundary.
+        // The rejection arm also satisfies window.onunhandledrejection.
+        p.then(
+          () => update((n) => n + 1),
+          () => update((n) => n + 1)
+        );
+      }
+      throw p;
+    }
+  }
+
+  const bindings = readBindings(Component);
+  return (
+    <Page
+      loader={bindings?.loader}
+      cache={bindings?.cache}
+      Wrapper={bindings?.Wrapper}
+      fallback={config.fallback}
+      errorFallback={config.errorFallback}
+      serverGuards={config.serverGuards}
+      clientGuards={config.clientGuards}
+      location={location}
+    >
+      <Component />
+    </Page>
+  );
+}
+
+export function wrapWithPage(
+  Component: ComponentType,
+  config: RouteConfig
+): (location: RouteHook) => JSX.Element {
+  return function PageRouteHandler(location: RouteHook) {
+    return (
+      <PageBoundary Component={Component} config={config} location={location} />
+    );
+  };
+}
 
 // Marker component. <Router> from this package replaces <Route> elements with
 // preact-iso <Route> elements whose `component` prop is wrapped in <Page>.
@@ -44,13 +127,13 @@ export type RouteProps<T> = PageConfig<T> & {
 // pnpm phantom deps, etc.) because Symbol.for is realm-wide by key.
 const ROUTE_MARKER = Symbol.for('@hono-preact/iso/Route');
 
-export function Route<T>(_props: RouteProps<T>): null {
+export function Route(_props: RouteProps): null {
   return null;
 }
 Route.displayName = 'Route';
 (Route as unknown as Record<symbol, unknown>)[ROUTE_MARKER] = true;
 
-function isOurRoute(node: unknown): node is VNode<RouteProps<unknown>> {
+function isOurRoute(node: unknown): node is VNode<RouteProps> {
   return (
     isValidElement(node) &&
     typeof node.type === 'function' &&
@@ -71,7 +154,9 @@ export type RouterProps = Omit<PreactIsoRouterProps, 'children'> & {
   children?: ComponentChildren;
 };
 
-function isFragmentNode(node: unknown): node is VNode<{ children?: ComponentChildren }> {
+function isFragmentNode(
+  node: unknown
+): node is VNode<{ children?: ComponentChildren }> {
   return isValidElement(node) && node.type === Fragment;
 }
 

--- a/packages/iso/src/use-loader-data.ts
+++ b/packages/iso/src/use-loader-data.ts
@@ -2,15 +2,12 @@ import { useContext } from 'preact/hooks';
 import { LoaderDataContext } from './contexts.js';
 import type { LoaderRef } from './define-loader.js';
 
-export function useLoaderData<T>(ref: LoaderRef<T>): T {
+export function useLoaderData<L>(): L extends LoaderRef<infer T> ? T : L {
   const ctx = useContext(LoaderDataContext);
-  if (!ctx)
-    throw new Error('useLoaderData must be called inside a <Loader>');
-  if (ctx.refId !== ref.__id) {
+  if (!ctx) {
     throw new Error(
-      'useLoaderData(ref) called with a ref that does not match the nearest <Loader>. ' +
-        'If you have nested loaders, the inner ref shadows the outer.'
+      'useLoaderData must be called inside a route page that has a loader.'
     );
   }
-  return ctx.data as T;
+  return ctx.data as never;
 }


### PR DESCRIPTION
## Summary

- Introduces `definePage(Component, { loader, cache, Wrapper })` for page-owned route bindings, attached via a realm-wide `Symbol.for('@hono-preact/iso/page-bindings')`. `<Route>` no longer accepts `loader`/`cache`/`Wrapper` props.
- `useLoaderData()` becomes argument-free; type narrowing comes from a type-only generic (`useLoaderData<typeof loader>()`). The runtime ref-identity check is replaced by compile-time type checking.
- `apps/app/src/iso.tsx` is now a paths-only route table; it imports zero `.server.ts` files.

## Why

`iso.tsx` was growing linearly with route count: per page, three named imports (with `as`-renames to dodge collisions) plus `loader=`/`cache=`/`Wrapper=` props on `<Route>`. The page file was also impure, importing the loader as a runtime value just to thread it through `useLoaderData(ref)`.

After this change, `iso.tsx` contains only paths and lazy refs. Each page owns its bindings on its default export. The trade-off accepted: lazy chunk fetch and loader RPC are now serialized (chunk first, then data), instead of running in parallel; prefetch-on-hover is the mitigation. Spec walks through this in detail.

## What changed

| Area | Change |
|------|--------|
| `@hono-preact/iso` | New `definePage` helper, new `lazy()` wrapper exposing `preload()` and `getResolvedDefault()`, slimmed `<Route>` props, internal `<PageBoundary>` for lazy + suspend, argument-free `useLoaderData` |
| `@hono-preact/iso` (internal) | `LoaderDataContext.refId` removed; `OptimisticOverlay` updated; `<Page>`/`<Loader>` primitives unchanged |
| `apps/app` | Pages migrated to `definePage`; `iso.tsx` paths-only; `MovieWrapper` relocated from `movies.tsx` to `movie.tsx` |
| docs | All 9 MDX files updated; `loaders.mdx` adds a "Page bindings with `definePage`" section |

Spec: [docs/superpowers/specs/2026-04-30-define-page-design.md](docs/superpowers/specs/2026-04-30-define-page-design.md)
Plan: [docs/superpowers/plans/2026-04-30-define-page.md](docs/superpowers/plans/2026-04-30-define-page.md)

## Trade-offs accepted

1. **Lazy chunk → loader RPC is now serialized.** Total navigation cost is `chunk + loader` instead of `max(chunk, loader)`. Prefetch-on-hover (already supported) typically warms the chunk before the click, collapsing the cost back to just the loader RPC.
2. **Lost runtime ref-identity check in `useLoaderData`.** Replaced by compile-time type narrowing via the conditional generic.
3. **`definePage` mutates its argument.** Attaching the bindings symbol directly to the component avoids a wrapper render layer. Idempotent and documented.

## Breaking changes (single-commit cutover, no compat shim)

- `<Route>` no longer accepts `loader`/`cache`/`Wrapper` props. Move them to `definePage` on the component.
- `useLoaderData(ref)` → `useLoaderData<typeof ref>()`.
- `LoaderDataContext` value shape changes from `{ refId, data }` to `{ data }` (internal; consumers that imported the context directly will need to adjust).

## Test plan

- [x] `pnpm test` — 247/247 tests pass across 27 files
- [x] `pnpm --filter app build` — clean (client + SSR bundles)
- [x] `tsc --noEmit` for both `packages/iso` and `apps/app` — clean
- [x] Dev-server smoke: all routes (`/`, `/test`, `/movies`, `/movies/:id`, `/watched`, `/docs/*`) return HTTP 200 with substantial content
- [x] No `.server.ts` content leaks into client bundles (verified by grep on `dist/static/`)
- [ ] Manual browser smoke: click through `/movies` → `/movies/:id`, mark/unmark watched, edit notes, upload photo. DevTools console clean.

## Out of scope (deferred)

- Generated route types so `useLoaderData()` can infer without `<typeof loader>`
- Eliminating duplicate `<Route path="/movies">` and `<Route path="/movies/*">` declarations (a real nested-router pattern)
- Migrating `serverGuards`/`clientGuards`/`actionGuards` into `definePage`
- Reconsidering `OptimisticOverlay`'s now-runtime-unused `loader` prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)