### PR TITLE
fix(iso): stable nested-layout rendering across sibling navigation

### DIFF
--- a/packages/iso/src/__tests__/define-routes.test.tsx
+++ b/packages/iso/src/__tests__/define-routes.test.tsx
@@ -2,9 +2,10 @@
 import { describe, it, expect } from 'vitest';
 import type { ComponentType, VNode } from 'preact';
 import { h } from 'preact';
-import { render } from '@testing-library/preact';
+import { useState } from 'preact/hooks';
+import { fireEvent, render, waitFor } from '@testing-library/preact';
 import { LocationProvider, Router } from 'preact-iso';
-import { defineRoutes, Routes } from '../define-routes.js';
+import { defineRoutes, Routes, type LayoutProps, type ViewProps } from '../define-routes.js';
 
 const noopView = () => Promise.resolve({ default: () => null });
 const noopLayout = () => Promise.resolve({ default: ({ children }: { children: unknown }) => children as never });
@@ -237,6 +238,17 @@ describe('flatten — layout groups', () => {
     expect(m.flat.map((f) => f.path)).toEqual(['/movies', '/movies/*']);
     // Same component reference for both:
     expect(m.flat[0].component).toBe(m.flat[1].component);
+    // And the same VNode key, so preact's diff treats the bare and wildcard
+    // registrations as the same child when navigation crosses between them.
+    expect(m.flat[0].key).toBe(m.flat[1].key);
+  });
+
+  it('assigns distinct keys to FlatRoute entries with distinct components', () => {
+    const m = defineRoutes([
+      { path: '/', view: noopView },
+      { path: '/about', view: () => Promise.resolve({ default: () => null }) },
+    ]);
+    expect(m.flat[0].key).not.toBe(m.flat[1].key);
   });
 
   it('mixes top-level leaves and layout groups in source order', () => {
@@ -318,5 +330,75 @@ describe('<Routes>', () => {
     }) => VNode)({ routes: m });
     expect(result.type).toBe(Router);
     expect((result.props as { onRouteChange?: unknown }).onRouteChange).toBeUndefined();
+  });
+});
+
+describe('layout integration: state survives intra-group navigation', () => {
+  it('preserves layout-owned useState across /movies <-> /movies/:id', async () => {
+    let layoutMounts = 0;
+    const Layout: ComponentType<LayoutProps> = ({ children }) => {
+      const [filter, setFilter] = useState(() => {
+        layoutMounts++;
+        return '';
+      });
+      return h(
+        'div',
+        null,
+        h('input', {
+          'data-testid': 'filter',
+          value: filter,
+          onInput: (e: Event) =>
+            setFilter((e.currentTarget as HTMLInputElement).value),
+        }),
+        children as never
+      );
+    };
+
+    const IndexView: ComponentType<ViewProps> = () =>
+      h('a', { href: '/movies/123', 'data-testid': 'to-detail' }, 'detail');
+    const DetailView: ComponentType<ViewProps> = () =>
+      h('a', { href: '/movies', 'data-testid': 'to-index' }, 'back');
+
+    const manifest = defineRoutes([
+      {
+        path: '/movies',
+        layout: () => Promise.resolve({ default: Layout }),
+        children: [
+          { path: '', view: () => Promise.resolve({ default: IndexView }) },
+          { path: ':id', view: () => Promise.resolve({ default: DetailView }) },
+        ],
+      },
+    ]);
+
+    history.replaceState(null, '', '/movies');
+    const { findByTestId } = render(
+      h(LocationProvider, null, h(Routes, { routes: manifest })) as VNode
+    );
+
+    const toDetail = (await findByTestId('to-detail')) as HTMLAnchorElement;
+    const input = (await findByTestId('filter')) as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'hello' } });
+    await waitFor(() => {
+      expect(
+        (document.querySelector('[data-testid=filter]') as HTMLInputElement).value
+      ).toBe('hello');
+    });
+
+    expect(layoutMounts).toBe(1);
+
+    fireEvent.click(toDetail);
+    await findByTestId('to-index');
+    expect(layoutMounts).toBe(1);
+    expect(
+      ((await findByTestId('filter')) as HTMLInputElement).value
+    ).toBe('hello');
+
+    const toIndex = (await findByTestId('to-index')) as HTMLAnchorElement;
+    fireEvent.click(toIndex);
+    await findByTestId('to-detail');
+    expect(layoutMounts).toBe(1);
+    expect(
+      ((await findByTestId('filter')) as HTMLInputElement).value
+    ).toBe('hello');
   });
 });

