### PR TITLE
feat(app): three-state docs sidebar rail

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^17.4.2",
     "hono": "^4.12.14",
     "hoofd": "^1.7.3",
+    "lucide-preact": "^1.14.0",
     "preact": "^10.29.1",
     "preact-iso": "github:preactjs/preact-iso#v3",
     "react": "npm:@preact/compat",
@@ -26,9 +27,9 @@
   "devDependencies": {
     "@babel/parser": "^7.29.2",
     "@babel/types": "^7.29.0",
-    "@hono-preact/vite": "workspace:*",
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",
+    "@hono-preact/vite": "workspace:*",
     "@hono/node-server": "^1.19.14",
     "@hono/vite-build": "^1.11.1",
     "@hono/vite-dev-server": "^0.25.1",

--- a/apps/app/src/components/DocsLayout.tsx
+++ b/apps/app/src/components/DocsLayout.tsx
@@ -1,15 +1,42 @@
 import type { ComponentChildren } from 'preact';
-import { useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { useRoute } from 'preact-iso';
+import { Pin, PinOff } from 'lucide-preact';
 import { nav } from '../pages/docs/nav.js';
 
 interface Props {
   children: ComponentChildren;
 }
 
+const COLLAPSED_W = 56;
+const EXPANDED_W = 240;
+const HOVER_CLOSE_DELAY_MS = 120;
+
 export function DocsLayout({ children }: Props) {
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { path } = useRoute();
+
+  useEffect(() => () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+  }, []);
+
+  const handleMouseEnter = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    closeTimer.current = setTimeout(() => setHovered(false), HOVER_CLOSE_DELAY_MS);
+  };
+
+  const expanded = pinned || hovered;
 
   const allEntries = nav.flatMap((s) => s.entries);
   const idx = allEntries.findIndex((e) => e.route === path);
@@ -18,44 +45,99 @@ export function DocsLayout({ children }: Props) {
     idx !== -1 && idx < allEntries.length - 1 ? allEntries[idx + 1] : null;
   const currentTitle = idx !== -1 ? allEntries[idx].title : '';
 
-  const navSections = nav.map((section) => (
-    <div class="flex flex-col gap-0.5">
-      <div class="text-[0.7rem] font-bold uppercase tracking-[0.08em] text-slate-400 mb-1.5 px-1.5">
-        {section.heading}
-      </div>
-      {section.entries.map((entry) => (
-        <a
-          href={entry.route}
-          class={`block py-1.5 px-2 rounded text-sm no-underline ${
-            entry.route === path
-              ? 'bg-blue-100 text-blue-700 font-semibold'
-              : 'text-slate-600 hover:text-slate-900 hover:bg-slate-200'
-          }`}
-        >
-          {entry.title}
-        </a>
+  const renderNav = (showText: boolean) => (
+    <div class="flex flex-col gap-4">
+      {nav.map((section) => (
+        <div key={section.heading} class="flex flex-col gap-0.5">
+          {showText && (
+            <div class="text-[0.7rem] font-bold uppercase tracking-[0.08em] text-slate-400 mb-1.5 px-3">
+              {section.heading}
+            </div>
+          )}
+          {section.entries.map((entry) => {
+            const Icon = entry.icon;
+            const active = entry.route === path;
+            return (
+              <a
+                key={entry.route}
+                href={entry.route}
+                aria-label={showText ? undefined : entry.title}
+                class={`flex items-center gap-3 h-9 rounded text-sm no-underline whitespace-nowrap ${
+                  showText ? 'px-3' : 'justify-center px-0'
+                } ${
+                  active
+                    ? 'bg-blue-100 text-blue-700 font-semibold'
+                    : 'text-slate-600 hover:text-slate-900 hover:bg-slate-200'
+                }`}
+              >
+                <Icon size={18} class="shrink-0" />
+                {showText && <span>{entry.title}</span>}
+              </a>
+            );
+          })}
+        </div>
       ))}
     </div>
-  ));
+  );
 
   return (
-    <div class="grid md:grid-cols-[220px_1fr] min-h-screen">
-      {/* Desktop sidebar */}
-      <aside class="hidden md:flex md:sticky md:top-0 md:h-screen md:overflow-y-auto md:bg-slate-50 md:border-r md:border-slate-200 md:p-4 md:flex-col md:gap-6">
-        <a
-          href="/docs"
-          class="font-bold text-[0.95rem] text-slate-900 no-underline hover:text-blue-700"
+    <div
+      class="min-h-screen grid"
+      style={{
+        gridTemplateColumns: pinned ? `${EXPANDED_W}px 1fr` : `${COLLAPSED_W}px 1fr`,
+        transition: `grid-template-columns var(--spring-duration) var(--spring-soft)`,
+      }}
+    >
+      {/* Desktop rail wrapper (sticky cell) */}
+      <aside
+        aria-label="Docs navigation"
+        class="hidden md:block md:sticky md:top-0 md:h-screen relative"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {/* Inner panel: absolute so hover-peek floats over content */}
+        <div
+          class="absolute top-0 left-0 h-full bg-slate-50 border-r border-slate-200 overflow-hidden flex flex-col z-20 shadow-sm"
+          style={{
+            width: expanded ? `${EXPANDED_W}px` : `${COLLAPSED_W}px`,
+            transition: `width var(--spring-duration) var(--spring-soft)`,
+          }}
         >
-          hono-preact docs
-        </a>
-        {navSections}
+          <a
+            href="/docs"
+            aria-label="hono-preact docs"
+            class={`flex items-center h-12 shrink-0 font-bold text-[0.95rem] text-slate-900 no-underline hover:text-blue-700 ${
+              expanded ? 'px-3' : 'justify-center px-0'
+            }`}
+          >
+            {expanded ? 'hono-preact docs' : <span class="text-lg">📚</span>}
+          </a>
+          <div class={`flex-1 overflow-y-auto overflow-x-hidden py-2 ${expanded ? 'px-2' : 'px-1.5'}`}>
+            {renderNav(expanded)}
+          </div>
+          <div class={`shrink-0 border-t border-slate-200 py-2 ${expanded ? 'px-2' : 'px-1.5'}`}>
+            <button
+              type="button"
+              aria-pressed={pinned}
+              aria-label={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+              onClick={() => setPinned((p) => !p)}
+              class={`flex items-center gap-3 h-9 w-full rounded text-sm text-slate-600 hover:text-slate-900 hover:bg-slate-200 ${
+                expanded ? 'px-3' : 'justify-center px-0'
+              }`}
+            >
+              {pinned ? <PinOff size={18} class="shrink-0" /> : <Pin size={18} class="shrink-0" />}
+              {expanded && <span>{pinned ? 'Unpin sidebar' : 'Pin sidebar'}</span>}
+            </button>
+          </div>
+        </div>
       </aside>
 
       {/* Mobile top bar */}
-      <div class="flex items-center gap-3 bg-slate-50 border-b border-slate-200 py-2.5 px-3 sticky top-0 z-30 md:hidden">
+      <div class="flex items-center gap-3 bg-slate-50 border-b border-slate-200 py-2.5 px-3 sticky top-0 z-30 md:hidden col-span-full">
         <button
+          type="button"
           class="flex items-center gap-1 bg-white border border-slate-200 rounded-md py-1 px-2.5 text-[0.8rem] font-semibold text-slate-600 cursor-pointer shadow-sm shrink-0 hover:bg-slate-100"
-          onClick={() => setDrawerOpen(true)}
+          onClick={() => setMobileOpen(true)}
         >
           ☰ Menu
         </button>
@@ -66,32 +148,37 @@ export function DocsLayout({ children }: Props) {
         )}
       </div>
 
-      {/* Mobile drawer overlay */}
+      {/* Mobile backdrop */}
       <div
-        class={`fixed inset-0 bg-black/35 z-40 starting:hidden ${drawerOpen ? 'block' : 'hidden'}`}
-        onClick={() => setDrawerOpen(false)}
+        class={`fixed inset-0 bg-black/35 z-40 md:hidden ${mobileOpen ? 'block' : 'hidden'}`}
+        onClick={() => setMobileOpen(false)}
       />
 
       {/* Mobile drawer */}
-      <div
-        class={`fixed top-0 bottom-0 left-0 w-65 bg-slate-50 border-r border-slate-200 z-50 transition-transform duration-200 ease-in-out flex flex-col ${drawerOpen ? 'translate-x-0' : '-translate-x-full'}`}
+      <aside
+        aria-label="Docs navigation menu"
+        class="fixed top-0 bottom-0 left-0 w-[260px] bg-slate-50 border-r border-slate-200 z-50 flex flex-col md:hidden"
+        style={{
+          transform: mobileOpen ? 'translateX(0)' : 'translateX(-100%)',
+          transition: `transform var(--spring-duration) var(--spring-soft)`,
+        }}
       >
         <div class="flex justify-between items-center px-4 py-3 border-b border-slate-200 font-bold text-[0.9rem] text-slate-900">
           Docs
           <button
+            type="button"
             class="bg-transparent border-none text-[1.1rem] text-slate-500 cursor-pointer leading-none p-1 hover:text-slate-900"
-            onClick={() => setDrawerOpen(false)}
+            onClick={() => setMobileOpen(false)}
+            aria-label="Close menu"
           >
             ✕
           </button>
         </div>
-        <div class="p-3 overflow-y-auto flex-1 flex flex-col gap-5">
-          {navSections}
-        </div>
-      </div>
+        <div class="p-3 overflow-y-auto flex-1">{renderNav(true)}</div>
+      </aside>
 
       {/* Main content */}
-      <main class="max-w-[65ch] py-8 px-6">
+      <main class="col-span-full md:col-auto max-w-[65ch] py-8 px-6">
         <article class="mdx-content">{children}</article>
         <nav class="flex justify-between mt-12 pt-6 border-t border-slate-200 text-sm">
           <span>

--- a/apps/app/src/components/DocsLayout.tsx
+++ b/apps/app/src/components/DocsLayout.tsx
@@ -12,8 +12,20 @@ const COLLAPSED_W = 56;
 const EXPANDED_W = 240;
 const HOVER_CLOSE_DELAY_MS = 120;
 
+// Module-scoped so pin state survives DocsLayout remounts as the user
+// navigates between docs pages (each page wraps its own DocsLayout).
+// Client-only mutation; server renders always start at false.
+let pinnedShared = false;
+
 export function DocsLayout({ children }: Props) {
-  const [pinned, setPinned] = useState(false);
+  const [pinned, setPinnedLocal] = useState(() => pinnedShared);
+  const setPinned = (updater: (prev: boolean) => boolean) => {
+    setPinnedLocal((prev) => {
+      const next = updater(prev);
+      pinnedShared = next;
+      return next;
+    });
+  };
   const [hovered, setHovered] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/app/src/components/DocsLayout.tsx
+++ b/apps/app/src/components/DocsLayout.tsx
@@ -19,9 +19,12 @@ export function DocsLayout({ children }: Props) {
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { path } = useRoute();
 
-  useEffect(() => () => {
-    if (closeTimer.current) clearTimeout(closeTimer.current);
-  }, []);
+  useEffect(
+    () => () => {
+      if (closeTimer.current) clearTimeout(closeTimer.current);
+    },
+    []
+  );
 
   const handleMouseEnter = () => {
     if (closeTimer.current) {
@@ -33,7 +36,10 @@ export function DocsLayout({ children }: Props) {
 
   const handleMouseLeave = () => {
     if (closeTimer.current) clearTimeout(closeTimer.current);
-    closeTimer.current = setTimeout(() => setHovered(false), HOVER_CLOSE_DELAY_MS);
+    closeTimer.current = setTimeout(
+      () => setHovered(false),
+      HOVER_CLOSE_DELAY_MS
+    );
   };
 
   const expanded = pinned || hovered;
@@ -49,11 +55,22 @@ export function DocsLayout({ children }: Props) {
     <div class="flex flex-col gap-4">
       {nav.map((section) => (
         <div key={section.heading} class="flex flex-col gap-0.5">
-          {showText && (
-            <div class="text-[0.7rem] font-bold uppercase tracking-[0.08em] text-slate-400 mb-1.5 px-3">
-              {section.heading}
+          <div
+            aria-hidden={!showText}
+            style={{
+              display: 'grid',
+              gridTemplateRows: showText ? '1fr' : '0fr',
+              opacity: showText ? 1 : 0,
+              transition:
+                'grid-template-rows var(--spring-duration) var(--spring-soft), opacity var(--spring-duration) var(--spring-soft)',
+            }}
+          >
+            <div class="overflow-hidden">
+              <div class="text-[0.7rem] font-bold uppercase tracking-[0.08em] text-slate-400 mb-1.5 px-3 whitespace-nowrap">
+                {section.heading}
+              </div>
             </div>
-          )}
+          </div>
           {section.entries.map((entry) => {
             const Icon = entry.icon;
             const active = entry.route === path;
@@ -84,7 +101,9 @@ export function DocsLayout({ children }: Props) {
     <div
       class="min-h-screen grid"
       style={{
-        gridTemplateColumns: pinned ? `${EXPANDED_W}px 1fr` : `${COLLAPSED_W}px 1fr`,
+        gridTemplateColumns: pinned
+          ? `${EXPANDED_W}px 1fr`
+          : `${COLLAPSED_W}px 1fr`,
         transition: `grid-template-columns var(--spring-duration) var(--spring-soft)`,
       }}
     >
@@ -106,16 +125,20 @@ export function DocsLayout({ children }: Props) {
           <a
             href="/docs"
             aria-label="hono-preact docs"
-            class={`flex items-center h-12 shrink-0 font-bold text-[0.95rem] text-slate-900 no-underline hover:text-blue-700 ${
+            class={`flex whitespace-nowrap overflow-hidden text-ellipsis items-center h-12 shrink-0 font-bold text-[0.95rem] text-slate-900 no-underline hover:text-blue-700 ${
               expanded ? 'px-3' : 'justify-center px-0'
             }`}
           >
             {expanded ? 'hono-preact docs' : <span class="text-lg">📚</span>}
           </a>
-          <div class={`flex-1 overflow-y-auto overflow-x-hidden py-2 ${expanded ? 'px-2' : 'px-1.5'}`}>
+          <div
+            class={`flex-1 overflow-y-auto overflow-x-hidden py-2 ${expanded ? 'px-2' : 'px-1.5'}`}
+          >
             {renderNav(expanded)}
           </div>
-          <div class={`shrink-0 border-t border-slate-200 py-2 ${expanded ? 'px-2' : 'px-1.5'}`}>
+          <div
+            class={`shrink-0 border-t border-slate-200 py-2 ${expanded ? 'px-2' : 'px-1.5'}`}
+          >
             <button
               type="button"
               aria-pressed={pinned}
@@ -125,8 +148,14 @@ export function DocsLayout({ children }: Props) {
                 expanded ? 'px-3' : 'justify-center px-0'
               }`}
             >
-              {pinned ? <PinOff size={18} class="shrink-0" /> : <Pin size={18} class="shrink-0" />}
-              {expanded && <span>{pinned ? 'Unpin sidebar' : 'Pin sidebar'}</span>}
+              {pinned ? (
+                <PinOff size={18} class="shrink-0" />
+              ) : (
+                <Pin size={18} class="shrink-0" />
+              )}
+              {expanded && (
+                <span>{pinned ? 'Unpin sidebar' : 'Pin sidebar'}</span>
+              )}
             </button>
           </div>
         </div>
@@ -157,7 +186,7 @@ export function DocsLayout({ children }: Props) {
       {/* Mobile drawer */}
       <aside
         aria-label="Docs navigation menu"
-        class="fixed top-0 bottom-0 left-0 w-[260px] bg-slate-50 border-r border-slate-200 z-50 flex flex-col md:hidden"
+        class="fixed top-0 bottom-0 left-0 w-65 bg-slate-50 border-r border-slate-200 z-50 flex flex-col md:hidden"
         style={{
           transform: mobileOpen ? 'translateX(0)' : 'translateX(-100%)',
           transition: `transform var(--spring-duration) var(--spring-soft)`,

--- a/apps/app/src/pages/docs/__tests__/nav.test.ts
+++ b/apps/app/src/pages/docs/__tests__/nav.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { nav } from '../nav.js';
+
+describe('docs nav', () => {
+  it('every entry has a title, route, and icon component', () => {
+    for (const section of nav) {
+      expect(section.heading).toBeTruthy();
+      for (const entry of section.entries) {
+        expect(entry.title).toBeTruthy();
+        expect(entry.route).toMatch(/^\/docs/);
+        expect(typeof entry.icon).toBe('function');
+      }
+    }
+  });
+
+  it('routes are unique', () => {
+    const routes = nav.flatMap((s) => s.entries.map((e) => e.route));
+    expect(new Set(routes).size).toBe(routes.length);
+  });
+});

--- a/apps/app/src/pages/docs/nav.ts
+++ b/apps/app/src/pages/docs/nav.ts
@@ -1,50 +1,69 @@
-export type NavEntry = { title: string; route: string };
+import {
+  BookOpen,
+  Cloud,
+  Database,
+  FileText,
+  FolderTree,
+  Layers,
+  Loader,
+  RefreshCw,
+  Rocket,
+  Send,
+  Settings,
+  ShieldAlert,
+  ShieldCheck,
+  Sparkles,
+  type LucideIcon,
+  Zap,
+} from 'lucide-preact';
+
+export type NavEntry = { title: string; route: string; icon: LucideIcon };
 export type NavSection = { heading: string; entries: NavEntry[] };
 
 export const nav: NavSection[] = [
   {
     heading: 'Introduction',
     entries: [
-      { title: 'Overview', route: '/docs' },
-      { title: 'Quick Start', route: '/docs/quick-start' },
+      { title: 'Overview', route: '/docs', icon: BookOpen },
+      { title: 'Quick Start', route: '/docs/quick-start', icon: Rocket },
     ],
   },
   {
     heading: 'Pages & Routing',
     entries: [
-      { title: 'Adding Pages', route: '/docs/pages' },
+      { title: 'Adding Pages', route: '/docs/pages', icon: FileText },
     ],
   },
   {
     heading: 'Data',
     entries: [
-      { title: 'Server Loaders', route: '/docs/loaders' },
-      { title: 'Loading States', route: '/docs/loading-states' },
-      { title: 'Reloading Data', route: '/docs/reloading' },
-      { title: 'Prefetching', route: '/docs/prefetch' },
+      { title: 'Server Loaders', route: '/docs/loaders', icon: Database },
+      { title: 'Loading States', route: '/docs/loading-states', icon: Loader },
+      { title: 'Reloading Data', route: '/docs/reloading', icon: RefreshCw },
+      { title: 'Prefetching', route: '/docs/prefetch', icon: Zap },
     ],
   },
   {
     heading: 'Mutations',
     entries: [
-      { title: 'Server Actions', route: '/docs/actions' },
-      { title: 'Action Guards', route: '/docs/action-guards' },
-      { title: 'Optimistic UI', route: '/docs/optimistic-ui' },
+      { title: 'Server Actions', route: '/docs/actions', icon: Send },
+      { title: 'Action Guards', route: '/docs/action-guards', icon: ShieldAlert },
+      { title: 'Optimistic UI', route: '/docs/optimistic-ui', icon: Sparkles },
     ],
   },
   {
     heading: 'Access Control',
     entries: [
-      { title: 'Route Guards', route: '/docs/guards' },
+      { title: 'Route Guards', route: '/docs/guards', icon: ShieldCheck },
     ],
   },
   {
     heading: 'Infrastructure',
     entries: [
-      { title: 'Vite Config', route: '/docs/vite-config' },
-      { title: 'Project Structure', route: '/docs/structure' },
-      { title: 'renderPage', route: '/docs/render-page' },
-      { title: 'Build & Deploy', route: '/docs/deployment' },
+      { title: 'Vite Config', route: '/docs/vite-config', icon: Settings },
+      { title: 'Project Structure', route: '/docs/structure', icon: FolderTree },
+      { title: 'renderPage', route: '/docs/render-page', icon: Layers },
+      { title: 'Build & Deploy', route: '/docs/deployment', icon: Cloud },
     ],
   },
 ];

--- a/apps/app/src/styles/root.css
+++ b/apps/app/src/styles/root.css
@@ -3,16 +3,17 @@
 :root {
   --spring-soft: linear(
     0,
-    0.5 7.5%,
-    0.85 14%,
-    1.02 21%,
-    1.04 28%,
-    1.01 38%,
-    0.998 50%,
-    1.001 70%,
+    0.18 6%,
+    0.42 14%,
+    0.66 24%,
+    0.84 34%,
+    0.94 44%,
+    0.985 55%,
+    1.005 70%,
+    1.001 82%,
     1
   );
-  --spring-duration: 280ms;
+  --spring-duration: 380ms;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/app/src/styles/root.css
+++ b/apps/app/src/styles/root.css
@@ -1,5 +1,26 @@
 @import 'tailwindcss';
 
+:root {
+  --spring-soft: linear(
+    0,
+    0.5 7.5%,
+    0.85 14%,
+    1.02 21%,
+    1.04 28%,
+    1.01 38%,
+    0.998 50%,
+    1.001 70%,
+    1
+  );
+  --spring-duration: 280ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --spring-duration: 0ms;
+  }
+}
+
 /* MDX prose defaults */
 .mdx-content {
   line-height: 1.75;

--- a/docs/superpowers/plans/2026-05-02-docs-sidebar-rail.md
+++ b/docs/superpowers/plans/2026-05-02-docs-sidebar-rail.md
@@ -1,0 +1,590 @@
+# Docs Sidebar Rail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `DocsLayout` with a three-state icon rail (collapsed / hover-peek / pinned) using `lucide-preact` icons and a CSS `linear()` spring curve, while preserving the existing mobile slide-in drawer.
+
+**Architecture:** Single `<aside>` component, viewport-branched via Tailwind `md:` prefix. Desktop uses a wrapper-cell whose width tracks `pinned`, with an inner panel whose width tracks `pinned || hovered`. The inner panel is `absolute` inside the sticky wrapper so the unpinned-hovered state floats over content without pushing layout. Mobile keeps current overlay drawer behavior, sharing the same nav rendering and icons. No persistence.
+
+**Tech Stack:** Preact, preact-iso, Tailwind v4, lucide-preact, vitest (Node env).
+
+**Commits:** This project requires explicit user approval before any `git commit`. The plan includes commit steps; the executor must confirm with the user before running each one.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-02-docs-sidebar-rail-design.md`.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `apps/app/package.json` | modify | add `lucide-preact` dep |
+| `apps/app/src/pages/docs/nav.ts` | modify | add `icon: LucideIcon` to `NavEntry`; populate per entry |
+| `apps/app/src/pages/docs/__tests__/nav.test.ts` | create | unit test: every entry has a valid icon |
+| `apps/app/src/styles/root.css` | modify | add `--spring-soft`, `--spring-duration`, reduced-motion override |
+| `apps/app/src/components/DocsLayout.tsx` | rewrite | three-state rail, pin button, mobile drawer, animation hookup |
+
+---
+
+## Task 1: Install lucide-preact
+
+**Files:**
+- Modify: `apps/app/package.json`
+
+- [ ] **Step 1: Add lucide-preact dependency**
+
+Run from repo root:
+
+```bash
+pnpm --filter app add lucide-preact
+```
+
+Expected: `apps/app/package.json` gains `"lucide-preact": "^x.y.z"` under `dependencies`. `pnpm-lock.yaml` updates.
+
+- [ ] **Step 2: Verify install resolves and the icon set imports**
+
+Run:
+
+```bash
+pnpm --filter app exec node -e "import('lucide-preact').then(m => console.log(typeof m.BookOpen, typeof m.Pin))"
+```
+
+Expected output: `function function`
+
+If the import fails or the named exports are undefined, fall back to lucide-react: `pnpm --filter app remove lucide-preact && pnpm --filter app add lucide-react` and use `lucide-react` everywhere `lucide-preact` is referenced in subsequent tasks. The project's `react` → `@preact/compat` alias makes lucide-react render via Preact.
+
+- [ ] **Step 3: Commit (confirm with user first)**
+
+```bash
+git add apps/app/package.json pnpm-lock.yaml
+git commit -m "chore(app): add lucide-preact for docs sidebar icons"
+```
+
+---
+
+## Task 2: Add icons to nav data with a data integrity test
+
+**Files:**
+- Modify: `apps/app/src/pages/docs/nav.ts`
+- Create: `apps/app/src/pages/docs/__tests__/nav.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/app/src/pages/docs/__tests__/nav.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { nav } from '../nav.js';
+
+describe('docs nav', () => {
+  it('every entry has a title, route, and icon component', () => {
+    for (const section of nav) {
+      expect(section.heading).toBeTruthy();
+      for (const entry of section.entries) {
+        expect(entry.title).toBeTruthy();
+        expect(entry.route).toMatch(/^\/docs/);
+        expect(typeof entry.icon).toBe('function');
+      }
+    }
+  });
+
+  it('routes are unique', () => {
+    const routes = nav.flatMap((s) => s.entries.map((e) => e.route));
+    expect(new Set(routes).size).toBe(routes.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from repo root:
+
+```bash
+pnpm test apps/app/src/pages/docs/__tests__/nav.test.ts
+```
+
+Expected: FAIL. `entry.icon` is undefined; `typeof undefined === 'undefined'`, not `'function'`.
+
+- [ ] **Step 3: Update nav.ts type and entries**
+
+Replace the contents of `apps/app/src/pages/docs/nav.ts`:
+
+```ts
+import {
+  BookOpen,
+  Rocket,
+  FileText,
+  Database,
+  Loader,
+  RefreshCw,
+  Zap,
+  Send,
+  Sparkles,
+  ShieldCheck,
+  ShieldAlert,
+  FolderTree,
+  Layers,
+  Settings,
+  Cloud,
+  type LucideIcon,
+} from 'lucide-preact';
+
+export type NavEntry = { title: string; route: string; icon: LucideIcon };
+export type NavSection = { heading: string; entries: NavEntry[] };
+
+export const nav: NavSection[] = [
+  {
+    heading: 'Introduction',
+    entries: [
+      { title: 'Overview', route: '/docs', icon: BookOpen },
+      { title: 'Quick Start', route: '/docs/quick-start', icon: Rocket },
+    ],
+  },
+  {
+    heading: 'Pages & Routing',
+    entries: [
+      { title: 'Adding Pages', route: '/docs/pages', icon: FileText },
+    ],
+  },
+  {
+    heading: 'Data',
+    entries: [
+      { title: 'Server Loaders', route: '/docs/loaders', icon: Database },
+      { title: 'Loading States', route: '/docs/loading-states', icon: Loader },
+      { title: 'Reloading Data', route: '/docs/reloading', icon: RefreshCw },
+      { title: 'Prefetching', route: '/docs/prefetch', icon: Zap },
+    ],
+  },
+  {
+    heading: 'Mutations',
+    entries: [
+      { title: 'Server Actions', route: '/docs/actions', icon: Send },
+      { title: 'Action Guards', route: '/docs/action-guards', icon: ShieldAlert },
+      { title: 'Optimistic UI', route: '/docs/optimistic-ui', icon: Sparkles },
+    ],
+  },
+  {
+    heading: 'Access Control',
+    entries: [
+      { title: 'Route Guards', route: '/docs/guards', icon: ShieldCheck },
+    ],
+  },
+  {
+    heading: 'Infrastructure',
+    entries: [
+      { title: 'Vite Config', route: '/docs/vite-config', icon: Settings },
+      { title: 'Project Structure', route: '/docs/structure', icon: FolderTree },
+      { title: 'renderPage', route: '/docs/render-page', icon: Layers },
+      { title: 'Build & Deploy', route: '/docs/deployment', icon: Cloud },
+    ],
+  },
+];
+```
+
+(If you fell back to `lucide-react` in Task 1, change the import path accordingly. The named exports are identical.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+pnpm test apps/app/src/pages/docs/__tests__/nav.test.ts
+```
+
+Expected: PASS, both `it` blocks green.
+
+- [ ] **Step 5: Run full test suite to confirm no regressions**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit (confirm with user first)**
+
+```bash
+git add apps/app/src/pages/docs/nav.ts apps/app/src/pages/docs/__tests__/nav.test.ts
+git commit -m "feat(docs): add per-entry icons to nav data"
+```
+
+---
+
+## Task 3: Add spring CSS variables to root.css
+
+**Files:**
+- Modify: `apps/app/src/styles/root.css`
+
+- [ ] **Step 1: Add the variables and reduced-motion override**
+
+Insert at the top of `apps/app/src/styles/root.css`, immediately after `@import 'tailwindcss';`:
+
+```css
+:root {
+  --spring-soft: linear(
+    0,
+    0.5 7.5%,
+    0.85 14%,
+    1.02 21%,
+    1.04 28%,
+    1.01 38%,
+    0.998 50%,
+    1.001 70%,
+    1
+  );
+  --spring-duration: 280ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --spring-duration: 0ms;
+  }
+}
+```
+
+- [ ] **Step 2: Verify the dev server still starts and applies styles**
+
+Run:
+
+```bash
+pnpm --filter app dev
+```
+
+Open `http://localhost:5173` (or whichever port Vite reports). Expected: page renders normally; no console errors. Inspect `<html>` in devtools and confirm `getComputedStyle(document.documentElement).getPropertyValue('--spring-duration')` returns `'280ms'`.
+
+Stop the dev server (`Ctrl+C`).
+
+- [ ] **Step 3: Commit (confirm with user first)**
+
+```bash
+git add apps/app/src/styles/root.css
+git commit -m "feat(app): add linear() spring CSS variables"
+```
+
+---
+
+## Task 4: Rewrite DocsLayout with the three-state rail
+
+This task is split into four sub-steps so each browser-verifiable change is small. Commit after the whole task; do not commit between sub-steps.
+
+**Files:**
+- Modify: `apps/app/src/components/DocsLayout.tsx`
+
+### Task 4a: Replace the layout skeleton with the unified rail structure
+
+- [ ] **Step 1: Rewrite DocsLayout.tsx with collapsed-rail desktop and current mobile**
+
+Replace the contents of `apps/app/src/components/DocsLayout.tsx`:
+
+```tsx
+import type { ComponentChildren } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { useRoute } from 'preact-iso';
+import { Pin, PinOff } from 'lucide-preact';
+import { nav } from '../pages/docs/nav.js';
+
+interface Props {
+  children: ComponentChildren;
+}
+
+const COLLAPSED_W = 56;
+const EXPANDED_W = 240;
+const HOVER_CLOSE_DELAY_MS = 120;
+
+export function DocsLayout({ children }: Props) {
+  const [pinned, setPinned] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { path } = useRoute();
+
+  useEffect(() => () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+  }, []);
+
+  const handleMouseEnter = () => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    closeTimer.current = setTimeout(() => setHovered(false), HOVER_CLOSE_DELAY_MS);
+  };
+
+  const expanded = pinned || hovered;
+
+  const allEntries = nav.flatMap((s) => s.entries);
+  const idx = allEntries.findIndex((e) => e.route === path);
+  const prev = idx > 0 ? allEntries[idx - 1] : null;
+  const next =
+    idx !== -1 && idx < allEntries.length - 1 ? allEntries[idx + 1] : null;
+  const currentTitle = idx !== -1 ? allEntries[idx].title : '';
+
+  const renderNav = (showText: boolean) => (
+    <div class="flex flex-col gap-4">
+      {nav.map((section) => (
+        <div class="flex flex-col gap-0.5">
+          {showText && (
+            <div class="text-[0.7rem] font-bold uppercase tracking-[0.08em] text-slate-400 mb-1.5 px-3">
+              {section.heading}
+            </div>
+          )}
+          {section.entries.map((entry) => {
+            const Icon = entry.icon;
+            const active = entry.route === path;
+            return (
+              <a
+                href={entry.route}
+                aria-label={entry.title}
+                class={`flex items-center gap-3 h-9 rounded text-sm no-underline whitespace-nowrap ${
+                  showText ? 'px-3' : 'justify-center px-0'
+                } ${
+                  active
+                    ? 'bg-blue-100 text-blue-700 font-semibold'
+                    : 'text-slate-600 hover:text-slate-900 hover:bg-slate-200'
+                }`}
+              >
+                <Icon size={18} class="shrink-0" />
+                {showText && <span>{entry.title}</span>}
+              </a>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div
+      class="min-h-screen grid"
+      style={{
+        gridTemplateColumns: pinned ? `${EXPANDED_W}px 1fr` : `${COLLAPSED_W}px 1fr`,
+        transition: `grid-template-columns var(--spring-duration) var(--spring-soft)`,
+      }}
+    >
+      {/* Desktop rail wrapper (sticky cell) */}
+      <aside
+        aria-label="Docs navigation"
+        class="hidden md:block md:sticky md:top-0 md:h-screen relative"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {/* Inner panel: absolute so hover-peek floats over content */}
+        <div
+          class="absolute top-0 left-0 h-full bg-slate-50 border-r border-slate-200 overflow-hidden flex flex-col z-20 shadow-sm"
+          style={{
+            width: expanded ? `${EXPANDED_W}px` : `${COLLAPSED_W}px`,
+            transition: `width var(--spring-duration) var(--spring-soft)`,
+          }}
+        >
+          <a
+            href="/docs"
+            aria-label="hono-preact docs"
+            class={`flex items-center h-12 shrink-0 font-bold text-[0.95rem] text-slate-900 no-underline hover:text-blue-700 ${
+              expanded ? 'px-3' : 'justify-center px-0'
+            }`}
+          >
+            {expanded ? 'hono-preact docs' : <span class="text-lg">📚</span>}
+          </a>
+          <div class={`flex-1 overflow-y-auto overflow-x-hidden py-2 ${expanded ? 'px-2' : 'px-1.5'}`}>
+            {renderNav(expanded)}
+          </div>
+          <div class={`shrink-0 border-t border-slate-200 py-2 ${expanded ? 'px-2' : 'px-1.5'}`}>
+            <button
+              type="button"
+              aria-pressed={pinned}
+              aria-label={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+              onClick={() => setPinned((p) => !p)}
+              class={`flex items-center gap-3 h-9 w-full rounded text-sm text-slate-600 hover:text-slate-900 hover:bg-slate-200 ${
+                expanded ? 'px-3' : 'justify-center px-0'
+              }`}
+            >
+              {pinned ? <PinOff size={18} class="shrink-0" /> : <Pin size={18} class="shrink-0" />}
+              {expanded && <span>{pinned ? 'Unpin sidebar' : 'Pin sidebar'}</span>}
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      {/* Mobile top bar */}
+      <div class="flex items-center gap-3 bg-slate-50 border-b border-slate-200 py-2.5 px-3 sticky top-0 z-30 md:hidden col-span-full">
+        <button
+          type="button"
+          class="flex items-center gap-1 bg-white border border-slate-200 rounded-md py-1 px-2.5 text-[0.8rem] font-semibold text-slate-600 cursor-pointer shadow-sm shrink-0 hover:bg-slate-100"
+          onClick={() => setMobileOpen(true)}
+        >
+          ☰ Menu
+        </button>
+        {currentTitle && (
+          <span class="text-[0.85rem] font-semibold text-slate-900 whitespace-nowrap overflow-hidden text-ellipsis">
+            {currentTitle}
+          </span>
+        )}
+      </div>
+
+      {/* Mobile backdrop */}
+      <div
+        class={`fixed inset-0 bg-black/35 z-40 md:hidden ${mobileOpen ? 'block' : 'hidden'}`}
+        onClick={() => setMobileOpen(false)}
+      />
+
+      {/* Mobile drawer */}
+      <aside
+        aria-label="Docs navigation"
+        class="fixed top-0 bottom-0 left-0 w-[260px] bg-slate-50 border-r border-slate-200 z-50 flex flex-col md:hidden"
+        style={{
+          transform: mobileOpen ? 'translateX(0)' : 'translateX(-100%)',
+          transition: `transform var(--spring-duration) var(--spring-soft)`,
+        }}
+      >
+        <div class="flex justify-between items-center px-4 py-3 border-b border-slate-200 font-bold text-[0.9rem] text-slate-900">
+          Docs
+          <button
+            type="button"
+            class="bg-transparent border-none text-[1.1rem] text-slate-500 cursor-pointer leading-none p-1 hover:text-slate-900"
+            onClick={() => setMobileOpen(false)}
+            aria-label="Close menu"
+          >
+            ✕
+          </button>
+        </div>
+        <div class="p-3 overflow-y-auto flex-1">{renderNav(true)}</div>
+      </aside>
+
+      {/* Main content */}
+      <main class="max-w-[65ch] py-8 px-6">
+        <article class="mdx-content">{children}</article>
+        <nav class="flex justify-between mt-12 pt-6 border-t border-slate-200 text-sm">
+          <span>
+            {prev && (
+              <a
+                href={prev.route}
+                class="text-blue-600 no-underline hover:underline"
+              >
+                ← {prev.title}
+              </a>
+            )}
+          </span>
+          <span>
+            {next && (
+              <a
+                href={next.route}
+                class="text-blue-600 no-underline hover:underline"
+              >
+                {next.title} →
+              </a>
+            )}
+          </span>
+        </nav>
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+
+```bash
+pnpm --filter app exec tsc --noEmit
+```
+
+Expected: no errors. If `LucideIcon` import or `Icon` JSX usage errors, the most likely cause is the lucide build target; try `import { type ComponentType } from 'preact'` and type the `icon` field as `ComponentType<{ size?: number | string; class?: string }>` in `nav.ts`.
+
+### Task 4b: Verify desktop collapsed + hover-peek
+
+- [ ] **Step 1: Run the dev server and navigate to /docs**
+
+```bash
+pnpm --filter app dev
+```
+
+Open `http://localhost:5173/docs` in a desktop-width browser window.
+
+Expected:
+- 56px-wide rail on the left.
+- Each nav row shows just an icon, centered. Section headings are hidden.
+- The active route's icon row has a blue tint.
+- Mousing over the rail expands it smoothly to 240px without shifting the main content (the article stays put). Section headings appear; titles fade in next to icons.
+- Mousing out collapses it back after a brief delay (~120ms).
+- The pin button at the bottom shows a pin icon when collapsed, expanded shows "Pin sidebar".
+
+If main content moves when hovering, the float-over is broken; check that the rail's inner panel is `position: absolute` and the wrapper width is governed by `pinned`, not `expanded`.
+
+### Task 4c: Verify pin behavior
+
+- [ ] **Step 1: Click the pin button while hovered**
+
+Expected:
+- Pin icon swaps to "PinOff", label becomes "Unpin sidebar".
+- Main content shifts right ~184px as the grid column grows from 56px to 240px (animated by the spring curve).
+- Mousing away does NOT collapse the rail (because pinned wins).
+- Click "Unpin sidebar". Rail snaps back to 240px-while-hovered, content shifts back to 56px column. Mousing away then collapses the rail.
+
+### Task 4d: Verify mobile drawer
+
+- [ ] **Step 1: Resize the window below the `md` breakpoint (768px)**
+
+Expected:
+- Desktop rail disappears; the `☰ Menu` top bar appears.
+- Tapping `☰ Menu` slides in the 260px drawer with the same icon + title rendering as the desktop expanded state.
+- Tapping the backdrop or `✕` closes it.
+- Tapping a nav link navigates and closes the drawer? (Note: current implementation does not auto-close on navigation; this matches the existing behavior.)
+
+- [ ] **Step 2: Confirm reduced-motion**
+
+In devtools, emulate `prefers-reduced-motion: reduce`. Toggle pin, hover, mobile drawer. Expected: state changes are instantaneous (no animation).
+
+- [ ] **Step 3: Stop the dev server**
+
+`Ctrl+C`.
+
+- [ ] **Step 4: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run a production build to catch any build-time issues**
+
+```bash
+pnpm --filter app build
+```
+
+Expected: build succeeds without errors. If lucide-preact triggers SSR issues, the most likely fix is to ensure icons are imported as named exports (already the case in this plan).
+
+- [ ] **Step 6: Commit (confirm with user first)**
+
+```bash
+git add apps/app/src/components/DocsLayout.tsx
+git commit -m "feat(app): three-state docs sidebar rail"
+```
+
+---
+
+## Spec Coverage Self-Check
+
+| Spec requirement | Task |
+|---|---|
+| Three states: collapsed / hover-peek / pinned | Task 4 (4b, 4c) |
+| Hover floats over content; pinned reserves layout | Task 4a (grid col tied to `pinned`, inner panel `absolute`) |
+| Pin button at bottom of rail | Task 4a |
+| No localStorage persistence | Task 4a (state local to component) |
+| Mobile preserves slide-in drawer | Task 4a, 4d |
+| Mobile and desktop share nav rendering and icons | Task 4a (`renderNav(showText)`) |
+| Per-entry icons added to `nav.ts` | Task 2 |
+| `lucide-preact` (with lucide-react fallback) | Task 1 |
+| `linear()` spring curve in `root.css` | Task 3 |
+| `prefers-reduced-motion` override | Task 3 |
+| 56px collapsed, 240px expanded, 280ms duration, 120ms hover-close | Task 4a (constants + CSS vars) |
+| Accessibility: aria-label on aside, aria-pressed on pin, aria-label on icon-only links | Task 4a |
+| Reduced-motion behavior | Task 3 + Task 4d Step 2 |

--- a/docs/superpowers/specs/2026-05-02-docs-sidebar-rail-design.md
+++ b/docs/superpowers/specs/2026-05-02-docs-sidebar-rail-design.md
@@ -1,0 +1,180 @@
+# Docs Sidebar Rail — Design
+
+## Summary
+
+Replace the current docs sidebar with a three-state, icon-aware rail:
+
+1. **Collapsed** (default): 56px wide, icon-only.
+2. **Hover-peek**: 240px wide, icons + text, floats over content (does not push layout).
+3. **Pinned**: 240px wide, icons + text, layout reserves the full width. Toggled by a pin button at the bottom of the rail.
+
+Mobile (`< md`) preserves the current full-width slide-in overlay drawer; the rail markup is unified across breakpoints, with state and width branched by viewport.
+
+Pin state is in-component state only. No persistence (localStorage / cookie).
+
+Width and translate animations use a CSS `linear()` spring curve declared in `root.css`.
+
+## Non-goals
+
+- localStorage / cookie persistence of pin state.
+- Mobile rail behavior (mobile keeps the existing slide-in drawer).
+- Swipe gestures or Base UI Drawer integration on either platform.
+- View-transition animation of the rail itself (existing route view-transitions are unaffected).
+- Configurable widths or user-tunable animation speed.
+
+## Architecture
+
+### Component
+
+A single `<aside>` rendered in `apps/app/src/components/DocsLayout.tsx`. The component owns three pieces of state:
+
+- `pinned: boolean` (default `false`)
+- `hovered: boolean` (driven by mouse enter/leave on the rail; an internal close-delay timer holds it true for ~120ms after leave)
+- `mobileOpen: boolean` (existing behavior, controlled by the `☰ Menu` button)
+
+The viewport split is purely CSS-driven via Tailwind's `md:` prefix; the same DOM is used at both breakpoints.
+
+### State, viewport, and layout
+
+| Viewport | State | Rail width | Grid column | Rail position |
+|---|---|---|---|---|
+| `< md` | closed | 0 (translated -100%) | n/a (rail is fixed) | `fixed`, off-screen |
+| `< md` | open | 260px | n/a | `fixed`, on-screen |
+| `≥ md` | collapsed | 56px | 56px | sticky in-flow |
+| `≥ md` | hover-peek (`!pinned && hovered`) | 240px | 56px | sticky in-flow, but the *inner* panel is `absolute` and overflows the cell so it floats over content |
+| `≥ md` | pinned | 240px | 240px | sticky in-flow |
+
+Implementation note: to make hover-peek "float over" content while pinned "reserves" width, the desktop layout grid template column is driven by `pinned`, not `hovered`:
+
+```
+grid-template-columns: ${pinned ? '240px' : '56px'} 1fr;
+```
+
+The rail itself uses a wrapper of width `pinned ? 240px : 56px` (matches the grid), with an inner panel whose width is `(pinned || hovered) ? 240px : 56px`. The inner panel is `position: absolute; top: 0; left: 0; height: 100%` and has `overflow: hidden`, with a higher `z-index` than main content. When unpinned and hovered, the inner panel grows to 240px while the wrapper stays at 56px, producing the float-over effect. When pinned, both are 240px, so no float.
+
+### Nav data shape change
+
+`apps/app/src/pages/docs/nav.ts` gains an `icon` field per entry:
+
+```ts
+import type { LucideIcon } from 'lucide-preact';
+
+export type NavEntry = { title: string; route: string; icon: LucideIcon };
+export type NavSection = { heading: string; entries: NavEntry[] };
+```
+
+Concrete icon assignments (subject to taste, easy to swap later):
+
+| Route | Icon |
+|---|---|
+| `/docs` | `BookOpen` |
+| `/docs/quick-start` | `Rocket` |
+| `/docs/pages` | `FileText` |
+| `/docs/loaders` | `Database` |
+| `/docs/loading-states` | `Loader` |
+| `/docs/reloading` | `RefreshCw` |
+| `/docs/prefetch` | `Zap` |
+| `/docs/actions` | `Send` |
+| `/docs/optimistic-ui` | `Sparkles` |
+| `/docs/guards` | `ShieldCheck` |
+| `/docs/action-guards` | `ShieldAlert` |
+| `/docs/structure` | `FolderTree` |
+| `/docs/render-page` | `Layers` |
+| `/docs/vite-config` | `Settings` |
+| `/docs/deployment` | `Cloud` |
+
+Section headings are unchanged (no icon at the section level).
+
+### Icon library
+
+Add `lucide-preact` to `apps/app/package.json`. It exports React-compatible Preact components that work with the existing `@preact/compat` aliasing. Tree-shaken; one icon adds ~1KB.
+
+If `lucide-preact` proves incompatible with the build for any reason, fall back to `lucide-react` (the project already aliases `react` → `@preact/compat`, so the React build of lucide should resolve to Preact-compatible components).
+
+### Rendering by state
+
+- **Collapsed:** each row shows only the icon, centered in a 56px square. Section headings are hidden. Active route is indicated by a colored background on the icon row.
+- **Hover-peek / pinned:** each row shows icon + title side by side, left-aligned with 12px padding. Section headings (the existing uppercase labels) are visible above each section.
+- **Mobile open:** identical visual treatment to "pinned" (icon + title + section headings), inside the existing 260px slide-in panel.
+
+The transition between collapsed and expanded visuals is driven by the inner-panel width animation; text labels fade in via `opacity` keyed off the same width threshold (CSS `@container` query on the panel, or a parallel `data-expanded` attribute).
+
+### Pin button
+
+Bottom of the rail, in a `mt-auto` flex container so it always sits at the bottom regardless of nav length.
+
+- Icon: `Pin` when unpinned, `PinOff` (or rotated `Pin`) when pinned.
+- Hidden on mobile (`md:flex` on the button row, since on mobile the drawer is always fully expanded when open).
+- Hidden text label in collapsed mode; visible "Pin sidebar" / "Unpin sidebar" label in hover-peek and pinned states.
+- Click: `setPinned(p => !p)`. On unpin while still hovered, the rail stays expanded (because `hovered` is still true) until the user mouses away, which feels natural.
+
+### Hover handling
+
+- `onMouseEnter` on the rail wrapper sets `hovered = true` and clears any pending close timer.
+- `onMouseLeave` schedules `setHovered(false)` after 120ms; re-entering cancels the timer.
+- No open delay; expansion is instant.
+
+The open and close timing live in the component, not in CSS, because the CSS `linear()` curve handles the *animation*, not the *trigger latency*.
+
+### Animation
+
+Add to `apps/app/src/styles/root.css`:
+
+```css
+:root {
+  --spring-soft: linear(
+    0, 0.5 7.5%, 0.85 14%, 1.02 21%, 1.04 28%, 1.01 38%,
+    0.998 50%, 1.001 70%, 1
+  );
+  --spring-duration: 280ms;
+}
+```
+
+Used by:
+
+- The rail inner-panel `width` (`56px` ↔ `240px`).
+- The desktop grid `grid-template-columns` (`56px` ↔ `240px`) when pinned toggles.
+- The mobile drawer `transform: translateX(...)` (`-100%` ↔ `0`).
+
+Per-property:
+
+```css
+transition:
+  width var(--spring-duration) var(--spring-soft),
+  transform var(--spring-duration) var(--spring-soft),
+  grid-template-columns var(--spring-duration) var(--spring-soft);
+```
+
+Note: `grid-template-columns` is animatable in modern browsers (Chrome / Safari / Firefox via interpolation between equivalent track lists). If browser support proves spotty, the fallback is to animate the rail wrapper width directly and let the main content reflow without an explicit grid transition; the user-perceived effect is similar.
+
+`linear()` is supported in Chrome 113+, Safari 17.2+, Firefox 112+. No fallback declaration needed for the project's target browsers.
+
+### Coexistence with view-transitions
+
+`@view-transition { navigation: auto }` (already in `root.css`) handles route changes with a fade. The rail's CSS transitions are scoped to the `<aside>` and apply to layout properties unrelated to view-transition pseudo-elements, so the two effects do not interact.
+
+When the route changes, the rail's "active" highlight moves; this is animated by the same `linear()` curve via `background-color` and color transitions on the link rows.
+
+## Accessibility
+
+- The rail is a single `<aside>` with `aria-label="Docs navigation"`.
+- The pin button is a `<button>` with `aria-pressed={pinned}` and an accessible name reflecting the current action ("Pin sidebar" / "Unpin sidebar").
+- Each link's accessible name is its `title`; in collapsed mode, the icon-only row has `aria-label={title}` so screen readers still get the route name.
+- `prefers-reduced-motion: reduce` overrides set `--spring-duration: 0ms` on the relevant transitions.
+
+## Files touched
+
+- `apps/app/src/components/DocsLayout.tsx` — rewrite the layout to introduce the three-state rail and unify mobile/desktop markup.
+- `apps/app/src/pages/docs/nav.ts` — add `icon` field per entry; populate from the table above.
+- `apps/app/src/styles/root.css` — add `--spring-soft` and `--spring-duration` variables; add `prefers-reduced-motion` override.
+- `apps/app/package.json` — add `lucide-preact` (or `lucide-react` if the former does not build cleanly).
+
+## Open questions
+
+None.
+
+## Risks
+
+- **`grid-template-columns` interpolation:** if the browser's interpolation produces a janky animation on the layout grid, fall back to animating only the rail wrapper width (the page main content reflows naturally as the rail wrapper changes width).
+- **lucide-preact build:** if Preact-compat aliasing causes resolution issues, swap to `lucide-react`. Both consume the same icon names; the change is mechanical.
+- **Hover trap on transient hovers:** the 120ms close delay is intentional; if testers report "rail stays open too long" or "rail closes too fast," tune in 40ms increments.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       hoofd:
         specifier: ^1.7.3
         version: 1.7.3(@preact/compat@18.3.2(preact@10.29.1))
+      lucide-preact:
+        specifier: ^1.14.0
+        version: 1.14.0(preact@10.29.1)
       preact:
         specifier: ^10.29.1
         version: 10.29.1
@@ -2192,6 +2195,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-preact@1.14.0:
+    resolution: {integrity: sha512-d3N5MpFSukscLyPPtZEeYvSIWohLEj/2OJvjrYovWOTKa40bsHaALX9sIDS6skSu+J6bwYRqfwX6GAxlErfSmQ==}
+    peerDependencies:
+      preact: ^10.27.2
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4872,6 +4880,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-preact@1.14.0(preact@10.29.1):
+    dependencies:
+      preact: 10.29.1
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary

- Replaces the docs sidebar with a three-state rail: **collapsed** (56px, icons only), **hover-peek** (240px, floats over content), **pinned** (240px, layout reserves the width).
- Adds per-entry [lucide-preact](https://lucide.dev) icons to `nav.ts` and a data-integrity test.
- New `--spring-soft` `linear()` curve and `--spring-duration` (380ms) in `root.css`, with `prefers-reduced-motion` override.
- Section headings animate height + opacity so they slide into space as the rail expands.
- Mobile slide-in drawer preserved; same nav rendering shared between desktop and mobile.
- No persistence: pin state resets on page load.

Spec: `docs/superpowers/specs/2026-05-02-docs-sidebar-rail-design.md`
Plan: `docs/superpowers/plans/2026-05-02-docs-sidebar-rail.md`

## Test plan

- [ ] `pnpm test` passes (235/235 including 2 new tests in `nav.test.ts`).
- [ ] `pnpm --filter app build` succeeds.
- [ ] On `/docs` at desktop width: rail starts at 56px showing only icons; hovering expands it to 240px floating over content (article does not shift); clicking the pin button reserves layout space; clicking again unpins; un-pinning while still hovered keeps the rail open until the mouse leaves.
- [ ] Section headings slide their height into space as the rail expands (no instant pop-in).
- [ ] Below the `md` breakpoint: a top bar appears with `☰ Menu`; tapping it slides in the existing drawer; main content spans full viewport width with no left gap.
- [ ] Reduced-motion: with `prefers-reduced-motion: reduce` enabled, all transitions are instant.

## Follow-ups (not in this PR)

- Mobile drawer focus-trap, `aria-modal`, and Escape-key close.
- Optional: defensive `aria-hidden` on the inactive `<aside>` at each breakpoint (currently both are `display: none`-hidden, which already suppresses them from the AT tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)