### PR TITLE
feat: per-route SSR navigation mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - uses: actions/setup-node@v4
         with:
@@ -47,7 +47,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/apps/app/src/__tests__/ssr-navigation.test.tsx
+++ b/apps/app/src/__tests__/ssr-navigation.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment node
+//
+// Integration test for the SSR navigation pipeline.
+//
+// Note: apps/app/src/server.tsx uses import.meta.glob and import.meta.env
+// (Vite compile-time APIs) that cannot be executed in a raw Node/vitest
+// environment. This test exercises the same renderPage + Page + Route
+// pipeline by constructing a minimal Hono app inline, which is functionally
+// equivalent and avoids the Vite-specific build-step dependency.
+
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { LocationProvider } from 'preact-iso';
+import { type ComponentChildren } from 'preact';
+import { definePage, Route, Router } from '@hono-preact/iso';
+import { location, renderPage } from '@hono-preact/server';
+
+declare module 'preact' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'hp-page-fragment': { children?: ComponentChildren };
+    }
+  }
+}
+
+// Minimal stand-in for the /test page: no CSS, no loader.
+function TestContent() {
+  return (
+    <section data-testid="test-page">
+      <a href="/">home</a>
+    </section>
+  );
+}
+TestContent.displayName = 'Test';
+
+const TestPage = definePage(TestContent);
+
+// Minimal layout that mirrors apps/app/src/server/layout.tsx without
+// the Vite-specific imports (CSS URLs, import.meta.env.PROD).
+function Layout() {
+  return (
+    <LocationProvider>
+      <html>
+        <head />
+        <body>
+          <section id="app">
+            <Router>
+              {[<Route key="test" path="/test" component={TestPage} navigate="ssr" />]}
+            </Router>
+          </section>
+        </body>
+      </html>
+    </LocationProvider>
+  );
+}
+
+function makeApp() {
+  const app = new Hono();
+  app.use(location).get('*', (c) => renderPage(c, <Layout />, { defaultTitle: 'hono-preact' }));
+  return app;
+}
+
+describe('SSR navigation end-to-end', () => {
+  it('returns a fragment envelope for an SSR-mode route', async () => {
+    const res = await makeApp().request('/test', {
+      headers: { 'X-HP-Navigate': 'fragment' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].type).toBe('envelope');
+    expect(body.events[0].html).not.toContain('hp-page-fragment');
+    expect(body.events[0].html.length).toBeGreaterThan(0);
+    expect(body.events[0].head).toBeDefined();
+  });
+
+  it('returns a full HTML document without the header', async () => {
+    const res = await makeApp().request('/test');
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const text = await res.text();
+    expect(text).toContain('<!doctype html>');
+    expect(text).not.toContain('hp-page-fragment');
+  });
+});

--- a/apps/app/src/iso.tsx
+++ b/apps/app/src/iso.tsx
@@ -17,7 +17,7 @@ export const Base: FunctionComponent = () => {
   return (
     <Router onRouteChange={onRouteChange}>
       <Route path="/" component={Home} />
-      <Route path="/test" component={Test} />
+      <Route path="/test" component={Test} navigate="ssr" />
       <Route path="/movies" component={Movies} />
       <Route path="/movies/*" component={Movies} />
       <Route path="/watched" component={Watched} />

--- a/apps/app/src/pages/test.tsx
+++ b/apps/app/src/pages/test.tsx
@@ -1,10 +1,10 @@
 import { useLink } from 'hoofd/preact';
-import { type FunctionComponent } from 'preact';
+import { definePage } from '@hono-preact/iso';
 import test from './test.css?url';
 import styles from './test.module.scss';
 import inline from './test.module.scss?inline';
 
-const Test: FunctionComponent = () => {
+function TestContent() {
   useLink({ rel: 'stylesheet', href: test });
   return (
     <section class="p-1">
@@ -14,7 +14,9 @@ const Test: FunctionComponent = () => {
       </a>
     </section>
   );
-};
-Test.displayName = 'Test';
+}
+TestContent.displayName = 'Test';
+
+const Test = definePage(TestContent);
 
 export default Test;

--- a/docs/superpowers/plans/2026-05-06-ssr-navigation-mode.md
+++ b/docs/superpowers/plans/2026-05-06-ssr-navigation-mode.md
@@ -1,0 +1,1807 @@
+# SSR Navigation Mode: Per-Route HTML Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-route opt-in (`navigate="ssr"`) that fetches a server-rendered HTML fragment on client-side navigation, splices it into a stable mount point, and hydrates as an island. Loader data rides in the fragment HTML via the existing DOM-based preload channel; no separate `/__loaders` round trip.
+
+**Architecture:** Reintroduce a thin `Route` wrapper from `@hono-preact/iso` that registers a path → mode entry and substitutes a `PageHost` adapter when `navigate="ssr"`. A `Navigator` module installs a capture-phase click listener, fetches `URL` with `X-HP-Navigate: fragment`, and notifies `PageHost` to transition into island mode (imperative `innerHTML = html` + `preactHydrate` against a stable host div). On the server, `renderPage` detects the header, sets a fragment-mode context, and `<Page>` wraps its rendered subtree in a `<hp-page-fragment>` sentinel that `renderPage` extracts. The wire envelope is `{ events: [{ type: 'envelope', html, head }] }`; loader values live in `data-loader` attributes on the captured wrapper element. Loader/Envelope use a moduleKey-derived id (not `useId`) so wire ids stay stable across server fragment render and client island hydrate.
+
+**Tech Stack:** TypeScript, Preact, preact-iso (`Router`/`Route`/`lazy`/`LocationProvider`/`exec`/`prerender`), Hono (server), Vite, Vitest, happy-dom, @testing-library/preact.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-ssr-navigation-mode-design.md`
+
+---
+
+## Pre-flight context for the executing engineer
+
+Read these files first to understand the surfaces you'll touch:
+
+- `packages/iso/src/index.ts`: public surface; currently re-exports `preact-iso`'s `Route`/`Router`/`lazy`. We will replace the `Route` re-export with our wrapper.
+- `packages/iso/src/internal.ts`: escape-hatch surface with `Loader`, `Envelope`, `getPreloadedData`/`deletePreloadedData`, `runRequestScope`, contexts, etc.
+- `packages/iso/src/define-page.tsx`: `definePage` returns `FunctionComponent<RouteHook>` (unchanged by this plan).
+- `packages/iso/src/define-loader.ts`: `LoaderRef.__id` is `Symbol.for('@hono-preact/loader:${moduleKey}')`.
+- `packages/iso/src/loader.tsx`: `<Loader>` currently calls `useId()` for the preload channel id; we will switch to a moduleKey-derived id.
+- `packages/iso/src/envelope.tsx`: reads `LoaderIdContext`, renders the `id`/`data-loader` attributes on the wrapper.
+- `packages/iso/src/page.tsx`: composes `RouteBoundary > Guards > Loader > Envelope`. Will gain a fragment-mode branch that wraps in `<hp-page-fragment>`.
+- `packages/iso/src/contexts.ts`: `LoaderIdContext`, `LoaderDataContext`, `GuardResultContext`.
+- `packages/iso/src/preload.ts`: DOM-based preload channel; reads `document.getElementById(id).dataset.loader`.
+- `packages/iso/src/cache.ts`: `runRequestScope` (AsyncLocalStorage on Node/Workers).
+- `packages/server/src/render.tsx`: `renderPage` uses `prerender` from `preact-iso/prerender`.
+- `apps/app/src/server.tsx`: `app.get('*', ...)` calls `renderPage(c, <Layout context={c} />)`.
+- `apps/app/src/iso.tsx`: central route table using preact-iso's `Route` today.
+- `node_modules/preact-iso/src/router.js`: for reference; `Route = props => h(props.component, props)`, click interception lives in `LocationProvider`, `exec` is exported.
+
+Run `pnpm test` from repo root before starting; confirm all tests pass.
+
+This is additive plus one breaking internal change: the `Loader` id source moves from `useId()` to `loaderRef.__id.description`. Any test asserting on the specific id format breaks; update those assertions.
+
+---
+
+## File Structure
+
+### New files (packages/iso)
+- `packages/iso/src/navigator.ts`: mode registry, capture-phase click handler, fetch + dispatch, subscribe API for PageHost.
+- `packages/iso/src/page-host.tsx`: `<PageHost>` component with pre-island and island modes.
+- `packages/iso/src/route.tsx`: `<Route>` wrapper from `@hono-preact/iso` (replaces the `preact-iso` re-export).
+- `packages/iso/src/fragment-mode.ts`: `FragmentModeContext` and helpers.
+- `packages/iso/src/__tests__/navigator.test.ts`
+- `packages/iso/src/__tests__/page-host.test.tsx`
+- `packages/iso/src/__tests__/route.test.tsx`
+- `packages/iso/src/__tests__/fragment-mode.test.tsx`
+
+### Modified files (packages/iso)
+- `packages/iso/src/loader.tsx`: derive wire id from `loaderRef.__id.description` instead of `useId()`.
+- `packages/iso/src/page.tsx`: wrap rendered subtree in `<hp-page-fragment>` when fragment-mode context is set.
+- `packages/iso/src/index.ts`: drop `Route` re-export from `preact-iso`; export our `Route` wrapper plus new authoring/runtime API (`PageHost`, `navigator`-related hooks if exposed).
+- `packages/iso/src/__tests__/loader.test.tsx`: update id assertions if any.
+
+### Modified files (packages/server)
+- `packages/server/src/render.tsx`: branch on `X-HP-Navigate: fragment`; render in fragment mode and return JSON envelope.
+- `packages/server/src/__tests__/render.test.tsx`: new tests for fragment-mode response.
+
+### Modified files (apps/app)
+- `apps/app/src/iso.tsx`: switch one route to `navigate="ssr"` for end-to-end verification.
+- `apps/app/src/__tests__/...`: optional integration test (recommend a unit-style test in `packages/iso/src/__tests__/integration.test.tsx` instead).
+
+### Files NOT touched
+- `packages/iso/src/define-page.tsx`: `definePage` is unchanged.
+- `packages/iso/src/define-loader.ts`: `defineLoader` is unchanged.
+- `packages/server/src/loaders-handler.ts`, `actions-handler.ts`: unchanged.
+- `packages/vite/src/*`: unchanged.
+
+---
+
+## Task 1: Loader id moves to moduleKey-derived
+
+**Files:**
+- Modify: `packages/iso/src/loader.tsx`
+- Test: `packages/iso/src/__tests__/loader.test.tsx`
+
+The wire id (used by `Envelope` for the wrapper element and by `getPreloadedData` for DOM lookup) must be stable between server fragment render and client island hydrate. `useId()` is tree-position-based and won't match. Switch to `loader-${moduleKey}` derived from `loaderRef.__id.description`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/iso/src/__tests__/loader.test.tsx` (or wherever loader tests live; create the file if absent):
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/preact';
+import { defineLoader } from '../define-loader.js';
+import { Loader } from '../loader.js';
+import { Envelope } from '../envelope.js';
+
+vi.mock('../preload.js', () => ({
+  getPreloadedData: vi.fn(() => null),
+  deletePreloadedData: vi.fn(),
+}));
+
+const loc = { path: '/x', url: '/x', searchParams: {}, pathParams: {} } as any;
+
+describe('Loader wire id', () => {
+  it('derives the preload-channel id from loaderRef moduleKey, not useId', async () => {
+    const ref = defineLoader<{ ok: true }>(async () => ({ ok: true }), {
+      __moduleKey: 'src/pages/movies',
+    });
+    const { container } = render(
+      <Loader loader={ref} location={loc}>
+        <Envelope as="section">child</Envelope>
+      </Loader>
+    );
+    // Wait one tick for Suspense to resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    const wrapper = container.querySelector('section');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.id).toBe('loader-src-pages-movies');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test loader
+```
+
+Expected: FAIL. current id format is from `useId()`, something like `:r0:` or `P0`.
+
+- [ ] **Step 3: Add the id derivation helper inside `loader.tsx`**
+
+Edit `packages/iso/src/loader.tsx`. Replace `const id = useId();` in the `Loader` component with a moduleKey-derived id:
+
+```tsx
+import type { LoaderRef } from './define-loader.js';
+
+const LOADER_ID_PREFIX = '@hono-preact/loader:';
+
+function deriveLoaderDomId(ref: LoaderRef<unknown>): string {
+  const desc = ref.__id.description ?? '';
+  const moduleKey = desc.startsWith(LOADER_ID_PREFIX)
+    ? desc.slice(LOADER_ID_PREFIX.length)
+    : 'unkeyed';
+  // DOM id chars: HTML allows anything but whitespace; replace path-unfriendly
+  // characters with hyphens for selector-safe ids.
+  const safe = moduleKey.replace(/[^a-zA-Z0-9_-]/g, '-');
+  return `loader-${safe}`;
+}
+```
+
+Then in the `Loader` body, replace `const id = useId();` with `const id = deriveLoaderDomId(loader);`. Remove the `useId` import if it's no longer used.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test loader
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the rest of the iso test suite**
+
+```bash
+pnpm --filter @hono-preact/iso test
+```
+
+Expected: all tests pass. If any test asserts on the older `useId`-based wrapper id, update it to `loader-<safe-moduleKey>`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/iso/src/loader.tsx packages/iso/src/__tests__/loader.test.tsx
+git commit -m "refactor(iso): derive Loader DOM id from loaderRef moduleKey
+
+The preload channel needs a stable id across server fragment render
+and client island hydrate. useId() is tree-position-based and cannot
+provide that. Derive 'loader-\${moduleKey}' from loaderRef.__id.description
+so server and client agree on the wrapper's id whether the page renders
+inside a full document tree or as an isolated island."
+```
+
+---
+
+## Task 2: FragmentModeContext
+
+**Files:**
+- Create: `packages/iso/src/fragment-mode.ts`
+- Test: `packages/iso/src/__tests__/fragment-mode.test.tsx`
+
+A boolean Preact context, set by `renderPage` in fragment mode and read by `<Page>` to swap rendering behavior. Lives in iso so both `<Page>` (iso) and `renderPage` (server) can consume it.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/iso/src/__tests__/fragment-mode.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { useContext } from 'preact/hooks';
+import { FragmentModeContext } from '../fragment-mode.js';
+
+describe('FragmentModeContext', () => {
+  it('defaults to false', () => {
+    let observed: boolean | undefined;
+    function Probe() {
+      observed = useContext(FragmentModeContext);
+      return null;
+    }
+    render(<Probe />);
+    expect(observed).toBe(false);
+  });
+
+  it('reads true when wrapped in a provider with value=true', () => {
+    let observed: boolean | undefined;
+    function Probe() {
+      observed = useContext(FragmentModeContext);
+      return null;
+    }
+    render(
+      <FragmentModeContext.Provider value={true}>
+        <Probe />
+      </FragmentModeContext.Provider>
+    );
+    expect(observed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test fragment-mode
+```
+
+Expected: FAIL. module does not exist.
+
+- [ ] **Step 3: Implement the module**
+
+Create `packages/iso/src/fragment-mode.ts`:
+
+```ts
+import { createContext } from 'preact';
+
+export const FragmentModeContext = createContext<boolean>(false);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test fragment-mode
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/fragment-mode.ts packages/iso/src/__tests__/fragment-mode.test.tsx
+git commit -m "feat(iso): add FragmentModeContext for SSR fragment rendering"
+```
+
+---
+
+## Task 3: `<Page>` wraps rendered subtree in sentinel under fragment mode
+
+**Files:**
+- Modify: `packages/iso/src/page.tsx`
+- Test: `packages/iso/src/__tests__/page.test.tsx` (extend or create)
+
+When `FragmentModeContext` is `true`, `<Page>` wraps its rendered subtree in `<hp-page-fragment>...</hp-page-fragment>`. The server's `renderPage` extracts content between these markers from the prerendered string. Custom-element name (must contain a dash) renders as-is in HTML.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/iso/src/__tests__/page.test.tsx` (create if absent, with the same `@vitest-environment happy-dom` header used elsewhere):
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { renderToString } from 'preact-render-to-string';
+import { LocationProvider, type RouteHook } from 'preact-iso';
+import { Page } from '../page.js';
+import { FragmentModeContext } from '../fragment-mode.js';
+
+const loc = { path: '/x', url: '/x', searchParams: {}, pathParams: {} } as RouteHook;
+
+describe('<Page> under fragment mode', () => {
+  it('wraps its rendered subtree in <hp-page-fragment>', () => {
+    function Inner() {
+      return <p>body</p>;
+    }
+    const html = renderToString(
+      <LocationProvider>
+        <FragmentModeContext.Provider value={true}>
+          <Page location={loc}>
+            <Inner />
+          </Page>
+        </FragmentModeContext.Provider>
+      </LocationProvider>
+    );
+    expect(html).toContain('<hp-page-fragment>');
+    expect(html).toContain('</hp-page-fragment>');
+    expect(html).toMatch(/<hp-page-fragment>.*<p>body<\/p>.*<\/hp-page-fragment>/s);
+  });
+
+  it('does not wrap when fragment mode is false (default)', () => {
+    function Inner() {
+      return <p>body</p>;
+    }
+    const html = renderToString(
+      <LocationProvider>
+        <Page location={loc}>
+          <Inner />
+        </Page>
+      </LocationProvider>
+    );
+    expect(html).not.toContain('<hp-page-fragment');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test page
+```
+
+Expected: FAIL. `<Page>` does not yet branch on `FragmentModeContext`.
+
+- [ ] **Step 3: Add the fragment-mode branch in `<Page>`**
+
+Edit `packages/iso/src/page.tsx`. Add `useContext(FragmentModeContext)` and wrap the existing JSX return in `<hp-page-fragment>` when true:
+
+```tsx
+import { useContext, useId } from 'preact/hooks';
+import { FragmentModeContext } from './fragment-mode.js';
+
+export function Page<T>({
+  loader, location, cache, serverGuards, clientGuards,
+  fallback, errorFallback, Wrapper, children,
+}: PageProps<T>): JSX.Element {
+  const id = useId();
+  const isFragment = useContext(FragmentModeContext);
+
+  const tree = (
+    <RouteBoundary fallback={fallback} errorFallback={errorFallback}>
+      <Guards server={serverGuards} client={clientGuards} location={location}>
+        {loader ? (
+          <Loader loader={loader} location={location} cache={cache} fallback={fallback}>
+            <Envelope as={Wrapper}>{children}</Envelope>
+          </Loader>
+        ) : (
+          <NoLoaderFrame id={id} as={Wrapper}>
+            {children}
+          </NoLoaderFrame>
+        )}
+      </Guards>
+    </RouteBoundary>
+  );
+
+  if (isFragment) {
+    // Custom element name (must contain a dash) renders as-is.
+    // renderPage extracts between these markers in fragment mode.
+    return <hp-page-fragment>{tree}</hp-page-fragment> as unknown as JSX.Element;
+  }
+  return tree;
+}
+```
+
+If TypeScript complains about the unknown `hp-page-fragment` element, declare it once at the top of the file:
+
+```tsx
+declare module 'preact' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'hp-page-fragment': { children?: ComponentChildren };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test page
+```
+
+Expected: PASS for both new tests, and all existing `<Page>` tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/page.tsx packages/iso/src/__tests__/page.test.tsx
+git commit -m "feat(iso): wrap Page output in <hp-page-fragment> under fragment mode"
+```
+
+---
+
+## Task 4: `renderPage` fragment-mode branch
+
+**Files:**
+- Modify: `packages/server/src/render.tsx`
+- Test: `packages/server/src/__tests__/render.test.tsx` (create if absent)
+
+`renderPage` checks `X-HP-Navigate: fragment` on the request. If set, it sets `FragmentModeContext` to `true`, prerenders the user's tree, extracts the content between `<hp-page-fragment>` markers, and returns a JSON envelope.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/server/src/__tests__/render.test.tsx`:
+
+```tsx
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { renderPage } from '../render.js';
+
+describe('renderPage fragment mode', () => {
+  it('returns a JSON envelope when X-HP-Navigate: fragment is set', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      renderPage(
+        c,
+        <html>
+          <body>
+            <hp-page-fragment>
+              <section id="loader-foo" data-loader="{&quot;ok&quot;:true}">hello</section>
+            </hp-page-fragment>
+          </body>
+        </html>
+      )
+    );
+    const res = await app.request('/test', {
+      headers: { 'X-HP-Navigate': 'fragment' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].type).toBe('envelope');
+    expect(body.events[0].html).toContain('loader-foo');
+    expect(body.events[0].html).toContain('hello');
+    expect(body.events[0].html).not.toContain('hp-page-fragment');
+  });
+
+  it('returns full HTML document when header is absent', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      renderPage(c, <html><body><p>hi</p></body></html>)
+    );
+    const res = await app.request('/test');
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('<!doctype html>');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/server test
+```
+
+Expected: FAIL. fragment-mode branch does not exist.
+
+- [ ] **Step 3: Implement the fragment-mode branch**
+
+Edit `packages/server/src/render.tsx`:
+
+```tsx
+import type { Context } from 'hono';
+import type { VNode } from 'preact';
+import { createDispatcher, HoofdProvider } from 'hoofd/preact';
+import { prerender } from 'preact-iso/prerender';
+import { GuardRedirect, env } from '@hono-preact/iso';
+import { runRequestScope } from '@hono-preact/iso/internal';
+import { FragmentModeContext } from '@hono-preact/iso/internal';
+
+// (existing escapeHtml/toAttrs helpers stay here)
+
+export async function renderPage(
+  c: Context,
+  node: VNode,
+  options?: { defaultTitle?: string }
+): Promise<Response> {
+  const isFragment = c.req.header('X-HP-Navigate') === 'fragment';
+  if (isFragment) return renderFragment(c, node);
+  return renderDocument(c, node, options);
+}
+
+const FRAGMENT_OPEN = '<hp-page-fragment>';
+const FRAGMENT_CLOSE = '</hp-page-fragment>';
+
+async function renderFragment(c: Context, node: VNode): Promise<Response> {
+  const dispatcher = createDispatcher();
+  const previousEnv = env.current;
+  env.current = 'server';
+
+  let html: string;
+  try {
+    ({ html } = await runRequestScope(() =>
+      prerender(
+        <FragmentModeContext.Provider value={true}>
+          <HoofdProvider value={dispatcher}>{node}</HoofdProvider>
+        </FragmentModeContext.Provider>
+      )
+    ));
+  } catch (e: unknown) {
+    if (e instanceof GuardRedirect) {
+      return c.json({
+        events: [{ type: 'redirect', location: e.location }],
+      });
+    }
+    throw e;
+  } finally {
+    env.current = previousEnv;
+  }
+
+  const start = html.indexOf(FRAGMENT_OPEN);
+  const end = html.indexOf(FRAGMENT_CLOSE);
+  if (start < 0 || end < 0 || end < start) {
+    // No fragment marker found. Either the matched route did not render <Page>,
+    // or the marker was stripped. Fall back to instructing the client to do a
+    // hard navigation.
+    return c.json({ events: [{ type: 'fallback' }] }, 200);
+  }
+  const captured = html.slice(start + FRAGMENT_OPEN.length, end);
+
+  const { title, metas = [], links = [] } = dispatcher.toStatic();
+  return c.json({
+    events: [
+      {
+        type: 'envelope',
+        html: captured,
+        head: { title, metas, links },
+      },
+    ],
+  });
+}
+
+async function renderDocument(
+  c: Context,
+  node: VNode,
+  options?: { defaultTitle?: string }
+): Promise<Response> {
+  // (existing renderPage body, unchanged: copy what was there)
+  ...
+}
+```
+
+You also need `FragmentModeContext` to be exported from `@hono-preact/iso/internal`. Add to `packages/iso/src/internal.ts`:
+
+```ts
+export { FragmentModeContext } from './fragment-mode.js';
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/server test
+```
+
+Expected: PASS for both fragment-mode and document-mode tests.
+
+- [ ] **Step 5: Run all server + iso tests to confirm no regression**
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/server/src/render.tsx packages/iso/src/internal.ts packages/server/src/__tests__/render.test.tsx
+git commit -m "feat(server): add fragment-mode branch to renderPage
+
+When X-HP-Navigate: fragment is set, prerender under FragmentModeContext,
+extract content between <hp-page-fragment> markers, and return a JSON
+envelope shaped { events: [{ type: 'envelope', html, head }] }. Loader
+data is already in the captured HTML's data-loader attributes via the
+existing Envelope render path; no separate loaders map needed."
+```
+
+---
+
+## Task 5: Navigator core (registry and subscription API)
+
+**Files:**
+- Create: `packages/iso/src/navigator.ts`
+- Test: `packages/iso/src/__tests__/navigator.test.ts`
+
+The navigator owns a path-mode registry, a buffer of latest fragment per path, and a subscribe API for `PageHost`. We start with the registry/subscribe surface; click handler and fetch land in Tasks 6 and 7.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/iso/src/__tests__/navigator.test.ts`:
+
+```ts
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerRouteMode,
+  lookupRouteMode,
+  clearRegistry,
+  setLatestFragment,
+  subscribeToFragment,
+  clearLatestFragment,
+} from '../navigator.js';
+
+beforeEach(() => {
+  clearRegistry();
+  clearLatestFragment();
+});
+
+describe('navigator route mode registry', () => {
+  it('returns "spa" for unregistered paths', () => {
+    expect(lookupRouteMode('/anything')).toBe('spa');
+  });
+
+  it('returns "ssr" for an exact registered path', () => {
+    registerRouteMode('/docs', 'ssr');
+    expect(lookupRouteMode('/docs')).toBe('ssr');
+  });
+
+  it('matches preact-iso path patterns with parameters', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    expect(lookupRouteMode('/docs/intro')).toBe('ssr');
+    expect(lookupRouteMode('/blog/x')).toBe('spa');
+  });
+
+  it('matches /docs/* rest patterns', () => {
+    registerRouteMode('/docs/*', 'ssr');
+    expect(lookupRouteMode('/docs/a')).toBe('ssr');
+    expect(lookupRouteMode('/docs/a/b/c')).toBe('ssr');
+  });
+});
+
+describe('navigator fragment buffer + subscription', () => {
+  it('delivers the latest fragment to a new subscriber for that path', () => {
+    setLatestFragment('/docs/*', '<section>hi</section>');
+    let received: string | null = null;
+    const unsub = subscribeToFragment('/docs/*', (html) => { received = html; });
+    expect(received).toBe('<section>hi</section>');
+    unsub();
+  });
+
+  it('notifies all current subscribers when a new fragment arrives', () => {
+    const seen: string[] = [];
+    const unsub = subscribeToFragment('/docs/*', (html) => seen.push(html));
+    setLatestFragment('/docs/*', 'A');
+    setLatestFragment('/docs/*', 'B');
+    expect(seen).toEqual(['A', 'B']);
+    unsub();
+  });
+
+  it('does not deliver fragments for other paths', () => {
+    const seen: string[] = [];
+    const unsub = subscribeToFragment('/docs/*', (h) => seen.push(h));
+    setLatestFragment('/blog/*', 'X');
+    expect(seen).toEqual([]);
+    unsub();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test navigator
+```
+
+Expected: FAIL. module does not exist.
+
+- [ ] **Step 3: Implement the navigator core**
+
+Create `packages/iso/src/navigator.ts`:
+
+```ts
+import { exec } from 'preact-iso';
+
+export type NavigateMode = 'spa' | 'ssr';
+
+const routeModes = new Map<string, NavigateMode>();
+const subscribers = new Map<string, Set<(html: string) => void>>();
+const latestFragments = new Map<string, string>();
+
+export function registerRouteMode(path: string, mode: NavigateMode): void {
+  routeModes.set(path, mode);
+}
+
+export function clearRegistry(): void {
+  routeModes.clear();
+}
+
+/**
+ * Look up the navigate mode for a URL by matching against registered paths.
+ * Defaults to 'spa' when no registered path matches.
+ */
+export function lookupRouteMode(url: string): NavigateMode {
+  for (const [pattern, mode] of routeModes) {
+    if (exec(url, pattern, {})) return mode;
+  }
+  return 'spa';
+}
+
+export function setLatestFragment(path: string, html: string): void {
+  latestFragments.set(path, html);
+  const subs = subscribers.get(path);
+  if (subs) for (const fn of subs) fn(html);
+}
+
+export function clearLatestFragment(): void {
+  latestFragments.clear();
+}
+
+export function subscribeToFragment(
+  path: string,
+  handler: (html: string) => void
+): () => void {
+  let set = subscribers.get(path);
+  if (!set) {
+    set = new Set();
+    subscribers.set(path, set);
+  }
+  set.add(handler);
+  // Replay latest fragment if one is buffered.
+  const latest = latestFragments.get(path);
+  if (latest !== undefined) handler(latest);
+  return () => {
+    const s = subscribers.get(path);
+    if (s) {
+      s.delete(handler);
+      if (s.size === 0) subscribers.delete(path);
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test navigator
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/navigator.ts packages/iso/src/__tests__/navigator.test.ts
+git commit -m "feat(iso): add navigator route-mode registry and fragment subscription API"
+```
+
+---
+
+## Task 6: Navigator click interceptor
+
+**Files:**
+- Modify: `packages/iso/src/navigator.ts`
+- Modify: `packages/iso/src/__tests__/navigator.test.ts`
+
+A capture-phase document `click` listener that runs before `preact-iso`'s. Mirrors `preact-iso`'s exclusion rules (modifier keys, target=_blank, cross-origin, download). For SSR-route hits: `preventDefault` and call `navigate(url)` (which will be implemented in Task 7).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/iso/src/__tests__/navigator.test.ts`:
+
+```ts
+import { vi } from 'vitest';
+import {
+  installClickInterceptor,
+  uninstallClickInterceptor,
+  __setNavigateForTesting,
+} from '../navigator.js';
+
+describe('navigator click interceptor', () => {
+  let navigateSpy: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    clearRegistry();
+    navigateSpy = vi.fn();
+    __setNavigateForTesting(navigateSpy);
+    installClickInterceptor();
+  });
+  afterEach(() => {
+    uninstallClickInterceptor();
+    __setNavigateForTesting(null);
+  });
+
+  function clickAnchor(href: string, init?: Partial<MouseEventInit>): MouseEvent {
+    const a = document.createElement('a');
+    a.href = href;
+    document.body.appendChild(a);
+    const ev = new MouseEvent('click', {
+      bubbles: true, cancelable: true, button: 0, ...init,
+    });
+    a.dispatchEvent(ev);
+    a.remove();
+    return ev;
+  }
+
+  it('intercepts SSR-route same-origin plain clicks', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const ev = clickAnchor(window.location.origin + '/docs/intro');
+    expect(ev.defaultPrevented).toBe(true);
+    expect(navigateSpy).toHaveBeenCalledWith('/docs/intro');
+  });
+
+  it('does not intercept SPA-route clicks', () => {
+    const ev = clickAnchor(window.location.origin + '/profile');
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept clicks with modifier keys', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const ev = clickAnchor(window.location.origin + '/docs/intro', { metaKey: true });
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept cross-origin clicks', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const ev = clickAnchor('https://example.com/docs/intro');
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept target=_blank', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const a = document.createElement('a');
+    a.href = window.location.origin + '/docs/intro';
+    a.target = '_blank';
+    document.body.appendChild(a);
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    a.dispatchEvent(ev);
+    a.remove();
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test navigator
+```
+
+Expected: FAIL. interceptor functions do not exist.
+
+- [ ] **Step 3: Implement the click interceptor**
+
+Append to `packages/iso/src/navigator.ts`:
+
+```ts
+let installed = false;
+let testingNavigate: ((url: string) => void) | null = null;
+
+export function __setNavigateForTesting(fn: ((url: string) => void) | null): void {
+  testingNavigate = fn;
+}
+
+function dispatchNavigate(url: string): void {
+  if (testingNavigate) testingNavigate(url);
+  else navigate(url); // implemented in Task 7
+}
+
+function shouldInterceptClick(event: MouseEvent): { url: string } | null {
+  if (event.defaultPrevented) return null;
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return null;
+  if (event.button !== 0) return null;
+  const target = event.composedPath().find(
+    (el): el is HTMLAnchorElement =>
+      el instanceof HTMLAnchorElement && !!el.href
+  );
+  if (!target) return null;
+  if (target.origin !== location.origin) return null;
+  if (target.hasAttribute('download')) return null;
+  if (target.target && !/^_?self$/i.test(target.target)) return null;
+  const href = target.getAttribute('href');
+  if (!href || /^#/.test(href)) return null;
+  return { url: target.href.replace(location.origin, '') };
+}
+
+function onClickCapture(event: MouseEvent): void {
+  const decision = shouldInterceptClick(event);
+  if (!decision) return;
+  if (lookupRouteMode(decision.url) !== 'ssr') return;
+  event.preventDefault();
+  dispatchNavigate(decision.url);
+}
+
+export function installClickInterceptor(): void {
+  if (installed) return;
+  if (typeof document === 'undefined') return;
+  document.addEventListener('click', onClickCapture, true);
+  installed = true;
+}
+
+export function uninstallClickInterceptor(): void {
+  if (!installed) return;
+  document.removeEventListener('click', onClickCapture, true);
+  installed = false;
+}
+
+// Auto-install on first SSR registration in the browser.
+const originalRegister = registerRouteMode;
+export const registerRouteMode_AutoInstall = (path: string, mode: NavigateMode) => {
+  originalRegister(path, mode);
+  if (mode === 'ssr') installClickInterceptor();
+};
+```
+
+Replace the original `registerRouteMode` body so it auto-installs:
+
+```ts
+export function registerRouteMode(path: string, mode: NavigateMode): void {
+  routeModes.set(path, mode);
+  if (mode === 'ssr') installClickInterceptor();
+}
+```
+
+(Drop the `registerRouteMode_AutoInstall` helper from the previous draft; we just inline the auto-install into the canonical function.)
+
+Also add a stub `navigate` function so the file type-checks:
+
+```ts
+export function navigate(url: string): void {
+  // Implemented in Task 7.
+  throw new Error('navigator.navigate() not yet implemented');
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test navigator
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/navigator.ts packages/iso/src/__tests__/navigator.test.ts
+git commit -m "feat(iso): add capture-phase click interceptor to navigator
+
+Listener installs lazily the first time an SSR route registers and
+mirrors preact-iso's link-click exclusion rules (modifiers, target,
+cross-origin, download). For SSR-route hits, preventDefault and
+hand off to navigate() (stub for now)."
+```
+
+---
+
+## Task 7: Navigator fetch + dispatch
+
+**Files:**
+- Modify: `packages/iso/src/navigator.ts`
+- Modify: `packages/iso/src/__tests__/navigator.test.ts`
+
+`navigate(url)` aborts any in-flight request, fetches `url` with `X-HP-Navigate: fragment`, and dispatches each event in the response. `envelope` events apply head patches and call `setLatestFragment`. `redirect` events recursively call `navigate`. `fallback` or non-2xx fall back to `location.assign(url)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/iso/src/__tests__/navigator.test.ts`:
+
+```ts
+import { navigate } from '../navigator.js';
+
+describe('navigator.navigate()', () => {
+  beforeEach(() => {
+    clearRegistry();
+    clearLatestFragment();
+  });
+
+  it('fetches URL with X-HP-Navigate: fragment and applies envelope', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        events: [{
+          type: 'envelope',
+          html: '<section id="loader-foo" data-loader="{}">x</section>',
+          head: { title: 'Doc', metas: [], links: [] },
+        }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    registerRouteMode('/docs/:slug', 'ssr');
+
+    const seen: string[] = [];
+    subscribeToFragment('/docs/:slug', (h) => seen.push(h));
+
+    await navigate('/docs/intro');
+
+    expect(fetchSpy).toHaveBeenCalledWith('/docs/intro', expect.objectContaining({
+      headers: expect.objectContaining({ 'X-HP-Navigate': 'fragment' }),
+    }));
+    expect(seen).toEqual(['<section id="loader-foo" data-loader="{}">x</section>']);
+    expect(document.title).toBe('Doc');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('falls back to location.assign on non-2xx response', async () => {
+    const assignSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, assign: assignSpy, origin: window.location.origin },
+      writable: true,
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('boom', { status: 500 })
+    );
+    registerRouteMode('/docs/*', 'ssr');
+    await navigate('/docs/x');
+    expect(assignSpy).toHaveBeenCalledWith('/docs/x');
+    vi.restoreAllMocks();
+  });
+
+  it('follows redirect events to a new navigate call', async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      calls++;
+      if (calls === 1) {
+        return new Response(JSON.stringify({
+          events: [{ type: 'redirect', location: '/login' }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({
+        events: [{ type: 'envelope', html: '<p>login</p>', head: { title: 'Login', metas: [], links: [] } }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    registerRouteMode('/docs/:slug', 'ssr');
+    registerRouteMode('/login', 'ssr');
+    const seen: string[] = [];
+    subscribeToFragment('/login', (h) => seen.push(h));
+    await navigate('/docs/secret');
+    expect(calls).toBe(2);
+    expect(seen).toEqual(['<p>login</p>']);
+    vi.restoreAllMocks();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pnpm --filter @hono-preact/iso test navigator
+```
+
+Expected: FAIL. `navigate` is a stub.
+
+- [ ] **Step 3: Implement `navigate`**
+
+Replace the stub in `packages/iso/src/navigator.ts`:
+
+```ts
+let inflight: AbortController | null = null;
+
+type Envelope = {
+  type: 'envelope';
+  html: string;
+  head: { title?: string; metas?: { name?: string; content?: string; property?: string }[]; links?: { rel?: string; href?: string }[] };
+};
+type Redirect = { type: 'redirect'; location: string };
+type Fallback = { type: 'fallback' };
+type EventItem = Envelope | Redirect | Fallback;
+
+function applyHead(head: Envelope['head']): void {
+  if (typeof document === 'undefined') return;
+  if (head.title !== undefined) document.title = head.title;
+  // For metas/links: imperatively reconcile with hoofd-rendered tags.
+  // v1 keeps this minimal; hoofd hooks in the hydrating tree will further
+  // reconcile after hydrate fires. See spec "Hoofd reconciliation" risk note.
+}
+
+function findMatchingPattern(url: string): string | null {
+  for (const [pattern] of routeModes) {
+    if (exec(url, pattern, {})) return pattern;
+  }
+  return null;
+}
+
+export async function navigate(url: string): Promise<void> {
+  if (testingNavigate) return testingNavigate(url) as unknown as void;
+  if (inflight) inflight.abort();
+  const ctrl = new AbortController();
+  inflight = ctrl;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { 'X-HP-Navigate': 'fragment' },
+      signal: ctrl.signal,
+    });
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return;
+    location.assign(url);
+    return;
+  }
+  if (!res.ok) {
+    location.assign(url);
+    return;
+  }
+  let body: { events?: EventItem[] };
+  try {
+    body = await res.json();
+  } catch {
+    location.assign(url);
+    return;
+  }
+  const events = body.events ?? [];
+  for (const event of events) {
+    if (event.type === 'envelope') {
+      applyHead(event.head);
+      const pattern = findMatchingPattern(url);
+      if (pattern) setLatestFragment(pattern, event.html);
+      // History update happens in Task 8 via LocationProvider integration.
+      history.pushState(null, '', url);
+    } else if (event.type === 'redirect') {
+      await navigate(event.location);
+      return;
+    } else if (event.type === 'fallback') {
+      location.assign(url);
+      return;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @hono-preact/iso test navigator
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add popstate handling**
+
+Browser back/forward changes the URL synchronously and fires `popstate`. preact-iso's `LocationProvider` updates its location signal in response, but no fragment is fetched. PageHost would receive a new `location` prop while still showing the old fragment HTML, hydrating against mismatched DOM.
+
+Add a `popstate` listener inside `installClickInterceptor` (rename it conceptually to "install handlers"; keep the name for now to avoid churn). Add a `push` option to `navigate` so popstate-triggered fetches don't double-push:
+
+```ts
+export async function navigate(
+  url: string,
+  opts: { push?: boolean } = { push: true }
+): Promise<void> {
+  // ... existing body ...
+  // In the envelope branch, replace `history.pushState(null, '', url)` with:
+  if (opts.push) history.pushState(null, '', url);
+}
+
+function onPopstate(): void {
+  const url = location.pathname + location.search;
+  if (lookupRouteMode(url) === 'ssr') {
+    void navigate(url, { push: false });
+  }
+}
+```
+
+Inside `installClickInterceptor`, after `addEventListener('click', ...)`, also:
+
+```ts
+window.addEventListener('popstate', onPopstate);
+```
+
+And in `uninstallClickInterceptor`, also:
+
+```ts
+window.removeEventListener('popstate', onPopstate);
+```
+
+Append a test to `navigator.test.ts`:
+
+```ts
+describe('navigator popstate handling', () => {
+  it('refetches the fragment on popstate for SSR routes without pushing state', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        events: [{ type: 'envelope', html: '<p>back</p>', head: {} }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const pushSpy = vi.spyOn(history, 'pushState');
+    registerRouteMode('/docs/*', 'ssr');
+    const seen: string[] = [];
+    subscribeToFragment('/docs/*', (h) => seen.push(h));
+
+    // Simulate browser back/forward to /docs/old.
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, pathname: '/docs/old', search: '' },
+      writable: true,
+    });
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetchSpy).toHaveBeenCalledWith('/docs/old', expect.anything());
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(seen).toEqual(['<p>back</p>']);
+
+    fetchSpy.mockRestore();
+    pushSpy.mockRestore();
+  });
+});
+```
+
+Run:
+
+```bash
+pnpm --filter @hono-preact/iso test navigator
+```
+
+Expected: PASS for the new popstate test plus all prior tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/iso/src/navigator.ts packages/iso/src/__tests__/navigator.test.ts
+git commit -m "feat(iso): implement navigator.navigate() with fetch, dispatch, popstate
+
+POST URL with X-HP-Navigate: fragment, dispatch envelope/redirect/fallback
+events. Apply title from envelope.head and broadcast HTML to subscribed
+PageHosts. Falls back to location.assign on network/parse failures.
+Popstate refetches the fragment for SSR routes without pushing state,
+keeping PageHost's island in sync with browser back/forward."
+```
+
+---
+
+## Task 8: PageHost component (pre-island mode)
+
+**Files:**
+- Create: `packages/iso/src/page-host.tsx`
+- Test: `packages/iso/src/__tests__/page-host.test.tsx`
+
+The `PageHost` adapter that the Route wrapper substitutes for SSR routes. Pre-island mode: just renders the user's component with the location prop. We add island mode in Task 9.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/iso/src/__tests__/page-host.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/preact';
+import { LocationProvider, type RouteHook } from 'preact-iso';
+import { PageHost } from '../page-host.js';
+
+afterEach(cleanup);
+
+const loc = { path: '/docs/x', url: '/docs/x', searchParams: {}, pathParams: { slug: 'x' } } as RouteHook;
+
+describe('PageHost (pre-island)', () => {
+  it('renders the user component with location prop', () => {
+    function User(props: RouteHook) {
+      return <p data-testid="page">slug={props.pathParams!.slug}</p>;
+    }
+    render(
+      <LocationProvider>
+        <PageHost component={User} location={loc} path="/docs/:slug" />
+      </LocationProvider>
+    );
+    expect(screen.getByTestId('page')).toHaveTextContent('slug=x');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test page-host
+```
+
+Expected: FAIL. `PageHost` does not exist.
+
+- [ ] **Step 3: Implement pre-island `PageHost`**
+
+Create `packages/iso/src/page-host.tsx`:
+
+```tsx
+import type { ComponentType } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import type { RouteHook } from 'preact-iso';
+import { subscribeToFragment } from './navigator.js';
+
+export type PageHostProps = {
+  component: ComponentType<RouteHook>;
+  location: RouteHook;
+  path: string;
+};
+
+export function PageHost({ component: User, location, path }: PageHostProps) {
+  const [fragment, setFragment] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsub = subscribeToFragment(path, (html) => setFragment(html));
+    return unsub;
+  }, [path]);
+
+  if (fragment === null) {
+    return <User {...location} />;
+  }
+  // Island mode lands in Task 9. For now, fallback to user component so any
+  // tests asserting pre-island behavior pass; the real island mode replaces
+  // this branch.
+  return <User {...location} />;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test page-host
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/page-host.tsx packages/iso/src/__tests__/page-host.test.tsx
+git commit -m "feat(iso): add PageHost component (pre-island mode)
+
+Subscribes to navigator fragments by path. Pre-island branch renders
+the user component normally; island branch arrives in the next commit."
+```
+
+---
+
+## Task 9: PageHost island mode
+
+**Files:**
+- Modify: `packages/iso/src/page-host.tsx`
+- Modify: `packages/iso/src/__tests__/page-host.test.tsx`
+
+When a fragment arrives, `PageHost` transitions: render a stable `<div ref dangerouslySetInnerHTML={{__html: ''}}>`, set `innerHTML = fragment` imperatively, run `preactHydrate(<User {...location} />, hostDiv)`. Subsequent fragments unmount + re-hydrate.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/iso/src/__tests__/page-host.test.tsx`:
+
+```tsx
+import { setLatestFragment, clearLatestFragment } from '../navigator.js';
+
+describe('PageHost (island mode)', () => {
+  beforeEach(() => clearLatestFragment());
+
+  it('splices fragment HTML and hydrates the user component into the host div', async () => {
+    function User(props: RouteHook) {
+      return <p data-testid="island">island slug={props.pathParams!.slug}</p>;
+    }
+    const { container } = render(
+      <LocationProvider>
+        <PageHost component={User} location={loc} path="/docs/:slug" />
+      </LocationProvider>
+    );
+    // Server-rendered fragment: a <p> with the same shape as User would
+    // produce, so hydrate matches.
+    setLatestFragment('/docs/:slug', '<p data-testid="island">island slug=x</p>');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByTestId('island')).toHaveTextContent('island slug=x');
+    // The host div is the only child rendered by the outer tree; the <p> is
+    // inside it as a hydrated island.
+    const host = container.querySelector('[data-hp-island="true"]');
+    expect(host).not.toBeNull();
+    expect(host!.querySelector('p')).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test page-host
+```
+
+Expected: FAIL. current PageHost renders `<User />` instead of an island.
+
+- [ ] **Step 3: Implement island mode**
+
+Replace `packages/iso/src/page-host.tsx`:
+
+```tsx
+import { hydrate, render, h, type ComponentType, type RefObject } from 'preact';
+import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
+import type { RouteHook } from 'preact-iso';
+import { subscribeToFragment } from './navigator.js';
+
+export type PageHostProps = {
+  component: ComponentType<RouteHook>;
+  location: RouteHook;
+  path: string;
+};
+
+export function PageHost({ component: User, location, path }: PageHostProps) {
+  const [fragment, setFragment] = useState<string | null>(null);
+  const hostRef: RefObject<HTMLDivElement> = useRef(null);
+
+  useEffect(() => {
+    const unsub = subscribeToFragment(path, (html) => setFragment(html));
+    return unsub;
+  }, [path]);
+
+  useLayoutEffect(() => {
+    if (fragment === null) return;
+    const host = hostRef.current;
+    if (!host) return;
+    // Unmount any prior inner Preact tree at this host.
+    render(null, host);
+    // Replace DOM with new server-rendered HTML.
+    host.innerHTML = fragment;
+    // Hydrate the user component against the now-populated DOM.
+    hydrate(h(User, location), host);
+  }, [fragment, location]);
+
+  if (fragment === null) {
+    return <User {...location} />;
+  }
+  // Stable container. dangerouslySetInnerHTML={{__html: ''}} tells Preact's
+  // outer reconciler not to manage children, so subsequent outer renders
+  // never stomp the inner hydrate root. We mutate innerHTML imperatively
+  // in useLayoutEffect.
+  return (
+    <div
+      ref={hostRef}
+      data-hp-island="true"
+      dangerouslySetInnerHTML={{ __html: '' }}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test page-host
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full iso suite**
+
+```bash
+pnpm --filter @hono-preact/iso test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/iso/src/page-host.tsx packages/iso/src/__tests__/page-host.test.tsx
+git commit -m "feat(iso): PageHost island mode (innerHTML splice + preactHydrate)
+
+When a fragment arrives, render a stable host div with empty
+dangerouslySetInnerHTML so outer reconciliation never touches its
+children. Imperatively assign innerHTML to the fragment and call
+preactHydrate against it with the user component vnode. Loader's
+moduleKey-based id reads its data-loader value from the spliced
+DOM and renders synchronously, no /__loaders fetch."
+```
+
+---
+
+## Task 10: Route wrapper
+
+**Files:**
+- Create: `packages/iso/src/route.tsx`
+- Test: `packages/iso/src/__tests__/route.test.tsx`
+
+Our `Route` component. For `navigate="ssr"`, register the path mode and substitute the user's component with a `PageHost` adapter. For everything else, pass through to `preact-iso`'s `Route`.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/iso/src/__tests__/route.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/preact';
+import { LocationProvider, Router } from 'preact-iso';
+import { Route } from '../route.js';
+import {
+  lookupRouteMode,
+  clearRegistry,
+  setLatestFragment,
+  clearLatestFragment,
+} from '../navigator.js';
+
+beforeEach(() => {
+  clearRegistry();
+  clearLatestFragment();
+  window.history.pushState({}, '', '/');
+});
+afterEach(cleanup);
+
+describe('<Route> wrapper', () => {
+  it('passes through to preact-iso Route when navigate is omitted', async () => {
+    function Page() { return <p data-testid="spa">spa</p>; }
+    window.history.pushState({}, '', '/spa');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/spa" component={Page} />
+        </Router>
+      </LocationProvider>
+    );
+    expect(await screen.findByTestId('spa')).toHaveTextContent('spa');
+    expect(lookupRouteMode('/spa')).toBe('spa');
+  });
+
+  it('registers SSR mode when navigate="ssr"', () => {
+    function Page() { return null; }
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/docs/:slug" component={Page} navigate="ssr" />
+        </Router>
+      </LocationProvider>
+    );
+    expect(lookupRouteMode('/docs/intro')).toBe('ssr');
+  });
+
+  it('substitutes PageHost for SSR routes', async () => {
+    function Page(props: any) {
+      return <p data-testid="spa-render">spa-render slug={props.pathParams.slug}</p>;
+    }
+    window.history.pushState({}, '', '/docs/intro');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/docs/:slug" component={Page} navigate="ssr" />
+        </Router>
+      </LocationProvider>
+    );
+    // Pre-island: same as SPA-mode
+    expect(await screen.findByTestId('spa-render')).toHaveTextContent('spa-render slug=intro');
+
+    // Island: deliver a fragment matching that path pattern
+    setLatestFragment('/docs/:slug', '<p data-testid="island-render">island</p>');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByTestId('island-render')).toHaveTextContent('island');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pnpm --filter @hono-preact/iso test route
+```
+
+Expected: FAIL. `Route` from local module does not exist.
+
+- [ ] **Step 3: Implement the wrapper**
+
+Create `packages/iso/src/route.tsx`:
+
+```tsx
+import type { ComponentType } from 'preact';
+import { Route as PreactIsoRoute, type RouteHook } from 'preact-iso';
+import { PageHost } from './page-host.js';
+import { registerRouteMode, type NavigateMode } from './navigator.js';
+
+export type RouteProps = {
+  path?: string;
+  default?: boolean;
+  component: ComponentType<RouteHook>;
+  navigate?: NavigateMode;
+};
+
+export function Route({ component, navigate, path, ...rest }: RouteProps) {
+  if (navigate === 'ssr' && path) {
+    registerRouteMode(path, 'ssr');
+    const HostedComponent: ComponentType<RouteHook> = (props) => (
+      <PageHost component={component} location={props} path={path} />
+    );
+    HostedComponent.displayName = `SsrRoute(${path})`;
+    return <PreactIsoRoute path={path} component={HostedComponent} {...rest} />;
+  }
+  return <PreactIsoRoute path={path} component={component} {...rest} />;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm --filter @hono-preact/iso test route
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/route.tsx packages/iso/src/__tests__/route.test.tsx
+git commit -m "feat(iso): add Route wrapper with navigate prop
+
+For navigate=\"ssr\" routes: register the path in the navigator's
+mode registry and substitute the user's component with a PageHost
+adapter. Otherwise pass through to preact-iso's Route."
+```
+
+---
+
+## Task 11: Update package exports
+
+**Files:**
+- Modify: `packages/iso/src/index.ts`
+
+Replace the `Route` re-export from `preact-iso` with our wrapper. Add `PageHost`, `navigate` (the public navigator function), and the `NavigateMode` type. Keep `Router` and `lazy` as `preact-iso` re-exports.
+
+- [ ] **Step 1: Edit `packages/iso/src/index.ts`**
+
+Find this block:
+
+```ts
+// Routing primitives: trivial re-exports of preact-iso. Listed here so
+// consumers have a single import surface for everything they need.
+export { Route, Router, lazy } from 'preact-iso';
+```
+
+Replace with:
+
+```ts
+// Routing primitives. Router and lazy are direct re-exports of preact-iso;
+// Route is our wrapper that adds the optional navigate="ssr" prop.
+export { Router, lazy } from 'preact-iso';
+export { Route } from './route.js';
+export type { RouteProps, NavigateMode } from './route.js';
+
+// Programmatic navigation that respects per-route SSR/SPA mode.
+export { navigate } from './navigator.js';
+
+// Hydration island used by SSR routes (also exported so advanced consumers
+// can compose their own routing).
+export { PageHost } from './page-host.js';
+export type { PageHostProps } from './page-host.js';
+```
+
+If `RouteProps` lives only in `route.tsx`, the type re-export above is correct. If `NavigateMode` is defined in `navigator.ts`, change the type re-export source:
+
+```ts
+export type { RouteProps } from './route.js';
+export type { NavigateMode } from './navigator.js';
+```
+
+- [ ] **Step 2: Run the iso build to confirm types compile**
+
+```bash
+pnpm --filter @hono-preact/iso build
+```
+
+Expected: clean build.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+pnpm test
+```
+
+Expected: PASS. Apps/app should still build and pass tests because it imports `Route` from `@hono-preact/iso` and our wrapper is API-compatible (only adds optional `navigate`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/iso/src/index.ts
+git commit -m "refactor(iso): export Route wrapper, PageHost, and navigate
+
+Replace the preact-iso Route re-export with our wrapper that adds the
+optional navigate=\"ssr\" prop. Router and lazy stay as re-exports.
+Also exposes navigate() for programmatic same-mode navigation, and
+PageHost for advanced consumers composing custom routers."
+```
+
+---
+
+## Task 12: End-to-end verification (apply navigate="ssr" to a real route)
+
+**Files:**
+- Modify: `apps/app/src/iso.tsx`
+- Test: `apps/app/src/__tests__/ssr-navigation.test.tsx` (create)
+
+Wire up one SSR route in the app to confirm the whole pipeline. Using `/test` as the candidate (a static page; no nested router complications). The test validates that:
+1. Initial document load of `/test` works as today.
+2. Client-side navigation from `/` to `/test` triggers a fragment fetch (not `/__loaders`), splices HTML, and hydrates the page with no Suspense fallback flicker.
+
+- [ ] **Step 1: Update `apps/app/src/iso.tsx`**
+
+Edit:
+
+```tsx
+<Route path="/test" component={Test} />
+```
+
+to:
+
+```tsx
+<Route path="/test" component={Test} navigate="ssr" />
+```
+
+(`Route` is already imported from `@hono-preact/iso`; nothing else changes.)
+
+- [ ] **Step 2: Build the app and run unit tests**
+
+```bash
+pnpm --filter app build
+pnpm test
+```
+
+Expected: clean build, all tests pass.
+
+- [ ] **Step 3: Manual verification (dev server)**
+
+```bash
+pnpm --filter app dev
+```
+
+Open the app in a browser. Navigate to `/`. Open DevTools Network panel. Click a link to `/test`.
+
+Expected:
+- A request to `/test` with header `X-HP-Navigate: fragment`.
+- The response Content-Type is `application/json`.
+- The response body is `{"events":[{"type":"envelope","html":"...","head":{...}}]}`.
+- No request to `/__loaders` (the test page has no loader anyway, but verify the absence).
+- The page content swaps without a fallback flicker.
+
+For a route with a loader, navigate to `/movies` (still SPA-mode, so it should hit `/__loaders` for now). Then change `<Route path="/movies" component={Movies} />` in `iso.tsx` to `navigate="ssr"`, restart, and verify that `/movies` navigation now uses the fragment endpoint and the loader's serialized data appears in the response HTML's `data-loader` attribute.
+
+After confirming, **revert any speculative `navigate="ssr"` changes you don't want to commit** and keep only the `/test` (or whichever single route you intend to ship in v1) change.
+
+- [ ] **Step 4: Write an integration test**
+
+`apps/app/src/__tests__/ssr-navigation.test.tsx`:
+
+```tsx
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import app from '../server.js';
+
+describe('SSR navigation end-to-end', () => {
+  it('returns a fragment envelope for an SSR-mode route', async () => {
+    const res = await app.request('/test', {
+      headers: { 'X-HP-Navigate': 'fragment' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].type).toBe('envelope');
+    expect(body.events[0].html).not.toContain('hp-page-fragment');
+    expect(body.events[0].html.length).toBeGreaterThan(0);
+    expect(body.events[0].head).toBeDefined();
+  });
+
+  it('returns a full HTML document without the header', async () => {
+    const res = await app.request('/test');
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const text = await res.text();
+    expect(text).toContain('<!doctype html>');
+    expect(text).not.toContain('hp-page-fragment');
+  });
+});
+```
+
+- [ ] **Step 5: Run the integration test**
+
+```bash
+pnpm --filter app test
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/app/src/iso.tsx apps/app/src/__tests__/ssr-navigation.test.tsx
+git commit -m "feat(app): apply navigate=\"ssr\" to /test for end-to-end validation
+
+Wires the SSR navigation pipeline through one real route. Adds an
+integration test that verifies the fragment envelope shape end-to-end
+through the app's server entry."
+```
+
+---
+
+## Self-Review Checklist (run after completing all tasks)
+
+- [ ] All spec acceptance criteria covered:
+  - [ ] No `/__loaders` request on SSR-route navigation (Task 7 + Task 12 manual).
+  - [ ] Exactly one `fetch` to the URL with `X-HP-Navigate: fragment` (Task 7).
+  - [ ] Persistent layout above the route stays mounted (structural; verify in Task 12 manual).
+  - [ ] Server-rendered HTML in the DOM before component code runs (Task 9 island mode).
+  - [ ] Initial document load works unchanged (Task 4 + Task 12 second test).
+  - [ ] SPA-mode routes alongside SSR-mode behave as today (Task 10 first test, Task 11).
+  - [ ] Lazy SSR routes work on first navigation (Task 10 covers this; mode is read from the JSX prop, not the resolved chunk).
+  - [ ] Loader wire id matches across all renders (Task 1).
+  - [ ] Browser back/forward refetches the fragment for SSR routes (Task 7 step 5).
+- [ ] No "TBD"/"TODO"/"placeholder" left in code or tests.
+- [ ] All test commands run cleanly: `pnpm test` and `pnpm --filter app build`.
+- [ ] Spec risks reviewed: nested prerender risk is sidestepped by the sentinel-extraction approach (used in Task 4); `dangerouslySetInnerHTML` outer-rerender stomping is mitigated by stable `__html=''` in Task 9.
+
+---
+
+**Plan complete.** Two execution options:
+
+1. **Subagent-Driven (recommended)**: dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution**: execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-06-ssr-navigation-mode-design.md
+++ b/docs/superpowers/specs/2026-05-06-ssr-navigation-mode-design.md
@@ -1,0 +1,265 @@
+# SSR Navigation Mode: Per-Route HTML Navigation
+
+**Date:** 2026-05-06
+**Status:** Draft
+
+## Problem
+
+Today, every client-side navigation to a route with a server loader posts JSON to `/__loaders` (via the Vite stub at `packages/vite/src/server-only.ts`). The route then renders on the client. This is fine for app-shell pages, but it has structural drawbacks for content-heavy routes:
+
+- **Two round trips of work for the same data.** The server already has a render path that can produce HTML; the client fetches data, then renders the same component a second time.
+- **Suspense fallback flicker on every navigation.** The loader fires after mount, so the new route paints with its `fallback` until JSON arrives.
+- **No HTML-first navigation option.** Authors can drop out of the SPA by using a real `<a target="_self">`, but that tears down the whole app and re-hydrates from scratch, losing any persistent layout state.
+
+We want a per-route opt-in that keeps the SPA shell mounted, fetches a server-rendered HTML fragment for the page, and hydrates it as an island. Loaders still run, but on the server during the same fragment render, and their data rides along in the response so the client never makes a separate `/__loaders` call for that navigation.
+
+## Goal
+
+A `<Route>` element can declare `navigate="ssr"`. When set, client-side navigations to that route fetch an HTML fragment from the same URL (with an `X-HP-Navigate: fragment` header), splice the HTML into a stable mount point, and hydrate the page as a Preact island. The persistent layout above the route stays mounted. Loader data is preloaded via the existing DOM-based preload channel, so the hydrated tree renders synchronously without firing `/__loaders`.
+
+`navigate` defaults to `'spa'`. SPA-mode behavior is unchanged.
+
+We are explicitly **not** doing islands-style code-splitting (page component code still ships to the client to support hydration). We are also not committing to streaming in v1; we leave the wire format forward-compatible for a future streaming pass.
+
+## Target Shape
+
+### Authoring
+
+```tsx
+// iso.tsx
+import { Route, Router, lazy } from '@hono-preact/iso';
+
+const Home = lazy(() => import('./pages/home.js'));
+const Docs = lazy(() => import('./pages/docs.js'));
+
+<Router>
+  <Route path="/" component={Home} />                              {/* SPA, today's behavior */}
+  <Route path="/docs/*" component={Docs} navigate="ssr" />         {/* SSR-mode */}
+</Router>
+```
+
+`definePage` is unchanged; mode is purely a routing-layer concern. `Route` becomes a thin wrapper from `@hono-preact/iso` (rather than a direct re-export of `preact-iso`'s `Route`). `Router` and `lazy` continue to re-export `preact-iso`'s primitives unchanged. The wrapper adds ~30 LOC of custom code, far less than the 243 LOC of routing machinery removed in commit `4239bab`.
+
+### Server response (fragment mode)
+
+For an `'ssr'` route navigation, the same URL the route already serves returns a JSON envelope when the request carries `X-HP-Navigate: fragment`:
+
+```jsonc
+{
+  "events": [
+    {
+      "type": "envelope",
+      "html": "<...rendered <Page> subtree, including <section id='loader-${moduleKey}' data-loader='...'>...</section>...>",
+      "head": { "title": "...", "metas": [...], "links": [...] }
+    }
+  ]
+}
+```
+
+The envelope is wrapped in an `events` array even in v1 (single event). This is the degenerate-stream form of the future streaming protocol; the client's apply logic dispatches by `type` from day one, so phase 2 streaming adds events without rewriting the client.
+
+Loader data is **not** carried separately in the envelope. The server's Envelope component already renders `data-loader={JSON.stringify(data)}` onto the wrapper element. With moduleKey-based ids (see "Loader id and hydration handoff" below), the spliced HTML self-encodes loader data at the matching DOM id, and the client's existing DOM-based preload channel resolves it synchronously during hydrate. Phase 2's deferred loaders arrive as separate `{type: 'loader-fill'}` events that imperatively write `data-loader` onto the already-spliced wrapper.
+
+`GuardRedirect` thrown during fragment render produces `{"events":[{"type":"redirect","location":"/login"}]}` rather than HTTP 302, since `fetch` follows redirects transparently and would break the envelope shape.
+
+Other 4xx/5xx responses fall back to a hard navigation (`location.assign(url)`) on the client.
+
+## Architecture
+
+### Components
+
+**`Route`** (new thin wrapper, `packages/iso/src/route.tsx`)
+
+```tsx
+export type NavigateMode = 'spa' | 'ssr';
+
+export type RouteProps<P = unknown> = {
+  path?: string;
+  default?: boolean;
+  component: ComponentType<P>;
+  navigate?: NavigateMode;
+};
+
+export function Route<P>({ component, navigate, path, ...rest }: RouteProps<P>) {
+  if (navigate === 'ssr' && path) {
+    registerRouteMode(path, 'ssr');
+    const HostedComponent = (loc: P) => (
+      <PageHost component={component} location={loc} />
+    );
+    return <PreactIsoRoute path={path} component={HostedComponent} {...rest} />;
+  }
+  return <PreactIsoRoute path={path} component={component} {...rest} />;
+}
+```
+
+The wrapper:
+- registers the path → mode in a module-level registry on render (idempotent for stable path/navigate),
+- substitutes `component` with a `PageHost` adapter when `navigate === 'ssr'`,
+- passes through to `preact-iso`'s `Route` otherwise.
+
+`Router` (re-exported from `preact-iso`) walks children and reads `vnode.props.path`/`vnode.props.default`/`vnode.props.component` exactly as today. Our `Route` wrapper sets the same prop shape, so `Router` matches and renders without modification.
+
+**`PageHost`** (new, `packages/iso/src/page-host.tsx`)
+
+The hydrate island for SSR-mode routes. Renders in one of two modes:
+
+1. **Pre-island mode** (initial paint, and any time before the first SSR fragment arrives for this host): renders `<Component {...location} />` directly. The server-rendered initial document hydrates through this code path with no special handling. Equivalent to what `preact-iso`'s `Route` would have rendered without our wrapper.
+2. **Island mode** (after the first client-side SSR navigation lands): renders `<div ref dangerouslySetInnerHTML={{ __html: lastHtml }} />`. The outer Preact tree commits the div with stable `__html` and never touches its children. A separate hydrate root is attached to that div via `preactHydrate(<Component {...location} />, hostDiv)`.
+
+`PageHost` subscribes to the navigator (see below) for new fragments. On each fragment it transitions to island mode (if not already), updates `lastHtml` imperatively (setting `hostDiv.innerHTML = html` directly to bypass Preact diff), and re-runs `preactHydrate` against the new DOM with a fresh component vnode.
+
+Cross-route SSR-to-SSR navigations unmount the old `PageHost` (different `<Route>` matches) and mount a new one. The new `PageHost` starts in pre-island mode and immediately transitions to island mode because the navigator already has the fragment.
+
+**`Navigator`** (new, `packages/iso/src/navigator.ts`)
+
+A single module that owns SSR-mode navigation:
+
+- Maintains the path-mode registry (`registerRouteMode(path, mode)` / `lookupRouteMode(url)`).
+- Maintains a single in-flight `AbortController`.
+- Installs a capture-phase document `click` listener at module load. The listener replicates `preact-iso`'s exclusion rules (modifier keys, `target=_blank`, cross-origin, `download` attribute) and bails out unless the link's URL matches a registered SSR route.
+- For SSR clicks: `preventDefault`; abort any in-flight; fetch URL with `X-HP-Navigate: fragment`; on response, dispatch the events:
+  - `envelope`: apply `head` patch; hand `html` to the matching `PageHost` (subscribers indexed by path); navigate via `useLocation().route(url)` so `LocationProvider`'s reducer updates URL state and history.
+  - `redirect`: re-enter `navigator.navigate(location)` (recursive, with the redirect target).
+  - any unrecognized type or non-2xx HTTP: fall back to `location.assign(url)`.
+- Exposes a `navigate(url)` for programmatic callers (guards, action handlers) so they get the same SPA-vs-SSR treatment as click-driven navigation.
+
+**Server fragment renderer** (extended, `packages/server/src/render.tsx`)
+
+- `renderPage(c, node, options?)` gains an optional `mode: 'document' | 'fragment'` (default `'document'`).
+- In `'fragment'` mode, the existing prerender pipeline runs to capture head tags via the same hoofd dispatcher and to run loaders via the same `runRequestScope` (imported from `@hono-preact/iso/internal`, as today).
+- The user's `<App>` tree is rendered as today; the `<Page>` component participates by capturing its own subtree to a request-scoped side channel (see "Page subtree capture" below) and rendering nothing into the outer string.
+- The outer HTML string is discarded; only the captured subtree string + dispatcher state ship. Loader values do not need separate serialization because they are already inlined as `data-loader` attributes on the captured subtree's wrapper elements.
+
+### Data flow: SSR-mode click
+
+```
+  user click on <a href="/docs/bar">
+        |
+        v
+  capture-phase click listener (installed by navigator)
+        |
+        +-- registry lookup: /docs/bar -> 'ssr'
+        |
+        v
+  preventDefault; navigator.navigate('/docs/bar')
+        |
+        +-- abort previous in-flight, if any
+        +-- fetch('/docs/bar', { headers: { 'X-HP-Navigate': 'fragment' } })
+        |
+        v
+  server route handler (existing app.get('*'))
+        +-- detects header; calls renderPage(c, <Layout/>, { mode: 'fragment' })
+        +-- prerender(<Layout/>) under runRequestScope
+              +-- <Page> for matched route runs its loader; Envelope renders
+                  the wrapper with id="loader-${moduleKey}" and data-loader=JSON
+              +-- captured HTML for the page subtree includes that wrapper
+              +-- envelope.head from hoofd dispatcher
+        |
+        v
+  client receives envelope
+        +-- for each event:
+              +-- 'envelope':
+                    apply head patch (title, metas, links)
+                    pushState(url); poke LocationProvider
+                    notify PageHost subscribed to /docs/* with the html
+        |
+        v
+  PageHost transitions to (or stays in) island mode
+        +-- imperatively set hostDiv.innerHTML = html
+        +-- preactHydrate(<Component {...location} />, hostDiv)
+              +-- Loader reads preloaded data from DOM, no /__loaders fetch
+              +-- hydration matches DOM, no fallback flicker
+```
+
+### Page subtree capture
+
+The fragment endpoint needs to extract the `<Page>` subtree's HTML from a render of the full `<Layout>` tree, without parsing the resulting HTML string. Approach: side-channel render.
+
+- `<Page>` reads a request-scoped flag (set by `renderPage` when `mode === 'fragment'`).
+- When the flag is set, `<Page>` runs `prerender` on its own children (a nested prerender), captures the result string to a request-scoped slot, and renders nothing into the outer tree.
+- The outer prerender continues so loaders still execute via `runRequestScope` and head tags accumulate via the shared hoofd dispatcher.
+- After the outer prerender completes, `renderPage` reads the captured string and dispatcher state, builds the envelope, and returns.
+
+Risk: the inner `prerender` shares the outer `HoofdProvider` only if the dispatcher is provided via context to both renders. Today `renderPage` wraps the render in `<HoofdProvider value={dispatcher}>`. The inner prerender of `<Page>`'s children inherits the outer context through the React-style context chain even across nested `prerender` calls (preact-iso's `prerender` re-uses the realm-wide context registry).
+
+If nested `prerender` turns out to interact poorly with shared loader scope or hoofd dispatcher, fall back to sentinel comments around `<Page>`'s output (`<!--hp:page-start-->...<!--hp:page-end-->`) and string-extract between them. The side-channel approach is preferred.
+
+### Loader id and hydration handoff
+
+The existing preload channel works through the DOM: `getPreloadedData(id)` (now exported from `@hono-preact/iso/internal`) reads `document.getElementById(id).dataset.loader`. The id is currently produced by `useId()` in `Loader`, propagated via `LoaderIdContext`, and rendered by `Envelope` onto the wrapper element.
+
+`useId()` is tree-position-based. Server-side fragment render places `<Page>` deep inside `<Layout>`; client-side island hydrate places `<Page>` at the root of a fresh `preactHydrate` call. Tree positions differ, so `useId()` produces different ids. The DOM lookup would fail, and Preact's hydrate would also report a mismatch on the wrapper's `id` attribute.
+
+**Resolution:** switch the Loader/Envelope id source from `useId()` to a moduleKey-derived id.
+
+- `LoaderRef.__id` is `Symbol.for('@hono-preact/loader:${moduleKey}')` (set by `defineLoader`).
+- `Loader` derives a stable wire id from `loaderRef.__id.description` (e.g., `loader-${moduleKey}`).
+- `Envelope` consumes `LoaderIdContext` as today; the value is the moduleKey-derived id rather than `useId()`.
+- `getPreloadedData` and `deletePreloadedData` are unchanged in shape (they still take a string id).
+
+This change applies to pages with a loader. Pages without a loader use `NoLoaderFrame`, which still uses `useId()` (no preload channel needed, no cross-render id stability requirement).
+
+The same module ID is the routing key for `/__loaders`, the cache identity for `cacheRegistry`, and now the wire/DOM identifier for preload. One stable identifier across the whole stack.
+
+A direct consequence: the envelope JSON does not need to carry loader values separately. The server's render of `<Page>` produces HTML that already contains `<wrapper id="loader-${moduleKey}" data-loader="...">...</wrapper>`. Splice the HTML, run `preactHydrate`, and `Loader`'s synchronous `getPreloadedData` finds the data on the just-spliced wrapper. No separate write-side preload API is needed.
+
+### Lazy components
+
+Because `navigate` is read off the `<Route>` JSX prop (not the resolved component), lazy components present no cold-start problem. The path-mode registry is populated on first render of `<Route>` regardless of whether the lazy chunk has resolved. The page chunk still has to load on first navigation, but that is the existing lazy cost; no additional latency is added by SSR mode.
+
+### Forward compatibility for streaming
+
+Three v1 commitments preserve a streaming path:
+
+1. **Versioned navigate header.** `X-HP-Navigate: fragment` is v1. A future `X-HP-Navigate: fragment-stream` opts into a streaming response. Old clients keep working.
+2. **Envelope wrapped in `events`.** The single-event JSON above is the degenerate stream. Phase 2 emits multiple events (NDJSON or chunked transfer) without changing the client's dispatch shape.
+3. **Stable moduleKey ids in the wire.** Phase 2's deferred-loader fills (`{type: 'loader-fill', moduleKey, key, data}`) write `data-loader` onto the already-spliced wrapper element by id. The id is the addressing primitive.
+
+Phase 2 (deferred loaders) and phase 3 (streaming HTML + selective hydration) are explicit non-goals for v1. See "Out of scope" below.
+
+## Edge Cases
+
+- **Initial document load.** Handled by pre-island mode in `PageHost`. The full document hydrates through the existing pipeline with no special path. Island mode flips on after the first client-side SSR navigation lands.
+- **Programmatic navigation.** `useLocation().route(url)` callers go through `navigator.navigate()` to get the same SPA-vs-SSR treatment as click-driven navigation. The navigator's `navigate(url)` either dispatches the fragment fetch (SSR) or delegates to `preact-iso`'s `route()` (SPA).
+- **Browser back / forward.** v1 refetches the fragment on `popstate` for SSR routes. A small `Map<url, envelope>` LRU cache is a phase 2 optimization; not in v1.
+- **Same-route URL change** (e.g. `/docs/foo` → `/docs/bar`, both matching `/docs/*`). `PageHost` stays mounted, receives a new envelope, updates innerHTML imperatively, re-runs `preactHydrate` against the new DOM and a fresh component vnode.
+- **SSR → SPA-mode navigation** (cross-route). Different `<Route>` matches → different host. `PageHost` unmounts, plain component mounts. Standard Preact reconciliation.
+- **SPA → SSR-mode navigation** (cross-route). Symmetric: plain component unmounts, `PageHost` mounts. The new `PageHost` starts in pre-island mode and immediately transitions to island mode after the navigator delivers the fragment.
+- **Forms and actions.** `defineAction` posts to `/__actions` regardless of navigate mode; nothing about that flow couples to SPA-vs-SSR.
+- **Prefetch.** `prefetch()` today warms loader caches over JSON. Phase 2 extension warms fragment envelopes for SSR routes. v1 leaves `prefetch()` SPA-only and documents the gap.
+- **Redirects mid-fragment.** Server emits a `{type: 'redirect'}` event in the envelope. Navigator re-enters `navigate()` with the redirect target, applying the same SPA-vs-SSR logic.
+- **Errors mid-fragment.** Non-2xx response: client falls back to a hard `location.assign(url)` so the user still ends up where they expected, just via a full document load.
+- **Modifier keys, target=_blank, cross-origin.** The capture-phase listener honors the same exclusion rules as `preact-iso`'s `handleNav`: anything that would normally bypass SPA routing also bypasses SSR routing. Source-of-truth helper lives in the navigator.
+- **Hoofd reconciliation.** The envelope's `head` is applied imperatively before hydrate. Hoofd hooks inside the hydrating tree re-register on mount; hoofd's reconciliation should converge without flicker. Worth a focused test; if it double-applies, gate the imperative step on first paint and let hoofd own subsequent updates.
+- **`dangerouslySetInnerHTML` isolation.** `PageHost` relies on Preact respecting `__html` as a "do not touch children" contract on subsequent rerenders of the outer tree. This is current Preact behavior; a regression test pins it. We must never re-render the outer div with a changed `__html` prop during island mode (we mutate `innerHTML` imperatively instead).
+
+## Out of Scope (v1)
+
+- Deferred loader resolution (`defer`-style API on `defineLoader`). Phase 2.
+- Streaming HTML response with selective per-boundary hydration. Phase 3.
+- Islands-architecture code-splitting (omitting page component code from the client bundle).
+- Fragment cache for back/forward. Phase 2 if measurements warrant.
+- `prefetch()` support for SSR routes. Phase 2.
+- Build-time mode manifest. Not needed because mode lives on `<Route>`, not the lazy page.
+- `<a data-no-spa>` or other per-link overrides. Routes own the mode.
+- Route-level mode override on a per-mount basis where the same component appears under multiple `<Route>` declarations. Authors set `navigate` per route declaration; if they want one component in two modes they put it under two `<Route>` declarations.
+
+## Risks and Open Questions
+
+- **Public surface placement.** `Loader`, `Envelope`, `getPreloadedData`/`deletePreloadedData`, `runRequestScope`, and the context objects are now `@hono-preact/iso/internal`. Our changes touch some of those (Loader's id source, Envelope's id propagation), but only as in-package edits. The new authoring/runtime API surface (`Route` wrapper, `PageHost`, `Navigator`) belongs on the main entrypoint alongside `Page`/`definePage`, not in `internal`.
+- **Nested `prerender`.** Whether running `prerender` on `<Page>`'s children inside an outer `prerender` cleanly shares the hoofd dispatcher and request scope. If not, fall back to sentinel-extraction. This is the most important pre-implementation question.
+- **Outer rerender stomping the island.** Preact's `dangerouslySetInnerHTML` semantics around stable `__html` need a regression test. Mitigation in design: never re-render `PageHost`'s outer div with a new `__html` value during island mode (mutate `innerHTML` imperatively).
+- **History coordination with preact-iso.** `LocationProvider` listens to `popstate` and to `click` events. Pushing state programmatically without going through `LocationProvider`'s reducer means its `url` state can get out of sync. Concretely, `LocationProvider`'s `route(url)` API is the right entry point: calling it dispatches into the reducer, which updates the location and (for a `pushState` path) updates history. The navigator should call `useLocation().route(url)` rather than touching `history.pushState` directly.
+- **moduleKey collisions.** Two loaders sharing a moduleKey would produce the same wire id. The Vite plugin derives moduleKey from the file path, so collisions can only occur if two `defineLoader` calls live in the same file (currently allowed but unusual). Add a dev-mode warning if a moduleKey is registered twice.
+- **Pages without loaders in SSR mode.** Still meaningful: server returns rendered HTML, client splices and hydrates. No preload data on the wrapper, no DOM lookup at hydrate time. `PageHost` works the same way; `useId()`-based ids inside `NoLoaderFrame` differ between server and client, but they aren't used for any cross-render lookup.
+
+## Acceptance Criteria
+
+- A route declared `navigate="ssr"` and mounting a page with a loader, when navigated to client-side via an `<a>` click, produces no `/__loaders` request.
+- The same navigation produces exactly one `fetch` to the route URL with `X-HP-Navigate: fragment`.
+- The persistent layout above the route stays mounted across the navigation (no remount of `DocsLayout` or equivalent).
+- Server-rendered HTML appears in the DOM before the page's component code runs on the client (verifiable via DevTools Performance timeline or a probe).
+- Initial document load of the same route works unchanged: full document SSR, normal hydration, no double-render.
+- A SPA-mode route mounted alongside SSR-mode routes behaves exactly as it does today.
+- Lazy `<Route>` components configured `navigate="ssr"` work on first navigation (no cold-start fallback to SPA).
+- A loader's wire id matches across server fragment render, client document hydrate, and client island hydrate. The DOM-based preload channel resolves loader data synchronously in all three.

--- a/packages/iso/src/__tests__/fragment-mode.test.tsx
+++ b/packages/iso/src/__tests__/fragment-mode.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/preact';
+import { useContext } from 'preact/hooks';
+import { FragmentModeContext } from '../fragment-mode.js';
+
+describe('FragmentModeContext', () => {
+  it('defaults to false', () => {
+    let observed: boolean | undefined;
+    function Probe() {
+      observed = useContext(FragmentModeContext);
+      return null;
+    }
+    render(<Probe />);
+    expect(observed).toBe(false);
+  });
+
+  it('reads true when wrapped in a provider with value=true', () => {
+    let observed: boolean | undefined;
+    function Probe() {
+      observed = useContext(FragmentModeContext);
+      return null;
+    }
+    render(
+      <FragmentModeContext.Provider value={true}>
+        <Probe />
+      </FragmentModeContext.Provider>
+    );
+    expect(observed).toBe(true);
+  });
+});

--- a/packages/iso/src/__tests__/loader.test.tsx
+++ b/packages/iso/src/__tests__/loader.test.tsx
@@ -5,6 +5,7 @@ import { useState } from 'preact/hooks';
 import { LocationProvider, type RouteHook } from 'preact-iso';
 import { defineLoader } from '../define-loader.js';
 import { Loader } from '../loader.js';
+import { Envelope } from '../envelope.js';
 import { useLoaderData } from '../use-loader-data.js';
 import { useReload } from '../reload-context.js';
 import { env } from '../is-browser.js';
@@ -267,6 +268,22 @@ describe('v3 <Loader> stability', () => {
     });
 
     await screen.findByText('reloaded');
+  });
+
+  it('derives the preload-channel id from loaderRef moduleKey, not useId', async () => {
+    const ref = defineLoader<{ ok: true }>(async () => ({ ok: true }), {
+      __moduleKey: 'src/pages/movies',
+    });
+    const { container } = render(
+      <Loader loader={ref} location={loc}>
+        <Envelope as="section">child</Envelope>
+      </Loader>
+    );
+    // Wait one tick for Suspense to resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    const wrapper = container.querySelector('section');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.id).toBe('loader-src-pages-movies');
   });
 
   it('refetches when searchParams change even though path is stable', async () => {

--- a/packages/iso/src/__tests__/loader.test.tsx
+++ b/packages/iso/src/__tests__/loader.test.tsx
@@ -286,6 +286,19 @@ describe('v3 <Loader> stability', () => {
     expect(wrapper!.id).toBe('loader-src-pages-movies');
   });
 
+  it('falls back to "loader-unkeyed" when defineLoader is called without a moduleKey', async () => {
+    const ref = defineLoader<{ ok: true }>(async () => ({ ok: true }));
+    const { container } = render(
+      <Loader loader={ref} location={loc}>
+        <Envelope as="section">child</Envelope>
+      </Loader>
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    const wrapper = container.querySelector('section');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.id).toBe('loader-unkeyed');
+  });
+
   it('refetches when searchParams change even though path is stable', async () => {
     const fn = vi.fn(({ location }: { location: RouteHook }) =>
       Promise.resolve({ q: location.searchParams.q ?? '' })

--- a/packages/iso/src/__tests__/navigator.test.ts
+++ b/packages/iso/src/__tests__/navigator.test.ts
@@ -105,6 +105,36 @@ describe('navigator click interceptor', () => {
     expect(ev.defaultPrevented).toBe(false);
     expect(navigateSpy).not.toHaveBeenCalled();
   });
+
+  it('does not push history state on click-intercepted navigation (preact-iso handles it)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        events: [{ type: 'envelope', html: '<p>x</p>', head: {} }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const pushSpy = vi.spyOn(history, 'pushState');
+    registerRouteMode('/docs/:slug', 'ssr');
+
+    // Simulate click via the real interceptor (drop testingNavigate so the real navigate runs).
+    __setNavigateForTesting(null);
+    const a = document.createElement('a');
+    a.href = window.location.origin + '/docs/intro';
+    document.body.appendChild(a);
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    a.dispatchEvent(ev);
+    a.remove();
+
+    // Wait for the navigate promise to settle.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+    pushSpy.mockRestore();
+    // Restore testingNavigate so afterEach works cleanly.
+    __setNavigateForTesting(navigateSpy as unknown as (url: string) => void);
+  });
 });
 
 describe('navigator fragment buffer + subscription', () => {
@@ -135,9 +165,13 @@ describe('navigator fragment buffer + subscription', () => {
 });
 
 describe('navigator.navigate()', () => {
+  const ORIGINAL_LOCATION = window.location;
   beforeEach(() => {
     clearRegistry();
     clearLatestFragment();
+  });
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: ORIGINAL_LOCATION, writable: true });
   });
 
   it('fetches URL with X-HP-Navigate: fragment and applies envelope', async () => {
@@ -146,7 +180,7 @@ describe('navigator.navigate()', () => {
         events: [{
           type: 'envelope',
           html: '<section id="loader-foo" data-loader="{}">x</section>',
-          head: { title: 'Doc', metas: [], links: [] },
+          head: { title: 'Doc' },
         }],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } })
     );
@@ -191,7 +225,7 @@ describe('navigator.navigate()', () => {
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       return new Response(JSON.stringify({
-        events: [{ type: 'envelope', html: '<p>login</p>', head: { title: 'Login', metas: [], links: [] } }],
+        events: [{ type: 'envelope', html: '<p>login</p>', head: { title: 'Login' } }],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     });
     registerRouteMode('/docs/:slug', 'ssr');
@@ -206,6 +240,11 @@ describe('navigator.navigate()', () => {
 });
 
 describe('navigator popstate handling', () => {
+  const ORIGINAL_LOCATION = window.location;
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: ORIGINAL_LOCATION, writable: true });
+  });
+
   it('refetches the fragment on popstate for SSR routes without pushing state', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({

--- a/packages/iso/src/__tests__/navigator.test.ts
+++ b/packages/iso/src/__tests__/navigator.test.ts
@@ -46,7 +46,7 @@ describe('navigator click interceptor', () => {
   beforeEach(() => {
     clearRegistry();
     navigateSpy = vi.fn();
-    __setNavigateForTesting(navigateSpy);
+    __setNavigateForTesting(navigateSpy as unknown as (url: string) => void);
     installClickInterceptor();
   });
   afterEach(() => {
@@ -183,7 +183,7 @@ describe('navigator.navigate()', () => {
 
   it('follows redirect events to a new navigate call', async () => {
     let calls = 0;
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
       calls++;
       if (calls === 1) {
         return new Response(JSON.stringify({

--- a/packages/iso/src/__tests__/navigator.test.ts
+++ b/packages/iso/src/__tests__/navigator.test.ts
@@ -10,6 +10,7 @@ import {
   installClickInterceptor,
   uninstallClickInterceptor,
   __setNavigateForTesting,
+  navigate,
 } from '../navigator.js';
 
 beforeEach(() => {
@@ -130,5 +131,105 @@ describe('navigator fragment buffer + subscription', () => {
     setLatestFragment('/blog/*', 'X');
     expect(seen).toEqual([]);
     unsub();
+  });
+});
+
+describe('navigator.navigate()', () => {
+  beforeEach(() => {
+    clearRegistry();
+    clearLatestFragment();
+  });
+
+  it('fetches URL with X-HP-Navigate: fragment and applies envelope', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        events: [{
+          type: 'envelope',
+          html: '<section id="loader-foo" data-loader="{}">x</section>',
+          head: { title: 'Doc', metas: [], links: [] },
+        }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    registerRouteMode('/docs/:slug', 'ssr');
+
+    const seen: string[] = [];
+    subscribeToFragment('/docs/:slug', (h) => seen.push(h));
+
+    await navigate('/docs/intro');
+
+    expect(fetchSpy).toHaveBeenCalledWith('/docs/intro', expect.objectContaining({
+      headers: expect.objectContaining({ 'X-HP-Navigate': 'fragment' }),
+    }));
+    expect(seen).toEqual(['<section id="loader-foo" data-loader="{}">x</section>']);
+    expect(document.title).toBe('Doc');
+
+    fetchSpy.mockRestore();
+  });
+
+  it('falls back to location.assign on non-2xx response', async () => {
+    const assignSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, assign: assignSpy, origin: window.location.origin },
+      writable: true,
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('boom', { status: 500 })
+    );
+    registerRouteMode('/docs/*', 'ssr');
+    await navigate('/docs/x');
+    expect(assignSpy).toHaveBeenCalledWith('/docs/x');
+    vi.restoreAllMocks();
+  });
+
+  it('follows redirect events to a new navigate call', async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      calls++;
+      if (calls === 1) {
+        return new Response(JSON.stringify({
+          events: [{ type: 'redirect', location: '/login' }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({
+        events: [{ type: 'envelope', html: '<p>login</p>', head: { title: 'Login', metas: [], links: [] } }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    registerRouteMode('/docs/:slug', 'ssr');
+    registerRouteMode('/login', 'ssr');
+    const seen: string[] = [];
+    subscribeToFragment('/login', (h) => seen.push(h));
+    await navigate('/docs/secret');
+    expect(calls).toBe(2);
+    expect(seen).toEqual(['<p>login</p>']);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('navigator popstate handling', () => {
+  it('refetches the fragment on popstate for SSR routes without pushing state', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        events: [{ type: 'envelope', html: '<p>back</p>', head: {} }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const pushSpy = vi.spyOn(history, 'pushState');
+    registerRouteMode('/docs/*', 'ssr');
+    const seen: string[] = [];
+    subscribeToFragment('/docs/*', (h) => seen.push(h));
+
+    // Simulate browser back/forward to /docs/old.
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, pathname: '/docs/old', search: '' },
+      writable: true,
+    });
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetchSpy).toHaveBeenCalledWith('/docs/old', expect.anything());
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(seen).toEqual(['<p>back</p>']);
+
+    fetchSpy.mockRestore();
+    pushSpy.mockRestore();
   });
 });

--- a/packages/iso/src/__tests__/navigator.test.ts
+++ b/packages/iso/src/__tests__/navigator.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerRouteMode,
+  lookupRouteMode,
+  clearRegistry,
+  setLatestFragment,
+  subscribeToFragment,
+  clearLatestFragment,
+} from '../navigator.js';
+
+beforeEach(() => {
+  clearRegistry();
+  clearLatestFragment();
+});
+
+describe('navigator route mode registry', () => {
+  it('returns "spa" for unregistered paths', () => {
+    expect(lookupRouteMode('/anything')).toBe('spa');
+  });
+
+  it('returns "ssr" for an exact registered path', () => {
+    registerRouteMode('/docs', 'ssr');
+    expect(lookupRouteMode('/docs')).toBe('ssr');
+  });
+
+  it('matches preact-iso path patterns with parameters', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    expect(lookupRouteMode('/docs/intro')).toBe('ssr');
+    expect(lookupRouteMode('/blog/x')).toBe('spa');
+  });
+
+  it('matches /docs/* rest patterns', () => {
+    registerRouteMode('/docs/*', 'ssr');
+    expect(lookupRouteMode('/docs/a')).toBe('ssr');
+    expect(lookupRouteMode('/docs/a/b/c')).toBe('ssr');
+  });
+});
+
+describe('navigator fragment buffer + subscription', () => {
+  it('delivers the latest fragment to a new subscriber for that path', () => {
+    setLatestFragment('/docs/*', '<section>hi</section>');
+    let received: string | null = null;
+    const unsub = subscribeToFragment('/docs/*', (html) => { received = html; });
+    expect(received).toBe('<section>hi</section>');
+    unsub();
+  });
+
+  it('notifies all current subscribers when a new fragment arrives', () => {
+    const seen: string[] = [];
+    const unsub = subscribeToFragment('/docs/*', (html) => seen.push(html));
+    setLatestFragment('/docs/*', 'A');
+    setLatestFragment('/docs/*', 'B');
+    expect(seen).toEqual(['A', 'B']);
+    unsub();
+  });
+
+  it('does not deliver fragments for other paths', () => {
+    const seen: string[] = [];
+    const unsub = subscribeToFragment('/docs/*', (h) => seen.push(h));
+    setLatestFragment('/blog/*', 'X');
+    expect(seen).toEqual([]);
+    unsub();
+  });
+});

--- a/packages/iso/src/__tests__/navigator.test.ts
+++ b/packages/iso/src/__tests__/navigator.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   registerRouteMode,
   lookupRouteMode,
@@ -7,6 +7,9 @@ import {
   setLatestFragment,
   subscribeToFragment,
   clearLatestFragment,
+  installClickInterceptor,
+  uninstallClickInterceptor,
+  __setNavigateForTesting,
 } from '../navigator.js';
 
 beforeEach(() => {
@@ -34,6 +37,72 @@ describe('navigator route mode registry', () => {
     registerRouteMode('/docs/*', 'ssr');
     expect(lookupRouteMode('/docs/a')).toBe('ssr');
     expect(lookupRouteMode('/docs/a/b/c')).toBe('ssr');
+  });
+});
+
+describe('navigator click interceptor', () => {
+  let navigateSpy: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    clearRegistry();
+    navigateSpy = vi.fn();
+    __setNavigateForTesting(navigateSpy);
+    installClickInterceptor();
+  });
+  afterEach(() => {
+    uninstallClickInterceptor();
+    __setNavigateForTesting(null);
+  });
+
+  function clickAnchor(href: string, init?: Partial<MouseEventInit>): MouseEvent {
+    const a = document.createElement('a');
+    a.href = href;
+    document.body.appendChild(a);
+    const ev = new MouseEvent('click', {
+      bubbles: true, cancelable: true, button: 0, ...init,
+    });
+    a.dispatchEvent(ev);
+    a.remove();
+    return ev;
+  }
+
+  it('intercepts SSR-route same-origin plain clicks', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const ev = clickAnchor(window.location.origin + '/docs/intro');
+    expect(ev.defaultPrevented).toBe(true);
+    expect(navigateSpy).toHaveBeenCalledWith('/docs/intro');
+  });
+
+  it('does not intercept SPA-route clicks', () => {
+    const ev = clickAnchor(window.location.origin + '/profile');
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept clicks with modifier keys', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const ev = clickAnchor(window.location.origin + '/docs/intro', { metaKey: true });
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept cross-origin clicks', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const ev = clickAnchor('https://example.com/docs/intro');
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not intercept target=_blank', () => {
+    registerRouteMode('/docs/:slug', 'ssr');
+    const a = document.createElement('a');
+    a.href = window.location.origin + '/docs/intro';
+    a.target = '_blank';
+    document.body.appendChild(a);
+    const ev = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    a.dispatchEvent(ev);
+    a.remove();
+    expect(ev.defaultPrevented).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/iso/src/__tests__/page-host.test.tsx
+++ b/packages/iso/src/__tests__/page-host.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/preact';
+import { LocationProvider, type RouteHook } from 'preact-iso';
+import { PageHost } from '../page-host.js';
+
+afterEach(cleanup);
+
+const loc = { path: '/docs/x', url: '/docs/x', searchParams: {}, pathParams: { slug: 'x' } } as RouteHook;
+
+describe('PageHost (pre-island)', () => {
+  it('renders the user component with location prop', () => {
+    function User(props: RouteHook) {
+      return <p data-testid="page">slug={props.pathParams!.slug}</p>;
+    }
+    render(
+      <LocationProvider>
+        <PageHost component={User} location={loc} path="/docs/:slug" />
+      </LocationProvider>
+    );
+    expect(screen.getByTestId('page')).toHaveTextContent('slug=x');
+  });
+});

--- a/packages/iso/src/__tests__/page-host.test.tsx
+++ b/packages/iso/src/__tests__/page-host.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/preact';
 import { LocationProvider, type RouteHook } from 'preact-iso';
 import { PageHost } from '../page-host.js';
+import { setLatestFragment, clearLatestFragment } from '../navigator.js';
 
 afterEach(cleanup);
 
@@ -19,5 +20,30 @@ describe('PageHost (pre-island)', () => {
       </LocationProvider>
     );
     expect(screen.getByTestId('page')).toHaveTextContent('slug=x');
+  });
+});
+
+describe('PageHost (island mode)', () => {
+  beforeEach(() => clearLatestFragment());
+
+  it('splices fragment HTML and hydrates the user component into the host div', async () => {
+    function User(props: RouteHook) {
+      return <p data-testid="island">island slug={props.pathParams!.slug}</p>;
+    }
+    const { container } = render(
+      <LocationProvider>
+        <PageHost component={User} location={loc} path="/docs/:slug" />
+      </LocationProvider>
+    );
+    // Server-rendered fragment: a <p> with the same shape as User would
+    // produce, so hydrate matches.
+    setLatestFragment('/docs/:slug', '<p data-testid="island">island slug=x</p>');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByTestId('island')).toHaveTextContent('island slug=x');
+    // The host div is the only child rendered by the outer tree; the <p> is
+    // inside it as a hydrated island.
+    const host = container.querySelector('[data-hp-island="true"]');
+    expect(host).not.toBeNull();
+    expect(host!.querySelector('p')).not.toBeNull();
   });
 });

--- a/packages/iso/src/__tests__/page-host.test.tsx
+++ b/packages/iso/src/__tests__/page-host.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/preact';
 import { LocationProvider, type RouteHook } from 'preact-iso';
 import { PageHost } from '../page-host.js';
-import { setLatestFragment, clearLatestFragment } from '../navigator.js';
+import { setLatestFragment, clearLatestFragment, registerRouteMode } from '../navigator.js';
 
 afterEach(cleanup);
 
@@ -45,5 +45,41 @@ describe('PageHost (island mode)', () => {
     const host = container.querySelector('[data-hp-island="true"]');
     expect(host).not.toBeNull();
     expect(host!.querySelector('p')).not.toBeNull();
+  });
+
+  it('outer rerender with new location does not blank the host innerHTML', async () => {
+    function User(props: RouteHook) {
+      return <p data-testid="island">island slug={props.pathParams!.slug}</p>;
+    }
+    registerRouteMode('/docs/:slug', 'ssr');
+    const loc1 = { ...loc, pathParams: { slug: 'x' } } as RouteHook;
+    const loc2 = { ...loc, pathParams: { slug: 'y' }, path: '/docs/y', url: '/docs/y' } as RouteHook;
+
+    const { rerender, container } = render(
+      <LocationProvider>
+        <PageHost component={User} location={loc1} path="/docs/:slug" />
+      </LocationProvider>
+    );
+
+    setLatestFragment('/docs/:slug', '<p data-testid="island">island slug=x</p>');
+    await new Promise((r) => setTimeout(r, 0));
+    const host = container.querySelector('[data-hp-island="true"]') as HTMLDivElement;
+    expect(host).not.toBeNull();
+    expect(host.innerHTML.length).toBeGreaterThan(0);
+
+    // Rerender outer tree with a new location prop.
+    rerender(
+      <LocationProvider>
+        <PageHost component={User} location={loc2} path="/docs/:slug" />
+      </LocationProvider>
+    );
+
+    // The host element is the same DOM node and its innerHTML has been
+    // re-hydrated by the useLayoutEffect (because location changed),
+    // but it MUST NOT have been blanked by Preact's outer reconciler
+    // between the rerender and the layout effect.
+    const sameHost = container.querySelector('[data-hp-island="true"]') as HTMLDivElement;
+    expect(sameHost).toBe(host);
+    expect(sameHost.innerHTML.length).toBeGreaterThan(0);
   });
 });

--- a/packages/iso/src/__tests__/page.test.tsx
+++ b/packages/iso/src/__tests__/page.test.tsx
@@ -6,6 +6,7 @@ import { Page } from '../page.js';
 import { defineLoader } from '../define-loader.js';
 import { createGuard, GuardRedirect, runGuards } from '../guard.js';
 import { env } from '../is-browser.js';
+import { FragmentModeContext } from '../fragment-mode.js';
 
 vi.mock('../preload.js', () => ({
   getPreloadedData: vi.fn(() => null),
@@ -159,5 +160,47 @@ describe('Page error boundary', () => {
     const el = await screen.findByTestId('error');
     expect(el).toHaveTextContent('boom');
     expect(screen.queryByTestId('content')).toBeNull();
+  });
+});
+
+const fragLoc = { path: '/x', url: '/x', searchParams: {}, pathParams: {} } as unknown as RouteHook;
+
+describe('<Page> under fragment mode', () => {
+  it('wraps its rendered subtree in <hp-page-fragment>', async () => {
+    function Inner() {
+      return <p data-testid="frag-inner">body</p>;
+    }
+    const { container } = render(
+      <LocationProvider>
+        <FragmentModeContext.Provider value={true}>
+          <Page location={fragLoc}>
+            <Inner />
+          </Page>
+        </FragmentModeContext.Provider>
+      </LocationProvider>
+    );
+
+    await screen.findByTestId('frag-inner');
+    const sentinel = container.querySelector('hp-page-fragment');
+    expect(sentinel).not.toBeNull();
+    const inner = screen.getByTestId('frag-inner');
+    expect(sentinel).toContainElement(inner);
+  });
+
+  it('does not wrap when fragment mode is false (default)', async () => {
+    function Inner() {
+      return <p data-testid="no-frag-inner">body</p>;
+    }
+    const { container } = render(
+      <LocationProvider>
+        <Page location={fragLoc}>
+          <Inner />
+        </Page>
+      </LocationProvider>
+    );
+
+    await screen.findByTestId('no-frag-inner');
+    const sentinel = container.querySelector('hp-page-fragment');
+    expect(sentinel).toBeNull();
   });
 });

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -8,6 +8,7 @@ import {
   clearRegistry,
   setLatestFragment,
   clearLatestFragment,
+  findMatchingPattern,
 } from '../navigator.js';
 
 beforeEach(() => {
@@ -42,6 +43,22 @@ describe('<Route> wrapper', () => {
       </LocationProvider>
     );
     expect(lookupRouteMode('/docs/intro')).toBe('ssr');
+  });
+
+  it('does not register the matched URL as an additional pattern after navigation', async () => {
+    function Page(props: any) {
+      return <p data-testid="x">slug={props.pathParams.slug}</p>;
+    }
+    window.history.pushState({}, '', '/docs/intro');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/docs/:slug" component={Page} navigate="ssr" />
+        </Router>
+      </LocationProvider>
+    );
+    await screen.findByTestId('x');
+    expect(findMatchingPattern('/docs/intro')).toBe('/docs/:slug');
   });
 
   it('substitutes PageHost for SSR routes', async () => {

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/preact';
+import { LocationProvider, Router } from 'preact-iso';
+import { Route } from '../route.js';
+import {
+  lookupRouteMode,
+  clearRegistry,
+  setLatestFragment,
+  clearLatestFragment,
+} from '../navigator.js';
+
+beforeEach(() => {
+  clearRegistry();
+  clearLatestFragment();
+  window.history.pushState({}, '', '/');
+});
+afterEach(cleanup);
+
+describe('<Route> wrapper', () => {
+  it('passes through to preact-iso Route when navigate is omitted', async () => {
+    function Page() { return <p data-testid="spa">spa</p>; }
+    window.history.pushState({}, '', '/spa');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/spa" component={Page} />
+        </Router>
+      </LocationProvider>
+    );
+    expect(await screen.findByTestId('spa')).toHaveTextContent('spa');
+    expect(lookupRouteMode('/spa')).toBe('spa');
+  });
+
+  it('registers SSR mode when navigate="ssr"', () => {
+    function Page() { return null; }
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/docs/:slug" component={Page} navigate="ssr" />
+        </Router>
+      </LocationProvider>
+    );
+    expect(lookupRouteMode('/docs/intro')).toBe('ssr');
+  });
+
+  it('substitutes PageHost for SSR routes', async () => {
+    function Page(props: any) {
+      return <p data-testid="spa-render">spa-render slug={props.pathParams.slug}</p>;
+    }
+    window.history.pushState({}, '', '/docs/intro');
+    render(
+      <LocationProvider>
+        <Router>
+          <Route path="/docs/:slug" component={Page} navigate="ssr" />
+        </Router>
+      </LocationProvider>
+    );
+    // Pre-island: same as SPA-mode
+    expect(await screen.findByTestId('spa-render')).toHaveTextContent('spa-render slug=intro');
+
+    // Island: deliver a fragment matching that path pattern. After delivery,
+    // PageHost switches to the host div. The data-testid attribute from the
+    // server HTML is preserved during hydration (Preact skips attribute updates
+    // in hydrate mode); text content comes from the hydrated component.
+    setLatestFragment('/docs/:slug', '<p data-testid="island-render">spa-render slug=intro</p>');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByTestId('island-render')).toHaveTextContent('spa-render slug=intro');
+  });
+});

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -9,6 +9,7 @@ import {
   setLatestFragment,
   clearLatestFragment,
   findMatchingPattern,
+  uninstallClickInterceptor,
 } from '../navigator.js';
 
 beforeEach(() => {
@@ -16,7 +17,10 @@ beforeEach(() => {
   clearLatestFragment();
   window.history.pushState({}, '', '/');
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  uninstallClickInterceptor();
+});
 
 describe('<Route> wrapper', () => {
   it('passes through to preact-iso Route when navigate is omitted', async () => {

--- a/packages/iso/src/__tests__/route.test.tsx
+++ b/packages/iso/src/__tests__/route.test.tsx
@@ -24,9 +24,8 @@ describe('<Route> wrapper', () => {
     window.history.pushState({}, '', '/spa');
     render(
       <LocationProvider>
-        <Router>
-          <Route path="/spa" component={Page} />
-        </Router>
+        {/* Router expects NestedArray<VNode> children; wrap in array to satisfy the type */}
+        <Router>{[<Route key="r" path="/spa" component={Page} />]}</Router>
       </LocationProvider>
     );
     expect(await screen.findByTestId('spa')).toHaveTextContent('spa');
@@ -37,9 +36,7 @@ describe('<Route> wrapper', () => {
     function Page() { return null; }
     render(
       <LocationProvider>
-        <Router>
-          <Route path="/docs/:slug" component={Page} navigate="ssr" />
-        </Router>
+        <Router>{[<Route key="r" path="/docs/:slug" component={Page} navigate="ssr" />]}</Router>
       </LocationProvider>
     );
     expect(lookupRouteMode('/docs/intro')).toBe('ssr');
@@ -52,9 +49,7 @@ describe('<Route> wrapper', () => {
     window.history.pushState({}, '', '/docs/intro');
     render(
       <LocationProvider>
-        <Router>
-          <Route path="/docs/:slug" component={Page} navigate="ssr" />
-        </Router>
+        <Router>{[<Route key="r" path="/docs/:slug" component={Page} navigate="ssr" />]}</Router>
       </LocationProvider>
     );
     await screen.findByTestId('x');
@@ -68,9 +63,7 @@ describe('<Route> wrapper', () => {
     window.history.pushState({}, '', '/docs/intro');
     render(
       <LocationProvider>
-        <Router>
-          <Route path="/docs/:slug" component={Page} navigate="ssr" />
-        </Router>
+        <Router>{[<Route key="r" path="/docs/:slug" component={Page} navigate="ssr" />]}</Router>
       </LocationProvider>
     );
     // Pre-island: same as SPA-mode

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -1,6 +1,8 @@
 import type { RouteHook } from 'preact-iso';
 import type { LoaderCache } from './cache.js';
 
+export const LOADER_ID_PREFIX = '@hono-preact/loader:';
+
 export type LoaderCtx = { location: RouteHook };
 
 export type Loader<T> = (ctx: LoaderCtx) => Promise<T>;
@@ -46,7 +48,7 @@ export function defineLoader<T>(
 ): LoaderRef<T> {
   if (opts?.__moduleKey) {
     return {
-      __id: Symbol.for(`@hono-preact/loader:${opts.__moduleKey}`),
+      __id: Symbol.for(`${LOADER_ID_PREFIX}${opts.__moduleKey}`),
       fn,
     };
   }
@@ -54,7 +56,7 @@ export function defineLoader<T>(
   // Identity is unstable across module reloads, which is acceptable for
   // tests that don't depend on cache-by-id behavior.
   return {
-    __id: Symbol(`@hono-preact/loader:<unkeyed>`),
+    __id: Symbol(`<unkeyed>`),
     fn,
   };
 }

--- a/packages/iso/src/fragment-mode.ts
+++ b/packages/iso/src/fragment-mode.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'preact';
+
+export const FragmentModeContext = createContext<boolean>(false);

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -4,9 +4,20 @@ export type { PageProps, WrapperProps } from './page.js';
 export { definePage } from './define-page.js';
 export type { PageBindings } from './define-page.js';
 
-// Routing primitives — trivial re-exports of preact-iso. Listed here so
-// consumers have a single import surface for everything they need.
-export { Route, Router, lazy } from 'preact-iso';
+// Routing primitives. Router and lazy are direct re-exports of preact-iso;
+// Route is our wrapper that adds the optional navigate="ssr" prop.
+export { Router, lazy } from 'preact-iso';
+export { Route } from './route.js';
+export type { RouteProps } from './route.js';
+export type { NavigateMode } from './navigator.js';
+
+// Programmatic navigation that respects per-route SSR/SPA mode.
+export { navigate } from './navigator.js';
+
+// Hydration island used by SSR routes (also exported so advanced consumers
+// can compose their own routing).
+export { PageHost } from './page-host.js';
+export type { PageHostProps } from './page-host.js';
 
 // Server bindings.
 export { defineLoader } from './define-loader.js';

--- a/packages/iso/src/internal.ts
+++ b/packages/iso/src/internal.ts
@@ -26,3 +26,4 @@ export { getPreloadedData, deletePreloadedData } from './preload.js';
 export { runRequestScope } from './cache.js';
 export { default as wrapPromise } from './wrap-promise.js';
 export { runGuards } from './guard.js';
+export { FragmentModeContext } from './fragment-mode.js';

--- a/packages/iso/src/loader.tsx
+++ b/packages/iso/src/loader.tsx
@@ -1,7 +1,7 @@
 import type { ComponentChildren, JSX } from 'preact';
 import type { RouteHook } from 'preact-iso';
 import { Suspense } from 'preact/compat';
-import { useCallback, useId, useRef, useState } from 'preact/hooks';
+import { useCallback, useRef, useState } from 'preact/hooks';
 import type { LoaderCache } from './cache.js';
 import { isBrowser } from './is-browser.js';
 import { ReloadContext } from './reload-context.js';
@@ -9,6 +9,18 @@ import { getPreloadedData } from './preload.js';
 import wrapPromise from './wrap-promise.js';
 import { LoaderDataContext, LoaderIdContext } from './contexts.js';
 import type { LoaderRef } from './define-loader.js';
+
+const LOADER_ID_PREFIX = '@hono-preact/loader:';
+
+function deriveLoaderDomId(ref: LoaderRef<unknown>): string {
+  const desc = ref.__id.description ?? '';
+  const moduleKey = desc.startsWith(LOADER_ID_PREFIX)
+    ? desc.slice(LOADER_ID_PREFIX.length)
+    : 'unkeyed';
+  // DOM id: replace path-unfriendly characters with hyphens for selector-safe ids.
+  const safe = moduleKey.replace(/[^a-zA-Z0-9_-]/g, '-');
+  return `loader-${safe}`;
+}
 
 type LoaderProps<T> = {
   loader: LoaderRef<T>;
@@ -25,7 +37,7 @@ export function Loader<T>({
   fallback,
   children,
 }: LoaderProps<T>) {
-  const id = useId();
+  const id = deriveLoaderDomId(loader);
   const effectiveCache = cache ?? loader.cache;
 
   return (

--- a/packages/iso/src/loader.tsx
+++ b/packages/iso/src/loader.tsx
@@ -9,15 +9,17 @@ import { getPreloadedData } from './preload.js';
 import wrapPromise from './wrap-promise.js';
 import { LoaderDataContext, LoaderIdContext } from './contexts.js';
 import type { LoaderRef } from './define-loader.js';
-
-const LOADER_ID_PREFIX = '@hono-preact/loader:';
+import { LOADER_ID_PREFIX } from './define-loader.js';
 
 function deriveLoaderDomId(ref: LoaderRef<unknown>): string {
   const desc = ref.__id.description ?? '';
   const moduleKey = desc.startsWith(LOADER_ID_PREFIX)
     ? desc.slice(LOADER_ID_PREFIX.length)
+    // Unkeyed loaders (no Vite plugin) all share this id, so the DOM
+    // preload channel is unreliable for them. Tests that don't depend
+    // on cache-by-id behavior tolerate this.
     : 'unkeyed';
-  // DOM id: replace path-unfriendly characters with hyphens for selector-safe ids.
+  // CSS-selector-safe: replace any char outside [a-zA-Z0-9_-] with a hyphen.
   const safe = moduleKey.replace(/[^a-zA-Z0-9_-]/g, '-');
   return `loader-${safe}`;
 }

--- a/packages/iso/src/navigator.ts
+++ b/packages/iso/src/navigator.ts
@@ -5,6 +5,7 @@ export type NavigateMode = 'spa' | 'ssr';
 const routeModes = new Map<string, NavigateMode>();
 const subscribers = new Map<string, Set<(html: string) => void>>();
 const latestFragments = new Map<string, string>();
+const pendingFragments = new Set<string>();
 
 export function registerRouteMode(path: string, mode: NavigateMode): void {
   routeModes.set(path, mode);
@@ -34,6 +35,28 @@ export function setLatestFragment(path: string, html: string): void {
 
 export function clearLatestFragment(): void {
   latestFragments.clear();
+  pendingFragments.clear();
+}
+
+/**
+ * Returns the buffered fragment HTML for a given path pattern, if any.
+ * Used by PageHost to initialize directly into island mode when the
+ * navigator already has a fragment buffered (e.g., the fetch resolved
+ * before PageHost mounted because a lazy chunk was still loading).
+ */
+export function getLatestFragment(path: string): string | undefined {
+  return latestFragments.get(path);
+}
+
+/**
+ * True while a fragment fetch is in flight for the given path pattern.
+ * PageHost reads this to skip rendering the user component during a
+ * client-side SSR navigation; rendering the user pre-island would
+ * fire a /__loaders fetch and flicker through the SPA path before the
+ * fragment arrives.
+ */
+export function isFragmentPending(path: string): boolean {
+  return pendingFragments.has(path);
 }
 
 export function subscribeToFragment(
@@ -112,6 +135,11 @@ export async function navigate(
   if (inflight) inflight.abort();
   const ctrl = new AbortController();
   inflight = ctrl;
+  // Mark the destination's pattern as pending so any PageHost mounting
+  // mid-fetch (e.g., after a lazy chunk resolves) renders a placeholder
+  // instead of pre-island User. Cleared once setLatestFragment fires.
+  const navPattern = findMatchingPattern(url);
+  if (navPattern) pendingFragments.add(navPattern);
   let res: Response;
   try {
     res = await fetch(url, {
@@ -119,11 +147,13 @@ export async function navigate(
       signal: ctrl.signal,
     });
   } catch (err) {
+    if (navPattern) pendingFragments.delete(navPattern);
     if ((err as Error).name === 'AbortError') return;
     location.assign(url);
     return;
   }
   if (!res.ok) {
+    if (navPattern) pendingFragments.delete(navPattern);
     location.assign(url);
     return;
   }
@@ -131,6 +161,7 @@ export async function navigate(
   try {
     body = await res.json();
   } catch {
+    if (navPattern) pendingFragments.delete(navPattern);
     location.assign(url);
     return;
   }
@@ -145,12 +176,19 @@ export async function navigate(
     if (event.type === 'envelope') {
       applyHead(event.head);
       const pattern = findMatchingPattern(url);
-      if (pattern) setLatestFragment(pattern, event.html);
+      if (pattern) {
+        // setLatestFragment notifies subscribers; clear pending first so
+        // any PageHost reacting to the notification sees pending=false.
+        pendingFragments.delete(pattern);
+        setLatestFragment(pattern, event.html);
+      }
       pushedHistoryFor = url;
     } else if (event.type === 'redirect') {
+      if (navPattern) pendingFragments.delete(navPattern);
       await navigate(event.location);
       return;
     } else if (event.type === 'fallback') {
+      if (navPattern) pendingFragments.delete(navPattern);
       location.assign(url);
       return;
     }

--- a/packages/iso/src/navigator.ts
+++ b/packages/iso/src/navigator.ts
@@ -58,21 +58,94 @@ export function subscribeToFragment(
   };
 }
 
-// Implemented in Task 7. Stub is intentionally loud to surface accidental misuse.
-export function navigate(url: string): void {
-  throw new Error(`navigator.navigate() not yet implemented (url: ${url})`);
+let inflight: AbortController | null = null;
+
+type Envelope = {
+  type: 'envelope';
+  html: string;
+  head: {
+    title?: string;
+    metas?: { name?: string; content?: string; property?: string }[];
+    links?: { rel?: string; href?: string }[];
+  };
+};
+type Redirect = { type: 'redirect'; location: string };
+type Fallback = { type: 'fallback' };
+type EventItem = Envelope | Redirect | Fallback;
+
+function applyHead(head: Envelope['head']): void {
+  if (typeof document === 'undefined') return;
+  if (head.title !== undefined) document.title = head.title;
+  // For metas/links: imperatively reconcile with hoofd-rendered tags.
+  // v1 keeps this minimal; hoofd hooks in the hydrating tree will further
+  // reconcile after hydrate fires. See spec "Hoofd reconciliation" risk note.
 }
 
-let installed = false;
+function findMatchingPattern(url: string): string | null {
+  for (const [pattern] of routeModes) {
+    if (exec(url, pattern, {})) return pattern;
+  }
+  return null;
+}
+
 let testingNavigate: ((url: string) => void) | null = null;
 
 export function __setNavigateForTesting(fn: ((url: string) => void) | null): void {
   testingNavigate = fn;
 }
 
+export async function navigate(
+  url: string,
+  opts: { push?: boolean } = { push: true }
+): Promise<void> {
+  if (testingNavigate) return testingNavigate(url) as unknown as void;
+  if (inflight) inflight.abort();
+  const ctrl = new AbortController();
+  inflight = ctrl;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { 'X-HP-Navigate': 'fragment' },
+      signal: ctrl.signal,
+    });
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return;
+    location.assign(url);
+    return;
+  }
+  if (!res.ok) {
+    location.assign(url);
+    return;
+  }
+  let body: { events?: EventItem[] };
+  try {
+    body = await res.json();
+  } catch {
+    location.assign(url);
+    return;
+  }
+  const events = body.events ?? [];
+  for (const event of events) {
+    if (event.type === 'envelope') {
+      applyHead(event.head);
+      const pattern = findMatchingPattern(url);
+      if (pattern) setLatestFragment(pattern, event.html);
+      // History update: gated by opts.push so popstate-triggered fetches
+      // don't double-push.
+      if (opts.push) history.pushState(null, '', url);
+    } else if (event.type === 'redirect') {
+      await navigate(event.location);
+      return;
+    } else if (event.type === 'fallback') {
+      location.assign(url);
+      return;
+    }
+  }
+}
+
 function dispatchNavigate(url: string): void {
   if (testingNavigate) testingNavigate(url);
-  else navigate(url);
+  else void navigate(url);
 }
 
 function shouldInterceptClick(event: MouseEvent): { url: string } | null {
@@ -100,15 +173,26 @@ function onClickCapture(event: MouseEvent): void {
   dispatchNavigate(decision.url);
 }
 
+function onPopstate(): void {
+  const url = location.pathname + location.search;
+  if (lookupRouteMode(url) === 'ssr') {
+    void navigate(url, { push: false });
+  }
+}
+
+let installed = false;
+
 export function installClickInterceptor(): void {
   if (installed) return;
   if (typeof document === 'undefined') return;
   document.addEventListener('click', onClickCapture, true);
+  window.addEventListener('popstate', onPopstate);
   installed = true;
 }
 
 export function uninstallClickInterceptor(): void {
   if (!installed) return;
   document.removeEventListener('click', onClickCapture, true);
+  window.removeEventListener('popstate', onPopstate);
   installed = false;
 }

--- a/packages/iso/src/navigator.ts
+++ b/packages/iso/src/navigator.ts
@@ -1,0 +1,58 @@
+import { exec } from 'preact-iso';
+
+export type NavigateMode = 'spa' | 'ssr';
+
+const routeModes = new Map<string, NavigateMode>();
+const subscribers = new Map<string, Set<(html: string) => void>>();
+const latestFragments = new Map<string, string>();
+
+export function registerRouteMode(path: string, mode: NavigateMode): void {
+  routeModes.set(path, mode);
+}
+
+export function clearRegistry(): void {
+  routeModes.clear();
+}
+
+/**
+ * Look up the navigate mode for a URL by matching against registered paths.
+ * Defaults to 'spa' when no registered path matches.
+ */
+export function lookupRouteMode(url: string): NavigateMode {
+  for (const [pattern, mode] of routeModes) {
+    if (exec(url, pattern, {})) return mode;
+  }
+  return 'spa';
+}
+
+export function setLatestFragment(path: string, html: string): void {
+  latestFragments.set(path, html);
+  const subs = subscribers.get(path);
+  if (subs) for (const fn of subs) fn(html);
+}
+
+export function clearLatestFragment(): void {
+  latestFragments.clear();
+}
+
+export function subscribeToFragment(
+  path: string,
+  handler: (html: string) => void
+): () => void {
+  let set = subscribers.get(path);
+  if (!set) {
+    set = new Set();
+    subscribers.set(path, set);
+  }
+  set.add(handler);
+  // Replay latest fragment if one is buffered.
+  const latest = latestFragments.get(path);
+  if (latest !== undefined) handler(latest);
+  return () => {
+    const s = subscribers.get(path);
+    if (s) {
+      s.delete(handler);
+      if (s.size === 0) subscribers.delete(path);
+    }
+  };
+}

--- a/packages/iso/src/navigator.ts
+++ b/packages/iso/src/navigator.ts
@@ -8,6 +8,7 @@ const latestFragments = new Map<string, string>();
 
 export function registerRouteMode(path: string, mode: NavigateMode): void {
   routeModes.set(path, mode);
+  if (mode === 'ssr') installClickInterceptor();
 }
 
 export function clearRegistry(): void {
@@ -55,4 +56,59 @@ export function subscribeToFragment(
       if (s.size === 0) subscribers.delete(path);
     }
   };
+}
+
+// Implemented in Task 7. Stub is intentionally loud to surface accidental misuse.
+export function navigate(url: string): void {
+  throw new Error(`navigator.navigate() not yet implemented (url: ${url})`);
+}
+
+let installed = false;
+let testingNavigate: ((url: string) => void) | null = null;
+
+export function __setNavigateForTesting(fn: ((url: string) => void) | null): void {
+  testingNavigate = fn;
+}
+
+function dispatchNavigate(url: string): void {
+  if (testingNavigate) testingNavigate(url);
+  else navigate(url);
+}
+
+function shouldInterceptClick(event: MouseEvent): { url: string } | null {
+  if (event.defaultPrevented) return null;
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return null;
+  if (event.button !== 0) return null;
+  const target = event.composedPath().find(
+    (el): el is HTMLAnchorElement =>
+      el instanceof HTMLAnchorElement && !!el.href
+  );
+  if (!target) return null;
+  if (target.origin !== location.origin) return null;
+  if (target.hasAttribute('download')) return null;
+  if (target.target && !/^_?self$/i.test(target.target)) return null;
+  const href = target.getAttribute('href');
+  if (!href || /^#/.test(href)) return null;
+  return { url: target.href.replace(location.origin, '') };
+}
+
+function onClickCapture(event: MouseEvent): void {
+  const decision = shouldInterceptClick(event);
+  if (!decision) return;
+  if (lookupRouteMode(decision.url) !== 'ssr') return;
+  event.preventDefault();
+  dispatchNavigate(decision.url);
+}
+
+export function installClickInterceptor(): void {
+  if (installed) return;
+  if (typeof document === 'undefined') return;
+  document.addEventListener('click', onClickCapture, true);
+  installed = true;
+}
+
+export function uninstallClickInterceptor(): void {
+  if (!installed) return;
+  document.removeEventListener('click', onClickCapture, true);
+  installed = false;
 }

--- a/packages/iso/src/navigator.ts
+++ b/packages/iso/src/navigator.ts
@@ -21,7 +21,7 @@ export function clearRegistry(): void {
  */
 export function lookupRouteMode(url: string): NavigateMode {
   for (const [pattern, mode] of routeModes) {
-    if (exec(url, pattern, {})) return mode;
+    if (exec(url, pattern)) return mode;
   }
   return 'spa';
 }
@@ -83,7 +83,7 @@ function applyHead(head: Envelope['head']): void {
 
 export function findMatchingPattern(url: string): string | null {
   for (const [pattern] of routeModes) {
-    if (exec(url, pattern, {})) return pattern;
+    if (exec(url, pattern)) return pattern;
   }
   return null;
 }

--- a/packages/iso/src/navigator.ts
+++ b/packages/iso/src/navigator.ts
@@ -94,6 +94,16 @@ export function __setNavigateForTesting(fn: ((url: string) => void) | null): voi
   testingNavigate = fn;
 }
 
+/**
+ * Programmatic navigation that respects per-route SSR/SPA mode.
+ *
+ * v1 limitation: when called outside a click context, this pushes
+ * history state but does not notify preact-iso's LocationProvider
+ * reducer. The matched <Route> may not advance until the next click
+ * or popstate. Click-driven navigation is unaffected (preact-iso's
+ * bubble-phase click listener picks up the URL after we
+ * preventDefault).
+ */
 export async function navigate(
   url: string,
   opts: { push?: boolean } = { push: true }
@@ -125,14 +135,18 @@ export async function navigate(
     return;
   }
   const events = body.events ?? [];
+  // v1 processes events sequentially. envelope sets state and continues
+  // (in practice the response has at most one envelope); redirect and
+  // fallback both terminate. Phase 2 streaming may emit multiple events
+  // per response (see spec "Forward compatibility for streaming"); when
+  // that happens, pushState behavior must be revisited.
+  let pushedHistoryFor: string | null = null;
   for (const event of events) {
     if (event.type === 'envelope') {
       applyHead(event.head);
       const pattern = findMatchingPattern(url);
       if (pattern) setLatestFragment(pattern, event.html);
-      // History update: gated by opts.push so popstate-triggered fetches
-      // don't double-push.
-      if (opts.push) history.pushState(null, '', url);
+      pushedHistoryFor = url;
     } else if (event.type === 'redirect') {
       await navigate(event.location);
       return;
@@ -141,11 +155,15 @@ export async function navigate(
       return;
     }
   }
+  if (opts.push && pushedHistoryFor) history.pushState(null, '', pushedHistoryFor);
 }
 
 function dispatchNavigate(url: string): void {
   if (testingNavigate) testingNavigate(url);
-  else void navigate(url);
+  // Click path: preact-iso's bubble-phase listener will run after ours
+  // and call history.pushState itself, so we skip the push here. The
+  // LocationProvider URL signal is updated by preact-iso's reducer.
+  else void navigate(url, { push: false });
 }
 
 function shouldInterceptClick(event: MouseEvent): { url: string } | null {

--- a/packages/iso/src/navigator.ts
+++ b/packages/iso/src/navigator.ts
@@ -81,7 +81,7 @@ function applyHead(head: Envelope['head']): void {
   // reconcile after hydrate fires. See spec "Hoofd reconciliation" risk note.
 }
 
-function findMatchingPattern(url: string): string | null {
+export function findMatchingPattern(url: string): string | null {
   for (const [pattern] of routeModes) {
     if (exec(url, pattern, {})) return pattern;
   }

--- a/packages/iso/src/page-host.tsx
+++ b/packages/iso/src/page-host.tsx
@@ -1,0 +1,27 @@
+import type { ComponentType } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import type { RouteHook } from 'preact-iso';
+import { subscribeToFragment } from './navigator.js';
+
+export type PageHostProps = {
+  component: ComponentType<RouteHook>;
+  location: RouteHook;
+  path: string;
+};
+
+export function PageHost({ component: User, location, path }: PageHostProps) {
+  const [fragment, setFragment] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsub = subscribeToFragment(path, (html) => setFragment(html));
+    return unsub;
+  }, [path]);
+
+  if (fragment === null) {
+    return <User {...location} />;
+  }
+  // Island mode lands in Task 9. For now, fallback to user component so any
+  // tests asserting pre-island behavior pass; the real island mode replaces
+  // this branch.
+  return <User {...location} />;
+}

--- a/packages/iso/src/page-host.tsx
+++ b/packages/iso/src/page-host.tsx
@@ -1,5 +1,5 @@
-import type { ComponentType } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { hydrate, render, h, type ComponentType, type RefObject } from 'preact';
+import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import type { RouteHook } from 'preact-iso';
 import { subscribeToFragment } from './navigator.js';
 
@@ -11,17 +11,37 @@ export type PageHostProps = {
 
 export function PageHost({ component: User, location, path }: PageHostProps) {
   const [fragment, setFragment] = useState<string | null>(null);
+  const hostRef: RefObject<HTMLDivElement> = useRef(null);
 
   useEffect(() => {
     const unsub = subscribeToFragment(path, (html) => setFragment(html));
     return unsub;
   }, [path]);
 
+  useLayoutEffect(() => {
+    if (fragment === null) return;
+    const host = hostRef.current;
+    if (!host) return;
+    // Unmount any prior inner Preact tree at this host.
+    render(null, host);
+    // Replace DOM with new server-rendered HTML.
+    host.innerHTML = fragment;
+    // Hydrate the user component against the now-populated DOM.
+    hydrate(h(User, location), host);
+  }, [fragment, location]);
+
   if (fragment === null) {
     return <User {...location} />;
   }
-  // Island mode lands in Task 9. For now, fallback to user component so any
-  // tests asserting pre-island behavior pass; the real island mode replaces
-  // this branch.
-  return <User {...location} />;
+  // Stable container. dangerouslySetInnerHTML={{__html: ''}} tells Preact's
+  // outer reconciler not to manage children, so subsequent outer renders
+  // never stomp the inner hydrate root. We mutate innerHTML imperatively
+  // in useLayoutEffect.
+  return (
+    <div
+      ref={hostRef}
+      data-hp-island="true"
+      dangerouslySetInnerHTML={{ __html: '' }}
+    />
+  );
 }

--- a/packages/iso/src/page-host.tsx
+++ b/packages/iso/src/page-host.tsx
@@ -1,7 +1,11 @@
 import { hydrate, render, h, type ComponentType, type RefObject } from 'preact';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import type { RouteHook } from 'preact-iso';
-import { subscribeToFragment } from './navigator.js';
+import {
+  getLatestFragment,
+  isFragmentPending,
+  subscribeToFragment,
+} from './navigator.js';
 
 export type PageHostProps = {
   component: ComponentType<RouteHook>;
@@ -10,7 +14,12 @@ export type PageHostProps = {
 };
 
 export function PageHost({ component: User, location, path }: PageHostProps) {
-  const [fragment, setFragment] = useState<string | null>(null);
+  // Initialize from any fragment the navigator already has buffered: the
+  // navigator may resolve before PageHost mounts (e.g., a lazy chunk
+  // delayed PageHost while the fragment fetch completed).
+  const [fragment, setFragment] = useState<string | null>(
+    () => getLatestFragment(path) ?? null
+  );
   const hostRef: RefObject<HTMLDivElement> = useRef(null);
 
   useEffect(() => {
@@ -31,6 +40,16 @@ export function PageHost({ component: User, location, path }: PageHostProps) {
   }, [fragment, location]);
 
   if (fragment === null) {
+    // During a client-side SSR navigation the navigator marks the path
+    // pending before fetching. Rendering <User> here would mount the
+    // page's loader and fire a /__loaders fetch, then the User subtree
+    // would be torn down again as soon as the fragment arrives, causing
+    // a visible flicker. The empty placeholder holds the slot until the
+    // fragment arrives, at which point we transition to the island
+    // branch below.
+    if (isFragmentPending(path)) {
+      return <div data-hp-pending="true" />;
+    }
     return <User {...location} />;
   }
   // Stable container. dangerouslySetInnerHTML={{__html: ''}} tells Preact's

--- a/packages/iso/src/page-host.tsx
+++ b/packages/iso/src/page-host.tsx
@@ -1,6 +1,11 @@
 import { hydrate, render, h, type ComponentType, type RefObject } from 'preact';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
-import { LocationProvider, type RouteHook } from 'preact-iso';
+import {
+  LocationProvider,
+  Route as PreactIsoRoute,
+  Router,
+  type RouteHook,
+} from 'preact-iso';
 import {
   getLatestFragment,
   isFragmentPending,
@@ -36,10 +41,25 @@ export function PageHost({ component: User, location, path }: PageHostProps) {
     // Replace DOM with new server-rendered HTML.
     host.innerHTML = fragment;
     // Hydrate the user component against the now-populated DOM. Wrap in
-    // LocationProvider because the page subtree may contain nested
-    // <Router>/useLocation() consumers; without a provider those throw
-    // and Preact's error handling tears down the spliced HTML.
-    hydrate(h(LocationProvider, null, h(User, location)), host);
+    // LocationProvider + Router so any nested useLocation()/useRoute()
+    // or nested <Router> in the page subtree sees the same context the
+    // outer tree provides. The Router matches the URL against `path` and
+    // sets up RouteContext with the correct `rest`/`pathParams`. Without
+    // this wrapping, a nested <Router> falls back to `rest = path` and
+    // matches the wrong URL segment (e.g. /movies's nested Router would
+    // treat "movies" as the :id param of /:id).
+    hydrate(
+      h(LocationProvider, null,
+        h(Router, null,
+          // preact-iso's Route props use a RouteHook discriminated union;
+          // path + component is sufficient at runtime, cast to bypass the
+          // strict type that expects matchProps fields the parent Router
+          // will inject.
+          h(PreactIsoRoute, { path, component: User } as never)
+        )
+      ),
+      host
+    );
   }, [fragment, location]);
 
   if (fragment === null) {

--- a/packages/iso/src/page-host.tsx
+++ b/packages/iso/src/page-host.tsx
@@ -1,6 +1,6 @@
 import { hydrate, render, h, type ComponentType, type RefObject } from 'preact';
 import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
-import type { RouteHook } from 'preact-iso';
+import { LocationProvider, type RouteHook } from 'preact-iso';
 import {
   getLatestFragment,
   isFragmentPending,
@@ -35,8 +35,11 @@ export function PageHost({ component: User, location, path }: PageHostProps) {
     render(null, host);
     // Replace DOM with new server-rendered HTML.
     host.innerHTML = fragment;
-    // Hydrate the user component against the now-populated DOM.
-    hydrate(h(User, location), host);
+    // Hydrate the user component against the now-populated DOM. Wrap in
+    // LocationProvider because the page subtree may contain nested
+    // <Router>/useLocation() consumers; without a provider those throw
+    // and Preact's error handling tears down the spliced HTML.
+    hydrate(h(LocationProvider, null, h(User, location)), host);
   }, [fragment, location]);
 
   if (fragment === null) {

--- a/packages/iso/src/page.tsx
+++ b/packages/iso/src/page.tsx
@@ -4,7 +4,7 @@ import type {
   FunctionComponent,
   JSX,
 } from 'preact';
-import { useId } from 'preact/hooks';
+import { useContext, useId } from 'preact/hooks';
 import type { RouteHook } from 'preact-iso';
 import type { LoaderCache } from './cache.js';
 import type { GuardFn } from './guard.js';
@@ -13,6 +13,15 @@ import { Envelope } from './envelope.js';
 import { Guards } from './guards.js';
 import { Loader } from './loader.js';
 import { RouteBoundary } from './route-boundary.js';
+import { FragmentModeContext } from './fragment-mode.js';
+
+declare module 'preact' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'hp-page-fragment': { children?: ComponentChildren };
+    }
+  }
+}
 
 export type WrapperProps = {
   id: string;
@@ -50,7 +59,9 @@ export function Page<T>({
   children,
 }: PageProps<T>): JSX.Element {
   const id = useId();
-  return (
+  const isFragment = useContext(FragmentModeContext);
+
+  const tree = (
     <RouteBoundary fallback={fallback} errorFallback={errorFallback}>
       <Guards server={serverGuards} client={clientGuards} location={location}>
         {loader ? (
@@ -70,6 +81,13 @@ export function Page<T>({
       </Guards>
     </RouteBoundary>
   );
+
+  if (isFragment) {
+    // Custom element name (must contain a dash) renders as-is in HTML.
+    // renderPage extracts content between these markers in fragment mode.
+    return <hp-page-fragment>{tree}</hp-page-fragment> as unknown as JSX.Element;
+  }
+  return tree;
 }
 
 const NoLoaderFrame: FunctionComponent<{

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -1,0 +1,48 @@
+import type { ComponentType, VNode } from 'preact';
+import { options } from 'preact';
+import { Route as PreactIsoRoute, type RouteHook } from 'preact-iso';
+import { PageHost } from './page-host.js';
+import {
+  registerRouteMode,
+  findMatchingPattern,
+  type NavigateMode,
+} from './navigator.js';
+
+export type RouteProps = {
+  path?: string;
+  default?: boolean;
+  component: ComponentType<RouteHook>;
+  navigate?: NavigateMode;
+};
+
+// Register SSR routes on VNode creation so that the mode registry is
+// populated even for routes that are not currently matched. The Router
+// iterates all child VNodes by reading their props directly, but only
+// renders the matched one; without this hook, registerRouteMode would
+// never fire for unmatched routes.
+const _prevVNode = options.vnode;
+options.vnode = (vnode: VNode) => {
+  if (vnode.type === Route) {
+    const props = vnode.props as RouteProps;
+    if (props.navigate === 'ssr' && props.path) {
+      registerRouteMode(props.path, 'ssr');
+    }
+  }
+  if (_prevVNode) _prevVNode(vnode);
+};
+
+export function Route({ component, navigate, path, ...rest }: RouteProps) {
+  if (navigate === 'ssr' && path) {
+    // When the Router matches a route, it overwrites the 'path' prop with
+    // the current URL (e.g. '/docs/intro') rather than the original pattern
+    // (e.g. '/docs/:slug'). PageHost uses the pattern as a subscription key
+    // to receive fragments, so we resolve it back here.
+    const pattern = findMatchingPattern(path) ?? path;
+    const HostedComponent: ComponentType<RouteHook> = (props) => (
+      <PageHost component={component} location={props} path={pattern} />
+    );
+    HostedComponent.displayName = `SsrRoute(${pattern})`;
+    return <PreactIsoRoute path={path} component={HostedComponent} {...rest} />;
+  }
+  return <PreactIsoRoute path={path} component={component} {...rest} />;
+}

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, VNode } from 'preact';
-import { options } from 'preact';
+import { h, options } from 'preact';
 import { Route as PreactIsoRoute, type RouteHook } from 'preact-iso';
 import { PageHost } from './page-host.js';
 import {
@@ -23,7 +23,7 @@ export type RouteProps = {
 const _prevVNode = options.vnode;
 options.vnode = (vnode: VNode) => {
   if (vnode.type === Route) {
-    const props = vnode.props as RouteProps & { searchParams?: unknown };
+    const props = vnode.props as unknown as RouteProps & { searchParams?: unknown };
     // Skip clones produced by preact-iso's Router, which add searchParams to
     // matchProps and overwrite `path` with the matched URL. Only the original
     // JSX VNode should drive registration.
@@ -49,7 +49,11 @@ export function Route({ component, navigate, path, ...rest }: RouteProps) {
       <PageHost component={component} location={props} path={pattern} />
     );
     HostedComponent.displayName = `SsrRoute(${pattern})`;
-    return <PreactIsoRoute path={path} component={HostedComponent} {...rest} />;
+    // preact-iso's Route uses a discriminated union ({ path } | { default: true })
+    // that TypeScript cannot satisfy when forwarding a spread containing
+    // `default?: boolean`. Use h() directly to bypass JSX prop checking.
+    return h(PreactIsoRoute, { path, component: HostedComponent, ...rest } as any);
   }
-  return <PreactIsoRoute path={path} component={component} {...rest} />;
+  // Same discriminated-union bypass for the non-SSR path.
+  return h(PreactIsoRoute, { path, component, ...rest } as any);
 }

--- a/packages/iso/src/route.tsx
+++ b/packages/iso/src/route.tsx
@@ -23,8 +23,15 @@ export type RouteProps = {
 const _prevVNode = options.vnode;
 options.vnode = (vnode: VNode) => {
   if (vnode.type === Route) {
-    const props = vnode.props as RouteProps;
-    if (props.navigate === 'ssr' && props.path) {
+    const props = vnode.props as RouteProps & { searchParams?: unknown };
+    // Skip clones produced by preact-iso's Router, which add searchParams to
+    // matchProps and overwrite `path` with the matched URL. Only the original
+    // JSX VNode should drive registration.
+    if (
+      props.navigate === 'ssr' &&
+      props.path &&
+      !('searchParams' in props)
+    ) {
       registerRouteMode(props.path, 'ssr');
     }
   }

--- a/packages/server/src/__tests__/render.test.tsx
+++ b/packages/server/src/__tests__/render.test.tsx
@@ -1,9 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
 import { useTitle, useLang, useMeta, useLink } from 'hoofd/preact';
-import type { JSX } from 'preact';
+import type { ComponentChildren, JSX } from 'preact';
 import { GuardRedirect, env } from '@hono-preact/iso';
 import { renderPage } from '../render.js';
+
+declare module 'preact' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'hp-page-fragment': { children?: ComponentChildren };
+    }
+  }
+}
 
 function TitledPage() {
   useTitle('Test Title');
@@ -157,5 +165,83 @@ describe('renderPage', () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain('no head tag');
+  });
+});
+
+describe('renderPage fragment mode', () => {
+  it('returns a JSON envelope when X-HP-Navigate: fragment is set', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      renderPage(
+        c,
+        <html>
+          <body>
+            <hp-page-fragment>
+              <section id="loader-foo" data-loader="{&quot;ok&quot;:true}">hello</section>
+            </hp-page-fragment>
+          </body>
+        </html>
+      )
+    );
+    const res = await app.request('/test', {
+      headers: { 'X-HP-Navigate': 'fragment' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].type).toBe('envelope');
+    expect(body.events[0].html).toContain('loader-foo');
+    expect(body.events[0].html).toContain('hello');
+    expect(body.events[0].html).not.toContain('hp-page-fragment');
+  });
+
+  it('returns full HTML document when header is absent', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      renderPage(c, <html><body><p>hi</p></body></html>)
+    );
+    const res = await app.request('/test');
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const body = await res.text();
+    expect(body).toContain('<!doctype html>');
+  });
+
+  it('returns a redirect event (not 302) when GuardRedirect is thrown in fragment mode', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      renderPage(
+        c,
+        <html>
+          <body>
+            <RedirectingPage />
+          </body>
+        </html>
+      )
+    );
+    const res = await app.request('/test', {
+      headers: { 'X-HP-Navigate': 'fragment' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].type).toBe('redirect');
+    expect(body.events[0].location).toBe('/login');
+  });
+
+  it('returns a fallback event when no hp-page-fragment marker is present', async () => {
+    const app = new Hono();
+    app.get('/test', (c) =>
+      renderPage(c, <html><body><p>no fragment here</p></body></html>)
+    );
+    const res = await app.request('/test', {
+      headers: { 'X-HP-Navigate': 'fragment' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].type).toBe('fallback');
   });
 });

--- a/packages/server/src/render.tsx
+++ b/packages/server/src/render.tsx
@@ -3,7 +3,7 @@ import type { VNode } from 'preact';
 import { createDispatcher, HoofdProvider } from 'hoofd/preact';
 import { prerender } from 'preact-iso/prerender';
 import { GuardRedirect, env } from '@hono-preact/iso';
-import { runRequestScope } from '@hono-preact/iso/internal';
+import { runRequestScope, FragmentModeContext } from '@hono-preact/iso/internal';
 
 function escapeHtml(str: string): string {
   return str
@@ -20,8 +20,67 @@ function toAttrs(obj: Record<string, string | undefined>): string {
     .join(' ');
 }
 
-// this is a bit too naive still
 export async function renderPage(
+  c: Context,
+  node: VNode,
+  options?: { defaultTitle?: string }
+): Promise<Response> {
+  const isFragment = c.req.header('X-HP-Navigate') === 'fragment';
+  if (isFragment) return renderFragment(c, node);
+  return renderDocument(c, node, options);
+}
+
+const FRAGMENT_OPEN = '<hp-page-fragment>';
+const FRAGMENT_CLOSE = '</hp-page-fragment>';
+
+async function renderFragment(c: Context, node: VNode): Promise<Response> {
+  const dispatcher = createDispatcher();
+  const previousEnv = env.current;
+  env.current = 'server';
+
+  let html: string;
+  try {
+    ({ html } = await runRequestScope(() =>
+      prerender(
+        <FragmentModeContext.Provider value={true}>
+          <HoofdProvider value={dispatcher}>{node}</HoofdProvider>
+        </FragmentModeContext.Provider>
+      )
+    ));
+  } catch (e: unknown) {
+    if (e instanceof GuardRedirect) {
+      return c.json({
+        events: [{ type: 'redirect', location: e.location }],
+      });
+    }
+    throw e;
+  } finally {
+    env.current = previousEnv;
+  }
+
+  const start = html.indexOf(FRAGMENT_OPEN);
+  const end = html.indexOf(FRAGMENT_CLOSE);
+  if (start < 0 || end < 0 || end < start) {
+    // No fragment marker found. Either the matched route did not render <Page>,
+    // or the marker was stripped. Fall back to instructing the client to do a
+    // hard navigation.
+    return c.json({ events: [{ type: 'fallback' }] }, 200);
+  }
+  const captured = html.slice(start + FRAGMENT_OPEN.length, end);
+
+  const { title, metas = [], links = [] } = dispatcher.toStatic();
+  return c.json({
+    events: [
+      {
+        type: 'envelope',
+        html: captured,
+        head: { title, metas, links },
+      },
+    ],
+  });
+}
+
+async function renderDocument(
   c: Context,
   node: VNode,
   options?: { defaultTitle?: string }

--- a/packages/server/src/render.tsx
+++ b/packages/server/src/render.tsx
@@ -68,13 +68,13 @@ async function renderFragment(c: Context, node: VNode): Promise<Response> {
   }
   const captured = html.slice(start + FRAGMENT_OPEN.length, end);
 
-  const { title, metas = [], links = [] } = dispatcher.toStatic();
+  const { title } = dispatcher.toStatic();
   return c.json({
     events: [
       {
         type: 'envelope',
         html: captured,
-        head: { title, metas, links },
+        head: { title },
       },
     ],
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: {
       '@hono-preact/iso/internal': path.resolve(__dirname, 'packages/iso/src/internal.ts'),
       '@hono-preact/iso': path.resolve(__dirname, 'packages/iso/src/index.ts'),
+      '@hono-preact/server': path.resolve(__dirname, 'packages/server/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Adds an opt-in per-route navigation mode that fetches a server-rendered HTML fragment on client-side navigation, splices it into a stable mount point, and hydrates as an island. Loader data rides in the fragment HTML via the existing DOM-based preload channel; no separate `/__loaders` round trip.

```tsx
<Route path="/docs/*" component={Docs} navigate="ssr" />
```

When `navigate="ssr"` is set:
- Click interceptor (capture phase) sees the link, fetches the URL with `X-HP-Navigate: fragment`.
- Server's `renderPage` detects the header, runs `prerender` under a `FragmentModeContext`, and returns `{ events: [{ type: 'envelope', html, head: { title } }] }`.
- `<Page>` wraps its rendered subtree in a `<hp-page-fragment>` sentinel that the server extracts.
- Client splices the HTML into a `<PageHost>` island (`dangerouslySetInnerHTML={{__html: ''}}` + imperative `innerHTML` + `preactHydrate`).
- `Loader` derives its DOM id from `loaderRef.__moduleKey`, stable across server fragment render and client island hydrate, so the spliced HTML's `data-loader` attribute is found synchronously by `getPreloadedData`.

The wire envelope is wrapped in `events: [...]` so phase 2 streaming can extend the protocol without rewriting the client dispatch.

## What changed

**New** (in `@hono-preact/iso`): `Route` wrapper (replaces preact-iso re-export), `PageHost`, `navigate`, `NavigateMode` type. Internal: `FragmentModeContext`, navigator registry/subscription/click interceptor/popstate handling.

**Modified**: `Loader`/`Envelope` derive id from `__moduleKey` instead of `useId()`. `<Page>` wraps in `<hp-page-fragment>` under fragment mode. `renderPage` branches on `X-HP-Navigate: fragment`. `LOADER_ID_PREFIX` shared between `define-loader.ts` and `loader.tsx`.

**Demo wiring**: `/test` route opted into SSR mode for end-to-end validation; `Test` component wrapped with `definePage` so it renders inside `<Page>`.

## Breaking change (internal surface only)

Consumers of `@hono-preact/iso/internal` may depend on `Loader`'s wire id being `useId()`-shaped (e.g. `:r0:`). It is now `loader-${moduleKey}` (e.g. `loader-src-pages-movies`). The `internal` surface explicitly disclaims stability between minor versions; the public surface is unaffected.

## v1 limitations (documented in spec)

- Programmatic `navigate(url)` (calls outside a click context) push history state but do not currently notify preact-iso's `LocationProvider` URL signal. Click-driven navigation is unaffected.
- `applyHead` only sets `document.title`; metas and links are dropped from the envelope payload until a hoofd reconciliation pass is added.
- `prefetch()` does not yet warm fragment envelopes for SSR routes.
- Browser back/forward refetches the fragment; no LRU cache.

## Test Plan

- [x] `pnpm test` — 289 tests across 35 files pass.
- [x] `pnpm --filter @hono-preact/iso build`, `--filter @hono-preact/server build`, `--filter @hono-preact/vite build`, `--filter app build` all clean.
- [x] Integration test (`apps/app/src/__tests__/ssr-navigation.test.tsx`): fragment-mode request returns `{ events: [{ type: 'envelope', ... }] }`; document-mode request returns `<!doctype html>`.
- [ ] Manual smoke test: dev server, click from `/` to `/test`, verify Network panel shows one `GET /test` with `X-HP-Navigate: fragment` and JSON response shape, no `/__loaders` request.

## Commit cadence

15 commits on the branch; each task in the plan committed independently with TDD (failing test → implementation → passing test → commit). Two follow-up `fix(iso):` commits address registry pollution from cloned route vnodes (`f24fa89`) and silently-introduced tsc errors across Tasks 5-10 (`55d6a66`). One `fix(iso):` final-review cleanup commit (`d65c8ea`) addresses double-pushState in click flow, test isolation, and PageHost outer-rerender regression coverage.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-06-ssr-navigation-mode-design.md`
- Plan: `docs/superpowers/plans/2026-05-06-ssr-navigation-mode.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)