--- a/packages/iso/src/define-routes.tsx
+++ b/packages/iso/src/define-routes.tsx
@@ -21,6 +21,12 @@ export type RouteDef = {
 export type FlatRoute = {
   path: string;
   component: ComponentType<ViewProps>;
+  // Stable per-component key. Two FlatRoute entries that share the same
+  // `component` (e.g. a layout group registered at both `/movies` and
+  // `/movies/*`) share this key, so preact's diff of preact-iso's matched
+  // child does not unmount the shared subtree when the URL crosses between
+  // them. See the `Routes` component below for why this matters.
+  key: string;
 };
 
 export type RoutesManifest = {
@@ -208,8 +214,17 @@ function buildInnerRoutes(
 function flattenTree(
   routes: ReadonlyArray<RouteDef>,
   viewCache: Map<unknown, ComponentType<ViewProps>>,
+  keyCache: Map<ComponentType<ViewProps>, string>,
   parentPath = ''
 ): FlatRoute[] {
+  const keyFor = (c: ComponentType<ViewProps>): string => {
+    let k = keyCache.get(c);
+    if (!k) {
+      k = `r${keyCache.size}`;
+      keyCache.set(c, k);
+    }
+    return k;
+  };
   const out: FlatRoute[] = [];
   for (const r of routes) {
     const here =
@@ -218,24 +233,17 @@ function flattenTree(
         : parentPath + (r.path === '' ? '' : '/' + r.path);
 
     if (r.view) {
-      out.push({
-        path: here,
-        component: getOrCreateLazyView(r.view, viewCache),
-      });
+      const component = getOrCreateLazyView(r.view, viewCache);
+      out.push({ path: here, component, key: keyFor(component) });
     } else if (r.layout && r.children) {
       const Group = makeLayoutGroupComponent(r.layout, r.children, viewCache);
-      out.push({
-        path: here,
-        component: Group,
-      });
-      out.push({
-        path: here + '/*',
-        component: Group,
-      });
+      const key = keyFor(Group);
+      out.push({ path: here, component: Group, key });
+      out.push({ path: here + '/*', component: Group, key });
     } else if (r.children) {
       // Path-grouping at top level: recurse with the prefix.
       const childParent = here === '/' ? '' : here;
-      out.push(...flattenTree(r.children, viewCache, childParent));
+      out.push(...flattenTree(r.children, viewCache, keyCache, childParent));
     }
   }
   return out;
@@ -244,9 +252,10 @@ function flattenTree(
 export function defineRoutes(tree: RouteDef[]): RoutesManifest {
   validate(tree);
   const viewCache = new Map<unknown, ComponentType<ViewProps>>();
+  const keyCache = new Map<ComponentType<ViewProps>, string>();
   return {
     tree,
-    flat: flattenTree(tree, viewCache),
+    flat: flattenTree(tree, viewCache, keyCache),
     serverImports: collectServerImports(tree),
   };
 }
@@ -262,7 +271,7 @@ export const Routes: ComponentType<RoutesProps> = ({ routes, onRouteChange }) =>
     onRouteChange ? { onRouteChange } : null,
     ...routes.flat.map((r) =>
       h(Route, {
-        key: r.path,
+        key: r.key,
         path: r.path,
         component: asRouteComponent(r.component),
       })


### PR DESCRIPTION
## Summary

Fixes the v0.1 sequencing item 5b: layout state was being lost on intra-group navigation (`/movies` ↔ `/movies/:id`), despite `defineRoutes` doing the right structural thing (one shared Group component registered at both bare and wildcard paths).

## Root cause

`Routes` assigned `key: r.path` to each Route VNode, so a layout group registered at `/movies` and `/movies/*` produced sibling Route VNodes with different keys. preact-iso's matched child becomes the single child of an internal `RouteContext.Provider`; preact's diff of that single child reconciles by key, so the shared subtree (Group → Layout → inner Router) remounted whenever navigation crossed between the bare and wildcard registrations. preact-iso's own `routeChanged` check correctly returned false but couldn't override preact's outer diff.

## Fix

- `FlatRoute` carries a per-component `key`, allocated in `flattenTree` via a `Map<ComponentType, string>`.
- Both registrations for the same Group share the key, so the matched child keeps its identity across intra-group navigation.
- View-leaf routes also get unique keys derived from component identity, preserving correct remount behavior across distinct routes.

## Test plan

- [x] Integration test in `packages/iso/src/__tests__/define-routes.test.tsx` asserts the Layout's `useState` initializer runs exactly once across `/movies → /movies/:id → /movies` and the filter input value survives both transitions.
- [x] Structural tests: shared-component layout-group entries get the same `key`; distinct components get distinct keys.
- [x] Full test suite (363 tests, 40 files) passes.
- [x] `pnpm -r build` succeeds.
- [ ] Reviewer: run the demo (`pnpm --filter app dev`), type into the movies filter at `/movies`, click into `/movies/:id` and back, confirm the filter value survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)