### PR TITLE
feat: SSR streaming for loaders (spec §5 PR 3)

### DIFF
--- a/packages/iso/src/cache.ts
+++ b/packages/iso/src/cache.ts
@@ -37,7 +37,7 @@ if (!looksLikeBrowser) {
   }
 }
 
-function getRequestStore(): RequestStore | undefined {
+export function getRequestStore(): RequestStore | undefined {
   return alsInstance?.getStore();
 }
 

--- a/packages/iso/src/internal.ts
+++ b/packages/iso/src/internal.ts
@@ -23,7 +23,7 @@ export {
 export { ReloadContext } from './reload-context.js';
 
 export { getPreloadedData, deletePreloadedData } from './internal/preload.js';
-export { runRequestScope } from './cache.js';
+export { runRequestScope, getRequestStore } from './cache.js';
 export { default as wrapPromise } from './internal/wrap-promise.js';
 export { runGuards } from './guard.js';
 
@@ -37,3 +37,9 @@ export {
   installStreamRegistry,
   subscribeToLoaderStream,
 } from './internal/stream-registry.js';
+
+export {
+  registerServerStreamingLoader,
+  takeServerStreamingLoaders,
+} from './internal/streaming-ssr.js';
+export type { ServerLoaderStream } from './internal/streaming-ssr.js';

--- a/packages/iso/src/internal.ts
+++ b/packages/iso/src/internal.ts
@@ -32,3 +32,8 @@ export {
   __subscribeRouteChange,
   __enableViewTransitions,
 } from './internal/route-change.js';
+
+export {
+  installStreamRegistry,
+  subscribeToLoaderStream,
+} from './internal/stream-registry.js';

--- a/packages/iso/src/internal/__tests__/stream-registry.test.ts
+++ b/packages/iso/src/internal/__tests__/stream-registry.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installStreamRegistry, subscribeToLoaderStream } from '../stream-registry.js';
+
+beforeEach(() => {
+  delete (window as { __HP_STREAM__?: unknown }).__HP_STREAM__;
+});
+
+describe('stream-registry', () => {
+  it('drains pre-hydration queued events to subscribers on install', () => {
+    (window as { __HP_STREAM__?: unknown }).__HP_STREAM__ = {
+      queue: [
+        { type: 'push', loaderId: 'L1', value: { count: 5 } },
+        { type: 'push', loaderId: 'L1', value: { count: 6 } },
+      ],
+    } as unknown as Window['__HP_STREAM__'];
+
+    let observed: unknown[] = [];
+    const unsub = subscribeToLoaderStream('L1', {
+      push: (v) => observed.push(v),
+      end: () => {},
+      error: () => {},
+    });
+
+    installStreamRegistry();
+
+    expect(observed).toEqual([{ count: 5 }, { count: 6 }]);
+    unsub();
+  });
+
+  it('routes post-hydration push() calls to subscribers', () => {
+    installStreamRegistry();
+
+    let observed: unknown[] = [];
+    const unsub = subscribeToLoaderStream('L2', {
+      push: (v) => observed.push(v),
+      end: () => {},
+      error: () => {},
+    });
+
+    window.__HP_STREAM__!.push('L2', { count: 1 });
+    window.__HP_STREAM__!.push('L2', { count: 2 });
+
+    expect(observed).toEqual([{ count: 1 }, { count: 2 }]);
+    unsub();
+  });
+
+  it('routes error() to the subscriber as an Error instance', () => {
+    installStreamRegistry();
+
+    let caught: Error | null = null;
+    const unsub = subscribeToLoaderStream('L3', {
+      push: () => {},
+      end: () => {},
+      error: (err) => { caught = err; },
+    });
+
+    window.__HP_STREAM__!.error('L3', { message: 'boom', name: 'TypeError' });
+
+    expect(caught).not.toBeNull();
+    expect((caught as unknown as Error).message).toBe('boom');
+    expect((caught as unknown as Error).name).toBe('TypeError');
+    unsub();
+  });
+
+  it('drains queued events only to the matching loaderId, leaves others queued', () => {
+    (window as { __HP_STREAM__?: unknown }).__HP_STREAM__ = {
+      queue: [
+        { type: 'push', loaderId: 'A', value: 1 },
+        { type: 'push', loaderId: 'B', value: 2 },
+      ],
+    } as unknown as Window['__HP_STREAM__'];
+
+    let aValues: unknown[] = [];
+    const unsubA = subscribeToLoaderStream('A', {
+      push: (v) => aValues.push(v),
+      end: () => {},
+      error: () => {},
+    });
+
+    expect(aValues).toEqual([1]);
+    expect(window.__HP_STREAM__!.queue).toEqual([
+      { type: 'push', loaderId: 'B', value: 2 },
+    ]);
+    unsubA();
+  });
+
+  it('unsubscribe stops dispatching to that subscriber', () => {
+    installStreamRegistry();
+
+    let observed: unknown[] = [];
+    const unsub = subscribeToLoaderStream('L4', {
+      push: (v) => observed.push(v),
+      end: () => {},
+      error: () => {},
+    });
+
+    window.__HP_STREAM__!.push('L4', 1);
+    unsub();
+    window.__HP_STREAM__!.push('L4', 2);
+
+    expect(observed).toEqual([1]);
+  });
+});

--- a/packages/iso/src/internal/__tests__/stream-registry.test.ts
+++ b/packages/iso/src/internal/__tests__/stream-registry.test.ts
@@ -1,13 +1,25 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach } from 'vitest';
-import { installStreamRegistry, subscribeToLoaderStream } from '../stream-registry.js';
+import {
+  installStreamRegistry,
+  subscribeToLoaderStream,
+  __resetStreamRegistryForTests,
+} from '../stream-registry.js';
 
 beforeEach(() => {
+  __resetStreamRegistryForTests();
   delete (window as { __HP_STREAM__?: unknown }).__HP_STREAM__;
 });
 
 describe('stream-registry', () => {
-  it('drains pre-hydration queued events to subscribers on install', () => {
+  it('subscribe-first, then install: pre-hydration events drain via the queue', () => {
+    let observed: unknown[] = [];
+    subscribeToLoaderStream('L1', {
+      push: (v) => observed.push(v),
+      end: () => {},
+      error: () => {},
+    });
+
     (window as { __HP_STREAM__?: unknown }).__HP_STREAM__ = {
       queue: [
         { type: 'push', loaderId: 'L1', value: { count: 5 } },
@@ -15,24 +27,52 @@ describe('stream-registry', () => {
       ],
     } as unknown as Window['__HP_STREAM__'];
 
+    installStreamRegistry();
+
+    expect(observed).toEqual([{ count: 5 }, { count: 6 }]);
+  });
+
+  it('install-first, then subscribe (real-world order): pre-hydration events still drain', () => {
+    (window as { __HP_STREAM__?: unknown }).__HP_STREAM__ = {
+      queue: [
+        { type: 'push', loaderId: 'L1', value: { count: 5 } },
+        { type: 'push', loaderId: 'L1', value: { count: 6 } },
+      ],
+    } as unknown as Window['__HP_STREAM__'];
+
+    installStreamRegistry();
+
     let observed: unknown[] = [];
-    const unsub = subscribeToLoaderStream('L1', {
+    subscribeToLoaderStream('L1', {
       push: (v) => observed.push(v),
       end: () => {},
       error: () => {},
     });
 
-    installStreamRegistry();
-
     expect(observed).toEqual([{ count: 5 }, { count: 6 }]);
-    unsub();
   });
 
-  it('routes post-hydration push() calls to subscribers', () => {
+  it('events arriving post-install but pre-subscribe are buffered and drained on subscribe', () => {
+    installStreamRegistry();
+
+    window.__HP_STREAM__!.push('LATE', { tick: 1 });
+    window.__HP_STREAM__!.push('LATE', { tick: 2 });
+
+    let observed: unknown[] = [];
+    subscribeToLoaderStream('LATE', {
+      push: (v) => observed.push(v),
+      end: () => {},
+      error: () => {},
+    });
+
+    expect(observed).toEqual([{ tick: 1 }, { tick: 2 }]);
+  });
+
+  it('routes live post-subscribe push() calls to subscribers', () => {
     installStreamRegistry();
 
     let observed: unknown[] = [];
-    const unsub = subscribeToLoaderStream('L2', {
+    subscribeToLoaderStream('L2', {
       push: (v) => observed.push(v),
       end: () => {},
       error: () => {},
@@ -42,14 +82,13 @@ describe('stream-registry', () => {
     window.__HP_STREAM__!.push('L2', { count: 2 });
 
     expect(observed).toEqual([{ count: 1 }, { count: 2 }]);
-    unsub();
   });
 
   it('routes error() to the subscriber as an Error instance', () => {
     installStreamRegistry();
 
-    let caught: Error | null = null;
-    const unsub = subscribeToLoaderStream('L3', {
+    let caught = null as Error | null;
+    subscribeToLoaderStream('L3', {
       push: () => {},
       end: () => {},
       error: (err) => { caught = err; },
@@ -60,29 +99,22 @@ describe('stream-registry', () => {
     expect(caught).not.toBeNull();
     expect((caught as unknown as Error).message).toBe('boom');
     expect((caught as unknown as Error).name).toBe('TypeError');
-    unsub();
   });
 
-  it('drains queued events only to the matching loaderId, leaves others queued', () => {
-    (window as { __HP_STREAM__?: unknown }).__HP_STREAM__ = {
-      queue: [
-        { type: 'push', loaderId: 'A', value: 1 },
-        { type: 'push', loaderId: 'B', value: 2 },
-      ],
-    } as unknown as Window['__HP_STREAM__'];
+  it('does not deliver events for other loader ids to a subscriber', () => {
+    installStreamRegistry();
 
     let aValues: unknown[] = [];
-    const unsubA = subscribeToLoaderStream('A', {
+    subscribeToLoaderStream('A', {
       push: (v) => aValues.push(v),
       end: () => {},
       error: () => {},
     });
 
-    expect(aValues).toEqual([1]);
-    expect(window.__HP_STREAM__!.queue).toEqual([
-      { type: 'push', loaderId: 'B', value: 2 },
-    ]);
-    unsubA();
+    window.__HP_STREAM__!.push('B', { x: 1 });
+    window.__HP_STREAM__!.push('A', { x: 2 });
+
+    expect(aValues).toEqual([{ x: 2 }]);
   });
 
   it('unsubscribe stops dispatching to that subscriber', () => {
@@ -100,5 +132,30 @@ describe('stream-registry', () => {
     window.__HP_STREAM__!.push('L4', 2);
 
     expect(observed).toEqual([1]);
+  });
+
+  it('after unsubscribe, post-unsubscribe events for that id are buffered until a new subscriber appears', () => {
+    installStreamRegistry();
+
+    const observed: unknown[] = [];
+    const unsub = subscribeToLoaderStream('L5', {
+      push: (v) => observed.push(v),
+      end: () => {},
+      error: () => {},
+    });
+    unsub();
+
+    window.__HP_STREAM__!.push('L5', 1);
+    // First subscriber is gone; event is buffered.
+
+    const reobserved: unknown[] = [];
+    subscribeToLoaderStream('L5', {
+      push: (v) => reobserved.push(v),
+      end: () => {},
+      error: () => {},
+    });
+
+    expect(observed).toEqual([]);
+    expect(reobserved).toEqual([1]);
   });
 });

--- a/packages/iso/src/internal/loader.tsx
+++ b/packages/iso/src/internal/loader.tsx
@@ -9,6 +9,7 @@ import wrapPromise from './wrap-promise.js';
 import { ActiveLoaderIdContext, LoaderDataContext, LoaderErrorContext, LoaderIdContext } from './contexts.js';
 import type { LoaderRef } from '../define-loader.js';
 import { fetchLoaderData } from './loader-fetch.js';
+import { subscribeToLoaderStream } from './stream-registry.js';
 
 type LoaderProps<T> = {
   loader: LoaderRef<T>;
@@ -169,6 +170,20 @@ function LoaderHost<T>({
     if (preloaded !== null) {
       loaderRef.cache.set(preloaded, locKey);
       readerRef.current = { read: () => preloaded };
+      if (isBrowser()) {
+        const unsub = subscribeToLoaderStream(id, {
+          push: (value) => setOverrideData(value as T),
+          end: () => { /* nothing to do */ },
+          error: (err) => setLoadError(err),
+        });
+        // Unsubscribe on unmount: attach to the abortRef signal.
+        if (abortRef.current) {
+          abortRef.current.signal.addEventListener('abort', unsub);
+        } else {
+          abortRef.current = new AbortController();
+          abortRef.current.signal.addEventListener('abort', unsub);
+        }
+      }
     } else if (isBrowser() && isFirstRender && loaderRef.cache.has(locKey)) {
       const cached = loaderRef.cache.get(locKey)!;
       readerRef.current = { read: () => cached };

--- a/packages/iso/src/internal/loader.tsx
+++ b/packages/iso/src/internal/loader.tsx
@@ -10,6 +10,7 @@ import { ActiveLoaderIdContext, LoaderDataContext, LoaderErrorContext, LoaderIdC
 import type { LoaderRef } from '../define-loader.js';
 import { fetchLoaderData } from './loader-fetch.js';
 import { subscribeToLoaderStream } from './stream-registry.js';
+import { registerServerStreamingLoader } from './streaming-ssr.js';
 
 type LoaderProps<T> = {
   loader: LoaderRef<T>;
@@ -36,6 +37,17 @@ export function Loader<T>({
         {children}
       </LoaderHost>
     </LoaderIdContext.Provider>
+  );
+}
+
+function isAsyncGenerator(
+  value: unknown
+): value is AsyncGenerator<unknown, unknown, unknown> {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof (value as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === 'function' &&
+    typeof (value as { next?: unknown }).next === 'function'
   );
 }
 
@@ -202,22 +214,41 @@ function LoaderHost<T>({
         typeof fetch === 'function' &&
         loaderRef.__moduleKey !== undefined;
 
-      const fetchPromise: Promise<T> = useFetchPath
-        ? fetchLoaderData<T>(
-            loaderRef.__moduleKey!,
-            {
-              path: location.path,
-              pathParams: (location.pathParams ?? {}) as Record<string, string>,
-              searchParams: (location.searchParams ?? {}) as Record<string, string>,
-            },
-            newAbortSignal(),
-            {
-              onChunk: (value) => setOverrideData(value),
-              onError: (err) => setLoadError(err),
-              onEnd: () => { /* nothing to do */ },
+      let fetchPromise: Promise<T>;
+      if (useFetchPath) {
+        fetchPromise = fetchLoaderData<T>(
+          loaderRef.__moduleKey!,
+          {
+            path: location.path,
+            pathParams: (location.pathParams ?? {}) as Record<string, string>,
+            searchParams: (location.searchParams ?? {}) as Record<string, string>,
+          },
+          newAbortSignal(),
+          {
+            onChunk: (value) => setOverrideData(value),
+            onError: (err) => setLoadError(err),
+            onEnd: () => { /* nothing to do */ },
+          }
+        );
+      } else {
+        // Direct-fn path. Result may be a Promise<T>, a
+        // Promise<ReadableStream<T>>, or an AsyncGenerator<T>. For an async
+        // generator (server-side streaming loader), take the first chunk
+        // for the Suspense render and register the rest with the per-request
+        // streaming-ssr registry so renderPage can flush further chunks.
+        fetchPromise = (async () => {
+          const result = await (loaderRef.fn({ location, signal: newAbortSignal() }) as Promise<unknown>);
+          if (isAsyncGenerator(result)) {
+            const step = await result.next();
+            if (step.done) {
+              return undefined as T; // generator returned without yielding
             }
-          )
-        : (loaderRef.fn({ location, signal: newAbortSignal() }) as Promise<T>);
+            registerServerStreamingLoader(id, result);
+            return step.value as T;
+          }
+          return result as T;
+        })();
+      }
 
       readerRef.current = wrapPromise(
         fetchPromise

--- a/packages/iso/src/internal/stream-registry.ts
+++ b/packages/iso/src/internal/stream-registry.ts
@@ -1,0 +1,94 @@
+type StreamEvent =
+  | { type: 'push'; loaderId: string; value: unknown }
+  | { type: 'end'; loaderId: string }
+  | { type: 'error'; loaderId: string; error: { message: string; name: string } };
+
+type Subscriber = {
+  push: (value: unknown) => void;
+  end: () => void;
+  error: (err: Error) => void;
+};
+
+type StreamRegistry = {
+  push: (loaderId: string, value: unknown) => void;
+  end: (loaderId: string) => void;
+  error: (loaderId: string, error: { message: string; name: string }) => void;
+  /** Pre-hydration buffer; the SSR inline bootstrap pushes events here. */
+  queue?: StreamEvent[];
+};
+
+declare global {
+  interface Window {
+    __HP_STREAM__?: StreamRegistry;
+  }
+}
+
+const subscribers = new Map<string, Subscriber>();
+
+/**
+ * Subscribe a loader mount to events for its loader id. Returns an
+ * unsubscribe function. If a buffered event exists for this id in the
+ * pre-hydration queue, it is dispatched immediately on subscribe.
+ */
+export function subscribeToLoaderStream(
+  loaderId: string,
+  sub: Subscriber
+): () => void {
+  subscribers.set(loaderId, sub);
+
+  // Drain any buffered events for this id from the pre-hydration queue.
+  if (typeof window !== 'undefined') {
+    const reg = window.__HP_STREAM__;
+    if (reg?.queue) {
+      const drained: StreamEvent[] = [];
+      for (const ev of reg.queue) {
+        if (ev.loaderId === loaderId) dispatch(ev);
+        else drained.push(ev);
+      }
+      reg.queue = drained;
+    }
+  }
+
+  return () => {
+    if (subscribers.get(loaderId) === sub) subscribers.delete(loaderId);
+  };
+}
+
+function dispatch(ev: StreamEvent): void {
+  const sub = subscribers.get(ev.loaderId);
+  if (!sub) return;
+  if (ev.type === 'push') sub.push(ev.value);
+  else if (ev.type === 'end') sub.end();
+  else if (ev.type === 'error') {
+    const err = new Error(ev.error.message);
+    err.name = ev.error.name;
+    sub.error(err);
+  }
+}
+
+/**
+ * Install the dispatcher on `window.__HP_STREAM__`. If the SSR inline
+ * bootstrap already populated a queue, drain it. After installation,
+ * subsequent script-tag pushes from the still-streaming response body
+ * route directly to live subscriptions.
+ */
+export function installStreamRegistry(): void {
+  if (typeof window === 'undefined') return;
+  const existing = window.__HP_STREAM__;
+  const queue = existing?.queue ?? [];
+
+  window.__HP_STREAM__ = {
+    push(loaderId: string, value: unknown) {
+      dispatch({ type: 'push', loaderId, value });
+    },
+    end(loaderId: string) {
+      dispatch({ type: 'end', loaderId });
+    },
+    error(loaderId: string, error: { message: string; name: string }) {
+      dispatch({ type: 'error', loaderId, error });
+    },
+  };
+
+  // Drain any pre-hydration events.
+  for (const ev of queue) dispatch(ev);
+}

--- a/packages/iso/src/internal/stream-registry.ts
+++ b/packages/iso/src/internal/stream-registry.ts
@@ -13,7 +13,12 @@ type StreamRegistry = {
   push: (loaderId: string, value: unknown) => void;
   end: (loaderId: string) => void;
   error: (loaderId: string, error: { message: string; name: string }) => void;
-  /** Pre-hydration buffer; the SSR inline bootstrap pushes events here. */
+  /**
+   * Pre-hydration buffer. The SSR inline bootstrap script populates this
+   * before the client bundle loads. After `installStreamRegistry()` runs,
+   * the field continues to back per-loader buffering of events whose
+   * subscriber hasn't mounted yet (the common case during streaming SSR).
+   */
   queue?: StreamEvent[];
 };
 
@@ -24,39 +29,23 @@ declare global {
 }
 
 const subscribers = new Map<string, Subscriber>();
+const buffered = new Map<string, StreamEvent[]>();
 
-/**
- * Subscribe a loader mount to events for its loader id. Returns an
- * unsubscribe function. If a buffered event exists for this id in the
- * pre-hydration queue, it is dispatched immediately on subscribe.
- */
-export function subscribeToLoaderStream(
-  loaderId: string,
-  sub: Subscriber
-): () => void {
-  subscribers.set(loaderId, sub);
-
-  // Drain any buffered events for this id from the pre-hydration queue.
-  if (typeof window !== 'undefined') {
-    const reg = window.__HP_STREAM__;
-    if (reg?.queue) {
-      const drained: StreamEvent[] = [];
-      for (const ev of reg.queue) {
-        if (ev.loaderId === loaderId) dispatch(ev);
-        else drained.push(ev);
-      }
-      reg.queue = drained;
+function dispatchOrBuffer(ev: StreamEvent): void {
+  const sub = subscribers.get(ev.loaderId);
+  if (sub) {
+    dispatch(ev, sub);
+  } else {
+    let bucket = buffered.get(ev.loaderId);
+    if (!bucket) {
+      bucket = [];
+      buffered.set(ev.loaderId, bucket);
     }
+    bucket.push(ev);
   }
-
-  return () => {
-    if (subscribers.get(loaderId) === sub) subscribers.delete(loaderId);
-  };
 }
 
-function dispatch(ev: StreamEvent): void {
-  const sub = subscribers.get(ev.loaderId);
-  if (!sub) return;
+function dispatch(ev: StreamEvent, sub: Subscriber): void {
   if (ev.type === 'push') sub.push(ev.value);
   else if (ev.type === 'end') sub.end();
   else if (ev.type === 'error') {
@@ -67,28 +56,57 @@ function dispatch(ev: StreamEvent): void {
 }
 
 /**
- * Install the dispatcher on `window.__HP_STREAM__`. If the SSR inline
- * bootstrap already populated a queue, drain it. After installation,
- * subsequent script-tag pushes from the still-streaming response body
- * route directly to live subscriptions.
+ * Subscribe a loader mount to events for its loader id. Returns an
+ * unsubscribe function. Drains any buffered events for this id
+ * immediately, in order.
+ */
+export function subscribeToLoaderStream(
+  loaderId: string,
+  sub: Subscriber
+): () => void {
+  subscribers.set(loaderId, sub);
+
+  const bucket = buffered.get(loaderId);
+  if (bucket) {
+    buffered.delete(loaderId);
+    for (const ev of bucket) dispatch(ev, sub);
+  }
+
+  return () => {
+    if (subscribers.get(loaderId) === sub) subscribers.delete(loaderId);
+  };
+}
+
+/**
+ * Install the live dispatcher on `window.__HP_STREAM__`. Any events that
+ * were buffered by the SSR inline bootstrap (in `window.__HP_STREAM__.queue`)
+ * are routed through `dispatchOrBuffer`, which either delivers them to an
+ * already-registered subscriber or holds them until one registers.
  */
 export function installStreamRegistry(): void {
   if (typeof window === 'undefined') return;
   const existing = window.__HP_STREAM__;
-  const queue = existing?.queue ?? [];
+  const initialQueue = existing?.queue ?? [];
 
   window.__HP_STREAM__ = {
     push(loaderId: string, value: unknown) {
-      dispatch({ type: 'push', loaderId, value });
+      dispatchOrBuffer({ type: 'push', loaderId, value });
     },
     end(loaderId: string) {
-      dispatch({ type: 'end', loaderId });
+      dispatchOrBuffer({ type: 'end', loaderId });
     },
     error(loaderId: string, error: { message: string; name: string }) {
-      dispatch({ type: 'error', loaderId, error });
+      dispatchOrBuffer({ type: 'error', loaderId, error });
     },
   };
 
-  // Drain any pre-hydration events.
-  for (const ev of queue) dispatch(ev);
+  for (const ev of initialQueue) dispatchOrBuffer(ev);
+}
+
+/**
+ * Test-only: clear all buffers and subscribers. Not exposed via internal.ts.
+ */
+export function __resetStreamRegistryForTests(): void {
+  subscribers.clear();
+  buffered.clear();
 }

--- a/packages/iso/src/internal/streaming-ssr.ts
+++ b/packages/iso/src/internal/streaming-ssr.ts
@@ -1,0 +1,41 @@
+import { getRequestStore } from '../cache.js';
+
+export type ServerLoaderStream = {
+  loaderId: string;
+  gen: AsyncGenerator<unknown, unknown, unknown>;
+};
+
+const REGISTRY_KEY = Symbol.for('@hono-preact/streaming-ssr-registry');
+
+/**
+ * Register a streaming loader's remaining generator iterations for the
+ * current request. Called from LoaderHost's server-side branch after the
+ * first chunk is already in the rendered HTML.
+ */
+export function registerServerStreamingLoader(
+  loaderId: string,
+  gen: AsyncGenerator<unknown, unknown, unknown>
+): void {
+  const store = getRequestStore();
+  if (!store) return; // outside any request scope (e.g., client)
+  let list = store.get(REGISTRY_KEY) as ServerLoaderStream[] | undefined;
+  if (!list) {
+    list = [];
+    store.set(REGISTRY_KEY, list);
+  }
+  list.push({ loaderId, gen });
+}
+
+/**
+ * Take ownership of the registered streaming loaders for the current
+ * request. After this returns, the registry is cleared. Called from
+ * `renderPage` after prerender resolves, while still inside
+ * `runRequestScope`.
+ */
+export function takeServerStreamingLoaders(): ServerLoaderStream[] {
+  const store = getRequestStore();
+  if (!store) return [];
+  const list = (store.get(REGISTRY_KEY) as ServerLoaderStream[] | undefined) ?? [];
+  store.set(REGISTRY_KEY, []);
+  return list;
+}

--- a/packages/server/src/__tests__/render-stream.test.tsx
+++ b/packages/server/src/__tests__/render-stream.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { renderPage } from '../render.js';
+import { defineLoader } from '@hono-preact/iso';
+import { Loader } from '@hono-preact/iso/internal';
+import type { RouteHook } from 'preact-iso';
+
+// Helper: read a streaming response body fully to a string.
+async function readBody(res: Response): Promise<string> {
+  if (!res.body) return await res.text();
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let out = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+const loc = {
+  path: '/',
+  pathParams: {},
+  searchParams: {},
+} as unknown as RouteHook;
+
+describe('renderPage: streaming SSR', () => {
+  it('preserves single-shot behavior when no streaming loaders are present', async () => {
+    const loader = defineLoader(async () => ({ msg: 'hi' }));
+    const app = new Hono();
+    app.get('/', (c) =>
+      renderPage(
+        c,
+        <Loader loader={loader} location={loc}>
+          <p>static</p>
+        </Loader>
+      )
+    );
+    const res = await app.request('/');
+    const body = await readBody(res);
+    expect(body).toContain('<!doctype html>');
+    expect(body).toContain('static');
+    expect(body).not.toContain('__HP_STREAM__');
+  });
+
+  it('streams chunks as inline script tags for an async-generator loader', async () => {
+    const loader = defineLoader<{ count: number }>(async function* () {
+      yield { count: 1 };
+      yield { count: 2 };
+      yield { count: 3 };
+    });
+    const app = new Hono();
+    app.get('/', (c) =>
+      renderPage(
+        c,
+        <Loader loader={loader} location={loc}>
+          <p>streaming</p>
+        </Loader>
+      )
+    );
+    const res = await app.request('/');
+    const body = await readBody(res);
+    expect(body).toContain('<!doctype html>');
+    expect(body).toContain('__HP_STREAM__');
+    // First chunk is baked into the initial render; chunks 2 and 3 arrive as script tags.
+    expect(body).toContain('window.__HP_STREAM__.push');
+    expect(body).toContain('"count":2');
+    expect(body).toContain('"count":3');
+    expect(body).toContain('window.__HP_STREAM__.end');
+    // Confirm the response terminates (controller.close() was called).
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it('emits an error script tag when the generator throws', async () => {
+    const loader = defineLoader(async function* (): AsyncGenerator<{ count: number }> {
+      yield { count: 1 };
+      throw new Error('mid-stream');
+    });
+    const app = new Hono();
+    app.get('/', (c) =>
+      renderPage(
+        c,
+        <Loader loader={loader} location={loc}>
+          <p>streaming</p>
+        </Loader>
+      )
+    );
+    const res = await app.request('/');
+    const body = await readBody(res);
+    expect(body).toContain('window.__HP_STREAM__.error');
+    expect(body).toContain('"message":"mid-stream"');
+  });
+});

--- a/packages/server/src/render.tsx
+++ b/packages/server/src/render.tsx
@@ -3,7 +3,8 @@ import type { VNode } from 'preact';
 import { createDispatcher, HoofdProvider } from 'hoofd/preact';
 import { prerender } from 'preact-iso/prerender';
 import { GuardRedirect, env } from '@hono-preact/iso';
-import { runRequestScope } from '@hono-preact/iso/internal';
+import { runRequestScope, takeServerStreamingLoaders } from '@hono-preact/iso/internal';
+import type { ServerLoaderStream } from '@hono-preact/iso/internal';
 
 function escapeHtml(str: string): string {
   return str
@@ -20,22 +21,25 @@ function toAttrs(obj: Record<string, string | undefined>): string {
     .join(' ');
 }
 
-// this is a bit too naive still
 export async function renderPage(
   c: Context,
   node: VNode,
   options?: { defaultTitle?: string }
 ): Promise<Response> {
   const dispatcher = createDispatcher();
-
   const previousEnv = env.current;
   env.current = 'server';
 
   let html: string;
+  let streamingLoaders: ServerLoaderStream[];
   try {
-    ({ html } = await runRequestScope(() =>
-      prerender(<HoofdProvider value={dispatcher}>{node}</HoofdProvider>)
-    ));
+    const result = await runRequestScope(async () => {
+      const rendered = await prerender(<HoofdProvider value={dispatcher}>{node}</HoofdProvider>);
+      const loaders = takeServerStreamingLoaders();
+      return { html: rendered.html, streamingLoaders: loaders };
+    });
+    html = result.html;
+    streamingLoaders = result.streamingLoaders;
   } catch (e: unknown) {
     if (e instanceof GuardRedirect) return c.redirect(e.location);
     throw e;
@@ -67,18 +71,99 @@ export async function renderPage(
   // <html lang> wrapper for backward compatibility.
   const startsWithHtml = /^\s*<html(\s|>)/i.test(inner);
 
-  if (startsWithHtml) {
-    const withLang =
-      lang != null
+  const fullHtml = startsWithHtml
+    ? (lang != null
         ? inner.replace(/<html(\s|>)/i, `<html lang="${escapeHtml(lang)}"$1`)
-        : inner;
-    return c.html(`<!doctype html>${withLang}`);
+        : inner)
+    : `<html lang="${escapeHtml(lang ?? 'en-US')}">\n${inner}\n</html>`;
+
+  // Non-streaming case: preserve existing single-shot behavior.
+  if (streamingLoaders.length === 0) {
+    return c.html(`<!doctype html>${fullHtml}`);
   }
 
-  return c.html(
-    `<!doctype html>
-      <html lang="${escapeHtml(lang ?? 'en-US')}">
-        ${inner}
-      </html>`
-  );
+  // Streaming case: split at </body> so we can interleave per-loader chunk
+  // script tags between the rendered body and the closing tags.
+  const bodyCloseIdx = fullHtml.lastIndexOf('</body>');
+  const beforeBody = bodyCloseIdx >= 0 ? fullHtml.slice(0, bodyCloseIdx) : fullHtml;
+  const afterBody = bodyCloseIdx >= 0 ? fullHtml.slice(bodyCloseIdx) : '';
+
+  // Inline bootstrap installs a queue on window.__HP_STREAM__ so that
+  // events flushed BEFORE the client bundle loads are buffered. The
+  // client entry calls installStreamRegistry() which drains the queue.
+  const bootstrap =
+    '<script>window.__HP_STREAM__=window.__HP_STREAM__||{queue:[],' +
+    'push(id,v){this.queue.push({type:"push",loaderId:id,value:v})},' +
+    'end(id){this.queue.push({type:"end",loaderId:id})},' +
+    'error(id,e){this.queue.push({type:"error",loaderId:id,error:e})}};</script>';
+
+  const encoder = new TextEncoder();
+  const requestSignal = c.req.raw.signal;
+
+  const responseStream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        controller.enqueue(encoder.encode(`<!doctype html>${beforeBody}\n${bootstrap}\n`));
+
+        // Drive each pending generator in parallel; emit script tags per chunk.
+        await Promise.all(
+          streamingLoaders.map(async ({ loaderId, gen }) => {
+            try {
+              while (true) {
+                if (requestSignal.aborted) {
+                  await gen.return(undefined).catch(() => { /* swallow */ });
+                  return;
+                }
+                const step = await gen.next();
+                if (step.done) {
+                  controller.enqueue(
+                    encoder.encode(
+                      `<script>window.__HP_STREAM__.end(${JSON.stringify(loaderId)})</script>\n`
+                    )
+                  );
+                  return;
+                }
+                controller.enqueue(
+                  encoder.encode(
+                    `<script>window.__HP_STREAM__.push(${JSON.stringify(loaderId)},${JSON.stringify(step.value)})</script>\n`
+                  )
+                );
+              }
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              const name = err instanceof Error ? err.name : 'Error';
+              controller.enqueue(
+                encoder.encode(
+                  `<script>window.__HP_STREAM__.error(${JSON.stringify(loaderId)},${JSON.stringify({ message, name })})</script>\n`
+                )
+              );
+            }
+          })
+        );
+
+        controller.enqueue(encoder.encode(afterBody));
+      } finally {
+        controller.close();
+      }
+    },
+    cancel() {
+      for (const { gen } of streamingLoaders) {
+        gen.return(undefined).catch(() => { /* swallow */ });
+      }
+    },
+  });
+
+  requestSignal.addEventListener('abort', () => {
+    for (const { gen } of streamingLoaders) {
+      gen.return(undefined).catch(() => { /* swallow */ });
+    }
+  });
+
+  return new Response(responseStream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Transfer-Encoding': 'chunked',
+    },
+  });
 }

--- a/packages/vite/src/__tests__/client-entry.test.ts
+++ b/packages/vite/src/__tests__/client-entry.test.ts
@@ -20,8 +20,9 @@ describe('generateClientEntrySource', () => {
     expect(src).toContain(`import { LocationProvider } from 'preact-iso';`);
     expect(src).toContain(`import { Routes } from '@hono-preact/iso';`);
     expect(src).toContain(
-      `import { __dispatchRouteChange } from '@hono-preact/iso/internal';`
+      `import { __dispatchRouteChange, installStreamRegistry } from '@hono-preact/iso/internal';`
     );
+    expect(src).toContain(`installStreamRegistry();`);
     expect(src).toContain(`import routes from '/proj/src/routes.ts';`);
   });
 

--- a/packages/vite/src/client-entry.ts
+++ b/packages/vite/src/client-entry.ts
@@ -15,8 +15,10 @@ export function generateClientEntrySource(
     `import { h, hydrate } from 'preact';\n` +
     `import { LocationProvider } from 'preact-iso';\n` +
     `import { Routes } from '@hono-preact/iso';\n` +
-    `import { __dispatchRouteChange } from '@hono-preact/iso/internal';\n` +
+    `import { __dispatchRouteChange, installStreamRegistry } from '@hono-preact/iso/internal';\n` +
     `import routes from '${opts.routesAbsPath}';\n` +
+    `\n` +
+    `installStreamRegistry();\n` +
     `\n` +
     `let lastPath;\n` +
     `function onRouteChange(path) {\n` +


### PR DESCRIPTION
## Summary

Implements PR 3 of `docs/superpowers/specs/2026-05-11-streaming-loaders-and-actions-design.md`. The payoff PR: initial page load streams loader chunks via the HTML response body — no follow-up fetch required.

After this PR, the streaming-loader story is complete:

- **Initial paint:** server renders with the loader's first chunk baked into HTML; response stays open.
- **Continued streaming on first paint:** server flushes `<script>window.__HP_STREAM__.push("<id>", value)</script>` inline as further chunks arrive from the loader's async generator.
- **Hydration takeover:** client-entry calls `installStreamRegistry()` before `hydrate()`; the inline bootstrap queue is drained into per-loader subscriptions as components mount.
- **Direct URL works the same as client navigation:** opening a streaming-loader page directly gets the same continuous-stream UX as navigating to it from elsewhere.

Combined with PR #17 (SSE wire + action streaming) and PR #18 (client-side loader streaming + cache fix), the v0.1 sequencing item 5 differentiator is functionally complete; PR 4 will add the `/live-stats` demo + docs.

## Changes

**Client-side registry (Task 12 + fix):**
- New `packages/iso/src/internal/stream-registry.ts`. The dispatcher routes via `dispatchOrBuffer`: events with a registered subscriber are delivered immediately; events without are buffered per loader id and drained on `subscribeToLoaderStream(id, ...)`. Both orderings (subscribe-first or install-first) work correctly. The initial implementation drained on install without buffering — a critical bug since `installStreamRegistry()` runs BEFORE `hydrate()`, meaning no subscribers exist yet. `5128a94` fixes that.
- `installStreamRegistry()` is wired into the framework's client entry template (`packages/vite/src/client-entry.ts`) so it runs before `hydrate()`.
- `LoaderHost` subscribes on the SSR-preload path (where `getPreloadedData(id)` returns a value) so the same `useId`-derived id is used end-to-end.

**Server-side pipeline (Task 13):**
- New `packages/iso/src/internal/streaming-ssr.ts` exposes a request-scoped registry (`registerServerStreamingLoader`, `takeServerStreamingLoaders`) backed by `AsyncLocalStorage` via the existing `runRequestScope` machinery.
- `LoaderHost`'s SSR branch detects async-generator loader returns: awaits `gen.next()` for the first chunk (which resolves the Suspense reader), then registers the remaining generator under the LoaderHost's `useId` id.
- `renderPage` is rewritten to keep the response open when streaming loaders are registered: emits HTML up to the last `</body>`, injects an inline `__HP_STREAM__` bootstrap (a queue that the client drains on `installStreamRegistry`), then drives all generators in parallel via `Promise.all`, emitting `push` / `end` / `error` script tags. Closes with the trailing tags. Request-abort signal aborts all in-flight generators.
- `cache.ts` exports `getRequestStore` (was private) so the streaming-ssr module can read/write per-request store entries.

## Test coverage

- `packages/iso/src/internal/__tests__/stream-registry.test.ts` — 8 tests covering subscribe-first, install-first, post-install pre-subscribe buffering, live routing, error reconstruction, loader-id isolation, unsubscribe, re-subscribe-after-unsubscribe.
- `packages/server/src/__tests__/render-stream.test.tsx` — 3 tests covering static loader (no streaming), 3-yield generator chunks, mid-stream error.
- Plus all pre-existing tests still pass.

`pnpm vitest run`: **406 tests pass** (up from 395 after Task 13's adds).
`pnpm -r build`: typecheck clean.

## Test plan

- [x] Full vitest suite passes.
- [x] Full typecheck passes.
- [ ] Reviewer: spot-check the bootstrap script emitted in `render.tsx` (the inline `<script>window.__HP_STREAM__ = ...</script>`) for correctness and brevity.
- [ ] Reviewer: PR 4 will add `/live-stats` for human verification of streaming SSR end-to-end. For now, you can construct the demo locally to test or wait for PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)