### PR TITLE
feat: path-keyed module identity for loader/action RPC

### DIFF
--- a/apps/app/src/pages/docs/actions.mdx
+++ b/apps/app/src/pages/docs/actions.mdx
@@ -50,7 +50,7 @@ app
   .get('*', (c) => renderPage(c, <Layout context={c} />, { defaultTitle: 'my-app' }));
 ```
 
-`actionsHandler` accepts an `import.meta.glob` result. Both lazy (default) and eager (`{ eager: true }`) globs work. It derives the module name from the filename by stripping the path prefix and `.server.*` extension.
+`actionsHandler` accepts an `import.meta.glob` result. Both lazy (default) and eager (`{ eager: true }`) globs work. It routes by `mod.__moduleKey` — the path-derived key injected into each `.server.*` file by `moduleKeyPlugin`.
 
 ## Calling actions with `useAction`
 

--- a/apps/app/src/pages/docs/guards.mdx
+++ b/apps/app/src/pages/docs/guards.mdx
@@ -60,7 +60,7 @@ const serverLoader: LoaderFn<{ stats: Stats }> = async () => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ stats: Stats }>('admin', serverLoader);
+export const loader = defineLoader<{ stats: Stats }>(serverLoader);
 export const cache = createCache<{ stats: Stats }>();
 
 export const serverGuards = [
@@ -133,7 +133,7 @@ export const helper = () => {};
 export default serverLoader;
 
 // ✅ allowed
-export const loader = defineLoader('admin', serverLoader);
+export const loader = defineLoader(serverLoader);
 export const serverGuards = [...];
 export default serverLoader;
 ```

--- a/apps/app/src/pages/docs/index.mdx
+++ b/apps/app/src/pages/docs/index.mdx
@@ -8,7 +8,7 @@ Every route is a file pair: a `.tsx` page component and a `.server.ts` file that
 // movies.server.ts: runs only on the server
 const serverLoader = async () => ({ movies: await getMovies() });
 export default serverLoader;
-export const loader = defineLoader('movies', serverLoader);
+export const loader = defineLoader(serverLoader);
 
 // movies.tsx: the page component, with bindings attached via definePage
 import { definePage, useLoaderData } from '@hono-preact/iso';

--- a/apps/app/src/pages/docs/loaders.mdx
+++ b/apps/app/src/pages/docs/loaders.mdx
@@ -105,7 +105,7 @@ app
   .get('*', (c) => renderPage(c, <Layout context={c} />, { defaultTitle: 'my-app' }));
 ```
 
-`loadersHandler` derives the module name from the filename by stripping the path prefix and `.server.*` extension. This matches the convention used by `actionsHandler`.
+`loadersHandler` and `actionsHandler` route by `mod.__moduleKey` — the path-derived key injected into each `.server.*` file by `moduleKeyPlugin`. Modules without `__moduleKey` are silently skipped at map-build time.
 
 ## Caching navigation results
 

--- a/apps/app/src/pages/docs/loaders.mdx
+++ b/apps/app/src/pages/docs/loaders.mdx
@@ -38,7 +38,7 @@ const serverLoader: LoaderFn<{ movies: MovieList }> = async () => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader);
+export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
 ```
 
 **`src/pages/movies.tsx`** is a pure component, with `definePage` attaching the loader binding:
@@ -70,7 +70,7 @@ const Movies = lazy(() => import('./pages/movies.js'));
 <Route path="/movies" component={Movies} />
 ```
 
-`defineLoader(name, fn)` returns a typed reference (`LoaderRef<T>`). The `name` argument is required, must be a non-empty string, and is used as a stable identity key (via `Symbol.for`) so that the SSR loader, the client RPC stub, and `useLoaderData` all agree on the same reference even when the module is loaded twice. `definePage(Component, { loader })` stamps that reference onto the page component so the route runtime can pick it up. `useLoaderData<typeof loader>()` is a type-only consumer: the generic narrows the return type to the loader's return shape without dragging the loader ref in as a runtime value.
+`defineLoader(fn)` returns a typed reference (`LoaderRef<T>`). The Vite `moduleKeyPlugin` rewrites the call at build time to `defineLoader(fn, { __moduleKey: 'src/pages/movies' })` where the key is the file's path relative to the Vite project root with `.server.{ts,tsx,js,jsx}` stripped. The key drives RPC routing (`/__loaders`, `/__actions`), the `__id` Symbol identity, and HMR. Two `.server.*` files in different folders produce distinct keys by construction, so basename collisions are no longer a concern. `definePage(Component, { loader })` stamps that reference onto the page component so the route runtime can pick it up. `useLoaderData<typeof loader>()` is a type-only consumer: the generic narrows the return type to the loader's return shape without dragging the loader ref in as a runtime value.
 
 ## Example: detail page (using route params)
 
@@ -88,7 +88,7 @@ const serverLoader: LoaderFn<{ movie: Movie }> = async ({ location }) => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movie: Movie }>('movie', serverLoader);
+export const loader = defineLoader<{ movie: Movie }>(serverLoader);
 ```
 
 ## Registering the loader endpoint
@@ -121,7 +121,7 @@ const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader);
+export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
 export const cache = createCache<{ movies: MovieList }>();
 ```
 

--- a/apps/app/src/pages/docs/quick-start.mdx
+++ b/apps/app/src/pages/docs/quick-start.mdx
@@ -72,7 +72,7 @@ const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: Movie[] }>('movies', serverLoader);
+export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
 ```
 
 Update `src/pages/movies.tsx` to a pure consumer of the loader data, and bind the loader to the page with `definePage`:
@@ -114,7 +114,7 @@ const Movies = lazy(() => import('./pages/movies.js'));
 
 Reload `http://localhost:5173/movies`. The list renders server-side on first load, with the data preloaded into the HTML. On client-side navigation away and back, the framework calls the loader over RPC. Same function, no manual wiring.
 
-`defineLoader(name, fn)` returns a typed reference. The `name` is required and must match the user-chosen identifier on both sides (server module and client RPC stub), wired by `Symbol.for`. `definePage(Component, { loader })` attaches the loader to the page component so the route can find it. `useLoaderData<typeof loader>()` is argument-free; the type-only generic narrows the return type without pulling the loader ref in as a runtime value.
+`defineLoader(fn)` returns a typed reference. The Vite `moduleKeyPlugin` rewrites the call at build time to `defineLoader(fn, { __moduleKey: 'src/pages/movies' })` where the key is the file's path relative to the Vite project root with `.server.{ts,tsx,js,jsx}` stripped. The key drives RPC routing (`/__loaders`, `/__actions`), the `__id` Symbol identity, and HMR. `definePage(Component, { loader })` attaches the loader to the page component so the route can find it. `useLoaderData<typeof loader>()` is argument-free; the type-only generic narrows the return type without pulling the loader ref in as a runtime value.
 
 ## 3. Add a server action
 
