### PR TITLE
fix: drop redundant LoaderFn annotations after path-keyed migration

### DIFF
--- a/apps/app/src/pages/docs/actions.mdx
+++ b/apps/app/src/pages/docs/actions.mdx
@@ -14,9 +14,9 @@ On the server, the `actionsHandler` middleware exposes a single `POST /__actions
 
 ```ts
 import { getMovies } from '@/server/movies.js';
-import { defineAction, type LoaderFn } from '@hono-preact/iso';
+import { defineAction } from '@hono-preact/iso';
 
-const serverLoader: LoaderFn<{ movies: MovieList }> = async () => {
+const serverLoader = async () => {
   const movies = await getMovies();
   return { movies };
 };

--- a/apps/app/src/pages/docs/guards.mdx
+++ b/apps/app/src/pages/docs/guards.mdx
@@ -50,17 +50,17 @@ guards: [checkAuthenticated, checkRole('admin')]
 **`src/pages/admin.server.ts`** holds server guards plus the loader ref (never reaches the browser bundle):
 
 ```ts
-import { createCache, createGuard, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { createCache, createGuard, defineLoader } from '@hono-preact/iso';
 import { getCurrentUser, getAdminStats } from '@/server/admin.js';
 
-const serverLoader: LoaderFn<{ stats: Stats }> = async () => {
+const serverLoader = async () => {
   const stats = await getAdminStats();
   return { stats };
 };
 
 export default serverLoader;
 
-export const loader = defineLoader<{ stats: Stats }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 export const cache = createCache<{ stats: Stats }>();
 
 export const serverGuards = [

--- a/apps/app/src/pages/docs/loaders.mdx
+++ b/apps/app/src/pages/docs/loaders.mdx
@@ -29,16 +29,16 @@ type Movie = { id: number; title: string };
 
 ```ts
 import { getMovies } from '@/server/movies.js';
-import { defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { defineLoader } from '@hono-preact/iso';
 
-const serverLoader: LoaderFn<{ movies: MovieList }> = async () => {
+const serverLoader = async () => {
   const movies = await getMovies(); // direct call; never runs in the browser
   return { movies };
 };
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 ```
 
 **`src/pages/movies.tsx`** is a pure component, with `definePage` attaching the loader binding:
@@ -74,21 +74,21 @@ const Movies = lazy(() => import('./pages/movies.js'));
 
 ## Example: detail page (using route params)
 
-`LoaderFn<T>` receives `{ location }` which carries `location.pathParams`. Use this to load a record by ID:
+The loader function receives `{ location }` which carries `location.pathParams`. Use this to load a record by ID. The function's return type is inferred and propagated through `defineLoader(fn)` to `useLoaderData<typeof loader>()` calls.
 
 ```ts
 // src/pages/movie.server.ts
 import { getMovie } from '@/server/movies.js';
-import { defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { defineLoader } from '@hono-preact/iso';
 
-const serverLoader: LoaderFn<{ movie: Movie }> = async ({ location }) => {
+const serverLoader = async ({ location }) => {
   const movie = await getMovie(location.pathParams.id);
   return { movie };
 };
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movie: Movie }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 ```
 
 ## Registering the loader endpoint
@@ -113,15 +113,15 @@ Export a `cache` from the `.server.ts` file alongside the loader, then pass it t
 
 ```ts
 // src/pages/movies.server.ts
-import { createCache, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { createCache, defineLoader } from '@hono-preact/iso';
 
-const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
+const serverLoader = async () => ({
   movies: await getMovies(),
 });
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 export const cache = createCache<{ movies: MovieList }>();
 ```
 

--- a/apps/app/src/pages/docs/quick-start.mdx
+++ b/apps/app/src/pages/docs/quick-start.mdx
@@ -55,7 +55,7 @@ Open `http://localhost:5173/movies`. You should see "Movies".
 Create `src/pages/movies.server.ts`. The loader ref lives next to the server function as a named export, so the page never needs to import `defineLoader` itself:
 
 ```ts
-import { defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { defineLoader } from '@hono-preact/iso';
 
 export type Movie = { id: string; title: string };
 
@@ -66,13 +66,13 @@ const store: Movie[] = [
 
 const getMovies = () => store;
 
-const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
+const serverLoader = async () => ({
   movies: getMovies(),
 });
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 ```
 
 Update `src/pages/movies.tsx` to a pure consumer of the loader data, and bind the loader to the page with `definePage`:
@@ -121,7 +121,7 @@ Reload `http://localhost:5173/movies`. The list renders server-side on first loa
 Add `serverActions` to `src/pages/movies.server.ts`:
 
 ```ts
-import { defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { defineAction, defineLoader } from '@hono-preact/iso';
 
 export type Movie = { id: string; title: string };
 
@@ -134,13 +134,13 @@ const getMovies = () => store;
 const addMovieToStore = (title: string) =>
   store.push({ id: String(store.length + 1), title });
 
-const serverLoader: LoaderFn<{ movies: Movie[] }> = async () => ({
+const serverLoader = async () => ({
   movies: getMovies(),
 });
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: Movie[] }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 
 export const serverActions = {
   addMovie: defineAction<{ title: string }, { ok: boolean }>(

--- a/apps/app/src/pages/docs/reloading.mdx
+++ b/apps/app/src/pages/docs/reloading.mdx
@@ -9,15 +9,15 @@ Snippets on this page assume `type MovieList = { results: { id: number; title: s
 **`src/pages/movies.server.ts`** holds the loader and cache exports:
 
 ```ts
-import { createCache, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { createCache, defineLoader } from '@hono-preact/iso';
 
-const serverLoader: LoaderFn<{ movies: MovieList }> = async () => ({
+const serverLoader = async () => ({
   movies: await getMovies(),
 });
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MovieList }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 export const cache = createCache<{ movies: MovieList }>();
 ```
 

--- a/apps/app/src/pages/docs/structure.mdx
+++ b/apps/app/src/pages/docs/structure.mdx
@@ -74,7 +74,7 @@ Isomorphic utilities shared between server and client (`packages/iso/`):
 - `define-page.ts`: `definePage(Component, { loader, cache, Wrapper })` factory that stamps page bindings onto a component via a well-known symbol; `<Route>` reads them at mount time.
 - `page.tsx`: `<Page>` component and `WrapperProps` type. Composes the route boundary, guards, loader, and envelope into a single page wrapper (used internally by `<Route>`). `<Page>` accepts `loader`, `location`, `cache`, `serverGuards`, `clientGuards`, `fallback`, `errorFallback`, and `Wrapper` (typed as `ComponentType<WrapperProps>`).
 - `loader.tsx`: `<Loader>` component that fetches and caches loader data, plus the `useReload` provider context.
-- `define-loader.ts`: `defineLoader` factory and `LoaderFn<T>` / `LoaderRef<T>` types.
+- `define-loader.ts`: `defineLoader` factory and `LoaderRef<T>` type.
 - `use-loader-data.ts`: `useLoaderData<typeof loader>()` hook for typed access to loader data inside children. The loader is supplied as a type-only generic, not as a runtime argument.
 - `envelope.tsx`: `<Envelope>` (default page Wrapper) that emits the SSR `data-loader` attribute. Accepts `as` (an intrinsic tag name or a `ComponentType<WrapperProps>`, defaults to `'section'`) and `children`.
 - `guards.tsx` / `guard.ts`: `<Guards>` component, `createGuard`, `runGuards`, guard types.

--- a/apps/app/src/pages/movie.server.ts
+++ b/apps/app/src/pages/movie.server.ts
@@ -1,6 +1,6 @@
 // apps/app/src/pages/movie.server.ts
 import { getMovie } from '@/server/movies.js';
-import { defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { defineAction, defineLoader } from '@hono-preact/iso';
 import type { Movie } from '@/server/data/movie.js';
 import {
   getWatched,
@@ -11,20 +11,19 @@ import {
   type WatchedRecord,
 } from '@/server/watched.js';
 
-const serverLoader: LoaderFn<{ movie: Movie | null; watched: WatchedRecord | null }> =
-  async ({ location }) => {
-    const idStr = location.pathParams.id;
-    const id = Number(idStr);
-    const [movie, watched] = await Promise.all([
-      getMovie(idStr),
-      Number.isFinite(id) ? getWatched(id) : Promise.resolve(null),
-    ]);
-    return { movie, watched };
-  };
+const serverLoader = async ({ location }) => {
+  const idStr = location.pathParams.id;
+  const id = Number(idStr);
+  const [movie, watched] = await Promise.all([
+    getMovie(idStr),
+    Number.isFinite(id) ? getWatched(id) : Promise.resolve(null),
+  ]);
+  return { movie, watched };
+};
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movie: Movie | null; watched: WatchedRecord | null }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 
 export const serverActions = {
   toggleWatched: defineAction<{ movieId: number; watched: boolean }, { ok: boolean }>(

--- a/apps/app/src/pages/movies.server.ts
+++ b/apps/app/src/pages/movies.server.ts
@@ -1,17 +1,17 @@
 // apps/app/src/pages/movies.server.ts
 import { getMovies } from '@/server/movies.js';
-import { createCache, defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { createCache, defineAction, defineLoader } from '@hono-preact/iso';
 import type { MoviesData } from '@/server/data/movies.js';
 import { listWatched, markWatched, unmarkWatched } from '@/server/watched.js';
 
-const serverLoader: LoaderFn<{ movies: MoviesData; watchedIds: number[] }> = async () => {
+const serverLoader = async () => {
   const [movies, watched] = await Promise.all([getMovies(), listWatched()]);
   return { movies, watchedIds: watched.map((w) => w.movieId) };
 };
 
 export default serverLoader;
 
-export const loader = defineLoader<{ movies: MoviesData; watchedIds: number[] }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 export const cache = createCache<{ movies: MoviesData; watchedIds: number[] }>('movies-list');
 
 export const serverActions = {

--- a/apps/app/src/pages/watched.server.ts
+++ b/apps/app/src/pages/watched.server.ts
@@ -1,6 +1,6 @@
 // apps/app/src/pages/watched.server.ts
 import { getMovie, getMovies } from '@/server/movies.js';
-import { createCache, defineAction, defineLoader, type LoaderFn } from '@hono-preact/iso';
+import { createCache, defineAction, defineLoader } from '@hono-preact/iso';
 import type { Movie } from '@/server/data/movie.js';
 import {
   listWatched,
@@ -16,7 +16,7 @@ export type WireWatched = {
 };
 type Entry = { movie: Movie | null; watched: WireWatched };
 
-const serverLoader: LoaderFn<{ entries: Entry[] }> = async () => {
+const serverLoader = async () => {
   const records = await listWatched();
   const entries: Entry[] = await Promise.all(
     records.map(async (w) => ({
@@ -34,7 +34,7 @@ const serverLoader: LoaderFn<{ entries: Entry[] }> = async () => {
 
 export default serverLoader;
 
-export const loader = defineLoader<{ entries: Entry[] }>(serverLoader);
+export const loader = defineLoader(serverLoader);
 export const cache = createCache<{ entries: Entry[] }>('watched');
 
 export const serverActions = {


### PR DESCRIPTION
## Summary

Cleanup pass after #8 (path-keyed module identity). Under the path-keyed `defineLoader(fn)` shape, the loader's payload type is inferred from the function's return type, so the explicit `LoaderFn<T>` annotation and the explicit `<T>` generic on `defineLoader<T>(...)` are both redundant.

## Changes

- 3 server modules in `apps/app/src/pages/` lose their `LoaderFn` annotation, the import, and the generic on `defineLoader`.
- 6 docs MDX files update their code samples to match. The prose paragraph in `loaders.mdx` that described `LoaderFn<T>` as a user-facing type is rewritten to describe inference. `structure.mdx`'s type listing drops `LoaderFn<T>`.

`LoaderFn` remains exported from `@hono-preact/iso` for anyone who wants to type a loader explicitly; we just stop showing it as the canonical authoring style.

## Test plan

- [x] `pnpm test` — 271/271 passing
- [x] `pnpm build` — clean
- [x] Dev smoke test: `/movies` page renders, `/__loaders` POST routes correctly