@@ -140,7 +140,7 @@ const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: Movie[] }>('movies', serverLoader);
+export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
 
 export const serverActions = {
   addMovie: defineAction<{ title: string }, { ok: boolean }>(

--- a/apps/app/src/pages/docs/reloading.mdx
+++ b/apps/app/src/pages/docs/reloading.mdx
@@ -17,7 +17,7 @@ const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>('movies', serverLoader);
+export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
 export const cache = createCache<{ movies: MovieList }>();
 ```
 

--- a/apps/app/src/pages/movie.server.ts
+++ b/apps/app/src/pages/movie.server.ts
@@ -24,7 +24,7 @@ const serverLoader: LoaderFn<{ movie: Movie | null; watched: WatchedRecord | nul
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>('movie', serverLoader);
+export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>(serverLoader);
 
 export const serverActions = {
   toggleWatched: defineAction<{ movieId: number; watched: boolean }, { ok: boolean }>(

--- a/apps/app/src/pages/movies.server.ts
+++ b/apps/app/src/pages/movies.server.ts
@@ -11,7 +11,7 @@ const serverLoader: LoaderFn<{ movies: MoviesData; watchedIds: number[] }> = asy
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>('movies', serverLoader);
+export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>(serverLoader);
 export const cache = createCache<{ movies: MoviesData; watchedIds: number[] }>('movies-list');
 
 export const serverActions = {

--- a/apps/app/src/pages/watched.server.ts
+++ b/apps/app/src/pages/watched.server.ts
@@ -34,7 +34,7 @@ const serverLoader: LoaderFn<{ entries: Entry[] }> = async () => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ entries: Entry[] }>('watched', serverLoader);
+export const loader = defineLoader<{ entries: Entry[] }>(serverLoader);
 export const cache = createCache<{ entries: Entry[] }>('watched');
 
 export const serverActions = {

--- a/docs/superpowers/plans/2026-05-05-path-keyed-module-identity.md
+++ b/docs/superpowers/plans/2026-05-05-path-keyed-module-identity.md
@@ -1,0 +1,1638 @@
+# Path-Keyed Module Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace basename-as-routing-key with a Vite-plugin-injected path-derived module key, eliminating basename collisions and decoupling routing identity from filename conventions.
+
+**Architecture:** A new Vite plugin (`moduleKeyPlugin`) transforms `.server.*` files at build time to inject a module-level `export const __moduleKey = '<path>'` constant whose value is the file's path relative to the Vite project root with the `.server.{ts,tsx,js,jsx}` extension stripped. The same plugin threads this key into `defineLoader` calls via a hidden second-arg metadata. The existing `serverOnlyPlugin` is updated to (a) capture `viteRoot` via `configResolved`, and (b) emit the same path key in client-side RPC stubs (`loaderFetchArrow` and the `serverActions` Proxy). Server handlers (`loadersHandler`, `actionsHandler`) read `mod.__moduleKey` from glob entries instead of computing from filenames. `defineLoader`'s public type drops the string-name argument; `defineAction`'s runtime is unchanged because all action identity flows through the Proxy.
+
+**Tech Stack:** TypeScript, Vite plugin API, Babel parser (`@babel/parser`), MagicString, Hono, vitest.
+
+**Companion to:** `docs/superpowers/research/2026-05-04-framework-simplification.md` §4.3, §6.3, §7.3, §9 step 1.
+
+---
+
+## File Structure
+
+### Modified files
+
+- `packages/iso/src/define-loader.ts` — accept `(fn, opts?)` overload where `opts.__moduleKey` builds `__id = Symbol.for('@hono-preact/loader:' + opts.__moduleKey)`. The legacy `(name, fn)` overload stays alive through this plan and is removed in the final task.
+- `packages/iso/src/__tests__/define-loader.test.ts` — replace tests covering the string-name shape with tests covering the `__moduleKey` opts shape and the path-keyed `__id` derivation.
+- `packages/vite/src/server-only.ts` — capture `viteRoot` via `configResolved`. Update `loaderFetchArrow` to take a key string instead of computing from `serverImport.source.value`. Update the `serverActions` Proxy emission to use the same key. Update `loader` import rewrite to use the plugin-derived key. Drop `extractLoaderName` (no longer needed) and `extractCacheName`'s loader-related fallback.
+- `packages/vite/src/__tests__/server-only-plugin.test.ts` — update assertions: `__module` and `__action` payloads carry the path key, not the basename. Update fixture filesystem expectations.
+- `packages/vite/src/index.ts` — re-export the new `moduleKeyPlugin`.
+- `packages/vite/src/hono-preact.ts` — wire `moduleKeyPlugin` into the meta-plugin's plugin list alongside `serverOnlyPlugin`.
+- `packages/server/src/loaders-handler.ts` — read `mod.__moduleKey` from each glob entry; remove `moduleNameFromPath`.
+- `packages/server/src/actions-handler.ts` — read `mod.__moduleKey` from each glob entry; remove `moduleNameFromPath`.
+- `packages/server/src/__tests__/loaders-handler.test.ts` — update fixtures to set `__moduleKey` instead of relying on filename keys.
+- `packages/server/src/__tests__/actions-handler.test.ts` — same.
+- `apps/app/src/pages/movies.server.ts` — drop the `'movies'` string argument from `defineLoader`.
+- `apps/app/src/pages/watched.server.ts` — drop the `'watched'` string argument from `defineLoader`.
+- `apps/app/src/pages/movie.server.ts` — drop the `'movie'` string argument from `defineLoader`.
+
+### Created files
+
+- `packages/vite/src/module-key.ts` — pure helper: `deriveModuleKey(absPath, viteRoot)` returning `path.relative(viteRoot, absPath).replace(/\.server\.[jt]sx?$/, '').replace(/\\/g, '/')`. Single responsibility: path → key. Used by both `moduleKeyPlugin` and `serverOnlyPlugin`.
+- `packages/vite/src/__tests__/module-key.test.ts` — unit tests for the helper.
+- `packages/vite/src/module-key-plugin.ts` — the new plugin. Captures `viteRoot` via `configResolved`. Transforms `.server.{ts,tsx,js,jsx}` files only. Parses, prepends `export const __moduleKey = '<key>';`, threads `{ __moduleKey }` into `defineLoader(fn)` calls (so the runtime symbol matches the client-side stub).
+- `packages/vite/src/__tests__/module-key-plugin.test.ts` — unit tests for the plugin's transform.
+
+### Deleted files
+
+None.
+
+---
+
+## Task 1: Add the `deriveModuleKey` helper
+
+**Files:**
+- Create: `packages/vite/src/module-key.ts`
+- Test: `packages/vite/src/__tests__/module-key.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/src/__tests__/module-key.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { deriveModuleKey } from '../module-key.js';
+
+describe('deriveModuleKey', () => {
+  it('produces a forward-slash path relative to root with the .server.ts extension stripped', () => {
+    const root = '/Users/me/repo';
+    const abs = '/Users/me/repo/apps/app/src/pages/movies.server.ts';
+    expect(deriveModuleKey(abs, root)).toBe('apps/app/src/pages/movies');
+  });
+
+  it('handles .server.tsx extensions', () => {
+    expect(
+      deriveModuleKey('/r/src/pages/admin.server.tsx', '/r')
+    ).toBe('src/pages/admin');
+  });
+
+  it('handles .server.js and .server.jsx extensions', () => {
+    expect(deriveModuleKey('/r/a/x.server.js', '/r')).toBe('a/x');
+    expect(deriveModuleKey('/r/a/x.server.jsx', '/r')).toBe('a/x');
+  });
+
+  it('normalizes Windows-style path separators to forward slashes', () => {
+    expect(
+      deriveModuleKey('C:\\repo\\src\\pages\\movies.server.ts', 'C:\\repo')
+    ).toBe('src/pages/movies');
+  });
+
+  it('produces distinct keys for files that share a basename in different folders', () => {
+    const root = '/r';
+    const a = deriveModuleKey('/r/pages/movies.server.ts', root);
+    const b = deriveModuleKey('/r/pages/admin/movies.server.ts', root);
+    expect(a).not.toBe(b);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key.test.ts`
+
+Expected: FAIL — "Cannot find module '../module-key.js'".
+
+- [ ] **Step 3: Implement the helper**
+
+Create `packages/vite/src/module-key.ts`:
+
+```ts
+import * as path from 'node:path';
+
+/**
+ * Derive the stable module key for a `.server.*` file.
+ *
+ * The key is the file's path relative to the Vite project root, with the
+ * `.server.{ts,tsx,js,jsx}` extension stripped, and path separators
+ * normalized to forward slashes (so the key is identical on Windows and
+ * POSIX). Used as the routing key for `__loaders`/`__actions` RPC, the
+ * payload of `Symbol.for(...)` for `__id`, and the value of the
+ * module-level `__moduleKey` export.
+ */
+export function deriveModuleKey(absPath: string, viteRoot: string): string {
+  const rel = path.relative(viteRoot, absPath);
+  const stripped = rel.replace(/\.server\.[jt]sx?$/, '');
+  return stripped.replace(/\\/g, '/');
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key.test.ts`
+
+Expected: PASS — 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/module-key.ts packages/vite/src/__tests__/module-key.test.ts
+git commit -m "feat(vite): add deriveModuleKey helper"
+```
+
+---
+
+## Task 2: Add `__moduleKey` opts overload to `defineLoader`
+
+**Files:**
+- Modify: `packages/iso/src/define-loader.ts`
+- Test: `packages/iso/src/__tests__/define-loader.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/iso/src/__tests__/define-loader.test.ts`:
+
+```ts
+describe('defineLoader (path-keyed __moduleKey form)', () => {
+  it('accepts (fn, { __moduleKey }) and derives __id from the key', () => {
+    const ref = defineLoader(async () => ({}), {
+      __moduleKey: 'apps/app/src/pages/movies',
+    });
+    expect(Symbol.keyFor(ref.__id)).toBe(
+      '@hono-preact/loader:apps/app/src/pages/movies'
+    );
+  });
+
+  it('produces the same __id symbol for two calls with the same __moduleKey', () => {
+    const a = defineLoader(async () => ({}), { __moduleKey: 'pages/movies' });
+    const b = defineLoader(async () => ({}), { __moduleKey: 'pages/movies' });
+    expect(a.__id).toBe(b.__id);
+  });
+
+  it('produces distinct __id for distinct __moduleKey values', () => {
+    const a = defineLoader(async () => ({}), { __moduleKey: 'pages/movies' });
+    const b = defineLoader(async () => ({}), {
+      __moduleKey: 'pages/admin/movies',
+    });
+    expect(a.__id).not.toBe(b.__id);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/iso/src/__tests__/define-loader.test.ts`
+
+Expected: FAIL — first test throws "name must be a non-empty string" because the runtime currently rejects the new shape.
+
+- [ ] **Step 3: Implement the overload**
+
+Update `packages/iso/src/define-loader.ts` in full:
+
+```ts
+import type { RouteHook } from 'preact-iso';
+import type { LoaderCache } from './cache.js';
+
+export type LoaderCtx = { location: RouteHook };
+
+export type Loader<T> = (ctx: LoaderCtx) => Promise<T>;
+
+export interface LoaderRef<T> {
+  readonly __id: symbol;
+  readonly fn: Loader<T>;
+  readonly cache?: LoaderCache<T>;
+}
+
+export type DefineLoaderOpts<T> = {
+  __moduleKey: string;
+  cache?: LoaderCache<T>;
+};
+
+// Public form (post-plugin authoring): defineLoader(fn) — the plugin will
+// rewrite this to defineLoader(fn, { __moduleKey: '...' }) at build time.
+export function defineLoader<T>(fn: Loader<T>): LoaderRef<T>;
+// Plugin-emitted form: defineLoader(fn, { __moduleKey, cache? }).
+export function defineLoader<T>(
+  fn: Loader<T>,
+  opts: DefineLoaderOpts<T>
+): LoaderRef<T>;
+// Legacy form (deprecated, removed in the final task of this plan):
+// defineLoader(name, fn, cache?).
+export function defineLoader<T>(
+  name: string,
+  fn: Loader<T>,
+  cache?: LoaderCache<T>
+): LoaderRef<T>;
+export function defineLoader<T>(
+  fnOrName: Loader<T> | string,
+  fnOrOpts?: Loader<T> | DefineLoaderOpts<T>,
+  legacyCache?: LoaderCache<T>
+): LoaderRef<T> {
+  if (typeof fnOrName === 'string') {
+    // Legacy (name, fn) form.
+    const name = fnOrName;
+    const fn = fnOrOpts as Loader<T>;
+    if (name.length === 0) {
+      throw new Error(
+        'defineLoader(name, fn): name must be a non-empty string. ' +
+          "Pick a stable identifier matching the .server.* module basename, " +
+          "e.g. defineLoader('movies', serverLoader)."
+      );
+    }
+    return {
+      __id: Symbol.for(`@hono-preact/loader:${name}`),
+      fn,
+      cache: legacyCache,
+    };
+  }
+
+  // New (fn, opts?) form. When opts is absent, the plugin hasn't run yet
+  // (e.g. in unit tests of consumer code that import the .server.* file
+  // directly). Use a placeholder symbol; identity will be unstable across
+  // module reloads, which is acceptable for tests.
+  const fn = fnOrName;
+  const opts = fnOrOpts as DefineLoaderOpts<T> | undefined;
+  if (opts?.__moduleKey) {
+    return {
+      __id: Symbol.for(`@hono-preact/loader:${opts.__moduleKey}`),
+      fn,
+      cache: opts.cache,
+    };
+  }
+  return {
+    __id: Symbol(`@hono-preact/loader:<unkeyed>`),
+    fn,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/iso/src/__tests__/define-loader.test.ts`
+
+Expected: PASS — all existing tests plus the three new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/define-loader.ts packages/iso/src/__tests__/define-loader.test.ts
+git commit -m "feat(iso): add defineLoader (fn, { __moduleKey }) overload"
+```
+
+---
+
+## Task 3: Capture `viteRoot` in `serverOnlyPlugin`
+
+**Files:**
+- Modify: `packages/vite/src/server-only.ts`
+- Test: `packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+The plugin currently has no access to the project root. Add a `configResolved` hook to capture it and a private accessor for tests.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/vite/src/__tests__/server-only-plugin.test.ts`:
+
+```ts
+describe('serverOnlyPlugin viteRoot capture', () => {
+  it('captures viteRoot from configResolved and exposes it for plugin coordination', () => {
+    const plugin = serverOnlyPlugin() as Plugin & {
+      configResolved?: (config: { root: string }) => void;
+      _viteRoot?: () => string | undefined;
+    };
+    expect(plugin._viteRoot?.()).toBeUndefined();
+    plugin.configResolved?.({ root: '/Users/me/repo' });
+    expect(plugin._viteRoot?.()).toBe('/Users/me/repo');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+Expected: FAIL — `plugin._viteRoot` is undefined.
+
+- [ ] **Step 3: Add the hook and accessor**
+
+In `packages/vite/src/server-only.ts`, replace the `export function serverOnlyPlugin(): Plugin {` body's opening with:
+
+```ts
+export function serverOnlyPlugin(): Plugin {
+  let viteRoot: string | undefined;
+  return {
+    name: 'server-only',
+    enforce: 'pre',
+    configResolved(config) {
+      viteRoot = config.root;
+    },
+    // Test-only accessor. Used by unit tests to verify the hook fires;
+    // not part of the public plugin contract.
+    _viteRoot: () => viteRoot,
+    transform(code: string, id: string, options?: { ssr?: boolean }) {
+      // ...existing body unchanged for now...
+```
+
+(Leave the existing `transform` body unchanged in this task — we'll consume `viteRoot` in Task 6.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+Expected: PASS — the new test passes; all existing tests still pass (no behavior change in `transform` yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/server-only.ts packages/vite/src/__tests__/server-only-plugin.test.ts
+git commit -m "feat(vite): capture viteRoot in serverOnlyPlugin via configResolved"
+```
+
+---
+
+## Task 4: Create `moduleKeyPlugin` skeleton (configResolved + .server.* gate)
+
+**Files:**
+- Create: `packages/vite/src/module-key-plugin.ts`
+- Test: `packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+This task delivers a plugin that recognizes `.server.*` files but does no transform yet (returns `undefined`). Subsequent tasks fill in behavior.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/src/__tests__/module-key-plugin.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { moduleKeyPlugin } from '../module-key-plugin.js';
+import type { Plugin } from 'vite';
+
+type TransformFn = (
+  code: string,
+  id: string
+) => { code: string; map: unknown } | undefined;
+
+function makePlugin() {
+  const plugin = moduleKeyPlugin() as Plugin & {
+    configResolved?: (config: { root: string }) => void;
+    transform: TransformFn;
+  };
+  plugin.configResolved?.({ root: '/Users/me/repo' });
+  return plugin;
+}
+
+describe('moduleKeyPlugin', () => {
+  it('returns undefined for non-server files', () => {
+    const plugin = makePlugin();
+    const result = plugin.transform.call(
+      {} as any,
+      `export const x = 1;`,
+      '/Users/me/repo/src/util.ts'
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for files outside the configured root', () => {
+    const plugin = makePlugin();
+    const result = plugin.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      '/elsewhere/movies.server.ts'
+    );
+    // viteRoot mismatch is a configuration error; plugin no-ops rather than
+    // throws to avoid breaking dev for files outside the watched root.
+    expect(result).toBeUndefined();
+  });
+
+  it('transforms .server.ts files inside the root (returns a code object)', () => {
+    const plugin = makePlugin();
+    const code = `export default async () => ({});`;
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result).toBeDefined();
+    expect(result?.code).toBeTypeOf('string');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the skeleton**
+
+Create `packages/vite/src/module-key-plugin.ts`:
+
+```ts
+import type { Plugin } from 'vite';
+
+/**
+ * Transforms `.server.*` files to inject a stable module-level
+ * `__moduleKey` export (and to thread that key into `defineLoader` calls).
+ * The key is path-derived (see `deriveModuleKey`), so it survives builds
+ * and HMR, and is unique per file.
+ *
+ * Pairs with `serverOnlyPlugin`, which transforms client-side imports of
+ * `.server.*` files. Both plugins compute the same key from the same
+ * absolute path + viteRoot.
+ */
+export function moduleKeyPlugin(): Plugin {
+  let viteRoot: string | undefined;
+  return {
+    name: 'module-key',
+    enforce: 'pre',
+    configResolved(config) {
+      viteRoot = config.root;
+    },
+    transform(code: string, id: string) {
+      if (viteRoot === undefined) return;
+      if (!/\.server\.[jt]sx?$/.test(id)) return;
+      if (!id.startsWith(viteRoot)) return;
+      // Skeleton: signals that we'll handle this file in subsequent tasks.
+      return { code, map: null };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+Expected: PASS — three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/module-key-plugin.ts packages/vite/src/__tests__/module-key-plugin.test.ts
+git commit -m "feat(vite): add moduleKeyPlugin skeleton"
+```
+
+---
+
+## Task 5: `moduleKeyPlugin` injects `__moduleKey` export
+
+**Files:**
+- Modify: `packages/vite/src/module-key-plugin.ts`
+- Modify: `packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/vite/src/__tests__/module-key-plugin.test.ts`:
+
+```ts
+describe('moduleKeyPlugin __moduleKey injection', () => {
+  it('prepends `export const __moduleKey = "<key>"` to .server.ts files', () => {
+    const plugin = makePlugin();
+    const code = `export default async () => ({});`;
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toMatch(
+      /^export const __moduleKey = "src\/pages\/movies";/
+    );
+  });
+
+  it('uses the path-derived key for nested folders', () => {
+    const plugin = makePlugin();
+    const result = plugin.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      '/Users/me/repo/src/pages/admin/movies.server.ts'
+    );
+    expect(result?.code).toMatch(
+      /^export const __moduleKey = "src\/pages\/admin\/movies";/
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+Expected: FAIL — output code does not contain `__moduleKey`.
+
+- [ ] **Step 3: Implement injection**
+
+Update `packages/vite/src/module-key-plugin.ts`:
+
+```ts
+import MagicString from 'magic-string';
+import type { Plugin } from 'vite';
+import { deriveModuleKey } from './module-key.js';
+
+export function moduleKeyPlugin(): Plugin {
+  let viteRoot: string | undefined;
+  return {
+    name: 'module-key',
+    enforce: 'pre',
+    configResolved(config) {
+      viteRoot = config.root;
+    },
+    transform(code: string, id: string) {
+      if (viteRoot === undefined) return;
+      if (!/\.server\.[jt]sx?$/.test(id)) return;
+      if (!id.startsWith(viteRoot)) return;
+
+      const key = deriveModuleKey(id, viteRoot);
+      const s = new MagicString(code);
+      s.prepend(`export const __moduleKey = ${JSON.stringify(key)};\n`);
+      return { code: s.toString(), map: s.generateMap({ hires: true }) };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/module-key-plugin.ts packages/vite/src/__tests__/module-key-plugin.test.ts
+git commit -m "feat(vite): moduleKeyPlugin injects __moduleKey export"
+```
+
+---
+
+## Task 6: `moduleKeyPlugin` threads `__moduleKey` into `defineLoader` calls
+
+**Files:**
+- Modify: `packages/vite/src/module-key-plugin.ts`
+- Modify: `packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/vite/src/__tests__/module-key-plugin.test.ts`:
+
+```ts
+describe('moduleKeyPlugin defineLoader threading', () => {
+  it('rewrites `defineLoader(fn)` to `defineLoader(fn, { __moduleKey })`', () => {
+    const plugin = makePlugin();
+    const code = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `const serverLoader = async () => ({});`,
+      `export default serverLoader;`,
+      `export const loader = defineLoader(serverLoader);`,
+    ].join('\n');
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toContain(
+      'defineLoader(serverLoader, { __moduleKey: "src/pages/movies" })'
+    );
+  });
+
+  it('leaves an existing two-arg defineLoader call unchanged', () => {
+    // Legacy (name, fn) form is still supported until the cleanup task; the
+    // plugin should not touch calls that already have a second argument.
+    const plugin = makePlugin();
+    const code = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `export const loader = defineLoader('movies', async () => ({}));`,
+    ].join('\n');
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toContain(
+      `defineLoader('movies', async () => ({}))`
+    );
+    expect(result?.code).not.toContain('__moduleKey: ');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+Expected: FAIL — first new test does not contain the expected rewrite.
+
+- [ ] **Step 3: Implement threading**
+
+Replace the body of `packages/vite/src/module-key-plugin.ts`:
+
+```ts
+import { parse } from '@babel/parser';
+import MagicString from 'magic-string';
+import type { CallExpression } from '@babel/types';
+import type { Plugin } from 'vite';
+import { deriveModuleKey } from './module-key.js';
+
+export function moduleKeyPlugin(): Plugin {
+  let viteRoot: string | undefined;
+  return {
+    name: 'module-key',
+    enforce: 'pre',
+    configResolved(config) {
+      viteRoot = config.root;
+    },
+    transform(code: string, id: string) {
+      if (viteRoot === undefined) return;
+      if (!/\.server\.[jt]sx?$/.test(id)) return;
+      if (!id.startsWith(viteRoot)) return;
+
+      const key = deriveModuleKey(id, viteRoot);
+      const s = new MagicString(code);
+      s.prepend(`export const __moduleKey = ${JSON.stringify(key)};\n`);
+
+      // Walk the AST for top-level CallExpressions whose callee is the
+      // identifier `defineLoader` and which have exactly one argument.
+      // Rewrite to `defineLoader(<arg>, { __moduleKey: '<key>' })`.
+      let ast;
+      try {
+        ast = parse(code, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+          errorRecovery: true,
+        });
+      } catch {
+        // If the file fails to parse we still emit the prepended
+        // __moduleKey so the routing layer works even if loader threading
+        // doesn't. Surface the parse error to Vite so the user sees it.
+        return { code: s.toString(), map: s.generateMap({ hires: true }) };
+      }
+
+      const visitCall = (node: CallExpression) => {
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'defineLoader' ||
+          node.arguments.length !== 1
+        ) {
+          return;
+        }
+        const arg = node.arguments[0];
+        if (arg.type === 'StringLiteral') return; // legacy (name, fn) form
+        const insertAt = arg.end;
+        if (insertAt == null) return;
+        s.appendRight(
+          insertAt,
+          `, { __moduleKey: ${JSON.stringify(key)} }`
+        );
+      };
+
+      // Top-level statement walk. defineLoader is overwhelmingly used at
+      // module scope; we don't recurse into nested function bodies to keep
+      // the plugin cheap.
+      for (const stmt of ast.program.body) {
+        if (
+          stmt.type === 'ExportNamedDeclaration' &&
+          stmt.declaration?.type === 'VariableDeclaration'
+        ) {
+          for (const decl of stmt.declaration.declarations) {
+            if (decl.init?.type === 'CallExpression') visitCall(decl.init);
+          }
+        } else if (
+          stmt.type === 'VariableDeclaration'
+        ) {
+          for (const decl of stmt.declarations) {
+            if (decl.init?.type === 'CallExpression') visitCall(decl.init);
+          }
+        }
+      }
+
+      return { code: s.toString(), map: s.generateMap({ hires: true }) };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+Expected: PASS — five tests in this file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/module-key-plugin.ts packages/vite/src/__tests__/module-key-plugin.test.ts
+git commit -m "feat(vite): moduleKeyPlugin threads __moduleKey into defineLoader calls"
+```
+
+---
+
+## Task 7: Register `moduleKeyPlugin` in the package's public surface
+
+**Files:**
+- Modify: `packages/vite/src/index.ts`
+- Modify: `packages/vite/src/hono-preact.ts`
+
+- [ ] **Step 1: Re-export the plugin**
+
+Update `packages/vite/src/index.ts` in full:
+
+```ts
+export { honoPreact } from './hono-preact.js';
+export { serverLoaderValidationPlugin } from './server-loader-validation.js';
+export { serverOnlyPlugin } from './server-only.js';
+export { moduleKeyPlugin } from './module-key-plugin.js';
+```
+
+- [ ] **Step 2: Wire `moduleKeyPlugin` into the meta-plugin's returned array**
+
+Open `packages/vite/src/hono-preact.ts`. Add the import near the existing plugin imports:
+
+```ts
+import { moduleKeyPlugin } from './module-key-plugin.js';
+```
+
+Find the returned plugin array (currently lines ~21–102). Add `moduleKeyPlugin()` immediately before `serverOnlyPlugin()`:
+
+```ts
+    serverLoaderValidationPlugin(),
+    moduleKeyPlugin(),
+    serverOnlyPlugin(),
+```
+
+(Order rationale: `moduleKeyPlugin` injects `__moduleKey` into `.server.*` files; `serverOnlyPlugin` rewrites client-side imports of those same files. Both run with `enforce: 'pre'`, so Vite orders them by array position.)
+
+- [ ] **Step 3: Build to confirm wiring**
+
+Run: `pnpm --filter @hono-preact/vite build`
+
+Expected: build succeeds; new types are emitted; `dist/index.d.ts` exports `moduleKeyPlugin`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/vite/src/index.ts packages/vite/src/hono-preact.ts
+git commit -m "feat(vite): wire moduleKeyPlugin into the public exports"
+```
+
+---
+
+## Task 8: `serverOnlyPlugin` emits the path key in client-side `loader` stubs
+
+**Files:**
+- Modify: `packages/vite/src/server-only.ts`
+- Modify: `packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+The plugin currently extracts the loader name from the `.server.*` source via `extractLoaderName` and falls back to the basename. After this task, the plugin uses `deriveModuleKey(absPath, viteRoot)` instead.
+
+- [ ] **Step 1: Refactor the existing tests + add new ones**
+
+Open `packages/vite/src/__tests__/server-only-plugin.test.ts`. The transform now requires `viteRoot`, so every test that asserts on transform output needs `configResolved` called first. Refactor the `transform` helper to do this, then update the basename-asserting tests to assert path keys.
+
+Replace the existing `transform` helper with:
+
+```ts
+function transform(
+  code: string,
+  id: string,
+  options: { ssr?: boolean; root?: string } = {}
+): { code: string; map: unknown } | undefined {
+  const plugin = serverOnlyPlugin() as Plugin & {
+    transform: TransformFn;
+    configResolved?: (c: { root: string }) => void;
+  };
+  plugin.configResolved?.({ root: options.root ?? '/Users/me/repo' });
+  const { ssr } = options;
+  return plugin.transform.call({} as any, code, id, ssr ? { ssr } : {});
+}
+```
+
+Then update the affected tests:
+
+- "replaces a default *.server.* import with an RPC fetch stub" — change `id` to `/Users/me/repo/src/pages/movies.tsx` and assert path-key payloads:
+
+```ts
+  it('replaces a default *.server.* import with an RPC fetch stub keyed by module path', () => {
+    const code = `import serverLoader from './movies.server.js';`;
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
+    expect(result?.code).toContain(`fetch('/__loaders'`);
+    expect(result?.code).toContain('"src/pages/movies"');
+    expect(result?.code).toContain('location.path');
+  });
+```
+
+- "stubs all .server imports when a file has more than one" — assert two distinct path keys derived from the resolved `.server.*` paths:
+
+```ts
+  it('stubs all .server imports when a file has more than one (each with its own path key)', () => {
+    const code = [
+      `import serverLoader from './movies.server.js';`,
+      `import authLoader from './auth.server.js';`,
+    ].join('\n');
+    const result = transform(code, '/Users/me/repo/src/pages/page.tsx');
+    expect(result?.code).toContain('"src/pages/movies"');
+    expect(result?.code).toContain('"src/pages/auth"');
+    expect(result?.code).not.toContain('async () => ({})');
+  });
+```
+
+- Add a new test for the named `loader` stub's symbol shape:
+
+```ts
+  it('emits the path key in named `loader` stubs as Symbol.for(@hono-preact/loader:<key>)', () => {
+    const code = `import { loader } from './movies.server.js';`;
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
+    expect(result?.code).toContain(
+      `Symbol.for('@hono-preact/loader:src/pages/movies')`
+    );
+  });
+```
+
+Tests that don't assert on the basename (`leaves non-server imports untouched`, `returns undefined when ssr option is true`, `does not transform *.server.* files themselves`, `returns undefined when the code contains no .server reference`, the `serverGuards` test, the `viteRoot capture` test from Task 3) keep working unchanged once the helper provides a default root.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+Expected: FAIL — emitted code still contains `"movies"`, not `"src/pages/movies"`.
+
+- [ ] **Step 3: Update the plugin to use `deriveModuleKey`**
+
+Open `packages/vite/src/server-only.ts`. Add the import alongside the existing imports:
+
+```ts
+import { deriveModuleKey } from './module-key.js';
+```
+
+Inside the existing `transform` function, immediately before the per-import `for` loop (i.e. just before `for (const serverImport of [...serverImports].reverse()) {`), add a guard:
+
+```ts
+      if (viteRoot === undefined) return;
+      const importerDir = path.dirname(id);
+```
+
+(`path` is already imported at the top of the file.)
+
+For each `serverImport`, replace the single line:
+
+```ts
+const moduleName = moduleNameFromSource(serverImport.source.value);
+```
+
+with:
+
+```ts
+const absServerPath = path.resolve(importerDir, serverImport.source.value);
+const moduleKey = deriveModuleKey(absServerPath, viteRoot);
+```
+
+Then update every subsequent usage in that block:
+
+- The default-import branch's `loaderFetchArrow(moduleName, '')` → `loaderFetchArrow(moduleKey, '')`.
+- The `serverActions` Proxy branch's `__module: ${JSON.stringify(moduleName)}` → `__module: ${JSON.stringify(moduleKey)}`.
+- The `loader` named-import branch — replace the existing AST-extracted loader-name path with the path key:
+  ```ts
+  } else if (
+    specifier.type === 'ImportSpecifier' &&
+    specifier.imported.type === 'Identifier' &&
+    specifier.imported.name === 'loader'
+  ) {
+    stubs.push(
+      `const ${specifier.local.name} = {\n` +
+      `  __id: Symbol.for('@hono-preact/loader:${moduleKey}'),\n` +
+      `  fn: ${loaderFetchArrow(moduleKey, '  ')},\n` +
+      `};`
+    );
+  }
+  ```
+- The `cache` named-import branch — change the fallback fed into `extractCacheName` from `moduleName` to `moduleKey`:
+  ```ts
+  const cacheName = extractCacheName(id, serverImport.source.value, moduleKey);
+  ```
+
+After these edits, two helpers are no longer referenced anywhere: `moduleNameFromSource` and `extractLoaderName`. Delete both. Keep `extractStringArgFromVarDecl`, `readSource`, and `extractCacheName` — the cache-name extraction path still relies on them, since `createCache('foo')` is consumer-typed and not replaced by path-keying.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+Expected: PASS — both new tests + all unmodified tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/server-only.ts packages/vite/src/__tests__/server-only-plugin.test.ts
+git commit -m "feat(vite): serverOnlyPlugin emits path-keyed RPC stubs"
+```
+
+---
+
+## Task 9: Update the `serverActions` Proxy assertions
+
+**Files:**
+- Modify: `packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+The existing test at line ~74 (`'replaces serverActions named import with a Proxy stub using module name from filename'`) asserts `__module: "movies"`. After Task 8, this becomes `__module: "src/pages/movies"`. Update.
+
+- [ ] **Step 1: Update the test**
+
+Use the centralized `transform` helper introduced in Task 8 step 1. Replace the test body:
+
+```ts
+  it('replaces serverActions named import with a Proxy stub keyed by module path', () => {
+    const code = `import { serverActions } from './movies.server.js';`;
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
+    expect(result?.code).toContain('const serverActions = new Proxy(');
+    expect(result?.code).toContain('__module: "src/pages/movies"');
+    expect(result?.code).toContain('__action: String(action)');
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/server-only-plugin.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/vite/src/__tests__/server-only-plugin.test.ts
+git commit -m "test(vite): assert path-keyed __module in Proxy stub"
+```
+
+---
+
+## Task 10: `loadersHandler` reads `mod.__moduleKey`
+
+**Files:**
+- Modify: `packages/server/src/loaders-handler.ts`
+- Modify: `packages/server/src/__tests__/loaders-handler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `packages/server/src/__tests__/loaders-handler.test.ts`. Add (or replace) a test that supplies a glob entry with `__moduleKey` and verifies the handler routes by it.
+
+```ts
+describe('loadersHandler path-keyed routing', () => {
+  it('routes lookups by mod.__moduleKey rather than filename', async () => {
+    const glob = {
+      // Filename and __moduleKey deliberately disagree to prove the
+      // handler trusts the export, not the path.
+      '/whatever.server.ts': {
+        __moduleKey: 'src/pages/movies',
+        default: async () => ({ id: 1 }),
+      },
+    };
+    const handler = loadersHandler(glob);
+    const req = new Request('http://localhost/__loaders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        module: 'src/pages/movies',
+        location: { path: '/movies', pathParams: {}, searchParams: {} },
+      }),
+    });
+    const ctx = { req: { json: () => req.json() } } as any;
+    const res = await handler(ctx, async () => undefined as any);
+    expect(res?.status).toBe(200);
+    const body = await (res as Response).json();
+    expect(body).toEqual({ id: 1 });
+  });
+
+  it('returns 404 when the requested module key does not match any export', async () => {
+    const glob = {
+      '/x.server.ts': { __moduleKey: 'a', default: async () => ({}) },
+    };
+    const handler = loadersHandler(glob);
+    const req = new Request('http://localhost/__loaders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        module: 'b',
+        location: { path: '/', pathParams: {}, searchParams: {} },
+      }),
+    });
+    const ctx = { req: { json: () => req.json() } } as any;
+    const res = await handler(ctx, async () => undefined as any);
+    expect(res?.status).toBe(404);
+  });
+});
+```
+
+(Adapt the `ctx` shape to match how the existing `loaders-handler.test.ts` mocks Hono's middleware context. The pattern is `(c) => Response`; copy from the existing tests in that file.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/server/src/__tests__/loaders-handler.test.ts`
+
+Expected: FAIL — handler still keys by filename basename, returns 404.
+
+- [ ] **Step 3: Implement path-keyed lookup**
+
+Replace `packages/server/src/loaders-handler.ts` in full:
+
+```ts
+import type { MiddlewareHandler } from 'hono';
+import { runRequestScope } from '@hono-preact/iso';
+
+type GlobModule = {
+  default?: unknown;
+  __moduleKey?: unknown;
+  [key: string]: unknown;
+};
+type LazyGlob = Record<string, () => Promise<unknown>>;
+type EagerGlob = Record<string, GlobModule>;
+
+type SerializedLocation = {
+  path: string;
+  pathParams: Record<string, string>;
+  searchParams: Record<string, string>;
+};
+
+type LoaderFn = (props: { location: SerializedLocation }) => Promise<unknown>;
+
+async function buildLoadersMap(
+  glob: LazyGlob | EagerGlob
+): Promise<Record<string, LoaderFn>> {
+  const result: Record<string, LoaderFn> = {};
+  for (const [, moduleOrLoader] of Object.entries(glob)) {
+    const mod =
+      typeof moduleOrLoader === 'function'
+        ? await (moduleOrLoader as () => Promise<GlobModule>)()
+        : (moduleOrLoader as GlobModule);
+    const key = mod.__moduleKey;
+    if (typeof key === 'string' && typeof mod.default === 'function') {
+      result[key] = mod.default as LoaderFn;
+    }
+  }
+  return result;
+}
+
+export function loadersHandler(glob: LazyGlob | EagerGlob): MiddlewareHandler {
+  let loadersMapPromise: Promise<Record<string, LoaderFn>> | null = null;
+
+  return async (c) => {
+    if (!loadersMapPromise) {
+      loadersMapPromise = buildLoadersMap(glob).catch((err) => {
+        loadersMapPromise = null;
+        return Promise.reject(err);
+      });
+    }
+
+    let loadersMap: Record<string, LoaderFn>;
+    try {
+      loadersMap = await loadersMapPromise;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: `Failed to load loaders: ${message}` }, 503);
+    }
+
+    let body: { module: unknown; location: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Invalid JSON body' }, 400);
+    }
+
+    const { module, location } = body;
+    if (typeof module !== 'string') {
+      return c.json(
+        { error: 'Request body must include string field: module' },
+        400
+      );
+    }
+
+    const loader = loadersMap[module];
+    if (!loader) {
+      return c.json({ error: `Module '${module}' not found` }, 404);
+    }
+
+    try {
+      const result = await runRequestScope(() =>
+        loader({ location: location as SerializedLocation })
+      );
+      return c.json(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return c.json({ error: message }, 500);
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/server/src/__tests__/loaders-handler.test.ts`
+
+Expected: PASS — new path-keyed tests pass; any existing tests that relied on basename keying need their fixtures updated to include `__moduleKey`. Update them in this step (mechanical: add `__moduleKey: 'matching-key'` to each fixture's module object).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server/src/loaders-handler.ts packages/server/src/__tests__/loaders-handler.test.ts
+git commit -m "feat(server): loadersHandler routes by mod.__moduleKey"
+```
+
+---
+
+## Task 11: `actionsHandler` reads `mod.__moduleKey`
+
+**Files:**
+- Modify: `packages/server/src/actions-handler.ts`
+- Modify: `packages/server/src/__tests__/actions-handler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/server/src/__tests__/actions-handler.test.ts`:
+
+```ts
+describe('actionsHandler path-keyed routing', () => {
+  it('routes lookups by mod.__moduleKey rather than filename', async () => {
+    const glob = {
+      '/whatever.server.ts': {
+        __moduleKey: 'src/pages/movies',
+        serverActions: {
+          toggleWatched: async (_c: unknown, p: { id: number }) => ({
+            ok: true,
+            id: p.id,
+          }),
+        },
+      },
+    };
+    const handler = actionsHandler(glob);
+    const req = new Request('http://localhost/__actions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        module: 'src/pages/movies',
+        action: 'toggleWatched',
+        payload: { id: 7 },
+      }),
+    });
+    const ctx = {
+      req: {
+        json: () => req.json(),
+        header: (h: string) => req.headers.get(h) ?? undefined,
+      },
+      json: (b: unknown, status = 200) =>
+        new Response(JSON.stringify(b), { status }),
+    } as any;
+    const res = await handler(ctx, async () => undefined as any);
+    expect(res?.status).toBe(200);
+    const body = await (res as Response).json();
+    expect(body).toEqual({ ok: true, id: 7 });
+  });
+});
+```
+
+(Match the exact `ctx` mock pattern used in the existing `actions-handler.test.ts`.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test packages/server/src/__tests__/actions-handler.test.ts`
+
+Expected: FAIL — current handler keys by basename.
+
+- [ ] **Step 3: Implement path-keyed lookup**
+
+Open `packages/server/src/actions-handler.ts`. Replace the `buildActionsMap` function and remove `moduleNameFromPath`:
+
+```ts
+type GlobModule = {
+  serverActions?: Record<string, unknown>;
+  actionGuards?: ActionGuardFn[];
+  __moduleKey?: unknown;
+  [key: string]: unknown;
+};
+
+async function buildActionsMap(
+  glob: LazyGlob | EagerGlob
+): Promise<Record<string, ModuleEntry>> {
+  const result: Record<string, ModuleEntry> = {};
+  for (const [, moduleOrLoader] of Object.entries(glob)) {
+    const mod =
+      typeof moduleOrLoader === 'function'
+        ? await (moduleOrLoader as () => Promise<GlobModule>)()
+        : (moduleOrLoader as GlobModule);
+    const key = mod.__moduleKey;
+    if (typeof key === 'string' && mod.serverActions) {
+      result[key] = {
+        actions: mod.serverActions as Record<string, unknown>,
+        guards: (mod.actionGuards as ActionGuardFn[] | undefined) ?? [],
+      };
+    }
+  }
+  return result;
+}
+```
+
+Delete the now-unused `moduleNameFromPath` declaration.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test packages/server/src/__tests__/actions-handler.test.ts`
+
+Expected: PASS — new test plus all existing tests after their fixtures are updated to include `__moduleKey` (mechanical sweep, same as Task 10 step 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server/src/actions-handler.ts packages/server/src/__tests__/actions-handler.test.ts
+git commit -m "feat(server): actionsHandler routes by mod.__moduleKey"
+```
+
+---
+
+## Task 12: Migrate `apps/app/src/pages/movies.server.ts`
+
+**Files:**
+- Modify: `apps/app/src/pages/movies.server.ts`
+
+- [ ] **Step 1: Drop the string argument**
+
+Edit `apps/app/src/pages/movies.server.ts`. Change:
+
+```ts
+export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>('movies', serverLoader);
+```
+
+to:
+
+```ts
+export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>(serverLoader);
+```
+
+- [ ] **Step 2: Run the app's tests to confirm no regression**
+
+Run: `pnpm test`
+
+Expected: PASS — all suites green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/app/src/pages/movies.server.ts
+git commit -m "refactor(app): drop defineLoader string arg in movies.server"
+```
+
+---
+
+## Task 13: Migrate `apps/app/src/pages/watched.server.ts`
+
+**Files:**
+- Modify: `apps/app/src/pages/watched.server.ts`
+
+- [ ] **Step 1: Drop the string argument**
+
+Change:
+
+```ts
+export const loader = defineLoader<{ entries: Entry[] }>('watched', serverLoader);
+```
+
+to:
+
+```ts
+export const loader = defineLoader<{ entries: Entry[] }>(serverLoader);
+```
+
+- [ ] **Step 2: Run the app's tests**
+
+Run: `pnpm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/app/src/pages/watched.server.ts
+git commit -m "refactor(app): drop defineLoader string arg in watched.server"
+```
+
+---
+
+## Task 14: Migrate `apps/app/src/pages/movie.server.ts`
+
+**Files:**
+- Modify: `apps/app/src/pages/movie.server.ts`
+
+- [ ] **Step 1: Drop the string argument**
+
+Change:
+
+```ts
+export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>('movie', serverLoader);
+```
+
+to:
+
+```ts
+export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>(serverLoader);
+```
+
+- [ ] **Step 2: Run the app's tests**
+
+Run: `pnpm test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/app/src/pages/movie.server.ts
+git commit -m "refactor(app): drop defineLoader string arg in movie.server"
+```
+
+---
+
+## Task 15: End-to-end SSR + RPC parity test
+
+**Files:**
+- Create: `packages/vite/src/__tests__/path-key-parity.test.ts`
+
+This test loads a fixture `.server.ts` file through both plugins (mimicking dev) and asserts that the server-side `__moduleKey` and the client-side stub both produce the same `Symbol.for('@hono-preact/loader:<key>')` payload, for the same root.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/src/__tests__/path-key-parity.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { moduleKeyPlugin } from '../module-key-plugin.js';
+import { serverOnlyPlugin } from '../server-only.js';
+import type { Plugin } from 'vite';
+
+const ROOT = '/Users/me/repo';
+
+function makePlugins() {
+  const m = moduleKeyPlugin() as Plugin & {
+    configResolved?: (c: { root: string }) => void;
+    transform: (code: string, id: string) => { code: string } | undefined;
+  };
+  const s = serverOnlyPlugin() as Plugin & {
+    configResolved?: (c: { root: string }) => void;
+    transform: (
+      code: string,
+      id: string,
+      options?: { ssr?: boolean }
+    ) => { code: string } | undefined;
+  };
+  m.configResolved?.({ root: ROOT });
+  s.configResolved?.({ root: ROOT });
+  return { m, s };
+}
+
+describe('path-key parity across moduleKeyPlugin and serverOnlyPlugin', () => {
+  it('uses the same key for the .server.* file and its client-side import', () => {
+    const { m, s } = makePlugins();
+
+    // Server side: moduleKeyPlugin transforms the .server.ts file.
+    const serverCode = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `export default async () => ({});`,
+      `export const loader = defineLoader(async () => ({}));`,
+    ].join('\n');
+    const serverResult = m.transform.call(
+      {} as any,
+      serverCode,
+      `${ROOT}/src/pages/movies.server.ts`
+    );
+    expect(serverResult?.code).toMatch(
+      /^export const __moduleKey = "src\/pages\/movies";/
+    );
+
+    // Client side: serverOnlyPlugin transforms a consumer that imports
+    // the same file.
+    const clientCode = `import { loader } from './movies.server.js';`;
+    const clientResult = s.transform.call(
+      {} as any,
+      clientCode,
+      `${ROOT}/src/pages/movies.tsx`
+    );
+    expect(clientResult?.code).toContain(
+      `Symbol.for('@hono-preact/loader:src/pages/movies')`
+    );
+  });
+
+  it('derives distinct keys for cross-folder same-basename collisions', () => {
+    const { m } = makePlugins();
+    const aResult = m.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      `${ROOT}/src/pages/movies.server.ts`
+    );
+    const bResult = m.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      `${ROOT}/src/pages/admin/movies.server.ts`
+    );
+    expect(aResult?.code).toContain('"src/pages/movies"');
+    expect(bResult?.code).toContain('"src/pages/admin/movies"');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `pnpm test packages/vite/src/__tests__/path-key-parity.test.ts`
+
+Expected: PASS — both plugins should already produce the matching keys after Tasks 5 and 8.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/vite/src/__tests__/path-key-parity.test.ts
+git commit -m "test(vite): assert path-key parity across plugin pair"
+```
+
+---
+
+## Task 16: Manually verify the running app
+
+**Files:** none.
+
+This step exercises the change in a real browser to catch anything the unit tests miss (typically `viteRoot` resolution drift in dev mode and `import.meta.glob` key mismatches in SSR).
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `pnpm dev`
+
+Expected: dev server boots with no errors. Open `http://localhost:<port>` in a browser.
+
+- [ ] **Step 2: Exercise loaders**
+
+Navigate `/` → `/movies` → `/movies/1` → `/watched` → back. Each page should render with data.
+
+- [ ] **Step 3: Exercise actions**
+
+On `/movies`, click "Mark watched" on a row. The optimistic flip should commit. On `/watched`, click "Bulk-import next 20" — the streaming progress should advance.
+
+- [ ] **Step 4: Inspect network payloads**
+
+Open the Network tab. Confirm:
+- POST `/__loaders` payloads contain `"module":"<path>/<file>"` (e.g. `"module":"src/pages/movies"`), not `"module":"movies"`.
+- POST `/__actions` payloads contain `"module":"<path>/<file>"`.
+- Both succeed with 200.
+
+- [ ] **Step 5: Build and preview**
+
+Run: `pnpm build && pnpm preview`
+
+Expected: build succeeds; preview boots; same flows pass against the production bundle. (This catches `viteRoot` resolving differently in build vs. dev.)
+
+- [ ] **Step 6: Commit (no diff expected)**
+
+If the manual verification surfaces a regression, fix it now and add a new task for the missing test coverage. If everything passes, no commit.
+
+---
+
+## Task 17: Drop the legacy `(name, fn)` form from `defineLoader`'s public type
+
+**Files:**
+- Modify: `packages/iso/src/define-loader.ts`
+- Modify: `packages/iso/src/__tests__/define-loader.test.ts`
+
+After all consumers migrate (Tasks 12–14), the legacy overload has no remaining callers. Remove it from the public surface; keep only the `(fn)` and `(fn, opts)` forms.
+
+- [ ] **Step 1: Update tests**
+
+Open `packages/iso/src/__tests__/define-loader.test.ts`. Delete the four legacy tests (`'throws when called without a name argument'`, `'throws when name is an empty string'`, `'keys __id with Symbol.for so two calls with the same name share identity'`, `'produces distinct __id for distinct names'`, `'aligns with the SSR stub symbol shape'`). The path-keyed tests added in Task 2 cover the equivalent behavior.
+
+- [ ] **Step 2: Drop the legacy overload**
+
+Replace `packages/iso/src/define-loader.ts` in full:
+
+```ts
+import type { RouteHook } from 'preact-iso';
+import type { LoaderCache } from './cache.js';
+
+export type LoaderCtx = { location: RouteHook };
+
+export type Loader<T> = (ctx: LoaderCtx) => Promise<T>;
+
+export interface LoaderRef<T> {
+  readonly __id: symbol;
+  readonly fn: Loader<T>;
+  readonly cache?: LoaderCache<T>;
+}
+
+export type DefineLoaderOpts<T> = {
+  __moduleKey: string;
+  cache?: LoaderCache<T>;
+};
+
+/**
+ * Define a server loader.
+ *
+ * Authored as `defineLoader(fn)` in `.server.*` files. The `moduleKeyPlugin`
+ * Vite plugin rewrites the call at build time to thread the path-derived
+ * module key in: `defineLoader(fn, { __moduleKey: 'src/pages/movies' })`.
+ *
+ * The `__moduleKey` is the routing key for `__loaders`/`__actions` RPC
+ * and the payload of `Symbol.for(...)` for `__id`. Two loaders defined in
+ * different files produce distinct `__id` symbols by construction.
+ *
+ * The optional `cache` slot binds a `LoaderCache` to the loader so
+ * consumers needn't pass it separately to `<Page>`.
+ */
+export function defineLoader<T>(fn: Loader<T>): LoaderRef<T>;
+export function defineLoader<T>(
+  fn: Loader<T>,
+  opts: DefineLoaderOpts<T>
+): LoaderRef<T>;
+export function defineLoader<T>(
+  fn: Loader<T>,
+  opts?: DefineLoaderOpts<T>
+): LoaderRef<T> {
+  if (opts?.__moduleKey) {
+    return {
+      __id: Symbol.for(`@hono-preact/loader:${opts.__moduleKey}`),
+      fn,
+      cache: opts.cache,
+    };
+  }
+  // Plugin-less context (a consumer testing their loader in isolation).
+  // Identity is unstable across module reloads, which is acceptable for
+  // tests that don't depend on cache-by-id behavior.
+  return {
+    __id: Symbol(`@hono-preact/loader:<unkeyed>`),
+    fn,
+  };
+}
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `pnpm test`
+
+Expected: PASS — all suites green; legacy tests are gone.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/iso/src/define-loader.ts packages/iso/src/__tests__/define-loader.test.ts
+git commit -m "refactor(iso): drop the legacy defineLoader (name, fn) form"
+```
+
+---
+
+## Task 18: Final integration sweep
+
+**Files:** none.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test`
+
+Expected: PASS — every suite green.
+
+- [ ] **Step 2: Build every package**
+
+Run: `pnpm build`
+
+Expected: each package builds cleanly. No type errors.
+
+- [ ] **Step 3: Run the dev + preview verification once more**
+
+Repeat Task 16 steps 1–5. Confirm the end-to-end app still works.
+
+- [ ] **Step 4: Push for review**
+
+The plan's work is done. Open a PR with the commit list from Tasks 1–17 and link the research doc:
+
+```
+git push -u origin <branch>
+gh pr create --title "feat: path-keyed module identity for loader/action RPC" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Replaces basename-as-routing-key with a path-derived module key
+  embedded into each .server.* file by a new Vite plugin.
+- defineLoader's string-name argument is removed; the plugin supplies
+  the key via a hidden second-arg metadata.
+- loadersHandler and actionsHandler route by mod.__moduleKey.
+- Eliminates the implicit "no two .server.* files may share a basename"
+  constraint by construction.
+
+## Test plan
+
+- [ ] All package test suites pass
+- [ ] pnpm build succeeds across the monorepo
+- [ ] Dev mode: /, /movies, /movies/:id, /watched all render with data
+- [ ] Dev mode: toggleWatched action works (network payload uses path key)
+- [ ] Dev mode: bulkImport action streams progress
+- [ ] Production preview: same flows pass against the production bundle
+
+Implements: docs/superpowers/research/2026-05-04-framework-simplification.md §4.3, §6.3, §9 step 1
+EOF
+)"
+```
+
+---
+
+## Risks called out in the research doc
+
+(Reproduced for the executor's awareness; mitigations are baked into the tasks above.)
+
+1. **`viteRoot` resolution drift across dev / build / SSR / test.** Mitigated by capturing `viteRoot` once via `configResolved` (Tasks 3, 4) and reusing the captured value. Task 16 step 5 exercises both dev and production builds; Task 15 covers test-environment parity.
+2. **Plugin parse failures on `.server.*` files with syntax errors.** The `moduleKeyPlugin` falls back to emitting only the `__moduleKey` export when the AST parse fails (Task 6 step 3 implementation). The user sees the parse error from Vite's normal error path; the routing layer keeps working.
+3. **Glob entries without `__moduleKey`.** After Task 10/11, `loadersHandler` and `actionsHandler` simply skip such entries (won't register them in the lookup map). In practice, every `.server.*` file in the watched glob is transformed by `moduleKeyPlugin`, so this is never observed in production. Defensive only.
+
+## What this plan does NOT cover
+
+- The surface trim (Plan B). Stages 2–6 of the research doc's §9 — `definePage` self-wrapping, deleting custom `Route`/`Router`/`lazy`, moving route-level props into `PageBindings`, the `internal.ts` extraction, dropping `PAGE_BINDINGS`/`wrapWithPage` — ship as a separate plan.
+- The deferred direction-#4 work: `useId`-keyed SSR hydration, monolithic `<Page>` internals, streaming SSR, Worker prefetch.

--- a/docs/superpowers/research/2026-05-04-framework-simplification.md
+++ b/docs/superpowers/research/2026-05-04-framework-simplification.md
@@ -94,17 +94,74 @@ When you ship an abstraction *and* an escape hatch *and* a comment explaining wh
 
 ## 3. Target shape
 
-### 3.1 Page module (after)
+### 3.1 Page module
+
+**Before** (today, `apps/app/src/pages/movies.tsx` + `movies.server.ts`):
 
 ```tsx
 // pages/movies.tsx
 import {
   cacheRegistry,
   definePage,
+  lazy,
+  Route,
+  Router,
   useLoaderData,
   useOptimisticAction,
 } from '@hono-preact/iso';
+import type { FunctionComponent } from 'preact';
 import { loader, cache, serverActions } from './movies.server.js';
+import Noop from './noop.js';
+
+const Movie = lazy(() => import('./movie.js'));
+
+const Movies: FunctionComponent = () => {
+  const { movies, watchedIds } = useLoaderData<typeof loader>();
+
+  const { mutate, value } = useOptimisticAction(serverActions.toggleWatched, {
+    base: watchedIds,
+    apply: (current, p) =>
+      p.watched ? [...current, p.movieId] : current.filter((id) => id !== p.movieId),
+    invalidate: 'auto',
+    onSuccess: () => cacheRegistry.invalidate('watched'),
+  });
+
+  return <ul>...</ul>;
+}
+Movies.displayName = 'Movies';
+
+export default definePage(Movies, { loader, cache });
+```
+
+```ts
+// pages/movies.server.ts
+import { createCache, defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
+
+const serverLoader: LoaderFn<{ ... }> = async () => ({ ... });
+export default serverLoader;
+
+export const loader = defineLoader<{ ... }>('movies', serverLoader);    // explicit name
+export const cache = createCache<{ ... }>('movies-list');
+export const serverActions = { ... };
+```
+
+**After**:
+
+```tsx
+// pages/movies.tsx
+import {
+  cacheRegistry,
+  definePage,
+  lazy,
+  Route,
+  Router,
+  useLoaderData,
+  useOptimisticAction,
+} from '@hono-preact/iso';                 // import surface unchanged
+import { loader, cache, serverActions } from './movies.server.js';
+import Noop from './noop.js';
+
+const Movie = lazy(() => import('./movie.js'));
 
 function Movies() {
   const { movies, watchedIds } = useLoaderData<typeof loader>();
@@ -130,18 +187,66 @@ import { createCache, defineAction, defineLoader } from '@hono-preact/iso';
 const serverLoader = async () => ({ ... });
 export default serverLoader;
 
-export const loader = defineLoader(serverLoader);   // no name; plugin derives 'movies'
-export const cache = createCache('movies-list');    // explicit; consumer-visible
+export const loader = defineLoader(serverLoader);    // no name; plugin derives 'movies'
+export const cache = createCache('movies-list');     // explicit; consumer-visible
 export const serverActions = { ... };
 ```
 
-### 3.2 Router (after)
+The leaf-level diff is one less argument to `defineLoader`. Everything else at the call site is identical. The `LoaderFn` type import goes away (no longer needed when the loader is a single arg) but isn't required to.
+
+### 3.2 Router
+
+**Before** (today, `apps/app/src/iso.tsx`):
 
 ```tsx
-// apps/app/src/iso.tsx
+import type { FunctionComponent } from 'preact';
+import { flushSync } from 'preact/compat';
+import { lazy, Route, Router } from '@hono-preact/iso';
+import { Route as IsoRoute } from 'preact-iso';
+import NotFound from './pages/not-found.js';
+
+const Home = lazy(() => import('./pages/home.js'));
+const Test = lazy(() => import('./pages/test.js'));
+const Movies = lazy(() => import('./pages/movies.js'));
+const Watched = lazy(() => import('./pages/watched.js'));
+const DocsRoute = lazy(() => import('./components/DocsRoute.js'));
+
+function onRouteChange() {
+  document.startViewTransition(() => flushSync(() => {}));
+}
+
+export const Base: FunctionComponent = () => (
+  <Router onRouteChange={onRouteChange}>
+    <Route path="/" component={Home} />
+    <Route path="/test" component={Test} />
+    <Route path="/movies" component={Movies} />
+    <Route path="/movies/*" component={Movies} />
+    <Route
+      path="/watched"
+      component={Watched}
+      fallback={<p class="p-1">Loading watched list…</p>}
+    />
+    {/* IsoRoute (preact-iso's Route) so both /docs and /docs/* hand the
+        same DocsRoute lazy reference to preact-iso. With our @hono-preact/iso
+        Route, wrapWithPage would mint a new PageRouteHandler per Route, and
+        preact-iso's component-identity check would treat /docs <-> /docs/foo
+        as a route change and remount DocsRoute (and the sidebar with it).
+        DocsRoute has no definePage bindings, so PageBoundary wrapping isn't
+        needed here. */}
+    <IsoRoute path="/docs" component={DocsRoute} />
+    <IsoRoute path="/docs/*" component={DocsRoute} />
+    <NotFound />
+  </Router>
+);
+```
+
+**After**:
+
+```tsx
 import { Route, Router, lazy } from '@hono-preact/iso';   // re-exports of preact-iso
 
 const Home = lazy(() => import('./pages/home.js'));
+const Test = lazy(() => import('./pages/test.js'));
 const Movies = lazy(() => import('./pages/movies.js'));
 const Watched = lazy(() => import('./pages/watched.js'));
 const DocsRoute = lazy(() => import('./components/DocsRoute.js'));
@@ -149,6 +254,7 @@ const DocsRoute = lazy(() => import('./components/DocsRoute.js'));
 export const Base = () => (
   <Router onRouteChange={onRouteChange}>
     <Route path="/" component={Home} />
+    <Route path="/test" component={Test} />
     <Route path="/movies" component={Movies} />
     <Route path="/movies/*" component={Movies} />
     <Route path="/watched" component={Watched} />
@@ -159,13 +265,22 @@ export const Base = () => (
 );
 ```
 
-The `IsoRoute` import vanishes. The multi-line comment vanishes. `DocsRoute` (which doesn't use `definePage`) and `Movies` (which does) route through the same component, because `definePage`'s output is itself a routable component now.
+The `IsoRoute` import vanishes. The route-level `fallback` on `/watched` moves into `definePage(WatchedPage, { … })` (see §6.2). The multi-line comment vanishes. `DocsRoute` (which doesn't use `definePage`) and `Movies` (which does) route through the same component, because `definePage`'s output is itself a routable component now.
 
-### 3.3 The `<Page>` escape (unchanged in spirit)
+### 3.3 The `<Page>` escape
 
-A page that needs something `definePage` can't express drops to `<Page>` directly:
+**Before**: there is no clean drop-into-`<Page>` escape today. A consumer who wants to bypass `definePage` has two unhappy options:
+
+1. Use the granular `<Loader>` / `<Guards>` / `<Envelope>` / `<RouteBoundary>` directly, which works but pulls in five separate exports and replicates `<Page>`'s composition by hand.
+2. Render `<Page>` from inside a component referenced by `<Route>` — but the custom `<Route>` will then call `wrapWithPage` again on the outer component, double-wrapping. Avoidable only by switching that route to `IsoRoute` (the workaround `DocsRoute` already uses).
+
+**After**: `<Page>` is a usable escape directly, because `<Route>` from `preact-iso` no longer wraps anything. A page that needs something `definePage` can't express:
 
 ```tsx
+import { Page } from '@hono-preact/iso';
+import type { RouteHook } from 'preact-iso';
+import { loader, cache } from './movie.server.js';
+
 function MoviePage({ location }: { location: RouteHook }) {
   return (
     <Page

--- a/docs/superpowers/research/2026-05-04-framework-simplification.md
+++ b/docs/superpowers/research/2026-05-04-framework-simplification.md
@@ -1,0 +1,493 @@
+# Framework Simplification: Trimming the `iso` Surface
+
+**Date:** 2026-05-04
+**Status:** research, exploratory
+**Companion to:** `2026-04-26-iso-page-composability.md`, `2026-04-26-iso-page-direction-2-hooks.md`, `2026-04-26-iso-page-direction-3-components.md`
+
+---
+
+## TL;DR
+
+`@hono-preact/iso` shipped both a granular component kit (directions #2 and #3 of the prior research) **and** a `definePage`-driven convenience layer on top, exporting roughly 30 named primitives from `index.ts`. Consumers feel the surface, not the internal cleanup. This doc proposes a "middle path" trim: keep `definePage` and the granular `<Page>` escape, delete the magical `Route`/`Router`/`wrapWithPage`/`PAGE_BINDINGS` orchestration on top, re-export `Route`/`Router`/`lazy` as trivial passthroughs of `preact-iso`, demote rarely-used pieces to a `@hono-preact/iso/internal` subpath, and make `defineLoader`'s name argument optional. Net public surface drops from ~30 to ~17 names. App churn is small.
+
+---
+
+## 1. The audit
+
+### 1.1 Surface count
+
+`packages/iso/src/index.ts` exports 30+ names (excluding pure type re-exports):
+
+```
+Page, Loader, Envelope, RouteBoundary,
+Guards, GuardGate, useGuardResult,
+defineLoader, definePage, PAGE_BINDINGS,
+useLoaderData,
+OptimisticOverlay, prefetch,
+LoaderIdContext, LoaderDataContext, GuardResultContext,
+ReloadContext, useReload,
+createCache, runRequestScope, cacheRegistry,
+createGuard, runGuards, GuardRedirect,
+isBrowser, env,
+getPreloadedData, deletePreloadedData,
+defineAction, useAction,
+ActionGuardError, defineActionGuard,
+Form,
+useOptimistic, useOptimisticAction,
+Route, Router, wrapWithPage,
+lazy
+```
+
+Most of these are reachable from any page module. The mental cost of "what's the right primitive for X?" grows linearly with this list.
+
+### 1.2 Layered accretion
+
+The package contains two coexisting authoring models:
+
+1. **Granular kit** (decomposed per direction #2/#3): `defineLoader`, `<Page>`, `<Loader>`, `<Envelope>`, `<RouteBoundary>`, `<Guards>`, `<GuardGate>`, `useLoaderData`, `prefetch`, `OptimisticOverlay`, `useOptimistic`, etc.
+2. **Convenience HOC layer** on top: `definePage(Component, bindings)` stamps a `Symbol.for`-keyed `PAGE_BINDINGS` property on the component; a custom `<Route>`/`<Router>` from `route.tsx` introspects that symbol (after probing `lazy.getResolvedDefault()` for code-split components) and replaces the marker with `wrapWithPage(component, config)`.
+
+The two layers are independently coherent. Together they double the count of things a consumer sees and create one outright leak: `apps/app/src/iso.tsx:36-37` bypasses the package's own `Route` for `/docs` and uses `preact-iso`'s `IsoRoute` directly, with a multi-line comment explaining why. The convenience layer's per-Route component identity churn would otherwise remount the docs sidebar on every nested route change.
+
+### 1.3 File-level density
+
+```
+194  route.tsx            custom Route/Router, fragment flattening, marker symbol, lazy introspection
+207  loader.tsx           reload state machine, queued reloads, override data, lazy fetch promise
+164  action.ts            fetch/stream dispatch, FormData, action options, action guards
+ 76  guards.tsx
+ 86  page.tsx             thin composition over RouteBoundary/Guards/Loader/Envelope
+ 49  lazy.ts              wrapped preact-iso lazy that exposes getResolvedDefault
+... 25 source files, 1488 LOC total
+```
+
+`loader.tsx` and `route.tsx` carry the bulk of the cognitive load. `route.tsx` exists almost entirely to wire the `definePage` magic into `preact-iso`'s router. `lazy.ts` exists to make that wiring possible across code-split routes.
+
+### 1.4 The leak in `iso.tsx`
+
+```tsx
+// apps/app/src/iso.tsx:29-37
+{/* IsoRoute (preact-iso's Route) so both /docs and /docs/* hand the
+    same DocsRoute lazy reference to preact-iso. With our @hono-preact/iso
+    Route, wrapWithPage would mint a new PageRouteHandler per Route, and
+    preact-iso's component-identity check would treat /docs <-> /docs/foo
+    as a route change and remount DocsRoute (and the sidebar with it).
+    DocsRoute has no definePage bindings, so PageBoundary wrapping isn't
+    needed here. */}
+<IsoRoute path="/docs" component={DocsRoute} />
+<IsoRoute path="/docs/*" component={DocsRoute} />
+```
+
+When you ship an abstraction *and* an escape hatch *and* a comment explaining when to use which, the abstraction is doing too much. This is the canary signal for the simplification work.
+
+---
+
+## 2. Goals
+
+1. **Cut the consumer-visible surface in half** without removing any capability the app uses.
+2. **Eliminate the `Route`/`Router`/`PAGE_BINDINGS`/`wrapWithPage` orchestration layer.** Keep the names `Route`, `Router`, `lazy` available from `@hono-preact/iso`, but as trivial re-exports of `preact-iso` so consumers don't have to know they came from somewhere else.
+3. **Preserve `definePage(Component, bindings)` as the per-page declaration.** It's the most concise call site and the user's preferred shape.
+4. **Make the granular kit (`<Loader>`, `<Envelope>`, `<RouteBoundary>`, `<Guards>`, `<GuardGate>`, etc.) reachable for advanced use** without putting them on the front door. Subpath: `@hono-preact/iso/internal`.
+5. **Drop one piece of ceremony per page**: make `defineLoader`'s string name optional, since the Vite plugin already infers it from the `.server.ts` filename in its fallback path.
+
+---
+
+## 3. Target shape
+
+### 3.1 Page module (after)
+
+```tsx
+// pages/movies.tsx
+import {
+  cacheRegistry,
+  definePage,
+  useLoaderData,
+  useOptimisticAction,
+} from '@hono-preact/iso';
+import { loader, cache, serverActions } from './movies.server.js';
+
+function Movies() {
+  const { movies, watchedIds } = useLoaderData<typeof loader>();
+
+  const { mutate, value } = useOptimisticAction(serverActions.toggleWatched, {
+    base: watchedIds,
+    apply: (current, p) =>
+      p.watched ? [...current, p.movieId] : current.filter((id) => id !== p.movieId),
+    invalidate: 'auto',
+    onSuccess: () => cacheRegistry.invalidate('watched'),
+  });
+
+  return <ul>...</ul>;
+}
+
+export default definePage(Movies, { loader, cache });
+```
+
+```ts
+// pages/movies.server.ts
+import { createCache, defineAction, defineLoader } from '@hono-preact/iso';
+
+const serverLoader = async () => ({ ... });
+export default serverLoader;
+
+export const loader = defineLoader(serverLoader);   // no name; plugin derives 'movies'
+export const cache = createCache('movies-list');    // explicit; consumer-visible
+export const serverActions = { ... };
+```
+
+### 3.2 Router (after)
+
+```tsx
+// apps/app/src/iso.tsx
+import { Route, Router, lazy } from '@hono-preact/iso';   // re-exports of preact-iso
+
+const Home = lazy(() => import('./pages/home.js'));
+const Movies = lazy(() => import('./pages/movies.js'));
+const Watched = lazy(() => import('./pages/watched.js'));
+const DocsRoute = lazy(() => import('./components/DocsRoute.js'));
+
+export const Base = () => (
+  <Router onRouteChange={onRouteChange}>
+    <Route path="/" component={Home} />
+    <Route path="/movies" component={Movies} />
+    <Route path="/movies/*" component={Movies} />
+    <Route path="/watched" component={Watched} />
+    <Route path="/docs" component={DocsRoute} />
+    <Route path="/docs/*" component={DocsRoute} />
+    <NotFound />
+  </Router>
+);
+```
+
+The `IsoRoute` import vanishes. The multi-line comment vanishes. `DocsRoute` (which doesn't use `definePage`) and `Movies` (which does) route through the same component, because `definePage`'s output is itself a routable component now.
+
+### 3.3 The `<Page>` escape (unchanged in spirit)
+
+A page that needs something `definePage` can't express drops to `<Page>` directly:
+
+```tsx
+function MoviePage({ location }: { location: RouteHook }) {
+  return (
+    <Page
+      loader={loader}
+      cache={cache}
+      location={location}
+      fallback={<Spinner />}
+      errorFallback={(err, retry) => <CustomError error={err} onRetry={retry} />}
+    >
+      <MovieDetail />
+    </Page>
+  );
+}
+```
+
+For consumers who need the granular pieces (per-step Suspense boundaries, distinct fallbacks for guards vs. loader, etc.), `@hono-preact/iso/internal` re-exports `<Loader>`, `<Envelope>`, `<RouteBoundary>`, `<Guards>`, `<GuardGate>`, the four contexts, and the SSR primitives. Not on the front door, but reachable.
+
+---
+
+## 4. Mechanism
+
+### 4.1 `definePage` self-wraps
+
+Today (`define-page.ts:19-27`):
+
+```ts
+export function definePage<T>(Component, bindings?) {
+  if (bindings) (Component as PageComponent<T>)[PAGE_BINDINGS] = bindings;
+  return Component;
+}
+```
+
+It returns the component unchanged, with a hidden symbol property. The custom `<Route>` later reads it.
+
+After:
+
+```ts
+export function definePage<T>(Component: ComponentType, bindings?: PageBindings<T>) {
+  const PageRoute = (location: RouteHook) => (
+    <Page
+      loader={bindings?.loader}
+      cache={bindings?.cache}
+      Wrapper={bindings?.Wrapper}
+      fallback={bindings?.fallback}
+      errorFallback={bindings?.errorFallback}
+      serverGuards={bindings?.serverGuards}
+      clientGuards={bindings?.clientGuards}
+      location={location}
+    >
+      <Component />
+    </Page>
+  );
+  PageRoute.displayName = `definePage(${Component.displayName ?? Component.name})`;
+  return PageRoute;
+}
+```
+
+The output is the routable component `(location) => JSX`. `preact-iso` accepts this as its `component` prop without modification. No symbol, no introspection, no two-pass bindings read on lazy resolution.
+
+`PageBindings` widens to include the route-level config that used to live on `<Route>`:
+
+```ts
+export type PageBindings<T> = {
+  loader?: LoaderRef<T>;
+  cache?: LoaderCache<T>;
+  Wrapper?: ComponentType<WrapperProps>;
+  fallback?: JSX.Element;
+  errorFallback?: JSX.Element | ((error: Error, reset: () => void) => JSX.Element);
+  serverGuards?: GuardFn[];
+  clientGuards?: GuardFn[];
+};
+```
+
+### 4.2 Re-exports in place of the custom `Route`/`Router`/`lazy`
+
+`packages/iso/src/route.tsx` (194 lines) is deleted. `packages/iso/src/lazy.ts` (49 lines) is deleted. `index.ts` adds:
+
+```ts
+export { Route, Router, lazy } from 'preact-iso';
+```
+
+That's the entire replacement.
+
+### 4.3 `defineLoader(fn)` with optional name
+
+Today:
+
+```ts
+defineLoader('movies', serverLoader)   // first arg required
+```
+
+After:
+
+```ts
+defineLoader(serverLoader)             // common case; name derived from filename
+defineLoader('movies', serverLoader)   // explicit; same result
+```
+
+**Plugin change.** `serverOnlyPlugin` already has `extractLoaderName` and falls back to the module filename when extraction fails. Today the runtime `defineLoader` throws if the name is missing. The change:
+
+1. `defineLoader(fnOrName, fn?)` — accept `(fn)` or `(name, fn)`. When a single fn is passed, use a placeholder symbol; the plugin overwrites at build time.
+2. `serverOnlyPlugin` continues to AST-extract; when no string arg is found, silently use the filename.
+3. **New**: a small SSR-side transform applies the same Symbol.for derivation to `.server.ts` files themselves. This guarantees server-side and client-side `__id` agree on `Symbol.for('@hono-preact/loader:movies')` regardless of which form the consumer used.
+
+Without step 3, server-side `defineLoader(fn)` would produce a unique `Symbol()` and client-side rewriting would produce `Symbol.for('movies')`, breaking identity comparison in `loader.tsx`. Step 3 closes that gap.
+
+`createCache('movies-list')` keeps its explicit name. The cache name is consumer-visible (`cacheRegistry.invalidate('movies-list')` references it from other modules), so there's nothing to auto-derive.
+
+---
+
+## 5. Public surface, before and after
+
+### 5.1 Before (30+ names from `index.ts`)
+
+Listed in §1.1.
+
+### 5.2 After (~17 names from `index.ts`)
+
+```ts
+// Page declaration
+export { definePage, Page } from './...';
+export type { PageBindings, PageProps, WrapperProps } from './...';
+
+// Routing — trivial re-exports of preact-iso
+export { Route, Router, lazy } from 'preact-iso';
+
+// Server bindings
+export { defineLoader } from './...';
+export type { LoaderRef, LoaderCtx, Loader as LoaderFn } from './...';
+export { defineAction, defineActionGuard, ActionGuardError } from './...';
+export type {
+  ActionStub, UseActionOptions, UseActionResult,
+  ActionGuardContext, ActionGuardFn,
+} from './...';
+
+// Hooks
+export { useLoaderData } from './...';
+export { useAction } from './...';
+export { useOptimisticAction, useOptimistic } from './...';
+export type { OptimisticHandle, UseOptimisticActionOptions, UseOptimisticActionResult } from './...';
+export { useReload } from './...';
+
+// Forms
+export { Form } from './...';
+
+// Cache + invalidation
+export { createCache, cacheRegistry } from './...';
+export type { LoaderCache } from './...';
+
+// Guards (definition / signaling)
+export { createGuard, GuardRedirect } from './...';
+export type { GuardFn, GuardResult, GuardContext } from './...';
+
+// Utilities
+export { prefetch } from './...';
+export { isBrowser, env } from './...';
+```
+
+### 5.3 Demoted to `@hono-preact/iso/internal`
+
+Components and hooks that `<Page>` composes over but consumers rarely touch:
+
+```ts
+// packages/iso/src/internal.ts
+export { Loader } from './loader.js';
+export { Envelope } from './envelope.js';
+export { RouteBoundary } from './route-boundary.js';
+export { Guards, GuardGate, useGuardResult } from './guards.js';
+export { OptimisticOverlay } from './optimistic-overlay.js';
+export {
+  LoaderIdContext, LoaderDataContext,
+  GuardResultContext,
+} from './contexts.js';
+export { ReloadContext } from './reload-context.js';
+export { getPreloadedData, deletePreloadedData } from './preload.js';
+export { runRequestScope } from './cache.js';
+export { default as wrapPromise } from './wrap-promise.js';
+export { runGuards } from './guard.js';
+```
+
+Wired via `package.json`:
+
+```json
+{
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "import": "./dist/internal.js"
+    }
+  }
+}
+```
+
+### 5.4 Removed entirely
+
+- `wrapWithPage`, `PAGE_BINDINGS`
+- `PageComponent`, `RouteProps`, `RouterProps`, `RouteConfig`, `PageConfig` (types)
+- The custom `route.tsx` and `lazy.ts` source files
+
+The corresponding behavior is folded into `definePage` (self-wrapping) and replaced by `preact-iso` (Route/Router/lazy).
+
+---
+
+## 6. App-level changes
+
+`apps/app/` churn is small:
+
+### 6.1 `apps/app/src/iso.tsx`
+
+- Remove `import { Route as IsoRoute } from 'preact-iso'`.
+- Remove the docs-route comment and the two `<IsoRoute>` lines.
+- Replace with `<Route path="/docs" component={DocsRoute} />` and `<Route path="/docs/*" component={DocsRoute} />` from the package.
+
+`DocsRoute` is not a `definePage` output; it's a plain Preact component. Under the new model, `<Route>` is `preact-iso`'s `Route` directly, which accepts any component. No wrapping happens. No remount problem.
+
+### 6.2 `apps/app/src/pages/watched.tsx`
+
+The only page with route-level config:
+
+```diff
+- <Route
+-   path="/watched"
+-   component={Watched}
+-   fallback={<p class="p-1">Loading watched list…</p>}
+- />
+```
+
+Move the fallback into `definePage`:
+
+```diff
+  export default definePage(WatchedPage, {
+    loader,
+    cache,
++   fallback: <p class="p-1">Loading watched list…</p>,
+  });
+```
+
+### 6.3 `apps/app/src/pages/*.server.ts`
+
+Optional: drop the explicit `'movies'` / `'watched'` / `'movie'` strings in `defineLoader` calls. They keep working unchanged; the change is purely cosmetic.
+
+### 6.4 No other touchpoints
+
+`pages/*.tsx`, `useLoaderData`/`useAction`/`useOptimisticAction` calls, `Form`, `cacheRegistry.invalidate` — all unchanged.
+
+---
+
+## 7. Tradeoffs
+
+### 7.1 Kept
+
+- The granular kit (`<Loader>`, `<Envelope>`, etc.) still exists in source. Anyone who wants direction-#3-style explicit composition imports from `@hono-preact/iso/internal`. The kit is reachable, just not centered.
+- `definePage` ergonomics. Single line per page. No new cognitive overhead.
+- The `<Page>` escape hatch covers the common "I need a slightly different shape" cases without dropping to internal.
+- All hooks (`useLoaderData`, `useAction`, `useOptimisticAction`, `useReload`, `useOptimistic`) keep their signatures.
+- All server primitives (`defineLoader`, `defineAction`, `defineActionGuard`, `createCache`, `cacheRegistry`, `createGuard`, `GuardRedirect`) keep their signatures (modulo `defineLoader`'s now-optional name).
+
+### 7.2 Lost
+
+- **The custom `<Route>`/`<Router>`'s implicit "any component with `PAGE_BINDINGS` is a routed page"** behavior. Consumers can no longer drop a non-`definePage` component into a route and have it discover bindings from imports. Replaced by: pages are `definePage` outputs; non-pages are plain components; both go through the same `preact-iso` `<Route>`.
+- **The wrapped `lazy()`** with `getResolvedDefault()`. No consumer code reads `getResolvedDefault` today; it exists solely so `<Route>`'s introspection could see post-resolution bindings. Goes away with the introspection.
+- **Nine names from `index.ts` move behind `/internal`.** Consumers who were already reaching for them (none, in `apps/app/`) need a one-token import path change.
+
+### 7.3 New risk
+
+The plugin-derived `__id` parity (§4.3 step 3) requires extending `serverOnlyPlugin` to transform `.server.ts` files, which it currently does not. This is not technically hard (`MagicString` + the existing AST walker), but it's the one new build-time concern in the plan. A failure mode here would be: HMR causing spurious refetches because server `__id` and client `__id` don't match. Existing HMR tests would catch this, but the plugin change needs its own coverage.
+
+If we want to defer that work, we can keep `defineLoader`'s name as required for now and ship the rest of the simplification first. The two changes are independent.
+
+---
+
+## 8. What this does not solve
+
+The simplification leaves several known issues untouched. They're called out for the next research step, not for this scope.
+
+1. **`useId`-keyed SSR hydration.** `<Loader>` calls `useId()` and `getPreloadedData(id)` matches against a DOM element with that id. Inserting or removing intermediate components anywhere on the path between `<Page>` and `<Loader>` would shift the fiber-position id, breaking hydration. This is fragile and is direction #4's territory: hydrate by loader name, not by `useId()`.
+2. **Pipeline ordering is still fixed inside `<Page>`** (guard → preload → cache → fetch). Consumers wanting a different order drop to `@hono-preact/iso/internal` and assemble their own. That's the same as today's "fork `<Page>`" workaround, just better-supported.
+3. **`<Page>` itself remains a monolithic orchestrator.** This work moves complexity off the consumer's plate but doesn't reduce the `loader.tsx` or `<Page>` internals. That's a follow-on cleanup, separate from the surface trim.
+4. **Streaming SSR, Worker prefetch, and other "iso runs outside React" stories** remain unaddressed. Direction #4 is the path; this doc is not that path.
+
+---
+
+## 9. Migration sketch
+
+A non-prescriptive ordering. Each step is independent enough to ship on its own.
+
+**Step 1 — `definePage` self-wraps.** Update `define-page.ts` to return a routable component. `<Page>` keeps its current props. `PAGE_BINDINGS` symbol stays for one transition release. Existing custom `<Route>`/`<Router>` continues to work because the bindings symbol is still set; the path through the marker just becomes redundant.
+
+**Step 2 — Replace `Route`/`Router`/`lazy` with re-exports.** Delete `route.tsx` and `lazy.ts`. Export `Route`, `Router`, `lazy` from `preact-iso` in `index.ts`. `apps/app/src/iso.tsx` cleanup happens here (drop `IsoRoute`, drop comment, no `definePage`-aware route needed).
+
+**Step 3 — Move route-level props to `PageBindings`.** Add `fallback`/`errorFallback`/`serverGuards`/`clientGuards` to `PageBindings`. Migrate `pages/watched.tsx`. Remove the (no-longer-useful) types `RouteProps`, `RouterProps`, `RouteConfig`, `PageConfig`.
+
+**Step 4 — `index.ts` trim.** Move `Loader`, `Envelope`, `RouteBoundary`, `Guards`, `GuardGate`, `useGuardResult`, `OptimisticOverlay`, all four context exports, `getPreloadedData`, `deletePreloadedData`, `runRequestScope`, `wrapPromise`, `runGuards` out of `index.ts` and into `internal.ts`. Add the `package.json` `exports` entry.
+
+**Step 5 — Drop `PAGE_BINDINGS` and `wrapWithPage`.** Delete the symbol and the helper. Remove from public exports. After step 1, nothing reads them anymore.
+
+**Step 6 — Optional `defineLoader` name.** Update `defineLoader` to accept a single-fn form. Update `serverOnlyPlugin` to silently use the filename when no string arg is found. Add the `.server.ts` transform that injects `Symbol.for(...)` into `defineLoader(fn)` calls so server/client `__id` parity is preserved.
+
+Steps 1–5 are mechanically driven by the existing test suite; step 6 needs new plugin tests that cross-check server and client `__id`s.
+
+---
+
+## 10. Bottom line
+
+The simplification is a refactor, not a redesign. It deletes one layer of orchestration that grew up to make `definePage` invisible, replaces it with a `definePage` that does its own wrapping, and pushes the granular kit behind a subpath import where advanced consumers can still reach it. The `<Page>` component, the loader/action/optimistic hooks, the cache primitives, and the guard primitives all keep their shape.
+
+Net change for the consumer:
+
+- `index.ts` shrinks from ~30 names to ~17.
+- `iso.tsx` loses an escape-hatch import and a six-line comment.
+- One page (`watched.tsx`) moves a `fallback` prop from `<Route>` to `definePage` bindings.
+- New optional shorthand: `defineLoader(fn)` instead of `defineLoader('name', fn)`.
+
+Net change for the package:
+
+- Two source files deleted (`route.tsx`, `lazy.ts`), ~243 LOC.
+- One source file added (`internal.ts`, ~15 LOC re-exports).
+- Two `package.json` exports entries.
+- One small `serverOnlyPlugin` extension (silent filename fallback + optional `.server.ts` transform).
+
+The unreduced complexity (loader state machine, `useId`-keyed hydration, pipeline ordering) is left for direction #4 if and when iso outgrows its current scope. This doc's scope is the front door, and the front door is what consumers feel.

--- a/docs/superpowers/research/2026-05-04-framework-simplification.md
+++ b/docs/superpowers/research/2026-05-04-framework-simplification.md
@@ -8,7 +8,12 @@
 
 ## TL;DR
 
-`@hono-preact/iso` shipped both a granular component kit (directions #2 and #3 of the prior research) **and** a `definePage`-driven convenience layer on top, exporting roughly 30 named primitives from `index.ts`. Consumers feel the surface, not the internal cleanup. This doc proposes a "middle path" trim: keep `definePage` and the granular `<Page>` escape, delete the magical `Route`/`Router`/`wrapWithPage`/`PAGE_BINDINGS` orchestration on top, re-export `Route`/`Router`/`lazy` as trivial passthroughs of `preact-iso`, demote rarely-used pieces to a `@hono-preact/iso/internal` subpath, and make `defineLoader`'s name argument optional. Net public surface drops from ~30 to ~17 names. App churn is small.
+`@hono-preact/iso` shipped both a granular component kit (directions #2 and #3 of the prior research) **and** a `definePage`-driven convenience layer on top, exporting roughly 30 named primitives from `index.ts`. Consumers feel the surface, not the internal cleanup. This doc proposes a coordinated cleanup with two strands:
+
+1. **Surface trim** (the original "middle path"): keep `definePage` and the granular `<Page>` escape, delete the magical `Route`/`Router`/`wrapWithPage`/`PAGE_BINDINGS` orchestration on top, re-export `Route`/`Router`/`lazy` as trivial passthroughs of `preact-iso`, and demote rarely-used pieces to a `@hono-preact/iso/internal` subpath.
+2. **Path-keyed module identity**: replace the basename-as-routing-key convention used by `loadersHandler` / `actionsHandler` with a path-derived module key embedded into each `.server.*` file at build time by the Vite plugin. The same key drives RPC routing, `__id` Symbol identity, and HMR. Eliminates the implicit "no two `.server.*` files may share a basename" constraint by construction; eliminates `defineLoader`'s string-name argument entirely.
+
+Net public surface drops from ~30 to ~17 names. App churn is small (one comment removed in `iso.tsx`, one `fallback` moved into a `definePage` binding, every `defineLoader('name', fn)` loses its string).
 
 ---
 
@@ -187,12 +192,12 @@ import { createCache, defineAction, defineLoader } from '@hono-preact/iso';
 const serverLoader = async () => ({ ... });
 export default serverLoader;
 
-export const loader = defineLoader(serverLoader);    // no name; plugin derives 'movies'
+export const loader = defineLoader(serverLoader);    // no name; plugin embeds path key
 export const cache = createCache('movies-list');     // explicit; consumer-visible
 export const serverActions = { ... };
 ```
 
-The leaf-level diff is one less argument to `defineLoader`. Everything else at the call site is identical. The `LoaderFn` type import goes away (no longer needed when the loader is a single arg) but isn't required to.
+The leaf-level diff is one less argument to `defineLoader`. The Vite plugin transforms this `.server.ts` file at build time to inject a module-level path-derived key (e.g. `pages/movies` for this file, or `pages/admin/movies` for a sibling at `pages/admin/movies.server.ts`); that key drives `__id`, the RPC routing lookup on the server, and the RPC routing emission on the client. See §4.3 for the mechanism. The `LoaderFn` type import goes away (no longer needed when the loader is a single arg) but isn't required to.
 
 ### 3.2 Router
 
@@ -364,30 +369,111 @@ export { Route, Router, lazy } from 'preact-iso';
 
 That's the entire replacement.
 
-### 4.3 `defineLoader(fn)` with optional name
+### 4.3 Path-keyed module identity
 
-Today:
+Today, three independent moving parts agree (or fail to agree) on a module's identity:
 
-```ts
-defineLoader('movies', serverLoader)   // first arg required
+- **Server-side RPC routing** (`packages/server/src/loaders-handler.ts:33`): `result[moduleNameFromPath(filePath)] = mod.default`. Keyed by basename only.
+- **Client-side RPC emission** (`packages/vite/src/server-only.ts:206`): plugin emits `{module: <basename>}` in the fetch arrow, AST-extracted from `defineLoader('name', fn)` with a basename fallback.
+- **Symbol identity** (`packages/iso/src/define-loader.ts:27`): `Symbol.for('@hono-preact/loader:' + name)`. Stable across module copies via `Symbol.for`.
+
+The shared currency is **basename**, which silently collides if two `.server.*` files share one (`pages/movies.server.ts` and `pages/admin/movies.server.ts` both resolve to `'movies'`). The current explicit-name scheme doesn't defend against this; the basename fallback hits the same outcome.
+
+The proposed scheme keys all three on a **path-derived module key** computed once at build time and embedded into the `.server.*` file itself.
+
+**The key.** For each `.server.*` file, the key is:
+
+```
+path.relative(viteRoot, absolutePath).replace(/\.server\.[jt]sx?$/, '')
 ```
 
-After:
+So `<root>/apps/app/src/pages/movies.server.ts` → `apps/app/src/pages/movies`. Stable across builds (pure function of file path), unique per file (path is unique by filesystem invariant), human-readable for debugging.
+
+**Plugin transform of `.server.*` files.** A new transform pass on `.server.*` modules injects the key as a module-level constant and threads it through `defineLoader` / `defineAction` calls:
 
 ```ts
-defineLoader(serverLoader)             // common case; name derived from filename
-defineLoader('movies', serverLoader)   // explicit; same result
+// Source:
+import { defineLoader, defineAction } from '@hono-preact/iso';
+
+const serverLoader = async () => ({ ... });
+export default serverLoader;
+export const loader = defineLoader(serverLoader);
+export const serverActions = {
+  toggleWatched: defineAction(async (_ctx, p) => { ... }),
+};
 ```
 
-**Plugin change.** `serverOnlyPlugin` already has `extractLoaderName` and falls back to the module filename when extraction fails. Today the runtime `defineLoader` throws if the name is missing. The change:
+```ts
+// After plugin transform:
+import { defineLoader, defineAction } from '@hono-preact/iso';
 
-1. `defineLoader(fnOrName, fn?)` — accept `(fn)` or `(name, fn)`. When a single fn is passed, use a placeholder symbol; the plugin overwrites at build time.
-2. `serverOnlyPlugin` continues to AST-extract; when no string arg is found, silently use the filename.
-3. **New**: a small SSR-side transform applies the same Symbol.for derivation to `.server.ts` files themselves. This guarantees server-side and client-side `__id` agree on `Symbol.for('@hono-preact/loader:movies')` regardless of which form the consumer used.
+export const __moduleKey = 'apps/app/src/pages/movies';
 
-Without step 3, server-side `defineLoader(fn)` would produce a unique `Symbol()` and client-side rewriting would produce `Symbol.for('movies')`, breaking identity comparison in `loader.tsx`. Step 3 closes that gap.
+const serverLoader = async () => ({ ... });
+export default serverLoader;
+export const loader = defineLoader(serverLoader, { __moduleKey });
+export const serverActions = {
+  toggleWatched: defineAction(async (_ctx, p) => { ... }, { __moduleKey, __action: 'toggleWatched' }),
+};
+```
 
-`createCache('movies-list')` keeps its explicit name. The cache name is consumer-visible (`cacheRegistry.invalidate('movies-list')` references it from other modules), so there's nothing to auto-derive.
+`defineLoader(fn, opts?)` and `defineAction(fn, opts?)` accept the second-arg metadata (typed as internal). At runtime they use it to construct `__id = Symbol.for('@hono-preact/loader:' + opts.__moduleKey)`.
+
+**Plugin transform of client-side `.server.*` imports** (existing path, simplified). The fetch arrow now sends the module key directly instead of basename-extracting:
+
+```ts
+// Generated client stub for `import { loader } from './movies.server.ts'`:
+const loader = {
+  __id: Symbol.for('@hono-preact/loader:apps/app/src/pages/movies'),
+  fn: async ({ location }) => {
+    const res = await fetch('/__loaders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ module: 'apps/app/src/pages/movies', location: { ... } }),
+    });
+    // ...
+  },
+};
+```
+
+The plugin computes the module key the same way as in the `.server.*` transform — both run from `id` (absolute path) and the resolved Vite root captured in `configResolved`. Same input, same output, no normalization mismatch.
+
+**Server handler change.** `loadersHandler` reads the key from each loaded module's exports rather than computing from the filename:
+
+```ts
+async function buildLoadersMap(glob) {
+  const result: Record<string, LoaderFn> = {};
+  for (const [filePath, moduleOrLoader] of Object.entries(glob)) {
+    const mod = typeof moduleOrLoader === 'function' ? await moduleOrLoader() : moduleOrLoader;
+    if (typeof mod.default === 'function' && typeof mod.__moduleKey === 'string') {
+      result[mod.__moduleKey] = mod.default;
+    }
+  }
+  return result;
+}
+```
+
+`actionsHandler` mirrors the change: it routes by `body.__module` (now the path key) and looks up handlers in a map keyed the same way.
+
+**`defineLoader`'s public API.** With the plugin embedding the key, the consumer-visible API has no name argument:
+
+```ts
+export function defineLoader<T>(fn: Loader<T>): LoaderRef<T>;
+```
+
+Internally there's an overload for the plugin's transformed call site:
+
+```ts
+export function defineLoader<T>(fn: Loader<T>, opts: { __moduleKey: string }): LoaderRef<T>;
+```
+
+The second form is not part of the public surface and isn't documented. It's the contract between the plugin and the runtime.
+
+**HMR identity.** The path key is stable across builds and HMR updates (the file's path doesn't change when its contents do). `Symbol.for('@hono-preact/loader:apps/app/src/pages/movies')` is the same in every dev session, every production build, every test run. Server and client agree by construction because both sides derive the key from the same filesystem reference.
+
+**Collision is by construction impossible.** Two distinct `.server.*` files have distinct paths, hence distinct keys. The implicit "no two `.server.*` files may share a basename" constraint disappears. Apps can grow nested page trees freely.
+
+`createCache('movies-list')` keeps its explicit name, unchanged. The cache name is consumer-visible (`cacheRegistry.invalidate('movies-list')` references it from other modules), so there's nothing to auto-derive.
 
 ---
 
@@ -408,9 +494,9 @@ export type { PageBindings, PageProps, WrapperProps } from './...';
 export { Route, Router, lazy } from 'preact-iso';
 
 // Server bindings
-export { defineLoader } from './...';
+export { defineLoader } from './...';                        // (fn) -> LoaderRef; plugin injects __moduleKey
 export type { LoaderRef, LoaderCtx, Loader as LoaderFn } from './...';
-export { defineAction, defineActionGuard, ActionGuardError } from './...';
+export { defineAction, defineActionGuard, ActionGuardError } from './...';   // (fn) -> ActionStub; plugin injects __moduleKey + __action
 export type {
   ActionStub, UseActionOptions, UseActionResult,
   ActionGuardContext, ActionGuardFn,
@@ -524,7 +610,14 @@ Move the fallback into `definePage`:
 
 ### 6.3 `apps/app/src/pages/*.server.ts`
 
-Optional: drop the explicit `'movies'` / `'watched'` / `'movie'` strings in `defineLoader` calls. They keep working unchanged; the change is purely cosmetic.
+Drop the explicit `'movies'` / `'watched'` / `'movie'` strings in `defineLoader` calls. The path-keyed scheme has no string-name argument; the plugin transform embeds the key. Mechanical edit across `pages/movies.server.ts`, `pages/watched.server.ts`, `pages/movie.server.ts`.
+
+```diff
+- export const loader = defineLoader<{ ... }>('movies', serverLoader);
++ export const loader = defineLoader(serverLoader);
+```
+
+`defineAction` calls keep their shape; the plugin will inject `__moduleKey` and `__action` (already implicit in the action stub today via the `serverActions` object pattern).
 
 ### 6.4 No other touchpoints
 
@@ -548,11 +641,27 @@ Optional: drop the explicit `'movies'` / `'watched'` / `'movie'` strings in `def
 - **The wrapped `lazy()`** with `getResolvedDefault()`. No consumer code reads `getResolvedDefault` today; it exists solely so `<Route>`'s introspection could see post-resolution bindings. Goes away with the introspection.
 - **Nine names from `index.ts` move behind `/internal`.** Consumers who were already reaching for them (none, in `apps/app/`) need a one-token import path change.
 
-### 7.3 New risk
+### 7.3 New risks
 
-The plugin-derived `__id` parity (§4.3 step 3) requires extending `serverOnlyPlugin` to transform `.server.ts` files, which it currently does not. This is not technically hard (`MagicString` + the existing AST walker), but it's the one new build-time concern in the plan. A failure mode here would be: HMR causing spurious refetches because server `__id` and client `__id` don't match. Existing HMR tests would catch this, but the plugin change needs its own coverage.
+Two structural changes carry new risk that need test coverage:
 
-If we want to defer that work, we can keep `defineLoader`'s name as required for now and ship the rest of the simplification first. The two changes are independent.
+**Plugin transform of `.server.*` files.** `serverOnlyPlugin` currently only transforms client-side imports of `.server.*` modules. Path-keying adds a second pass that transforms the `.server.*` files themselves to inject `__moduleKey` and thread it through `defineLoader` / `defineAction` calls. The transform is small (~20 LOC of `MagicString` work over the existing AST walker), but it's a new code path on the server build. The chief failure mode is: server-side `__moduleKey` and client-side RPC payload disagree, breaking RPC routing silently.
+
+Mitigation: capture `viteRoot` once via `configResolved` and reuse on both transform paths. Add a contract test that loads the same `.server.ts` file under both transform paths in dev and production builds, asserts the keys match.
+
+**`viteRoot` resolution drift.** The path key is computed via `path.relative(viteRoot, absolutePath)`. If `viteRoot` resolves differently in dev vs. build vs. SSR vs. test (e.g., a workspace-root config in monorepos), keys diverge across environments and RPC breaks.
+
+Mitigation: never recompute `viteRoot` from `id` directly; only read the value captured in `configResolved`. Add an integration test that exercises a monorepo layout (already the case here — `apps/app` under a pnpm workspace).
+
+### 7.4 Collision handling
+
+The basename-collision concern from earlier exploration ("two `.server.*` files in different folders sharing a name") is dissolved by path-keying:
+
+- Symbol identity: distinct paths produce distinct `Symbol.for(...)` keys.
+- RPC routing: the server handler's lookup map is keyed by path; collisions are filesystem-impossible.
+- Cache registry: unaffected — `createCache(name)` is consumer-typed and independent.
+
+No build-time lint check needed; no UUID needed; no hash suffix needed. The collision class goes away.
 
 ---
 
@@ -560,7 +669,7 @@ If we want to defer that work, we can keep `defineLoader`'s name as required for
 
 The simplification leaves several known issues untouched. They're called out for the next research step, not for this scope.
 
-1. **`useId`-keyed SSR hydration.** `<Loader>` calls `useId()` and `getPreloadedData(id)` matches against a DOM element with that id. Inserting or removing intermediate components anywhere on the path between `<Page>` and `<Loader>` would shift the fiber-position id, breaking hydration. This is fragile and is direction #4's territory: hydrate by loader name, not by `useId()`.
+1. **`useId`-keyed SSR hydration.** `<Loader>` calls `useId()` and `getPreloadedData(id)` matches against a DOM element with that id. Inserting or removing intermediate components anywhere on the path between `<Page>` and `<Loader>` would shift the fiber-position id, breaking hydration. This is fragile and is direction #4's territory: hydrate by loader name, not by `useId()`. Note that the path-keyed module identity from §4.3 is a natural foundation for this: the same `__moduleKey` could key SSR data injection (`<script type="application/json" data-loader-key="apps/app/src/pages/movies">`) and hydration lookup, decoupling SSR from React fiber position. Out of scope here; flagged as the natural next step.
 2. **Pipeline ordering is still fixed inside `<Page>`** (guard → preload → cache → fetch). Consumers wanting a different order drop to `@hono-preact/iso/internal` and assemble their own. That's the same as today's "fork `<Page>`" workaround, just better-supported.
 3. **`<Page>` itself remains a monolithic orchestrator.** This work moves complexity off the consumer's plate but doesn't reduce the `loader.tsx` or `<Page>` internals. That's a follow-on cleanup, separate from the surface trim.
 4. **Streaming SSR, Worker prefetch, and other "iso runs outside React" stories** remain unaddressed. Direction #4 is the path; this doc is not that path.
@@ -569,40 +678,42 @@ The simplification leaves several known issues untouched. They're called out for
 
 ## 9. Migration sketch
 
-A non-prescriptive ordering. Each step is independent enough to ship on its own.
+A non-prescriptive ordering. The path-keyed routing change ships first because it's the largest structural piece and the surface trim doesn't depend on it landing first; doing it earlier means the test surface stabilizes before the cosmetic changes pile on top.
 
-**Step 1 — `definePage` self-wraps.** Update `define-page.ts` to return a routable component. `<Page>` keeps its current props. `PAGE_BINDINGS` symbol stays for one transition release. Existing custom `<Route>`/`<Router>` continues to work because the bindings symbol is still set; the path through the marker just becomes redundant.
+**Step 1 — Path-keyed module identity.** Extend `serverOnlyPlugin` with a second transform pass that runs on `.server.*` files: inject `export const __moduleKey = '<path>'` and thread the key into `defineLoader` / `defineAction` calls via a hidden second arg. Update the existing client-side import transform to emit the path key in RPC payloads instead of basename. Update `loadersHandler` and `actionsHandler` in `packages/server` to read `mod.__moduleKey` for routing instead of `moduleNameFromPath`. Update `defineLoader` and `defineAction` runtime to accept the hidden options arg and use it for `__id`. Drop `defineLoader`'s string-name argument from the public type. Migrate `apps/app/src/pages/*.server.ts` (mechanical: drop `'movies'` etc.). Test: contract test asserting server-rendered `__moduleKey` matches client-emitted RPC payload across dev and production builds.
 
-**Step 2 — Replace `Route`/`Router`/`lazy` with re-exports.** Delete `route.tsx` and `lazy.ts`. Export `Route`, `Router`, `lazy` from `preact-iso` in `index.ts`. `apps/app/src/iso.tsx` cleanup happens here (drop `IsoRoute`, drop comment, no `definePage`-aware route needed).
+**Step 2 — `definePage` self-wraps.** Update `define-page.ts` to return a routable component. `<Page>` keeps its current props. `PAGE_BINDINGS` symbol stays for one transition release. Existing custom `<Route>`/`<Router>` continues to work because the bindings symbol is still set; the path through the marker just becomes redundant.
 
-**Step 3 — Move route-level props to `PageBindings`.** Add `fallback`/`errorFallback`/`serverGuards`/`clientGuards` to `PageBindings`. Migrate `pages/watched.tsx`. Remove the (no-longer-useful) types `RouteProps`, `RouterProps`, `RouteConfig`, `PageConfig`.
+**Step 3 — Replace `Route`/`Router`/`lazy` with re-exports.** Delete `route.tsx` and `lazy.ts`. Export `Route`, `Router`, `lazy` from `preact-iso` in `index.ts`. `apps/app/src/iso.tsx` cleanup happens here (drop `IsoRoute`, drop comment, no `definePage`-aware route needed).
 
-**Step 4 — `index.ts` trim.** Move `Loader`, `Envelope`, `RouteBoundary`, `Guards`, `GuardGate`, `useGuardResult`, `OptimisticOverlay`, all four context exports, `getPreloadedData`, `deletePreloadedData`, `runRequestScope`, `wrapPromise`, `runGuards` out of `index.ts` and into `internal.ts`. Add the `package.json` `exports` entry.
+**Step 4 — Move route-level props to `PageBindings`.** Add `fallback`/`errorFallback`/`serverGuards`/`clientGuards` to `PageBindings`. Migrate `pages/watched.tsx`. Remove the (no-longer-useful) types `RouteProps`, `RouterProps`, `RouteConfig`, `PageConfig`.
 
-**Step 5 — Drop `PAGE_BINDINGS` and `wrapWithPage`.** Delete the symbol and the helper. Remove from public exports. After step 1, nothing reads them anymore.
+**Step 5 — `index.ts` trim.** Move `Loader`, `Envelope`, `RouteBoundary`, `Guards`, `GuardGate`, `useGuardResult`, `OptimisticOverlay`, all four context exports, `getPreloadedData`, `deletePreloadedData`, `runRequestScope`, `wrapPromise`, `runGuards` out of `index.ts` and into `internal.ts`. Add the `package.json` `exports` entry.
 
-**Step 6 — Optional `defineLoader` name.** Update `defineLoader` to accept a single-fn form. Update `serverOnlyPlugin` to silently use the filename when no string arg is found. Add the `.server.ts` transform that injects `Symbol.for(...)` into `defineLoader(fn)` calls so server/client `__id` parity is preserved.
+**Step 6 — Drop `PAGE_BINDINGS` and `wrapWithPage`.** Delete the symbol and the helper. Remove from public exports. After step 2, nothing reads them anymore.
 
-Steps 1–5 are mechanically driven by the existing test suite; step 6 needs new plugin tests that cross-check server and client `__id`s.
+Step 1 is the riskiest and gets its own PR plus contract tests. Steps 2–6 are mechanically driven by the existing test suite. The surface trim (steps 2–6) is independent of step 1 and could ship first if path-keying needs to bake longer; the only coupling is that step 1 removes `defineLoader`'s string argument, so a deferred step 1 means step 6's `defineLoader(fn)` form needs the optional-name compromise from earlier explorations.
 
 ---
 
 ## 10. Bottom line
 
-The simplification is a refactor, not a redesign. It deletes one layer of orchestration that grew up to make `definePage` invisible, replaces it with a `definePage` that does its own wrapping, and pushes the granular kit behind a subpath import where advanced consumers can still reach it. The `<Page>` component, the loader/action/optimistic hooks, the cache primitives, and the guard primitives all keep their shape.
+The simplification is a refactor plus one structural change. The refactor deletes the orchestration layer that grew up to make `definePage` invisible, replaces it with a `definePage` that does its own wrapping, and pushes the granular kit behind a subpath import where advanced consumers can still reach it. The structural change retires basename-as-routing-key in favor of path-derived module identity embedded by the plugin, eliminating an implicit constraint and making `defineLoader` a single-arg primitive. The `<Page>` component, the loader/action/optimistic hooks, the cache primitives, and the guard primitives all keep their shape.
 
 Net change for the consumer:
 
 - `index.ts` shrinks from ~30 names to ~17.
 - `iso.tsx` loses an escape-hatch import and a six-line comment.
 - One page (`watched.tsx`) moves a `fallback` prop from `<Route>` to `definePage` bindings.
-- New optional shorthand: `defineLoader(fn)` instead of `defineLoader('name', fn)`.
+- `defineLoader(fn)` is the only form. Every existing `defineLoader('name', fn)` call drops its string.
+- Filenames stop being load-bearing for routing. Folders can be organized however the app wants.
 
 Net change for the package:
 
 - Two source files deleted (`route.tsx`, `lazy.ts`), ~243 LOC.
 - One source file added (`internal.ts`, ~15 LOC re-exports).
 - Two `package.json` exports entries.
-- One small `serverOnlyPlugin` extension (silent filename fallback + optional `.server.ts` transform).
+- `serverOnlyPlugin` gains a `.server.*` transform pass that injects `__moduleKey` and threads it into `defineLoader` / `defineAction` calls.
+- `loadersHandler` and `actionsHandler` switch from basename-keying to `__moduleKey`-keying.
 
-The unreduced complexity (loader state machine, `useId`-keyed hydration, pipeline ordering) is left for direction #4 if and when iso outgrows its current scope. This doc's scope is the front door, and the front door is what consumers feel.
+The unreduced complexity (loader state machine, `useId`-keyed hydration, pipeline ordering) is left for direction #4 if and when iso outgrows its current scope. The path-keyed module identity from §4.3 is the natural foundation for `useId`-free SSR hydration when that work begins. This doc's scope is the front door plus the routing-identity layer underneath; both are what consumers feel directly or indirectly when their app grows.

--- a/packages/iso/src/__tests__/define-loader.test.ts
+++ b/packages/iso/src/__tests__/define-loader.test.ts
@@ -11,36 +11,6 @@ describe('defineLoader', () => {
     expect(Symbol.keyFor(ref.__id)).toBeUndefined();
   });
 
-  it('throws when name is an empty string', () => {
-    expect(() => defineLoader('', async () => ({}))).toThrow(
-      /name must be a non-empty string/
-    );
-  });
-
-  it('keys __id with Symbol.for so two calls with the same name share identity', () => {
-    const a = defineLoader('movies', async () => ({}));
-    const b = defineLoader('movies', async () => ({}));
-    // Same name produces the same registered symbol, even across distinct
-    // defineLoader call sites. This ensures stable loader identity for prefetch
-    // and cache keying when a consumer imports two copies of the same .server.* module.
-    expect(a.__id).toBe(b.__id);
-    expect(typeof Symbol.keyFor(a.__id)).toBe('string');
-    expect(Symbol.keyFor(a.__id)).toBe('@hono-preact/loader:movies');
-  });
-
-  it('produces distinct __id for distinct names', () => {
-    const a = defineLoader('movies', async () => ({}));
-    const b = defineLoader('reviews', async () => ({}));
-    expect(a.__id).not.toBe(b.__id);
-  });
-
-  it('aligns with the SSR stub symbol shape (Symbol.for("@hono-preact/loader:<name>"))', () => {
-    const ref = defineLoader('movies', async () => ({}));
-    const stubSymbol = Symbol.for('@hono-preact/loader:movies');
-    // The stub fabricated by the server-only Vite plugin uses this exact key,
-    // so identity is stable across the user-authored module and the client stub.
-    expect(ref.__id).toBe(stubSymbol);
-  });
 });
 
 describe('defineLoader (path-keyed __moduleKey form)', () => {

--- a/packages/iso/src/__tests__/define-loader.test.ts
+++ b/packages/iso/src/__tests__/define-loader.test.ts
@@ -13,6 +13,15 @@ describe('defineLoader', () => {
 
 });
 
+describe('defineLoader type-level guards', () => {
+  it('rejects the legacy (name, fn) form at the type level', () => {
+    // @ts-expect-error: defineLoader no longer accepts a string as the first
+    // argument; the (name, fn) overload was removed in the path-keyed identity
+    // refactor.
+    defineLoader('movies', async () => ({}));
+  });
+});
+
 describe('defineLoader (path-keyed __moduleKey form)', () => {
   it('accepts (fn, { __moduleKey }) and derives __id from the key', () => {
     const ref = defineLoader(async () => ({}), {

--- a/packages/iso/src/__tests__/define-loader.test.ts
+++ b/packages/iso/src/__tests__/define-loader.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { defineLoader } from '../define-loader.js';
 
 describe('defineLoader', () => {
-  it('throws when called without a name argument', () => {
-    expect(() =>
-      // @ts-expect-error: name is required
-      defineLoader(async () => ({}))
-    ).toThrow(/name must be a non-empty string/);
+  it('returns an unkeyed LoaderRef when called with only a function (no name, no opts)', () => {
+    // The (fn) form is now valid. The plugin will rewrite it to (fn, { __moduleKey })
+    // at build time. Without opts the symbol is local (not registered), so
+    // Symbol.keyFor returns undefined.
+    const ref = defineLoader(async () => ({}));
+    expect(typeof ref.__id).toBe('symbol');
+    expect(Symbol.keyFor(ref.__id)).toBeUndefined();
   });
 
   it('throws when name is an empty string', () => {
@@ -38,5 +40,30 @@ describe('defineLoader', () => {
     // The stub fabricated by the server-only Vite plugin uses this exact key,
     // so identity is stable across the user-authored module and the client stub.
     expect(ref.__id).toBe(stubSymbol);
+  });
+});
+
+describe('defineLoader (path-keyed __moduleKey form)', () => {
+  it('accepts (fn, { __moduleKey }) and derives __id from the key', () => {
+    const ref = defineLoader(async () => ({}), {
+      __moduleKey: 'apps/app/src/pages/movies',
+    });
+    expect(Symbol.keyFor(ref.__id)).toBe(
+      '@hono-preact/loader:apps/app/src/pages/movies'
+    );
+  });
+
+  it('produces the same __id symbol for two calls with the same __moduleKey', () => {
+    const a = defineLoader(async () => ({}), { __moduleKey: 'pages/movies' });
+    const b = defineLoader(async () => ({}), { __moduleKey: 'pages/movies' });
+    expect(a.__id).toBe(b.__id);
+  });
+
+  it('produces distinct __id for distinct __moduleKey values', () => {
+    const a = defineLoader(async () => ({}), { __moduleKey: 'pages/movies' });
+    const b = defineLoader(async () => ({}), {
+      __moduleKey: 'pages/admin/movies',
+    });
+    expect(a.__id).not.toBe(b.__id);
   });
 });

--- a/packages/iso/src/__tests__/define-page.test.ts
+++ b/packages/iso/src/__tests__/define-page.test.ts
@@ -6,7 +6,7 @@ import { createCache } from '../cache.js';
 describe('definePage', () => {
   it('attaches bindings under the realm-wide PAGE_BINDINGS symbol', () => {
     const fn = async () => ({ msg: 'ok' });
-    const loader = defineLoader<{ msg: string }>('define-page-test-1', fn);
+    const loader = defineLoader<{ msg: string }>(fn, { __moduleKey: 'define-page-test-1' });
     const cache = createCache<{ msg: string }>('define-page-test-1');
     const Inner = () => null;
 
@@ -38,8 +38,8 @@ describe('definePage', () => {
   it('replaces previously-attached bindings if called twice on the same component', () => {
     const fn1 = async () => ({ a: 1 });
     const fn2 = async () => ({ b: 2 });
-    const loader1 = defineLoader('define-page-test-replace-1', fn1);
-    const loader2 = defineLoader('define-page-test-replace-2', fn2);
+    const loader1 = defineLoader(fn1, { __moduleKey: 'define-page-test-replace-1' });
+    const loader2 = defineLoader(fn2, { __moduleKey: 'define-page-test-replace-2' });
     const Inner = () => null;
 
     definePage(Inner, { loader: loader1 });

--- a/packages/iso/src/__tests__/loader.test.tsx
+++ b/packages/iso/src/__tests__/loader.test.tsx
@@ -37,7 +37,7 @@ describe('v3 <Loader> stability', () => {
       callCount++;
       return Promise.resolve({ msg: `call ${callCount}` });
     });
-    const ref = defineLoader<{ msg: string }>('refire-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'refire-test' });
 
     function Child() {
       const { msg } = useLoaderData<typeof ref>();
@@ -86,7 +86,7 @@ describe('v3 <Loader> stability', () => {
             resolveReload = r;
           })
       );
-    const ref = defineLoader<{ msg: string }>('preserve-state-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'preserve-state-test' });
 
     function Child() {
       const { msg } = useLoaderData<typeof ref>();
@@ -156,7 +156,7 @@ describe('v3 <Loader> stability', () => {
           resolve = r;
         })
     );
-    const ref = defineLoader<{ msg: string }>('dup-xhr-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'dup-xhr-test' });
 
     function Child() {
       const { msg } = useLoaderData<typeof ref>();
@@ -221,7 +221,7 @@ describe('v3 <Loader> stability', () => {
             resolveReload = r;
           })
       );
-    const ref = defineLoader<{ msg: string }>('search-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'search-test' });
 
     function Fallback() {
       const { reload } = useReload();
@@ -273,7 +273,7 @@ describe('v3 <Loader> stability', () => {
     const fn = vi.fn(({ location }: { location: RouteHook }) =>
       Promise.resolve({ q: location.searchParams.q ?? '' })
     );
-    const ref = defineLoader<{ q: string }>('search-q-test', fn);
+    const ref = defineLoader<{ q: string }>(fn, { __moduleKey: 'search-q-test' });
 
     function Child() {
       const { q } = useLoaderData<typeof ref>();

--- a/packages/iso/src/__tests__/page.test.tsx
+++ b/packages/iso/src/__tests__/page.test.tsx
@@ -35,7 +35,7 @@ afterEach(() => {
   cleanup();
 });
 
-const emptyLoader = defineLoader<Record<string, never>>('empty-page-test', async () => ({}));
+const emptyLoader = defineLoader<Record<string, never>>(async () => ({}), { __moduleKey: 'empty-page-test' });
 
 describe('guard { render }', () => {
   it('renders the guard-supplied component instead of the page', async () => {
@@ -137,9 +137,9 @@ describe('Page without a loader', () => {
 
 describe('Page error boundary', () => {
   it('renders errorFallback when the loader rejects', async () => {
-    const failing = defineLoader<{ msg: string }>('failing-page-test', async () => {
+    const failing = defineLoader<{ msg: string }>(async () => {
       throw new Error('boom');
-    });
+    }, { __moduleKey: 'failing-page-test' });
 
     render(
       <LocationProvider>

--- a/packages/iso/src/__tests__/prefetch.test.ts
+++ b/packages/iso/src/__tests__/prefetch.test.ts
@@ -4,38 +4,38 @@ import { prefetch } from '../prefetch.js';
 
 describe('prefetch', () => {
   it('derives pathParams from url + route', async () => {
-    const ref = defineLoader('movie-by-id', async ({ location }) => {
+    const ref = defineLoader(async ({ location }) => {
       return { id: location.pathParams.id };
-    });
+    }, { __moduleKey: 'movie-by-id' });
     const result = await prefetch(ref, { url: '/movies/42', route: '/movies/:id' });
     expect(result).toEqual({ id: '42' });
   });
 
   it('derives searchParams from url query string', async () => {
-    const ref = defineLoader('search-by-q', async ({ location }) => {
+    const ref = defineLoader(async ({ location }) => {
       return { q: location.searchParams.q };
-    });
+    }, { __moduleKey: 'search-by-q' });
     const result = await prefetch(ref, { url: '/search?q=hi' });
     expect(result).toEqual({ q: 'hi' });
   });
 
   it('derives a clean path (no trailing slash, leading slash preserved)', async () => {
-    const ref = defineLoader('path-echo', async ({ location }) => {
+    const ref = defineLoader(async ({ location }) => {
       return { path: location.path };
-    });
+    }, { __moduleKey: 'path-echo' });
     expect(await prefetch(ref, { url: '/movies/' })).toEqual({ path: '/movies' });
     expect(await prefetch(ref, { url: '/' })).toEqual({ path: '/' });
     expect(await prefetch(ref, { url: '/movies/42?x=1' })).toEqual({ path: '/movies/42' });
   });
 
   it('back-compat: location overrides url/route derivation', async () => {
-    const ref = defineLoader('back-compat', async ({ location }) => {
+    const ref = defineLoader(async ({ location }) => {
       return {
         path: location.path,
         id: location.pathParams.id,
         q: location.searchParams.q,
       };
-    });
+    }, { __moduleKey: 'back-compat' });
     const result = await prefetch(ref, {
       url: '/should-be-ignored',
       route: '/should-be-ignored/:id',
@@ -49,13 +49,13 @@ describe('prefetch', () => {
   });
 
   it('no-args call resolves with an empty but type-complete location', async () => {
-    const ref = defineLoader('empty-loc', async ({ location }) => {
+    const ref = defineLoader(async ({ location }) => {
       return {
         path: location.path,
         pathParams: location.pathParams,
         searchParams: location.searchParams,
       };
-    });
+    }, { __moduleKey: 'empty-loc' });
     const result = await prefetch(ref);
     expect(result).toEqual({ path: '', pathParams: {}, searchParams: {} });
   });

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -48,7 +48,7 @@ describe('wrapWithPage', () => {
 
   it('renders the component with loader data via useLoaderData', async () => {
     const fn = vi.fn(async () => ({ msg: 'ok' }));
-    const ref = defineLoader<{ msg: string }>('wrap-with-page-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'wrap-with-page-test' });
     const Inner = () => {
       const { msg } = useLoaderData<typeof ref>();
       return <p data-testid="msg">{msg}</p>;
@@ -69,7 +69,7 @@ describe('wrapWithPage', () => {
 describe('<Router> + <Route>', () => {
   it('renders the matched route wrapped in <Page> with loader data', async () => {
     const fn = vi.fn(async () => ({ msg: 'foo-data' }));
-    const ref = defineLoader<{ msg: string }>('router-route-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'router-route-test' });
     const Foo = () => {
       const { msg } = useLoaderData<typeof ref>();
       return <p data-testid="foo">{msg}</p>;
@@ -128,7 +128,7 @@ describe('<Router> + <Route>', () => {
 
   it('reads loader/cache/Wrapper from PAGE_BINDINGS on the component', async () => {
     const fn = vi.fn(async () => ({ msg: 'page-data' }));
-    const ref = defineLoader<{ msg: string }>('page-bindings-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'page-bindings-test' });
 
     const Inner = () => {
       const { msg } = useLoaderData<typeof ref>();
@@ -152,7 +152,7 @@ describe('<Router> + <Route>', () => {
 
   it('reads PAGE_BINDINGS off a lazy component once resolved', async () => {
     const fn = vi.fn(async () => ({ msg: 'lazy-data' }));
-    const ref = defineLoader<{ msg: string }>('page-bindings-lazy-test', fn);
+    const ref = defineLoader<{ msg: string }>(fn, { __moduleKey: 'page-bindings-lazy-test' });
 
     const Inner = () => {
       const { msg } = useLoaderData<typeof ref>();

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -11,6 +11,12 @@ export interface LoaderRef<T> {
   readonly cache?: LoaderCache<T>;
 }
 
+/**
+ * Plugin-emitted opts for `defineLoader`. Authored code should never
+ * construct this literal directly — it's threaded in by the
+ * `moduleKeyPlugin` Vite transform when it rewrites
+ * `defineLoader(fn)` to `defineLoader(fn, { __moduleKey: '...' })`.
+ */
 export type DefineLoaderOpts<T> = {
   __moduleKey: string;
   cache?: LoaderCache<T>;
@@ -59,6 +65,8 @@ export function defineLoader<T>(
   // directly). Use a placeholder symbol; identity will be unstable across
   // module reloads, which is acceptable for tests.
   const fn = fnOrName;
+  // At this point fnOrName is Loader<T>, so fnOrOpts is either
+  // DefineLoaderOpts<T> or undefined (not a Loader<T>).
   const opts = fnOrOpts as DefineLoaderOpts<T> | undefined;
   if (opts?.__moduleKey) {
     return {

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -11,21 +11,64 @@ export interface LoaderRef<T> {
   readonly cache?: LoaderCache<T>;
 }
 
+export type DefineLoaderOpts<T> = {
+  __moduleKey: string;
+  cache?: LoaderCache<T>;
+};
+
+// Public form (post-plugin authoring): defineLoader(fn) — the plugin will
+// rewrite this to defineLoader(fn, { __moduleKey: '...' }) at build time.
+export function defineLoader<T>(fn: Loader<T>): LoaderRef<T>;
+// Plugin-emitted form: defineLoader(fn, { __moduleKey, cache? }).
+export function defineLoader<T>(
+  fn: Loader<T>,
+  opts: DefineLoaderOpts<T>
+): LoaderRef<T>;
+// Legacy form (deprecated, removed in the final task of this plan):
+// defineLoader(name, fn, cache?).
 export function defineLoader<T>(
   name: string,
   fn: Loader<T>,
   cache?: LoaderCache<T>
+): LoaderRef<T>;
+export function defineLoader<T>(
+  fnOrName: Loader<T> | string,
+  fnOrOpts?: Loader<T> | DefineLoaderOpts<T>,
+  legacyCache?: LoaderCache<T>
 ): LoaderRef<T> {
-  if (typeof name !== 'string' || name.length === 0) {
-    throw new Error(
-      'defineLoader(name, fn): name must be a non-empty string. ' +
-      "Pick a stable identifier matching the .server.* module basename, " +
-      "e.g. defineLoader('movies', serverLoader)."
-    );
+  if (typeof fnOrName === 'string') {
+    // Legacy (name, fn) form.
+    const name = fnOrName;
+    const fn = fnOrOpts as Loader<T>;
+    if (name.length === 0) {
+      throw new Error(
+        'defineLoader(name, fn): name must be a non-empty string. ' +
+          "Pick a stable identifier matching the .server.* module basename, " +
+          "e.g. defineLoader('movies', serverLoader)."
+      );
+    }
+    return {
+      __id: Symbol.for(`@hono-preact/loader:${name}`),
+      fn,
+      cache: legacyCache,
+    };
+  }
+
+  // New (fn, opts?) form. When opts is absent, the plugin hasn't run yet
+  // (e.g. in unit tests of consumer code that import the .server.* file
+  // directly). Use a placeholder symbol; identity will be unstable across
+  // module reloads, which is acceptable for tests.
+  const fn = fnOrName;
+  const opts = fnOrOpts as DefineLoaderOpts<T> | undefined;
+  if (opts?.__moduleKey) {
+    return {
+      __id: Symbol.for(`@hono-preact/loader:${opts.__moduleKey}`),
+      fn,
+      cache: opts.cache,
+    };
   }
   return {
-    __id: Symbol.for(`@hono-preact/loader:${name}`),
+    __id: Symbol(`@hono-preact/loader:<unkeyed>`),
     fn,
-    cache,
   };
 }

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -13,7 +13,7 @@ export interface LoaderRef<T> {
 
 /**
  * Plugin-emitted opts for `defineLoader`. Authored code should never
- * construct this literal directly — it's threaded in by the
+ * construct this literal directly -- it's threaded in by the
  * `moduleKeyPlugin` Vite transform when it rewrites
  * `defineLoader(fn)` to `defineLoader(fn, { __moduleKey: '...' })`.
  */
@@ -22,52 +22,29 @@ export type DefineLoaderOpts<T> = {
   cache?: LoaderCache<T>;
 };
 
-// Public form (post-plugin authoring): defineLoader(fn) — the plugin will
-// rewrite this to defineLoader(fn, { __moduleKey: '...' }) at build time.
+/**
+ * Define a server loader.
+ *
+ * Authored as `defineLoader(fn)` in `.server.*` files. The `moduleKeyPlugin`
+ * Vite plugin rewrites the call at build time to thread the path-derived
+ * module key in: `defineLoader(fn, { __moduleKey: 'src/pages/movies' })`.
+ *
+ * The `__moduleKey` is the routing key for `__loaders`/`__actions` RPC
+ * and the payload of `Symbol.for(...)` for `__id`. Two loaders defined in
+ * different files produce distinct `__id` symbols by construction.
+ *
+ * The optional `cache` slot binds a `LoaderCache` to the loader so
+ * consumers needn't pass it separately to `<Page>`.
+ */
 export function defineLoader<T>(fn: Loader<T>): LoaderRef<T>;
-// Plugin-emitted form: defineLoader(fn, { __moduleKey, cache? }).
 export function defineLoader<T>(
   fn: Loader<T>,
   opts: DefineLoaderOpts<T>
 ): LoaderRef<T>;
-// Legacy form (deprecated, removed in the final task of this plan):
-// defineLoader(name, fn, cache?).
 export function defineLoader<T>(
-  name: string,
   fn: Loader<T>,
-  cache?: LoaderCache<T>
-): LoaderRef<T>;
-export function defineLoader<T>(
-  fnOrName: Loader<T> | string,
-  fnOrOpts?: Loader<T> | DefineLoaderOpts<T>,
-  legacyCache?: LoaderCache<T>
+  opts?: DefineLoaderOpts<T>
 ): LoaderRef<T> {
-  if (typeof fnOrName === 'string') {
-    // Legacy (name, fn) form.
-    const name = fnOrName;
-    const fn = fnOrOpts as Loader<T>;
-    if (name.length === 0) {
-      throw new Error(
-        'defineLoader(name, fn): name must be a non-empty string. ' +
-          "Pick a stable identifier matching the .server.* module basename, " +
-          "e.g. defineLoader('movies', serverLoader)."
-      );
-    }
-    return {
-      __id: Symbol.for(`@hono-preact/loader:${name}`),
-      fn,
-      cache: legacyCache,
-    };
-  }
-
-  // New (fn, opts?) form. When opts is absent, the plugin hasn't run yet
-  // (e.g. in unit tests of consumer code that import the .server.* file
-  // directly). Use a placeholder symbol; identity will be unstable across
-  // module reloads, which is acceptable for tests.
-  const fn = fnOrName;
-  // At this point fnOrName is Loader<T>, so fnOrOpts is either
-  // DefineLoaderOpts<T> or undefined (not a Loader<T>).
-  const opts = fnOrOpts as DefineLoaderOpts<T> | undefined;
   if (opts?.__moduleKey) {
     return {
       __id: Symbol.for(`@hono-preact/loader:${opts.__moduleKey}`),
@@ -75,6 +52,9 @@ export function defineLoader<T>(
       cache: opts.cache,
     };
   }
+  // Plugin-less context (a consumer testing their loader in isolation).
+  // Identity is unstable across module reloads, which is acceptable for
+  // tests that don't depend on cache-by-id behavior.
   return {
     __id: Symbol(`@hono-preact/loader:<unkeyed>`),
     fn,

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -17,7 +17,7 @@ export interface LoaderRef<T> {
  * `moduleKeyPlugin` Vite transform when it rewrites
  * `defineLoader(fn)` to `defineLoader(fn, { __moduleKey: '...' })`.
  */
-export type DefineLoaderOpts<T> = {
+export type DefineLoaderOpts = {
   __moduleKey: string;
 };
 
@@ -38,11 +38,11 @@ export type DefineLoaderOpts<T> = {
 export function defineLoader<T>(fn: Loader<T>): LoaderRef<T>;
 export function defineLoader<T>(
   fn: Loader<T>,
-  opts: DefineLoaderOpts<T>
+  opts: DefineLoaderOpts
 ): LoaderRef<T>;
 export function defineLoader<T>(
   fn: Loader<T>,
-  opts?: DefineLoaderOpts<T>
+  opts?: DefineLoaderOpts
 ): LoaderRef<T> {
   if (opts?.__moduleKey) {
     return {

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -19,7 +19,6 @@ export interface LoaderRef<T> {
  */
 export type DefineLoaderOpts<T> = {
   __moduleKey: string;
-  cache?: LoaderCache<T>;
 };
 
 /**
@@ -33,8 +32,8 @@ export type DefineLoaderOpts<T> = {
  * and the payload of `Symbol.for(...)` for `__id`. Two loaders defined in
  * different files produce distinct `__id` symbols by construction.
  *
- * The optional `cache` slot binds a `LoaderCache` to the loader so
- * consumers needn't pass it separately to `<Page>`.
+ * To bind a `LoaderCache` to a loader, pass it via `definePage(Component,
+ * { loader, cache })` rather than through `defineLoader` opts.
  */
 export function defineLoader<T>(fn: Loader<T>): LoaderRef<T>;
 export function defineLoader<T>(
@@ -49,7 +48,6 @@ export function defineLoader<T>(
     return {
       __id: Symbol.for(`@hono-preact/loader:${opts.__moduleKey}`),
       fn,
-      cache: opts.cache,
     };
   }
   // Plugin-less context (a consumer testing their loader in isolation).

--- a/packages/server/src/__tests__/actions-handler.test.ts
+++ b/packages/server/src/__tests__/actions-handler.test.ts
@@ -28,7 +28,7 @@ describe('actionsHandler', () => {
   it('calls the matching action with the Hono context and payload', async () => {
     const createFn = vi.fn().mockResolvedValue({ id: 1 });
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { create: createFn } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { create: createFn } },
     });
 
     const res = await post(app, {
@@ -57,7 +57,7 @@ describe('actionsHandler', () => {
 
   it('returns 404 when the action is not found in the module', async () => {
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { create: vi.fn() } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { create: vi.fn() } },
     });
     const res = await post(app, { module: 'movies', action: 'destroy', payload: {} });
     expect(res.status).toBe(404);
@@ -67,6 +67,7 @@ describe('actionsHandler', () => {
   it('returns 500 when the action throws', async () => {
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: {
           create: async () => {
             throw new Error('DB error');
@@ -83,7 +84,7 @@ describe('actionsHandler', () => {
     const createFn = vi.fn().mockResolvedValue({ ok: true });
     const lazyGlob = {
       './pages/movies.server.ts': () =>
-        Promise.resolve({ serverActions: { create: createFn } }),
+        Promise.resolve({ __moduleKey: 'movies', serverActions: { create: createFn } }),
     };
     const app = makeApp(lazyGlob);
 
@@ -94,18 +95,18 @@ describe('actionsHandler', () => {
 
   it('ignores modules without serverActions', async () => {
     const app = makeApp({
-      './pages/movies.server.ts': { serverLoader: async () => ({}) },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverLoader: async () => ({}) },
     });
     const res = await post(app, { module: 'movies', action: 'create', payload: {} });
     expect(res.status).toBe(404);
   });
 
-  it('derives module name by stripping path and .server.* extension', async () => {
+  it('routes by __moduleKey rather than filename basename', async () => {
     const createFn = vi.fn().mockResolvedValue({ ok: true });
     const app = makeApp({
-      './src/pages/movies.server.tsx': { serverActions: { create: createFn } },
+      './src/pages/movies.server.tsx': { __moduleKey: 'src/pages/movies', serverActions: { create: createFn } },
     });
-    const res = await post(app, { module: 'movies', action: 'create', payload: {} });
+    const res = await post(app, { module: 'src/pages/movies', action: 'create', payload: {} });
     expect(res.status).toBe(200);
   });
 
@@ -120,7 +121,7 @@ describe('actionsHandler', () => {
 
   it('returns 400 when body is missing module or action fields', async () => {
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { create: vi.fn() } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { create: vi.fn() } },
     });
     const res = await post(app, { payload: {} });
     expect(res.status).toBe(400);
@@ -139,6 +140,7 @@ describe('actionsHandler', () => {
 
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: { process: async () => stream },
       },
     });
@@ -156,7 +158,7 @@ describe('actionsHandler — multipart/form-data', () => {
   it('dispatches action from multipart form data with __module and __action fields', async () => {
     const uploadFn = vi.fn().mockResolvedValue({ ok: true });
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { upload: uploadFn } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { upload: uploadFn } },
     });
 
     const fd = new FormData();
@@ -174,7 +176,7 @@ describe('actionsHandler — multipart/form-data', () => {
   it('surfaces File objects in the action payload', async () => {
     const uploadFn = vi.fn().mockResolvedValue({ stored: true });
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { upload: uploadFn } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { upload: uploadFn } },
     });
 
     const fd = new FormData();
@@ -191,7 +193,7 @@ describe('actionsHandler — multipart/form-data', () => {
 
   it('returns 400 when __module or __action is missing from form data', async () => {
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { upload: vi.fn() } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { upload: vi.fn() } },
     });
     const fd = new FormData();
     fd.append('title', 'Dune');
@@ -204,7 +206,7 @@ describe('actionsHandler — multipart/form-data', () => {
   it('collects repeated form field names into an array', async () => {
     const uploadFn = vi.fn().mockResolvedValue({ ok: true });
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { upload: uploadFn } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { upload: uploadFn } },
     });
 
     const fd = new FormData();
@@ -221,7 +223,7 @@ describe('actionsHandler — multipart/form-data', () => {
   it('detects multipart/form-data even with boundary suffix in Content-Type', async () => {
     const uploadFn = vi.fn().mockResolvedValue({ ok: true });
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { upload: uploadFn } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { upload: uploadFn } },
     });
 
     // Manually build a minimal multipart body to test the Content-Type detection
@@ -249,7 +251,7 @@ describe('actionsHandler — multipart/form-data', () => {
 
   it('returns 400 when form data body is malformed', async () => {
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { upload: vi.fn() } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { upload: vi.fn() } },
     });
 
     const res = await app.request('http://localhost/__actions', {
@@ -267,6 +269,7 @@ describe('actionsHandler — action guards', () => {
     const createFn = vi.fn().mockResolvedValue({ id: 1 });
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: { create: createFn },
         actionGuards: [guardFn],
       },
@@ -281,6 +284,7 @@ describe('actionsHandler — action guards', () => {
   it('returns 403 when a guard throws ActionGuardError', async () => {
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: { create: vi.fn() },
         actionGuards: [
           async () => {
@@ -298,6 +302,7 @@ describe('actionsHandler — action guards', () => {
   it('uses the status from ActionGuardError', async () => {
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: { create: vi.fn() },
         actionGuards: [
           async () => {
@@ -316,6 +321,7 @@ describe('actionsHandler — action guards', () => {
     const createFn = vi.fn();
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: { create: createFn },
         actionGuards: [
           async () => { throw new ActionGuardError('Blocked'); },
@@ -334,6 +340,7 @@ describe('actionsHandler — action guards', () => {
     const guardFn = vi.fn().mockImplementation(async (_ctx: unknown, next: () => Promise<void>) => next());
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: { create: vi.fn().mockResolvedValue({}) },
         actionGuards: [guardFn],
       },
@@ -349,7 +356,7 @@ describe('actionsHandler — action guards', () => {
   it('works for modules without actionGuards', async () => {
     const createFn = vi.fn().mockResolvedValue({ id: 1 });
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { create: createFn } },
+      './pages/movies.server.ts': { __moduleKey: 'movies', serverActions: { create: createFn } },
     });
 
     const res = await post(app, { module: 'movies', action: 'create', payload: {} });
@@ -361,6 +368,7 @@ describe('actionsHandler — action guards', () => {
     const createFn = vi.fn().mockResolvedValue({ id: 1 });
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'movies',
         serverActions: { create: createFn },
         actionGuards: [async () => { /* intentionally does not call next() */ }],
       },
@@ -368,5 +376,56 @@ describe('actionsHandler — action guards', () => {
     const res = await post(app, { module: 'movies', action: 'create', payload: {} });
     expect(res.status).toBe(200);
     expect(createFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('actionsHandler path-keyed routing', () => {
+  it('routes lookups by mod.__moduleKey rather than filename', async () => {
+    const toggleWatched = vi.fn().mockResolvedValue({ ok: true, id: 7 });
+    // Filename and __moduleKey deliberately disagree to prove the
+    // handler trusts the export, not the path.
+    const app = makeApp({
+      '/whatever.server.ts': {
+        __moduleKey: 'src/pages/movies',
+        serverActions: { toggleWatched },
+      },
+    });
+    const res = await post(app, {
+      module: 'src/pages/movies',
+      action: 'toggleWatched',
+      payload: { id: 7 },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, id: 7 });
+    expect(toggleWatched).toHaveBeenCalled();
+  });
+
+  it('returns 404 when the requested module key does not match any export', async () => {
+    const app = makeApp({
+      '/x.server.ts': {
+        __moduleKey: 'a',
+        serverActions: { x: vi.fn() },
+      },
+    });
+    const res = await post(app, {
+      module: 'b',
+      action: 'x',
+      payload: {},
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('skips modules that lack __moduleKey', async () => {
+    const app = makeApp({
+      '/no-key.server.ts': {
+        serverActions: { x: vi.fn() },
+      },
+    });
+    const res = await post(app, {
+      module: 'no-key',
+      action: 'x',
+      payload: {},
+    });
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/server/src/__tests__/loaders-handler.test.ts
+++ b/packages/server/src/__tests__/loaders-handler.test.ts
@@ -22,10 +22,10 @@ describe('loadersHandler', () => {
   it('calls the matching serverLoader with the location and returns JSON', async () => {
     const loaderFn = vi.fn().mockResolvedValue({ movies: [] });
     const app = makeApp({
-      './pages/movies.server.ts': { default: loaderFn },
+      './pages/movies.server.ts': { __moduleKey: 'pages/movies', default: loaderFn },
     });
 
-    const res = await post(app, { module: 'movies', location: loc });
+    const res = await post(app, { module: 'pages/movies', location: loc });
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ movies: [] });
@@ -40,19 +40,20 @@ describe('loadersHandler', () => {
 
   it('returns 404 when the module has no default export', async () => {
     const app = makeApp({
-      './pages/movies.server.ts': { serverActions: { create: vi.fn() } },
+      './pages/movies.server.ts': { __moduleKey: 'pages/movies', serverActions: { create: vi.fn() } },
     });
-    const res = await post(app, { module: 'movies', location: loc });
+    const res = await post(app, { module: 'pages/movies', location: loc });
     expect(res.status).toBe(404);
   });
 
   it('returns 500 when the loader throws', async () => {
     const app = makeApp({
       './pages/movies.server.ts': {
+        __moduleKey: 'pages/movies',
         default: async () => { throw new Error('DB error'); },
       },
     });
-    const res = await post(app, { module: 'movies', location: loc });
+    const res = await post(app, { module: 'pages/movies', location: loc });
     expect(res.status).toBe(500);
     expect((await res.json() as { error: string }).error).toBe('DB error');
   });
@@ -60,18 +61,18 @@ describe('loadersHandler', () => {
   it('resolves lazy glob modules before handling requests', async () => {
     const loaderFn = vi.fn().mockResolvedValue({ ok: true });
     const lazyGlob = {
-      './pages/movies.server.ts': () => Promise.resolve({ default: loaderFn }),
+      './pages/movies.server.ts': () => Promise.resolve({ __moduleKey: 'pages/movies', default: loaderFn }),
     };
     const app = makeApp(lazyGlob);
 
-    const res = await post(app, { module: 'movies', location: loc });
+    const res = await post(app, { module: 'pages/movies', location: loc });
     expect(res.status).toBe(200);
     expect(loaderFn).toHaveBeenCalled();
   });
 
   it('returns 400 when body is missing module field', async () => {
     const app = makeApp({
-      './pages/movies.server.ts': { default: vi.fn() },
+      './pages/movies.server.ts': { __moduleKey: 'pages/movies', default: vi.fn() },
     });
     const res = await post(app, { location: loc });
     expect(res.status).toBe(400);
@@ -82,34 +83,64 @@ describe('loadersHandler', () => {
     const app = makeApp({
       './pages/movies.server.ts': () => Promise.reject(new Error('load failed')),
     });
-    const res = await post(app, { module: 'movies', location: loc });
+    const res = await post(app, { module: 'pages/movies', location: loc });
     expect(res.status).toBe(503);
     expect((await res.json() as { error: string }).error).toContain('load failed');
-  });
-
-  it('derives module name by stripping path and .server.* extension', async () => {
-    const loaderFn = vi.fn().mockResolvedValue({ ok: true });
-    const app = makeApp({
-      './src/pages/movies.server.tsx': { default: loaderFn },
-    });
-    const res = await post(app, { module: 'movies', location: loc });
-    expect(res.status).toBe(200);
   });
 
   it('propagates location.searchParams through to the loader', async () => {
     const loaderFn = vi.fn().mockResolvedValue({ ok: true });
     const app = makeApp({
-      './pages/movies.server.ts': { default: loaderFn },
+      './pages/movies.server.ts': { __moduleKey: 'pages/movies', default: loaderFn },
     });
     const locWithParams = {
       path: '/movies',
       pathParams: {},
       searchParams: { genre: 'action' },
     };
-    const res = await post(app, { module: 'movies', location: locWithParams });
+    const res = await post(app, { module: 'pages/movies', location: locWithParams });
     expect(res.status).toBe(200);
     expect(loaderFn).toHaveBeenCalledWith({ location: locWithParams });
     const callArg = loaderFn.mock.calls[0][0] as { location: { searchParams: Record<string, string> } };
     expect(callArg.location.searchParams).toEqual({ genre: 'action' });
+  });
+});
+
+describe('loadersHandler path-keyed routing', () => {
+  it('routes lookups by mod.__moduleKey rather than filename', async () => {
+    const loaderFn = vi.fn().mockResolvedValue({ id: 1 });
+    // Filename and __moduleKey deliberately disagree to prove the
+    // handler trusts the export, not the path.
+    const app = makeApp({
+      '/whatever.server.ts': {
+        __moduleKey: 'src/pages/movies',
+        default: loaderFn,
+      },
+    });
+    const res = await post(app, {
+      module: 'src/pages/movies',
+      location: loc,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: 1 });
+    expect(loaderFn).toHaveBeenCalled();
+  });
+
+  it('returns 404 when the requested module key does not match any export', async () => {
+    const app = makeApp({
+      '/x.server.ts': { __moduleKey: 'a', default: async () => ({}) },
+    });
+    const res = await post(app, { module: 'b', location: loc });
+    expect(res.status).toBe(404);
+  });
+
+  it('skips modules that lack __moduleKey (defensive)', async () => {
+    // A module without __moduleKey can't be routed; the handler should
+    // simply not register it.
+    const app = makeApp({
+      '/no-key.server.ts': { default: async () => ({}) },
+    });
+    const res = await post(app, { module: 'no-key', location: loc });
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -2,6 +2,7 @@ import type { MiddlewareHandler } from 'hono';
 import { ActionGuardError, runRequestScope, type ActionGuardFn, type ActionGuardContext } from '@hono-preact/iso';
 
 type GlobModule = {
+  __moduleKey?: unknown;
   serverActions?: Record<string, unknown>;
   actionGuards?: ActionGuardFn[];
   [key: string]: unknown;
@@ -14,24 +15,18 @@ type ModuleEntry = {
   guards: ActionGuardFn[];
 };
 
-function moduleNameFromPath(filePath: string): string {
-  return filePath
-    .split('/')
-    .pop()!
-    .replace(/\.server\.[jt]sx?$/, '');
-}
-
 async function buildActionsMap(
   glob: LazyGlob | EagerGlob
 ): Promise<Record<string, ModuleEntry>> {
   const result: Record<string, ModuleEntry> = {};
-  for (const [filePath, moduleOrLoader] of Object.entries(glob)) {
+  for (const [, moduleOrLoader] of Object.entries(glob)) {
     const mod =
       typeof moduleOrLoader === 'function'
         ? await (moduleOrLoader as () => Promise<GlobModule>)()
         : (moduleOrLoader as GlobModule);
-    if (mod.serverActions) {
-      result[moduleNameFromPath(filePath)] = {
+    const key = mod.__moduleKey;
+    if (typeof key === 'string' && mod.serverActions) {
+      result[key] = {
         actions: mod.serverActions as Record<string, unknown>,
         guards: (mod.actionGuards as ActionGuardFn[] | undefined) ?? [],
       };

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -1,16 +1,13 @@
 import type { MiddlewareHandler } from 'hono';
 import { runRequestScope } from '@hono-preact/iso';
 
-type GlobModule = { default?: unknown; [key: string]: unknown };
+type GlobModule = {
+  default?: unknown;
+  __moduleKey?: unknown;
+  [key: string]: unknown;
+};
 type LazyGlob = Record<string, () => Promise<unknown>>;
 type EagerGlob = Record<string, GlobModule>;
-
-function moduleNameFromPath(filePath: string): string {
-  return filePath
-    .split('/')
-    .pop()!
-    .replace(/\.server\.[jt]sx?$/, '');
-}
 
 type SerializedLocation = {
   path: string;
@@ -24,13 +21,14 @@ async function buildLoadersMap(
   glob: LazyGlob | EagerGlob
 ): Promise<Record<string, LoaderFn>> {
   const result: Record<string, LoaderFn> = {};
-  for (const [filePath, moduleOrLoader] of Object.entries(glob)) {
+  for (const [, moduleOrLoader] of Object.entries(glob)) {
     const mod =
       typeof moduleOrLoader === 'function'
         ? await (moduleOrLoader as () => Promise<GlobModule>)()
         : (moduleOrLoader as GlobModule);
-    if (typeof mod.default === 'function') {
-      result[moduleNameFromPath(filePath)] = mod.default as LoaderFn;
+    const key = mod.__moduleKey;
+    if (typeof key === 'string' && typeof mod.default === 'function') {
+      result[key] = mod.default as LoaderFn;
     }
   }
   return result;
@@ -64,7 +62,10 @@ export function loadersHandler(glob: LazyGlob | EagerGlob): MiddlewareHandler {
 
     const { module, location } = body;
     if (typeof module !== 'string') {
-      return c.json({ error: 'Request body must include string field: module' }, 400);
+      return c.json(
+        { error: 'Request body must include string field: module' },
+        400
+      );
     }
 
     const loader = loadersMap[module];

--- a/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts
+++ b/packages/vite/src/__tests__/fixtures/leak-test/pages/foo.server.ts
@@ -14,7 +14,7 @@ const serverLoader: LoaderFn<{ secret: string }> = async () => {
 };
 export default serverLoader;
 
-export const loader = defineLoader<{ secret: string }>('foo', serverLoader);
+export const loader = defineLoader<{ secret: string }>(serverLoader);
 export const cache = createCache<{ secret: string }>('foo');
 
 export const serverActions = {

--- a/packages/vite/src/__tests__/module-key-plugin.test.ts
+++ b/packages/vite/src/__tests__/module-key-plugin.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { moduleKeyPlugin } from '../module-key-plugin.js';
+import type { Plugin } from 'vite';
+
+type TransformFn = (
+  code: string,
+  id: string
+) => { code: string; map: unknown } | undefined;
+
+function makePlugin() {
+  const plugin = moduleKeyPlugin() as Plugin & {
+    configResolved?: (config: { root: string }) => void;
+    transform: TransformFn;
+  };
+  plugin.configResolved?.({ root: '/Users/me/repo' });
+  return plugin;
+}
+
+describe('moduleKeyPlugin', () => {
+  it('returns undefined for non-server files', () => {
+    const plugin = makePlugin();
+    const result = plugin.transform.call(
+      {} as any,
+      `export const x = 1;`,
+      '/Users/me/repo/src/util.ts'
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for files outside the configured root', () => {
+    const plugin = makePlugin();
+    const result = plugin.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      '/elsewhere/movies.server.ts'
+    );
+    // viteRoot mismatch is a configuration error; plugin no-ops rather than
+    // throws to avoid breaking dev for files outside the watched root.
+    expect(result).toBeUndefined();
+  });
+
+  it('transforms .server.ts files inside the root (returns a code object)', () => {
+    const plugin = makePlugin();
+    const code = `export default async () => ({});`;
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result).toBeDefined();
+    expect(result?.code).toBeTypeOf('string');
+  });
+});

--- a/packages/vite/src/__tests__/module-key-plugin.test.ts
+++ b/packages/vite/src/__tests__/module-key-plugin.test.ts
@@ -16,6 +16,33 @@ function makePlugin() {
   return plugin;
 }
 
+describe('moduleKeyPlugin __moduleKey injection', () => {
+  it('prepends `export const __moduleKey = "<key>"` to .server.ts files', () => {
+    const plugin = makePlugin();
+    const code = `export default async () => ({});`;
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toMatch(
+      /^export const __moduleKey = "src\/pages\/movies";/
+    );
+  });
+
+  it('uses the path-derived key for nested folders', () => {
+    const plugin = makePlugin();
+    const result = plugin.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      '/Users/me/repo/src/pages/admin/movies.server.ts'
+    );
+    expect(result?.code).toMatch(
+      /^export const __moduleKey = "src\/pages\/admin\/movies";/
+    );
+  });
+});
+
 describe('moduleKeyPlugin', () => {
   it('returns undefined for non-server files', () => {
     const plugin = makePlugin();

--- a/packages/vite/src/__tests__/module-key-plugin.test.ts
+++ b/packages/vite/src/__tests__/module-key-plugin.test.ts
@@ -78,3 +78,42 @@ describe('moduleKeyPlugin', () => {
     expect(result?.code).toBeTypeOf('string');
   });
 });
+
+describe('moduleKeyPlugin defineLoader threading', () => {
+  it('rewrites `defineLoader(fn)` to `defineLoader(fn, { __moduleKey })`', () => {
+    const plugin = makePlugin();
+    const code = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `const serverLoader = async () => ({});`,
+      `export default serverLoader;`,
+      `export const loader = defineLoader(serverLoader);`,
+    ].join('\n');
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toContain(
+      'defineLoader(serverLoader, { __moduleKey: "src/pages/movies" })'
+    );
+  });
+
+  it('leaves an existing two-arg defineLoader call unchanged', () => {
+    // Legacy (name, fn) form is still supported until the cleanup task; the
+    // plugin should not touch calls that already have a second argument.
+    const plugin = makePlugin();
+    const code = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `export const loader = defineLoader('movies', async () => ({}));`,
+    ].join('\n');
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toContain(
+      `defineLoader('movies', async () => ({}))`
+    );
+    expect(result?.code).not.toContain('__moduleKey: ');
+  });
+});

--- a/packages/vite/src/__tests__/module-key.test.ts
+++ b/packages/vite/src/__tests__/module-key.test.ts
@@ -31,4 +31,12 @@ describe('deriveModuleKey', () => {
     const b = deriveModuleKey('/r/pages/admin/movies.server.ts', root);
     expect(a).not.toBe(b);
   });
+
+  it('documents out-of-root behavior: callers must verify absPath is inside viteRoot', () => {
+    // The helper does not validate; an out-of-root absPath produces a
+    // `../`-prefixed string. Callers (the Vite plugins) gate this case
+    // with an explicit `id.startsWith(viteRoot)` check before calling.
+    const result = deriveModuleKey('/elsewhere/movies.server.ts', '/r');
+    expect(result.startsWith('..')).toBe(true);
+  });
 });

--- a/packages/vite/src/__tests__/module-key.test.ts
+++ b/packages/vite/src/__tests__/module-key.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { deriveModuleKey } from '../module-key.js';
+
+describe('deriveModuleKey', () => {
+  it('produces a forward-slash path relative to root with the .server.ts extension stripped', () => {
+    const root = '/Users/me/repo';
+    const abs = '/Users/me/repo/apps/app/src/pages/movies.server.ts';
+    expect(deriveModuleKey(abs, root)).toBe('apps/app/src/pages/movies');
+  });
+
+  it('handles .server.tsx extensions', () => {
+    expect(
+      deriveModuleKey('/r/src/pages/admin.server.tsx', '/r')
+    ).toBe('src/pages/admin');
+  });
+
+  it('handles .server.js and .server.jsx extensions', () => {
+    expect(deriveModuleKey('/r/a/x.server.js', '/r')).toBe('a/x');
+    expect(deriveModuleKey('/r/a/x.server.jsx', '/r')).toBe('a/x');
+  });
+
+  it('normalizes Windows-style path separators to forward slashes', () => {
+    expect(
+      deriveModuleKey('C:\\repo\\src\\pages\\movies.server.ts', 'C:\\repo')
+    ).toBe('src/pages/movies');
+  });
+
+  it('produces distinct keys for files that share a basename in different folders', () => {
+    const root = '/r';
+    const a = deriveModuleKey('/r/pages/movies.server.ts', root);
+    const b = deriveModuleKey('/r/pages/admin/movies.server.ts', root);
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/vite/src/__tests__/path-key-parity.test.ts
+++ b/packages/vite/src/__tests__/path-key-parity.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { moduleKeyPlugin } from '../module-key-plugin.js';
+import { serverOnlyPlugin } from '../server-only.js';
+import type { Plugin } from 'vite';
+
+const ROOT = '/Users/me/repo';
+
+function makePlugins() {
+  const m = moduleKeyPlugin() as Plugin & {
+    configResolved?: (c: { root: string }) => void;
+    transform: (code: string, id: string) => { code: string } | undefined;
+  };
+  const s = serverOnlyPlugin() as Plugin & {
+    configResolved?: (c: { root: string }) => void;
+    transform: (
+      code: string,
+      id: string,
+      options?: { ssr?: boolean }
+    ) => { code: string } | undefined;
+  };
+  m.configResolved?.({ root: ROOT });
+  s.configResolved?.({ root: ROOT });
+  return { m, s };
+}
+
+describe('path-key parity across moduleKeyPlugin and serverOnlyPlugin', () => {
+  it('uses the same key for the .server.* file and its client-side import', () => {
+    const { m, s } = makePlugins();
+
+    // Server side: moduleKeyPlugin transforms the .server.ts file.
+    const serverCode = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `export default async () => ({});`,
+      `export const loader = defineLoader(async () => ({}));`,
+    ].join('\n');
+    const serverResult = m.transform.call(
+      {} as any,
+      serverCode,
+      `${ROOT}/src/pages/movies.server.ts`
+    );
+    expect(serverResult?.code).toMatch(
+      /^export const __moduleKey = "src\/pages\/movies";/
+    );
+
+    // Client side: serverOnlyPlugin transforms a consumer that imports
+    // the same file.
+    const clientCode = `import { loader } from './movies.server.js';`;
+    const clientResult = s.transform.call(
+      {} as any,
+      clientCode,
+      `${ROOT}/src/pages/movies.tsx`
+    );
+    expect(clientResult?.code).toContain(
+      `Symbol.for('@hono-preact/loader:src/pages/movies')`
+    );
+  });
+
+  it('derives distinct keys for cross-folder same-basename collisions', () => {
+    const { m } = makePlugins();
+    const aResult = m.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      `${ROOT}/src/pages/movies.server.ts`
+    );
+    const bResult = m.transform.call(
+      {} as any,
+      `export default async () => ({});`,
+      `${ROOT}/src/pages/admin/movies.server.ts`
+    );
+    expect(aResult?.code).toContain('"src/pages/movies"');
+    expect(bResult?.code).toContain('"src/pages/admin/movies"');
+  });
+});

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -11,18 +11,23 @@ type TransformFn = (
 function transform(
   code: string,
   id: string,
-  options: { ssr?: boolean } = {}
+  options: { ssr?: boolean; root?: string } = {}
 ): { code: string; map: unknown } | undefined {
-  const plugin = serverOnlyPlugin() as Plugin & { transform: TransformFn };
-  return plugin.transform.call({} as any, code, id, options);
+  const plugin = serverOnlyPlugin() as Plugin & {
+    transform: TransformFn;
+    configResolved?: (c: { root: string }) => void;
+  };
+  plugin.configResolved?.({ root: options.root ?? '/Users/me/repo' });
+  const { ssr } = options;
+  return plugin.transform.call({} as any, code, id, ssr ? { ssr } : {});
 }
 
 describe('serverOnlyPlugin', () => {
-  it('replaces a default *.server.* import with an RPC fetch stub', () => {
+  it('replaces a default *.server.* import with an RPC fetch stub keyed by module path', () => {
     const code = `import serverLoader from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
-    expect(result?.code).toContain('fetch(\'/__loaders\'');
-    expect(result?.code).toContain('"movies"');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
+    expect(result?.code).toContain(`fetch('/__loaders'`);
+    expect(result?.code).toContain('"src/pages/movies"');
     expect(result?.code).toContain('location.path');
     expect(result?.code).toContain('location.pathParams');
     expect(result?.code).toContain('location.searchParams');
@@ -31,7 +36,7 @@ describe('serverOnlyPlugin', () => {
 
   it('replaces serverGuards named import with an empty array stub', () => {
     const code = `import serverLoader, { serverGuards } from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('fetch(\'/__loaders\'');
     expect(result?.code).toContain('const serverGuards = [];');
   });
@@ -60,61 +65,61 @@ describe('serverOnlyPlugin', () => {
     expect(result).toBeUndefined();
   });
 
-  it('stubs all .server imports when a file has more than one', () => {
+  it('stubs all .server imports when a file has more than one (each with its own path key)', () => {
     const code = [
       `import serverLoader from './movies.server.js';`,
       `import authLoader from './auth.server.js';`,
     ].join('\n');
-    const result = transform(code, '/src/pages/page.tsx');
-    expect(result?.code).toContain('"movies"');
-    expect(result?.code).toContain('"auth"');
+    const result = transform(code, '/Users/me/repo/src/pages/page.tsx');
+    expect(result?.code).toContain('"src/pages/movies"');
+    expect(result?.code).toContain('"src/pages/auth"');
     expect(result?.code).not.toContain('async () => ({})');
   });
 
-  it('replaces serverActions named import with a Proxy stub using module name from filename', () => {
+  it('replaces serverActions named import with a Proxy stub using module path key', () => {
     const code = `import { serverActions } from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('const serverActions = new Proxy(');
-    expect(result?.code).toContain('__module: "movies"');
+    expect(result?.code).toContain('__module: "src/pages/movies"');
     expect(result?.code).toContain('__action: String(action)');
   });
 
   it('handles serverActions alongside default import in the same statement', () => {
     const code = `import serverLoader, { serverActions } from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('fetch(\'/__loaders\'');
     expect(result?.code).toContain('const serverActions = new Proxy(');
-    expect(result?.code).toContain('__module: "movies"');
+    expect(result?.code).toContain('__module: "src/pages/movies"');
   });
 
   it('handles serverActions alongside serverGuards in the same statement', () => {
     const code = `import { serverGuards, serverActions } from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('const serverGuards = [];');
     expect(result?.code).toContain('const serverActions = new Proxy(');
   });
 
-  it('derives module name from nested path correctly', () => {
+  it('derives module key from nested path correctly', () => {
     const code = `import { serverActions } from '../../pages/profile.server.ts';`;
-    const result = transform(code, '/src/components/nav.tsx');
-    expect(result?.code).toContain('__module: "profile"');
+    const result = transform(code, '/Users/me/repo/src/components/nav.tsx');
+    expect(result?.code).toContain('__module: "pages/profile"');
   });
 
   it('leaves serverActions import untouched in SSR builds', () => {
     const code = `import { serverActions } from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx', { ssr: true });
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx', { ssr: true });
     expect(result).toBeUndefined();
   });
 
   it('replaces actionGuards named import with an empty array stub', () => {
     const code = `import { actionGuards } from './movies.server.js';`;
-    const result = transform(code, 'movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('const actionGuards = [];');
   });
 
   it('handles actionGuards alongside serverActions in the same statement', () => {
     const code = `import { actionGuards, serverActions } from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('const actionGuards = [];');
     expect(result?.code).toContain('const serverActions = new Proxy(');
   });
@@ -122,58 +127,58 @@ describe('serverOnlyPlugin', () => {
   it('stubs renamed actionGuards imports using the local alias name', () => {
     // The plugin detects via imported.name ('actionGuards') and stubs using the local alias
     const code = `import { actionGuards as guards } from './movies.server.js';`;
-    const result = transform(code, 'movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     // The plugin detects the import via imported.name ('actionGuards') and stubs it
     // using the local alias name — so 'guards' becomes the stub variable.
     // This means renamed imports ARE transformed; the stub uses the alias.
     expect(result?.code).toContain('const guards = [];');
   });
 
-  it('derives module name for default stub from the import source, not the consumer file', () => {
+  it('derives module key for default stub from the import source, not the consumer file', () => {
     const code = `import loader from './profile.server.ts';`;
-    const result = transform(code, '/src/pages/some-other-page.tsx');
-    expect(result?.code).toContain('"profile"');
-    expect(result?.code).not.toContain('"some-other-page"');
+    const result = transform(code, '/Users/me/repo/src/pages/some-other-page.tsx');
+    expect(result?.code).toContain('"src/pages/profile"');
+    expect(result?.code).not.toContain('"src/pages/some-other-page"');
   });
 });
 
 describe('loader and cache specifiers', () => {
   it('replaces a `loader` named import with a client-side LoaderRef stub', () => {
     const code = `import { loader } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
-    expect(result?.code).toMatch(/const loader = \{[\s\S]*__id: Symbol\.for\(['"]@hono-preact\/loader:movies['"]\)[\s\S]*fn:\s*async/);
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
+    expect(result?.code).toMatch(/const loader = \{[\s\S]*__id: Symbol\.for\(['"]@hono-preact\/loader:src\/movies['"]\)[\s\S]*fn:\s*async/);
     expect(result?.code).toContain("fetch('/__loaders'");
-    expect(result?.code).toContain('"movies"');
+    expect(result?.code).toContain('"src/movies"');
   });
 
   it('replaces a `cache` named import with a createCache call using the source-file name', () => {
-    // The fixture file isn't available here; the plugin should fall back to module name.
+    // The fixture file isn't available here; the plugin should fall back to module key.
     const code = `import { cache } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result?.code).toContain('createCache as');
-    // Expect the fallback name (module name) since no fixture exists for source-extraction.
-    // The plugin uses a unique alias (e.g. __$createCache_movies) to avoid collisions,
-    // so match `createCache[_a-zA-Z0-9$]*("movies")` to allow either bare or aliased call sites.
-    expect(result?.code).toMatch(/createCache[_a-zA-Z0-9$]*\(['"]movies['"]\)/);
+    // Expect the fallback name (module key derived from server file path) since no fixture exists.
+    // The plugin uses a unique alias (e.g. __$createCache_...) to avoid collisions,
+    // so match `createCache[_a-zA-Z0-9$]*("src/movies")` to allow either bare or aliased call sites.
+    expect(result?.code).toMatch(/createCache[_a-zA-Z0-9$]*\(['"]src\/movies['"]\)/);
   });
 
   it('handles `loader` aliased to a different local name', () => {
     const code = `import { loader as moviesLoader } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result?.code).toMatch(/const moviesLoader = \{[\s\S]*Symbol\.for/);
-    expect(result?.code).toContain('"movies"');
+    expect(result?.code).toContain('"src/movies"');
   });
 
   it('handles `cache` aliased to a different local name', () => {
     const code = `import { cache as moviesCache } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result?.code).toContain('const moviesCache =');
-    expect(result?.code).toMatch(/createCache[_a-zA-Z0-9$]*\(['"]movies['"]\)/);
+    expect(result?.code).toMatch(/createCache[_a-zA-Z0-9$]*\(['"]src\/movies['"]\)/);
   });
 
   it('handles mixed loader + cache + serverActions in one import statement', () => {
     const code = `import { loader, cache, serverActions } from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('const loader =');
     expect(result?.code).toContain('const cache =');
     expect(result?.code).toContain('const serverActions = new Proxy');
@@ -181,7 +186,7 @@ describe('loader and cache specifiers', () => {
 
   it('handles mixed default + loader in one import statement', () => {
     const code = `import serverLoader, { loader } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result?.code).toContain('const serverLoader =');
     expect(result?.code).toContain('const loader =');
   });
@@ -190,7 +195,7 @@ describe('loader and cache specifiers', () => {
     // This is the bug from the route-level-loaders migration: imports with only
     // `loader` were silently passed through.
     const code = `import { loader } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result).toBeDefined();
     expect(result?.code).not.toContain("import { loader }");
     expect(result?.code).toContain('const loader =');
@@ -198,7 +203,7 @@ describe('loader and cache specifiers', () => {
 
   it('matches an import that has ONLY cache (no default, no actions, no guards)', () => {
     const code = `import { cache } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result).toBeDefined();
     expect(result?.code).not.toContain("import { cache }");
     expect(result?.code).toContain('const cache =');
@@ -206,16 +211,24 @@ describe('loader and cache specifiers', () => {
 
   it('emits cache stubs that go through cacheRegistry.acquire for identity', () => {
     const code = `import { cache } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result?.code).toContain('.acquire(');
     expect(result?.code).toContain('cacheRegistry');
+  });
+
+  it('emits the path key in named `loader` stubs as Symbol.for(@hono-preact/loader:<key>)', () => {
+    const code = `import { loader } from './movies.server.js';`;
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
+    expect(result?.code).toContain(
+      `Symbol.for('@hono-preact/loader:src/pages/movies')`
+    );
   });
 });
 
 describe('unknown specifiers from .server.* imports', () => {
   it('throws a clear error when an unknown named export is imported from .server.*', () => {
     const code = `import { unknownExport } from './movies.server.js';`;
-    expect(() => transform(code, '/src/iso.tsx')).toThrow(
+    expect(() => transform(code, '/Users/me/repo/src/iso.tsx')).toThrow(
       /unknownExport.*not a recognized.*server/i
     );
   });
@@ -224,7 +237,7 @@ describe('unknown specifiers from .server.* imports', () => {
 describe('side-effect and type-only imports', () => {
   it('strips a side-effect-only .server.* import', () => {
     const code = `import './x.server.js';\nconst foo = 1;`;
-    const result = transform(code, '/p.tsx');
+    const result = transform(code, '/Users/me/repo/p.tsx');
     expect(result?.code).not.toContain('.server');
     expect(result?.code).toContain('const foo = 1');
   });
@@ -232,13 +245,13 @@ describe('side-effect and type-only imports', () => {
   it('leaves `import type { Foo } from .server.*` untouched (or stripped — either is safe since types are erased)', () => {
     const code = `import type { Foo } from './x.server.js';\nconst foo = 1;`;
     // Should NOT throw. The exact transform output is flexible — assert no throw.
-    expect(() => transform(code, '/p.tsx')).not.toThrow();
+    expect(() => transform(code, '/Users/me/repo/p.tsx')).not.toThrow();
   });
 
   it('handles mixed `import { type Foo, default as loader } from .server.*`', () => {
     const code = `import { type Foo, default as loader } from './x.server.js';`;
-    expect(() => transform(code, '/p.tsx')).not.toThrow();
-    const result = transform(code, '/p.tsx');
+    expect(() => transform(code, '/Users/me/repo/p.tsx')).not.toThrow();
+    const result = transform(code, '/Users/me/repo/p.tsx');
     // The default import should still be stubbed.
     expect(result?.code).toContain("fetch('/__loaders'");
     // The type import should be skipped (no Foo declaration emitted).
@@ -249,14 +262,14 @@ describe('side-effect and type-only imports', () => {
 describe('loader RPC stub uses searchParams (not the deprecated query)', () => {
   it('default import stub builds searchParams from location.searchParams', () => {
     const code = `import serverLoader from './movies.server.js';`;
-    const result = transform(code, '/src/pages/movies.tsx');
+    const result = transform(code, '/Users/me/repo/src/pages/movies.tsx');
     expect(result?.code).toContain('searchParams: location.searchParams');
     expect(result?.code).not.toContain('query: location.query');
   });
 
   it('loader named-import stub builds searchParams from location.searchParams', () => {
     const code = `import { loader } from './movies.server.js';`;
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result?.code).toContain('searchParams: location.searchParams');
     expect(result?.code).not.toContain('query: location.query');
   });
@@ -265,28 +278,28 @@ describe('loader RPC stub uses searchParams (not the deprecated query)', () => {
 describe('re-exports from .server.* are rejected', () => {
   it('throws on `export { loader } from .server.*`', () => {
     const code = `export { loader } from './movies.server.js';`;
-    expect(() => transform(code, '/src/aggregator.ts')).toThrow(
+    expect(() => transform(code, '/Users/me/repo/src/aggregator.ts')).toThrow(
       /re-export.*from.*\.server.*not supported/i
     );
   });
 
   it('throws on `export { loader as moviesLoader } from .server.*`', () => {
     const code = `export { loader as moviesLoader } from './movies.server.js';`;
-    expect(() => transform(code, '/src/aggregator.ts')).toThrow(
+    expect(() => transform(code, '/Users/me/repo/src/aggregator.ts')).toThrow(
       /re-export.*from.*\.server.*not supported/i
     );
   });
 
   it('throws on `export * from .server.*`', () => {
     const code = `export * from './movies.server.js';`;
-    expect(() => transform(code, '/src/aggregator.ts')).toThrow(
+    expect(() => transform(code, '/Users/me/repo/src/aggregator.ts')).toThrow(
       /re-export.*from.*\.server.*not supported/i
     );
   });
 
   it('does not throw on regular `export * from` of a non-server module', () => {
     const code = `export * from './utils.js';`;
-    expect(() => transform(code, '/src/aggregator.ts')).not.toThrow();
+    expect(() => transform(code, '/Users/me/repo/src/aggregator.ts')).not.toThrow();
   });
 });
 
@@ -299,7 +312,7 @@ describe('cache alias suffix is collision-free', () => {
       `import { cache as a } from './foo-bar.server.js';`,
       `import { cache as b } from './foo_bar.server.js';`,
     ].join('\n');
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result).toBeDefined();
     // Two distinct cacheRegistry alias bindings should be emitted.
     const matches = result!.code.match(/__\$cacheRegistry_[a-zA-Z0-9$_]+/g) ?? [];
@@ -314,7 +327,7 @@ describe('loader RPC stub key alignment', () => {
       `import serverLoader from './movies.server.js';`,
       `import { loader } from './movies.server.js';`,
     ].join('\n');
-    const result = transform(code, '/src/iso.tsx');
+    const result = transform(code, '/Users/me/repo/src/iso.tsx');
     expect(result).toBeDefined();
     // Both stubs include the same module RPC body shape.
     const fetchOccurrences =
@@ -322,7 +335,7 @@ describe('loader RPC stub key alignment', () => {
     expect(fetchOccurrences).toBe(2);
     // Same module string is referenced from both stubs.
     const moduleOccurrences =
-      (result!.code.match(/module:\s*"movies"/g) ?? []).length;
+      (result!.code.match(/module:\s*"src\/movies"/g) ?? []).length;
     expect(moduleOccurrences).toBe(2);
   });
 });
@@ -339,28 +352,28 @@ describe('serverOnlyPlugin viteRoot capture', () => {
   });
 });
 
-describe('loader stub Symbol.for keying matches user-provided name', () => {
-  it("extracts the name argument from defineLoader('foo', ...) in the source file", () => {
-    // Use the fixture .server.ts which has `defineLoader<...>('foo', serverLoader)`.
-    // The plugin should statically extract 'foo' and key the stub on it,
-    // even if the module filename happened to differ from the chosen name.
+describe('loader stub Symbol.for keying uses path-derived key', () => {
+  it('uses the path-derived key (not defineLoader name) for the loader Symbol', () => {
+    // After path-keying, the Symbol is derived from the module path, not the
+    // defineLoader('foo', ...) first-arg string in the source file.
+    const fixtureRoot =
+      '/Users/stevenbeshensky/Documents/repos/hono-preact/packages/vite/src/__tests__/fixtures/leak-test';
+    const importerPath = fixtureRoot + '/iso.tsx';
     const code = `import { loader } from './pages/foo.server.js';`;
-    const importerPath =
-      '/Users/stevenbeshensky/Documents/repos/hono-preact/packages/vite/src/__tests__/fixtures/leak-test/iso.tsx';
-    const result = transform(code, importerPath);
+    const result = transform(code, importerPath, { root: fixtureRoot });
     expect(result).toBeDefined();
     expect(result?.code).toContain(
-      "__id: Symbol.for('@hono-preact/loader:foo')"
+      "__id: Symbol.for('@hono-preact/loader:pages/foo')"
     );
   });
 
-  it('falls back to module basename when the source file is unreachable', () => {
+  it('uses path key even when the source file is unreachable', () => {
     const code = `import { loader } from './nope.server.js';`;
-    const result = transform(code, '/no/such/path/iso.tsx');
+    const result = transform(code, '/Users/me/repo/no/such/path/iso.tsx');
     expect(result).toBeDefined();
-    // Falls back to the module basename derived from the import source.
+    // Uses path-derived key, not basename fallback.
     expect(result?.code).toContain(
-      "__id: Symbol.for('@hono-preact/loader:nope')"
+      "__id: Symbol.for('@hono-preact/loader:no/such/path/nope')"
     );
   });
 });

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -327,6 +327,18 @@ describe('loader RPC stub key alignment', () => {
   });
 });
 
+describe('serverOnlyPlugin viteRoot capture', () => {
+  it('captures viteRoot from configResolved and exposes it for plugin coordination', () => {
+    const plugin = serverOnlyPlugin() as Plugin & {
+      configResolved?: (config: { root: string }) => void;
+      _viteRoot?: () => string | undefined;
+    };
+    expect(plugin._viteRoot?.()).toBeUndefined();
+    plugin.configResolved?.({ root: '/Users/me/repo' });
+    expect(plugin._viteRoot?.()).toBe('/Users/me/repo');
+  });
+});
+
 describe('loader stub Symbol.for keying matches user-provided name', () => {
   it("extracts the name argument from defineLoader('foo', ...) in the source file", () => {
     // Use the fixture .server.ts which has `defineLoader<...>('foo', serverLoader)`.

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { serverOnlyPlugin } from '../index.js';
+import { serverOnlyPlugin, VITE_ROOT_ACCESSOR } from '../index.js';
 import type { Plugin } from 'vite';
 
 type TransformFn = (
@@ -341,14 +341,14 @@ describe('loader RPC stub key alignment', () => {
 });
 
 describe('serverOnlyPlugin viteRoot capture', () => {
-  it('captures viteRoot from configResolved and exposes it for plugin coordination', () => {
+  it('captures viteRoot from configResolved and exposes it via VITE_ROOT_ACCESSOR', () => {
     const plugin = serverOnlyPlugin() as Plugin & {
       configResolved?: (config: { root: string }) => void;
-      _viteRoot?: () => string | undefined;
+      [VITE_ROOT_ACCESSOR]?: () => string | undefined;
     };
-    expect(plugin._viteRoot?.()).toBeUndefined();
+    expect(plugin[VITE_ROOT_ACCESSOR]?.()).toBeUndefined();
     plugin.configResolved?.({ root: '/Users/me/repo' });
-    expect(plugin._viteRoot?.()).toBe('/Users/me/repo');
+    expect(plugin[VITE_ROOT_ACCESSOR]?.()).toBe('/Users/me/repo');
   });
 });
 

--- a/packages/vite/src/hono-preact.ts
+++ b/packages/vite/src/hono-preact.ts
@@ -3,6 +3,7 @@ import devServer, { defaultOptions } from '@hono/vite-dev-server';
 import cloudflareAdapter from '@hono/vite-dev-server/cloudflare';
 import { type BuildEnvironmentOptions, type Plugin } from 'vite';
 import { serverLoaderValidationPlugin } from './server-loader-validation.js';
+import { moduleKeyPlugin } from './module-key-plugin.js';
 import { serverOnlyPlugin } from './server-only.js';
 
 export interface HonoPreactOptions {
@@ -80,6 +81,7 @@ export function honoPreact({
       },
     },
     serverLoaderValidationPlugin(),
+    moduleKeyPlugin(),
     serverOnlyPlugin(),
     Object.assign(build({ entry }), {
       apply: (_: unknown, { command, mode }: { command: string; mode: string }) =>

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,3 +1,4 @@
 export { honoPreact } from './hono-preact.js';
 export { serverLoaderValidationPlugin } from './server-loader-validation.js';
 export { serverOnlyPlugin } from './server-only.js';
+export { moduleKeyPlugin } from './module-key-plugin.js';

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,4 +1,4 @@
 export { honoPreact } from './hono-preact.js';
 export { serverLoaderValidationPlugin } from './server-loader-validation.js';
-export { serverOnlyPlugin } from './server-only.js';
+export { serverOnlyPlugin, VITE_ROOT_ACCESSOR } from './server-only.js';
 export { moduleKeyPlugin } from './module-key-plugin.js';

--- a/packages/vite/src/module-key-plugin.ts
+++ b/packages/vite/src/module-key-plugin.ts
@@ -1,4 +1,6 @@
+import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
+import { deriveModuleKey } from './module-key.js';
 
 /**
  * Transforms `.server.*` files to inject a stable module-level
@@ -22,8 +24,11 @@ export function moduleKeyPlugin(): Plugin {
       if (viteRoot === undefined) return;
       if (!/\.server\.[jt]sx?$/.test(id)) return;
       if (!id.startsWith(viteRoot)) return;
-      // Skeleton: signals that we'll handle this file in subsequent tasks.
-      return { code, map: null };
+
+      const key = deriveModuleKey(id, viteRoot);
+      const s = new MagicString(code);
+      s.prepend(`export const __moduleKey = ${JSON.stringify(key)};\n`);
+      return { code: s.toString(), map: s.generateMap({ hires: true }) };
     },
   };
 }

--- a/packages/vite/src/module-key-plugin.ts
+++ b/packages/vite/src/module-key-plugin.ts
@@ -1,0 +1,29 @@
+import type { Plugin } from 'vite';
+
+/**
+ * Transforms `.server.*` files to inject a stable module-level
+ * `__moduleKey` export (and to thread that key into `defineLoader` calls).
+ * The key is path-derived (see `deriveModuleKey`), so it survives builds
+ * and HMR, and is unique per file.
+ *
+ * Pairs with `serverOnlyPlugin`, which transforms client-side imports of
+ * `.server.*` files. Both plugins compute the same key from the same
+ * absolute path + viteRoot.
+ */
+export function moduleKeyPlugin(): Plugin {
+  let viteRoot: string | undefined;
+  return {
+    name: 'module-key',
+    enforce: 'pre',
+    configResolved(config) {
+      viteRoot = config.root;
+    },
+    transform(code: string, id: string) {
+      if (viteRoot === undefined) return;
+      if (!/\.server\.[jt]sx?$/.test(id)) return;
+      if (!id.startsWith(viteRoot)) return;
+      // Skeleton: signals that we'll handle this file in subsequent tasks.
+      return { code, map: null };
+    },
+  };
+}

--- a/packages/vite/src/module-key-plugin.ts
+++ b/packages/vite/src/module-key-plugin.ts
@@ -25,7 +25,7 @@ export function moduleKeyPlugin(): Plugin {
     transform(code: string, id: string) {
       if (viteRoot === undefined) return;
       if (!/\.server\.[jt]sx?$/.test(id)) return;
-      if (!id.startsWith(viteRoot)) return;
+      if (!id.startsWith(viteRoot + '/')) return;
 
       const key = deriveModuleKey(id, viteRoot);
       const s = new MagicString(code);
@@ -57,7 +57,7 @@ export function moduleKeyPlugin(): Plugin {
           return;
         }
         const arg = node.arguments[0];
-        if (arg.type === 'StringLiteral') return; // legacy (name, fn) form
+        if (arg.type === 'StringLiteral') return; // single-arg string literal isn't a valid defineLoader form; skip to avoid garbling
         const insertAt = arg.end;
         if (insertAt == null) return;
         s.appendRight(

--- a/packages/vite/src/module-key-plugin.ts
+++ b/packages/vite/src/module-key-plugin.ts
@@ -22,10 +22,15 @@ export function moduleKeyPlugin(): Plugin {
     configResolved(config) {
       viteRoot = config.root;
     },
+    // transform receives an `options.ssr` argument from Vite, but we want
+    // __moduleKey injected into both the client and SSR builds (so the SSR
+    // runtime sees the same routing key the handler reads), so we ignore the
+    // flag and always run.
     transform(code: string, id: string) {
       if (viteRoot === undefined) return;
       if (!/\.server\.[jt]sx?$/.test(id)) return;
       if (!id.startsWith(viteRoot + '/')) return;
+      if (/^\s*export\s+const\s+__moduleKey\s*=/m.test(code)) return;
 
       const key = deriveModuleKey(id, viteRoot);
       const s = new MagicString(code);

--- a/packages/vite/src/module-key-plugin.ts
+++ b/packages/vite/src/module-key-plugin.ts
@@ -1,10 +1,12 @@
+import { parse } from '@babel/parser';
 import MagicString from 'magic-string';
+import type { CallExpression } from '@babel/types';
 import type { Plugin } from 'vite';
 import { deriveModuleKey } from './module-key.js';
 
 /**
  * Transforms `.server.*` files to inject a stable module-level
- * `__moduleKey` export (and to thread that key into `defineLoader` calls).
+ * `__moduleKey` export and to thread that key into `defineLoader` calls.
  * The key is path-derived (see `deriveModuleKey`), so it survives builds
  * and HMR, and is unique per file.
  *
@@ -28,6 +30,62 @@ export function moduleKeyPlugin(): Plugin {
       const key = deriveModuleKey(id, viteRoot);
       const s = new MagicString(code);
       s.prepend(`export const __moduleKey = ${JSON.stringify(key)};\n`);
+
+      // Walk the AST for top-level CallExpressions whose callee is the
+      // identifier `defineLoader` and which have exactly one argument.
+      // Rewrite to `defineLoader(<arg>, { __moduleKey: '<key>' })`.
+      let ast;
+      try {
+        ast = parse(code, {
+          sourceType: 'module',
+          plugins: ['typescript', 'jsx'],
+          errorRecovery: true,
+        });
+      } catch {
+        // If the file fails to parse we still emit the prepended
+        // __moduleKey so the routing layer works even if loader threading
+        // doesn't. Surface the parse error to Vite so the user sees it.
+        return { code: s.toString(), map: s.generateMap({ hires: true }) };
+      }
+
+      const visitCall = (node: CallExpression) => {
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'defineLoader' ||
+          node.arguments.length !== 1
+        ) {
+          return;
+        }
+        const arg = node.arguments[0];
+        if (arg.type === 'StringLiteral') return; // legacy (name, fn) form
+        const insertAt = arg.end;
+        if (insertAt == null) return;
+        s.appendRight(
+          insertAt,
+          `, { __moduleKey: ${JSON.stringify(key)} }`
+        );
+      };
+
+      // Top-level statement walk. defineLoader is overwhelmingly used at
+      // module scope; we don't recurse into nested function bodies to keep
+      // the plugin cheap.
+      for (const stmt of ast.program.body) {
+        if (
+          stmt.type === 'ExportNamedDeclaration' &&
+          stmt.declaration?.type === 'VariableDeclaration'
+        ) {
+          for (const decl of stmt.declaration.declarations) {
+            if (decl.init?.type === 'CallExpression') visitCall(decl.init);
+          }
+        } else if (
+          stmt.type === 'VariableDeclaration'
+        ) {
+          for (const decl of stmt.declarations) {
+            if (decl.init?.type === 'CallExpression') visitCall(decl.init);
+          }
+        }
+      }
+
       return { code: s.toString(), map: s.generateMap({ hires: true }) };
     },
   };

--- a/packages/vite/src/module-key.ts
+++ b/packages/vite/src/module-key.ts
@@ -1,0 +1,21 @@
+import * as path from 'node:path';
+
+/**
+ * Derive the stable module key for a `.server.*` file.
+ *
+ * The key is the file's path relative to the Vite project root, with the
+ * `.server.{ts,tsx,js,jsx}` extension stripped, and path separators
+ * normalized to forward slashes (so the key is identical on Windows and
+ * POSIX). Used as the routing key for `__loaders`/`__actions` RPC, the
+ * payload of `Symbol.for(...)` for `__id`, and the value of the
+ * module-level `__moduleKey` export.
+ */
+export function deriveModuleKey(absPath: string, viteRoot: string): string {
+  // Normalize backslashes to forward slashes before computing the relative
+  // path so that Windows-style inputs work correctly on any platform.
+  const normalizedAbs = absPath.replace(/\\/g, '/');
+  const normalizedRoot = viteRoot.replace(/\\/g, '/');
+  const rel = path.posix.relative(normalizedRoot, normalizedAbs);
+  const stripped = rel.replace(/\.server\.[jt]sx?$/, '');
+  return stripped;
+}

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -5,13 +5,7 @@ import { parse } from '@babel/parser';
 import type { ImportDeclaration } from '@babel/types';
 import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
-
-function moduleNameFromSource(importSource: string): string {
-  return importSource
-    .split('/')
-    .pop()!
-    .replace(/\.server(\.[jt]sx?)?$/, '');
-}
+import { deriveModuleKey } from './module-key.js';
 
 function hashSuffix(input: string): string {
   return crypto.createHash('sha1').update(input).digest('hex').slice(0, 8);
@@ -89,18 +83,6 @@ function extractCacheName(
   );
 }
 
-function extractLoaderName(
-  importerPath: string,
-  importSource: string,
-  fallbackModuleName: string
-): string {
-  const src = readSource(importerPath, importSource);
-  if (src === null) return fallbackModuleName;
-  return (
-    extractStringArgFromVarDecl(src, 'loader', 'defineLoader', 0) ?? fallbackModuleName
-  );
-}
-
 function loaderFetchArrow(moduleName: string, indent: string): string {
   const i = indent;
   return (
@@ -166,13 +148,17 @@ export function serverOnlyPlugin(): Plugin {
       const s = new MagicString(code);
       const needsCacheImport = new Set<string>();
 
+      if (viteRoot === undefined) return;
+      const importerDir = path.dirname(id);
+
       for (const serverImport of [...serverImports].reverse()) {
         if ((serverImport as unknown as { importKind?: string }).importKind === 'type') {
           s.overwrite(serverImport.start!, serverImport.end!, '');
           continue;
         }
 
-        const moduleName = moduleNameFromSource(serverImport.source.value);
+        const absServerPath = path.resolve(importerDir, serverImport.source.value);
+        const moduleKey = deriveModuleKey(absServerPath, viteRoot);
         const stubs: string[] = [];
         let hasValueSpecifier = false;
 
@@ -188,7 +174,7 @@ export function serverOnlyPlugin(): Plugin {
               specifier.imported.name === 'default');
           if (isDefaultImport) {
             stubs.push(
-              `const ${specifier.local.name} = ${loaderFetchArrow(moduleName, '')};`
+              `const ${specifier.local.name} = ${loaderFetchArrow(moduleKey, '')};`
             );
           } else if (
             specifier.type === 'ImportSpecifier' &&
@@ -203,18 +189,17 @@ export function serverOnlyPlugin(): Plugin {
             specifier.imported.name === 'serverActions'
           ) {
             stubs.push(
-              `const ${specifier.local.name} = new Proxy({}, { get(_, action) { return { __module: ${JSON.stringify(moduleName)}, __action: String(action) }; } });`
+              `const ${specifier.local.name} = new Proxy({}, { get(_, action) { return { __module: ${JSON.stringify(moduleKey)}, __action: String(action) }; } });`
             );
           } else if (
             specifier.type === 'ImportSpecifier' &&
             specifier.imported.type === 'Identifier' &&
             specifier.imported.name === 'loader'
           ) {
-            const loaderName = extractLoaderName(id, serverImport.source.value, moduleName);
             stubs.push(
               `const ${specifier.local.name} = {\n` +
-              `  __id: Symbol.for('@hono-preact/loader:${loaderName}'),\n` +
-              `  fn: ${loaderFetchArrow(moduleName, '  ')},\n` +
+              `  __id: Symbol.for('@hono-preact/loader:${moduleKey}'),\n` +
+              `  fn: ${loaderFetchArrow(moduleKey, '  ')},\n` +
               `};`
             );
           } else if (
@@ -222,7 +207,7 @@ export function serverOnlyPlugin(): Plugin {
             specifier.imported.type === 'Identifier' &&
             specifier.imported.name === 'cache'
           ) {
-            const cacheName = extractCacheName(id, serverImport.source.value, moduleName);
+            const cacheName = extractCacheName(id, serverImport.source.value, moduleKey);
             const aliasSuffix = hashSuffix(serverImport.source.value);
             needsCacheImport.add(aliasSuffix);
             stubs.push(

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -7,6 +7,11 @@ import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
 import { deriveModuleKey } from './module-key.js';
 
+// Symbol-keyed accessor used by unit tests to verify `configResolved` fires
+// and captures the root. Hidden behind a Symbol so it does not appear in IDE
+// autocomplete for the public Plugin surface.
+export const VITE_ROOT_ACCESSOR = Symbol.for('@hono-preact/vite/server-only/viteRoot');
+
 function hashSuffix(input: string): string {
   return crypto.createHash('sha1').update(input).digest('hex').slice(0, 8);
 }
@@ -109,9 +114,7 @@ export function serverOnlyPlugin(): Plugin {
     configResolved(config) {
       viteRoot = config.root;
     },
-    // Test-only accessor. Used by unit tests to verify the hook fires;
-    // not part of the public plugin contract.
-    _viteRoot: () => viteRoot,
+    [VITE_ROOT_ACCESSOR]: () => viteRoot,
     transform(code: string, id: string, options?: { ssr?: boolean }) {
       if (options?.ssr) return;
       if (!/\.[jt]sx?$/.test(id)) return;
@@ -144,7 +147,14 @@ export function serverOnlyPlugin(): Plugin {
 
       const serverImports = ast.program.body.filter(isServerImport);
       if (serverImports.length === 0) return;
-      if (viteRoot === undefined) return;
+      if (viteRoot === undefined) {
+        this.warn(
+          `serverOnlyPlugin: configResolved hasn't fired before transform on ${id}. ` +
+          `.server.* imports will not be transformed; this can leak server code into the client bundle. ` +
+          `Ensure moduleKeyPlugin and serverOnlyPlugin are added to the Vite config under the standard plugin pipeline.`
+        );
+        return;
+      }
       const importerDir = path.dirname(id);
 
       const s = new MagicString(code);
@@ -158,6 +168,13 @@ export function serverOnlyPlugin(): Plugin {
 
         const absServerPath = path.resolve(importerDir, serverImport.source.value);
         const moduleKey = deriveModuleKey(absServerPath, viteRoot);
+        if (moduleKey.startsWith('..')) {
+          this.warn(
+            `serverOnlyPlugin: import of '${serverImport.source.value}' from '${id}' resolves outside the Vite root (${viteRoot}). ` +
+            `Generated module key '${moduleKey}' will not match any server-side moduleKeyPlugin output, so RPC calls will return 404. ` +
+            `Move the .server.* file inside the Vite root, or restructure the import.`
+          );
+        }
         const stubs: string[] = [];
         let hasValueSpecifier = false;
 
@@ -246,5 +263,5 @@ export function serverOnlyPlugin(): Plugin {
 
       return { code: s.toString(), map: s.generateMap({ hires: true }) };
     },
-  } as Plugin & { _viteRoot: () => string | undefined };
+  } as Plugin & { [VITE_ROOT_ACCESSOR]: () => string | undefined };
 }

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -120,9 +120,16 @@ function loaderFetchArrow(moduleName: string, indent: string): string {
 }
 
 export function serverOnlyPlugin(): Plugin {
+  let viteRoot: string | undefined;
   return {
     name: 'server-only',
     enforce: 'pre',
+    configResolved(config) {
+      viteRoot = config.root;
+    },
+    // Test-only accessor. Used by unit tests to verify the hook fires;
+    // not part of the public plugin contract.
+    _viteRoot: () => viteRoot,
     transform(code: string, id: string, options?: { ssr?: boolean }) {
       if (options?.ssr) return;
       if (!/\.[jt]sx?$/.test(id)) return;
@@ -255,5 +262,5 @@ export function serverOnlyPlugin(): Plugin {
 
       return { code: s.toString(), map: s.generateMap({ hires: true }) };
     },
-  };
+  } as Plugin & { _viteRoot: () => string | undefined };
 }

--- a/packages/vite/src/server-only.ts
+++ b/packages/vite/src/server-only.ts
@@ -144,12 +144,11 @@ export function serverOnlyPlugin(): Plugin {
 
       const serverImports = ast.program.body.filter(isServerImport);
       if (serverImports.length === 0) return;
+      if (viteRoot === undefined) return;
+      const importerDir = path.dirname(id);
 
       const s = new MagicString(code);
       const needsCacheImport = new Set<string>();
-
-      if (viteRoot === undefined) return;
-      const importerDir = path.dirname(id);
 
       for (const serverImport of [...serverImports].reverse()) {
         if ((serverImport as unknown as { importKind?: string }).importKind === 'type') {


### PR DESCRIPTION
## Summary

Replaces basename-as-routing-key with a Vite-plugin-injected path-derived module key. The same key drives RPC routing (`/__loaders`, `/__actions`), `__id` Symbol identity, and HMR. Eliminates the implicit "no two `.server.*` files may share a basename" constraint by construction.

`defineLoader`'s string-name argument is removed; the plugin supplies the key via a hidden second-arg metadata.

Implements §4.3, §6.3, §7.3, and §9 step 1 of the framework-simplification research at `docs/superpowers/research/2026-05-04-framework-simplification.md`.

## What changed

**New**
- `packages/vite/src/module-key.ts` — pure helper `deriveModuleKey(absPath, viteRoot)`
- `packages/vite/src/module-key-plugin.ts` — new Vite plugin transforms `.server.*` files: prepends `export const __moduleKey = "<path>"` and threads the key into `defineLoader(fn)` calls
- `packages/vite/src/__tests__/path-key-parity.test.ts` — asserts the two plugins agree on keys

**Modified**
- `packages/iso/src/define-loader.ts` — drops the legacy `(name, fn)` overload; public surface is `defineLoader(fn)` plus a hidden `(fn, opts)` form for plugin emission
- `packages/vite/src/server-only.ts` — emits path-keyed RPC stubs using `deriveModuleKey`; drops `moduleNameFromSource` and `extractLoaderName`
- `packages/vite/src/{index.ts,hono-preact.ts}` — wires `moduleKeyPlugin` ahead of `serverOnlyPlugin`
- `packages/server/src/{loaders-handler,actions-handler}.ts` — route by `mod.__moduleKey`; drop `moduleNameFromPath`
- `apps/app/src/pages/{movies,watched,movie}.server.ts` — drop the string arg to `defineLoader`

## Test plan

- [x] `pnpm test` — 270/270 passing across 31 files
- [x] `pnpm build` — production builds clean (client + SSR)
- [x] Dev smoke test: GET /, GET /movies render with data
- [x] Dev smoke test: POST /__loaders with `{"module":"src/pages/movies",...}` returns the loader payload
- [x] Dev smoke test: POST /__loaders with old basename `"movies"` correctly returns 404
- [x] Dev smoke test: POST /__actions with `{"module":"src/pages/movies","action":"toggleWatched",...}` returns 200
- [x] Dev smoke test: POST /__actions with old basename `"movies"` correctly returns 404
- [ ] Manual UI clickthrough: /movies, /movies/:id, /watched, /docs all render and interact correctly (defer to user)
- [ ] Production preview (`pnpm preview`): same flows pass against the production bundle

## Migration notes

- Authored `defineLoader('name', fn)` calls become `defineLoader(fn)`. The plugin injects `{ __moduleKey: '<path>' }` at build time.
- `loadersHandler` and `actionsHandler` now key by `mod.__moduleKey`. Module objects without that export are silently skipped at map-build time. The plugin sets it on every transformed `.server.*` file, so this should never matter in practice.
- HMR identity remains stable (the path key is a pure function of file path, unchanged across reloads).

## Notes

This PR delivers Plan A from the simplification research (path-keyed module identity). Plan B (the surface trim — `definePage` self-wraps, deleting custom `Route`/`Router`/`lazy`, the `internal` subpath, dropping `PAGE_BINDINGS`/`wrapWithPage`) ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)