### PR TITLE
Mount user app ahead of reserved RPC paths (#43)

### DIFF
--- a/apps/site/src/pages/docs/csrf.mdx
+++ b/apps/site/src/pages/docs/csrf.mdx
@@ -47,7 +47,7 @@ app.use('/__actions', async (c, next) => {
 export default app;
 ```
 
-This works because the framework mounts your `api.ts` app **ahead of** its own reserved paths (`/__loaders`, `/__actions`) and the page renderer. Middleware you register in `api.ts` therefore runs before the framework's RPC and SSR handlers — `app.use('/__actions', …)` reaches the actions endpoint, and `app.use('*', …)` is effectively app-wide. Middleware via `app.use(…)` is always safe: it calls `next()` and composes ahead of the framework handlers rather than replacing them. What you must not do is register a catch-all _route_ — `app.get('*', …)`, `app.all('/*', …)`, or `app.on(…)` with `'*'` as the path — or the literal paths `/__loaders` / `/__actions` in `api.ts`: those shadow the framework's handlers, so the build rejects them.
+This works because the framework mounts your `api.ts` app **ahead of** its own reserved paths (`/__loaders`, `/__actions`) and the page renderer. Middleware you register in `api.ts` therefore runs before the framework's RPC and SSR handlers: `app.use('/__actions', …)` reaches the actions endpoint, and `app.use('*', …)` is effectively app-wide. Middleware via `app.use(…)` is always safe: it calls `next()` and composes ahead of the framework handlers rather than replacing them. What you must not do is register a catch-all _route_ (`app.get('*', …)`, `app.all('/*', …)`, or `app.on(…)` with `'*'` as the path) or the literal paths `/__loaders` / `/__actions` in `api.ts`: those shadow the framework's handlers, so the build rejects them.
 
 ### Configure the allowed origin
 

--- a/apps/site/src/pages/docs/csrf.mdx
+++ b/apps/site/src/pages/docs/csrf.mdx
@@ -47,7 +47,7 @@ app.use('/__actions', async (c, next) => {
 export default app;
 ```
 
-This works because the framework mounts your `api.ts` app **ahead of** its own reserved paths (`/__loaders`, `/__actions`) and the page renderer. Middleware you register in `api.ts` therefore runs before the framework's RPC and SSR handlers — `app.use('/__actions', …)` reaches the actions endpoint, and `app.use('*', …)` is effectively app-wide. The flip side: do not register a catch-all route (`*`, `/*`, `app.on(...)` on `'*'`) or the literal paths `/__loaders` / `/__actions` in `api.ts` — they would shadow the framework's handlers, so the build rejects them.
+This works because the framework mounts your `api.ts` app **ahead of** its own reserved paths (`/__loaders`, `/__actions`) and the page renderer. Middleware you register in `api.ts` therefore runs before the framework's RPC and SSR handlers — `app.use('/__actions', …)` reaches the actions endpoint, and `app.use('*', …)` is effectively app-wide. Middleware via `app.use(…)` is always safe: it calls `next()` and composes ahead of the framework handlers rather than replacing them. What you must not do is register a catch-all _route_ — `app.get('*', …)`, `app.all('/*', …)`, or `app.on(…)` with `'*'` as the path — or the literal paths `/__loaders` / `/__actions` in `api.ts`: those shadow the framework's handlers, so the build rejects them.
 
 ### Configure the allowed origin
 

--- a/apps/site/src/pages/docs/csrf.mdx
+++ b/apps/site/src/pages/docs/csrf.mdx
@@ -47,6 +47,8 @@ app.use('/__actions', async (c, next) => {
 export default app;
 ```
 
+This works because the framework mounts your `api.ts` app **ahead of** its own reserved paths (`/__loaders`, `/__actions`) and the page renderer. Middleware you register in `api.ts` therefore runs before the framework's RPC and SSR handlers — `app.use('/__actions', …)` reaches the actions endpoint, and `app.use('*', …)` is effectively app-wide. The flip side: do not register a catch-all route (`*`, `/*`, `app.on(...)` on `'*'`) or the literal paths `/__loaders` / `/__actions` in `api.ts` — they would shadow the framework's handlers, so the build rejects them.
+
 ### Configure the allowed origin
 
 Hard-code the production origin or read it from an environment variable. **Do not derive it from the request** (e.g. `new URL(c.req.url).origin`); behind a CDN or reverse proxy, the request URL the worker sees may use a different scheme or host than the browser sent, and the comparison will silently mis-match or, worse, silently allow.

--- a/docs/superpowers/plans/2026-05-17-reserved-path-middleware.md
+++ b/docs/superpowers/plans/2026-05-17-reserved-path-middleware.md
@@ -1,0 +1,823 @@
+# Reserved-path middleware: mount user app on top — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users apply HTTP middleware (e.g. `csrf()`) to the framework's reserved RPC paths by mounting the user's `api.ts` app ahead of the framework handlers in the generated server entry.
+
+**Architecture:** The generated server entry currently registers `POST /__loaders` and `POST /__actions` before `.route('/', userApp)`. Hono composes matched handlers in registration order, so user middleware never runs before the reserved-path handlers. We flip the order (user app first), and replace the lost "user code cannot shadow reserved paths" structural guarantee with build-time detection that fails the build on catch-all routes and literal reserved-path registrations in `api.ts`.
+
+**Tech Stack:** TypeScript, Vite plugin API (Rollup `PluginContext`), `@babel/parser` for static analysis of `api.ts`, Hono, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md`
+
+---
+
+## File Structure
+
+- `packages/vite/src/server-entry.ts` — modified. `generateServerEntrySource` reorders the mount; the `CatchAllWarning` type and `findApiCatchAllRoutes` walker are renamed and extended; `serverEntryPlugin`'s `buildStart` switches severity between `this.warn` and `this.error`.
+- `packages/vite/src/__tests__/server-entry.test.ts` — modified. Updated assertions for the new order, the renamed/extended detector, and the error-vs-warn `buildStart` behavior; new mount-order composition test.
+- `apps/site/src/pages/docs/csrf.mdx` — modified. Note that the recipe works because the user app mounts ahead of reserved paths; note `api.ts` middleware is effectively app-wide.
+- `docs/superpowers/research/2026-05-14-hono-primitives-audit.md` — modified. Correct the now-false `hono/csrf` claim and annotate recommendation 1.
+
+---
+
+## Task 1: Reorder the generated server entry
+
+**Files:**
+- Modify: `packages/vite/src/server-entry.ts:43-50` (`generateServerEntrySource` return value)
+- Test: `packages/vite/src/__tests__/server-entry.test.ts:74-89`
+
+- [ ] **Step 1: Update the failing test**
+
+Replace the test at `server-entry.test.ts:74-89` (`it('emits the api import and mount when apiAbsPath is provided, before the catchall', ...)`) with:
+
+```ts
+  it('emits the api import and mounts userApp before the reserved paths and catchall', () => {
+    const src = generateServerEntrySource({
+      layoutAbsPath: '/proj/src/Layout.tsx',
+      routesAbsPath: '/proj/src/routes.ts',
+      apiAbsPath: '/proj/src/api.ts',
+    });
+
+    expect(src).toContain(`import userApp from '/proj/src/api.ts';`);
+    expect(src).toContain(`.route('/', userApp)`);
+
+    // The user's app must be mounted BEFORE the reserved paths so that
+    // middleware registered in api.ts composes ahead of loadersHandler /
+    // actionsHandler. See docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md
+    const apiIdx = src.indexOf(`.route('/', userApp)`);
+    const loadersIdx = src.indexOf(`'/__loaders'`);
+    const actionsIdx = src.indexOf(`'/__actions'`);
+    const catchallIdx = src.indexOf(`.get('*'`);
+    expect(apiIdx).toBeGreaterThan(-1);
+    expect(loadersIdx).toBeGreaterThan(apiIdx);
+    expect(actionsIdx).toBeGreaterThan(loadersIdx);
+    expect(catchallIdx).toBeGreaterThan(actionsIdx);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts -t "mounts userApp before"`
+Expected: FAIL — `loadersIdx` is currently less than `apiIdx` (api is mounted after the reserved paths).
+
+- [ ] **Step 3: Reorder the mount in `generateServerEntrySource`**
+
+In `packages/vite/src/server-entry.ts`, the return value currently ends:
+
+```ts
+    `export const app = new Hono()\n` +
+    `  .post('/__loaders', loadersHandler(serverModules, handlerOpts))\n` +
+    `  .post('/__actions', actionsHandler(serverModules, handlerOpts))\n` +
+    apiMount +
+    `  .get('*', (c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes })))));\n` +
+```
+
+Move `apiMount` above the two `.post(...)` lines:
+
+```ts
+    `export const app = new Hono()\n` +
+    apiMount +
+    `  .post('/__loaders', loadersHandler(serverModules, handlerOpts))\n` +
+    `  .post('/__actions', actionsHandler(serverModules, handlerOpts))\n` +
+    `  .get('*', (c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes })))));\n` +
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts`
+Expected: PASS — all `generateServerEntrySource` and `serverEntryPlugin` tests green (the no-api test and the existing `buildStart` tests are unaffected by the reorder).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/server-entry.ts packages/vite/src/__tests__/server-entry.test.ts
+git commit -m "feat(vite): mount user api app ahead of reserved RPC paths"
+```
+
+---
+
+## Task 2: Mount-order composition regression test
+
+This is a **characterization test**: it exercises Hono's composition semantics plus the order Task 1 produces, so it passes as soon as it is written (there is no red phase — it is a regression guard documenting *why* the order matters).
+
+**Files:**
+- Test: `packages/vite/src/__tests__/server-entry.test.ts` (append a new `describe` block)
+
+- [ ] **Step 1: Add the composition test**
+
+Append this `describe` block at the end of `packages/vite/src/__tests__/server-entry.test.ts`:
+
+```ts
+describe('mount-order composition (why api.ts is mounted first)', () => {
+  it('middleware in the user app guards the reserved /__actions path', async () => {
+    const { Hono } = await import('hono');
+    const { csrf } = await import('hono/csrf');
+
+    let actionRan = false;
+    const userApp = new Hono();
+    userApp.use('*', csrf({ origin: 'https://example.com' }));
+
+    // Mirrors the order generateServerEntrySource emits: userApp first.
+    const app = new Hono()
+      .route('/', userApp)
+      .post('/__actions', (c) => {
+        actionRan = true;
+        return c.json({ ok: true });
+      });
+
+    // Cross-origin form post: csrf rejects before the action handler runs.
+    const blocked = await app.request('https://example.com/__actions', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://evil.example',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'x=1',
+    });
+    expect(blocked.status).toBe(403);
+    expect(actionRan).toBe(false);
+
+    // Same-origin form post: passes csrf, reaches the action handler.
+    const ok = await app.request('https://example.com/__actions', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://example.com',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'x=1',
+    });
+    expect(ok.status).toBe(200);
+    expect(actionRan).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts -t "middleware in the user app guards"`
+Expected: PASS. If it fails, the assumption behind Task 1 is wrong — stop and re-check `hono/csrf` behavior before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/vite/src/__tests__/server-entry.test.ts
+git commit -m "test(vite): pin that user-app middleware guards reserved RPC paths"
+```
+
+---
+
+## Task 3: Extend shadow detection — rename, severity, reserved paths, `.on()` fix
+
+Rename `findApiCatchAllRoutes` to `findApiShadowingRoutes` and `CatchAllWarning` to `ApiShadowingRoute`; add a `severity` field; detect literal reserved-path registrations; fix the `.on()` path-argument index.
+
+**Files:**
+- Modify: `packages/vite/src/server-entry.ts:53-173` (type, constants, `findApiCatchAllRoutes`, `walk`)
+- Test: `packages/vite/src/__tests__/server-entry.test.ts:92-183` (`findApiCatchAllRoutes` describe block)
+
+- [ ] **Step 1: Update the detector tests**
+
+Replace the entire `describe('findApiCatchAllRoutes', ...)` block (`server-entry.test.ts:92-183`) with:
+
+```ts
+describe('findApiShadowingRoutes', () => {
+  it('flags literal "*" on any HTTP method as an error', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().get('*', (c) => c.text('catch'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'wildcard',
+      method: 'get',
+      pattern: '*',
+      severity: 'error',
+    });
+  });
+
+  it('flags literal "/*" as an error', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().all('/*', (c) => c.text('catch'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'wildcard',
+      method: 'all',
+      pattern: '/*',
+      severity: 'error',
+    });
+  });
+
+  it('flags an app.on() catch-all (path is the second argument)', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().on('GET', '*', (c) => c.text('catch'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'wildcard',
+      method: 'on',
+      pattern: '*',
+      severity: 'error',
+    });
+  });
+
+  it('flags a literal /__actions registration as a reserved-path error', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().post('/__actions', (c) => c.text('mine'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'reserved',
+      method: 'post',
+      pattern: '/__actions',
+      severity: 'error',
+    });
+  });
+
+  it('flags a literal /__loaders registration as a reserved-path error', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().get('/__loaders', (c) => c.text('mine'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'reserved',
+      method: 'get',
+      pattern: '/__loaders',
+      severity: 'error',
+    });
+  });
+
+  it('flags app.notFound(...) as a warning, not an error', () => {
+    const src = `
+      import { Hono } from 'hono';
+      const app = new Hono();
+      app.notFound((c) => c.text('nope', 404));
+      export default app;
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ kind: 'notFound', severity: 'warning' });
+  });
+
+  it('does not flag variable-arg routes', () => {
+    const src = `
+      import { Hono } from 'hono';
+      const path = '/api/foo';
+      export default new Hono().get(path, (c) => c.text('ok'));
+    `;
+    expect(findApiShadowingRoutes(src)).toEqual([]);
+  });
+
+  it('does not flag pathless app.use(...) middleware', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().use((c, next) => next());
+    `;
+    expect(findApiShadowingRoutes(src)).toEqual([]);
+  });
+
+  it('does not flag a specific path on a chained call', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono()
+        .get('/api/watched/:id/photo', (c) => c.text('ok'))
+        .post('/api/watched', (c) => c.text('ok'));
+    `;
+    expect(findApiShadowingRoutes(src)).toEqual([]);
+  });
+
+  it('returns multiple entries if multiple shadowing routes are present', () => {
+    const src = `
+      import { Hono } from 'hono';
+      const app = new Hono();
+      app.get('*', (c) => c.text('a'));
+      app.notFound((c) => c.text('b'));
+      export default app;
+    `;
+    expect(findApiShadowingRoutes(src)).toHaveLength(2);
+  });
+
+  it('does not flag c.notFound() inside a handler body', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().get('/api/x/:id', (c) => {
+        const id = Number(c.req.param('id'));
+        if (!Number.isFinite(id)) return c.notFound();
+        return c.text('ok');
+      });
+    `;
+    expect(findApiShadowingRoutes(src)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Update the import in the test file**
+
+In `server-entry.test.ts:5-11`, change `findApiCatchAllRoutes` to `findApiShadowingRoutes` in the import from `'../server-entry.js'`.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts -t "findApiShadowingRoutes"`
+Expected: FAIL — `findApiShadowingRoutes` is not exported yet.
+
+- [ ] **Step 4: Replace the type and add the reserved-paths constant**
+
+In `packages/vite/src/server-entry.ts`, replace the `CatchAllWarning` type (lines 53-60):
+
+```ts
+export type CatchAllWarning =
+  | {
+      kind: 'wildcard';
+      method: string;
+      pattern: string;
+      line: number | undefined;
+    }
+  | { kind: 'notFound'; line: number | undefined };
+```
+
+with:
+
+```ts
+export type ApiShadowingRoute =
+  | {
+      kind: 'wildcard';
+      method: string;
+      pattern: string;
+      line: number | undefined;
+      severity: 'error';
+    }
+  | {
+      kind: 'reserved';
+      method: string;
+      pattern: string;
+      line: number | undefined;
+      severity: 'error';
+    }
+  | { kind: 'notFound'; line: number | undefined; severity: 'warning' };
+
+// Framework-reserved request paths. A literal registration of either in
+// api.ts shadows the framework's RPC handler now that the user app mounts
+// ahead of them.
+const RESERVED_PATHS = new Set(['/__loaders', '/__actions']);
+```
+
+- [ ] **Step 5: Replace `findApiCatchAllRoutes` with `findApiShadowingRoutes`**
+
+Replace the function (lines 87-113) — only the name, the result type, and the local variable change:
+
+```ts
+export function findApiShadowingRoutes(source: string): ApiShadowingRoute[] {
+  const found: ApiShadowingRoute[] = [];
+
+  let ast: ReturnType<typeof parse>;
+  try {
+    ast = parse(source, {
+      sourceType: 'module',
+      plugins: BABEL_PARSER_PLUGINS,
+      errorRecovery: true,
+    });
+  } catch (err) {
+    // If api.ts won't parse, the build will fail elsewhere with a clearer
+    // error. Surface a note so the framework user can correlate a missing
+    // shadowing warning with a parse-time syntax issue rather than wondering
+    // why nothing was reported.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[hono-preact] Failed to parse api.ts for shadowing-route detection: ${msg}. ` +
+        `The build will surface the real syntax error; this warning explains why ` +
+        `route-overlap diagnostics may be missing.`
+    );
+    return found;
+  }
+
+  walk(ast.program, found);
+  return found;
+}
+```
+
+- [ ] **Step 6: Update the `walk` function**
+
+Replace the `walk` function (lines 115-173). The signature's array type and the `CallExpression` handling change; the recursion is unchanged except the parameter name:
+
+```ts
+function walk(node: unknown, found: ApiShadowingRoute[]): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child, found);
+    return;
+  }
+
+  const n = node as {
+    type?: string;
+    callee?: {
+      type?: string;
+      property?: { type?: string; name?: string };
+    };
+    arguments?: Array<{ type?: string; value?: unknown }>;
+    loc?: { start?: { line?: number } };
+  };
+
+  if (
+    n.type === 'CallExpression' &&
+    n.callee?.type === 'MemberExpression' &&
+    n.callee.property?.type === 'Identifier' &&
+    typeof n.callee.property.name === 'string'
+  ) {
+    const method = n.callee.property.name;
+    const line = n.loc?.start?.line;
+
+    if (method === 'notFound') {
+      found.push({ kind: 'notFound', line, severity: 'warning' });
+    } else if (HONO_METHODS.has(method)) {
+      // `app.on(method, path, ...)` puts the path at argument index 1;
+      // every other Hono routing method takes the path as argument 0.
+      const pathArg = n.arguments?.[method === 'on' ? 1 : 0];
+      if (
+        pathArg?.type === 'StringLiteral' &&
+        typeof pathArg.value === 'string'
+      ) {
+        if (WILDCARD_PATTERNS.has(pathArg.value)) {
+          found.push({
+            kind: 'wildcard',
+            method,
+            pattern: pathArg.value,
+            line,
+            severity: 'error',
+          });
+        } else if (RESERVED_PATHS.has(pathArg.value)) {
+          found.push({
+            kind: 'reserved',
+            method,
+            pattern: pathArg.value,
+            line,
+            severity: 'error',
+          });
+        }
+      }
+    }
+  }
+
+  const isFunctionParent =
+    typeof n.type === 'string' && FUNCTION_BODY_PARENTS.has(n.type);
+
+  for (const key of Object.keys(node as object)) {
+    if (
+      key === 'loc' ||
+      key === 'leadingComments' ||
+      key === 'trailingComments'
+    )
+      continue;
+    if (isFunctionParent && key === 'body') continue;
+    walk((node as Record<string, unknown>)[key], found);
+  }
+}
+```
+
+- [ ] **Step 7: Run the detector tests to verify they pass**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts -t "findApiShadowingRoutes"`
+Expected: PASS (all 11 tests).
+
+Note: `buildStart` still calls the old name — `pnpm exec tsc` would fail right now. That is fixed in Task 4. Do not commit yet.
+
+- [ ] **Step 8: Commit (with Task 4)**
+
+The `buildStart` caller is updated in Task 4; commit both together there.
+
+---
+
+## Task 4: `buildStart` — fail the build on errors, warn on warnings
+
+**Files:**
+- Modify: `packages/vite/src/server-entry.ts:246-264` (the `buildStart` warning loop)
+- Test: `packages/vite/src/__tests__/server-entry.test.ts:290-329` (the catch-all `buildStart` test)
+
+- [ ] **Step 1: Replace the catch-all `buildStart` test with error + warning tests**
+
+Replace the test at `server-entry.test.ts:290-329` (`it('buildStart emits this.warn for catchall routes in api.ts', ...)`) with these three tests:
+
+```ts
+  it('buildStart throws via this.error for a catch-all route in api.ts', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'src', 'api.ts'),
+      `import { Hono } from 'hono';\nexport default new Hono().get('*', (c) => c.text('catch'));\n`
+    );
+    const outputPath = path.join(
+      tmp,
+      '.vite',
+      'hono-preact',
+      'server-entry.tsx'
+    );
+    const plugin = serverEntryPlugin({
+      layout: 'src/Layout.tsx',
+      routes: 'src/routes.ts',
+      api: 'src/api.ts',
+      outputPath,
+    });
+    (
+      plugin as { configResolved?: (c: { root: string }) => void }
+    ).configResolved?.({ root: tmp });
+
+    // Rollup's this.error throws; mimic that.
+    const ctx = {
+      warn: () => {},
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    expect(() =>
+      (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+        ctx
+      )
+    ).toThrow(/catch-all/);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('buildStart throws via this.error for a literal /__actions registration', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'src', 'api.ts'),
+      `import { Hono } from 'hono';\nexport default new Hono().post('/__actions', (c) => c.text('mine'));\n`
+    );
+    const outputPath = path.join(
+      tmp,
+      '.vite',
+      'hono-preact',
+      'server-entry.tsx'
+    );
+    const plugin = serverEntryPlugin({
+      layout: 'src/Layout.tsx',
+      routes: 'src/routes.ts',
+      api: 'src/api.ts',
+      outputPath,
+    });
+    (
+      plugin as { configResolved?: (c: { root: string }) => void }
+    ).configResolved?.({ root: tmp });
+
+    const ctx = {
+      warn: () => {},
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    expect(() =>
+      (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+        ctx
+      )
+    ).toThrow(/reserved/);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('buildStart warns (does not throw) for app.notFound in api.ts', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'src', 'api.ts'),
+      `import { Hono } from 'hono';\nconst app = new Hono();\napp.notFound((c) => c.text('nope', 404));\nexport default app;\n`
+    );
+    const outputPath = path.join(
+      tmp,
+      '.vite',
+      'hono-preact',
+      'server-entry.tsx'
+    );
+    const plugin = serverEntryPlugin({
+      layout: 'src/Layout.tsx',
+      routes: 'src/routes.ts',
+      api: 'src/api.ts',
+      outputPath,
+    });
+    (
+      plugin as { configResolved?: (c: { root: string }) => void }
+    ).configResolved?.({ root: tmp });
+
+    const warnings: string[] = [];
+    const ctx = {
+      warn: (m: string) => warnings.push(m),
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    expect(() =>
+      (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+        ctx
+      )
+    ).not.toThrow();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('notFound');
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts -t "buildStart"`
+Expected: FAIL — `buildStart` still calls the removed `findApiCatchAllRoutes` and uses `this.warn` for catch-alls.
+
+- [ ] **Step 3: Update `buildStart`**
+
+In `packages/vite/src/server-entry.ts`, replace the block from `if (!apiAbsPath) return;` through the end of the `for` loop (lines 246-264):
+
+```ts
+      if (!apiAbsPath) return;
+      const apiSource = fs.readFileSync(apiAbsPath, 'utf8');
+      const warnings = findApiCatchAllRoutes(apiSource);
+      for (const w of warnings) {
+        const where = `${apiAbsPath}${w.line != null ? `:${w.line}` : ''}`;
+        if (w.kind === 'notFound') {
+          this.warn(
+            `[hono-preact] ${where}: app.notFound(...) acts as a catch-all and ` +
+              `will be shadowed by the framework's renderPage handler. ` +
+              `Move the behavior to a more specific path, or accept that it won't fire.`
+          );
+        } else {
+          this.warn(
+            `[hono-preact] ${where}: app.${w.method}('${w.pattern}', ...) is a ` +
+              `catch-all route and will be shadowed by the framework's renderPage ` +
+              `handler. Move it to a more specific path, or accept that it won't fire.`
+          );
+        }
+      }
+```
+
+with:
+
+```ts
+      if (!apiAbsPath) return;
+      const apiSource = fs.readFileSync(apiAbsPath, 'utf8');
+      const shadowing = findApiShadowingRoutes(apiSource);
+      const errors: string[] = [];
+      for (const r of shadowing) {
+        const where = `${apiAbsPath}${r.line != null ? `:${r.line}` : ''}`;
+        if (r.kind === 'notFound') {
+          this.warn(
+            `[hono-preact] ${where}: app.notFound(...) will not fire — the ` +
+              `framework's renderPage handler matches every unmatched request. ` +
+              `Move the behavior to a specific path, or accept that it won't fire.`
+          );
+        } else if (r.kind === 'wildcard') {
+          errors.push(
+            `${where}: app.${r.method}('${r.pattern}', ...) is a catch-all route`
+          );
+        } else {
+          errors.push(
+            `${where}: app.${r.method}('${r.pattern}', ...) registers the ` +
+              `framework-reserved path '${r.pattern}'`
+          );
+        }
+      }
+      if (errors.length > 0) {
+        this.error(
+          `[hono-preact] api.ts registers routes that shadow framework handlers:\n` +
+            errors.map((e) => `  - ${e}`).join('\n') +
+            `\nThe framework mounts your app ahead of its reserved paths ` +
+            `(/__loaders, /__actions) and the SSR handler, so these routes break ` +
+            `loaders/actions and/or page rendering. Use specific, non-wildcard paths.`
+        );
+      }
+```
+
+- [ ] **Step 4: Run the full server-entry suite to verify it passes**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts`
+Expected: PASS — all tests green.
+
+- [ ] **Step 5: Typecheck the vite package**
+
+Run: `pnpm --filter '@hono-preact/vite' exec tsc --noEmit`
+Expected: exit 0, no errors (confirms no remaining `findApiCatchAllRoutes` / `CatchAllWarning` references).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/vite/src/server-entry.ts packages/vite/src/__tests__/server-entry.test.ts
+git commit -m "feat(vite): fail the build on api.ts routes that shadow reserved paths"
+```
+
+---
+
+## Task 5: Documentation — `csrf.mdx`
+
+The existing recipe in `apps/site/src/pages/docs/csrf.mdx` (`app.use('/__actions', …)` in `api.ts`) only became *functional* with this change. Add the explanation and the app-wide-middleware note.
+
+**Files:**
+- Modify: `apps/site/src/pages/docs/csrf.mdx`
+
+- [ ] **Step 1: Add the mount-order note after the recipe code block**
+
+In `csrf.mdx`, immediately after the recipe code block (the one ending `export default app;`) and before the `### Configure the allowed origin` heading, insert this paragraph:
+
+```mdx
+This works because the framework mounts your `api.ts` app **ahead of** its own reserved paths (`/__loaders`, `/__actions`) and the page renderer. Middleware you register in `api.ts` therefore runs before the framework's RPC and SSR handlers — `app.use('/__actions', …)` reaches the actions endpoint, and `app.use('*', …)` is effectively app-wide. The flip side: do not register a catch-all route (`*`, `/*`, `app.on(...)` on `'*'`) or the literal paths `/__loaders` / `/__actions` in `api.ts` — they would shadow the framework's handlers, so the build rejects them.
+```
+
+- [ ] **Step 2: Verify the docs site still builds**
+
+Run: `pnpm --filter site exec astro check 2>/dev/null || pnpm exec prettier --check apps/site/src/pages/docs/csrf.mdx`
+Expected: the prettier check passes (`astro check` may not be wired; the prettier check is the reliable gate). If prettier reports formatting, run `pnpm exec prettier --write apps/site/src/pages/docs/csrf.mdx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/site/src/pages/docs/csrf.mdx
+git commit -m "docs(csrf): explain reserved-path mount order and the catch-all rule"
+```
+
+---
+
+## Task 6: Correct the primitives audit
+
+**Files:**
+- Modify: `docs/superpowers/research/2026-05-14-hono-primitives-audit.md`
+
+- [ ] **Step 1: Fix the `hono/csrf` table row**
+
+In `docs/superpowers/research/2026-05-14-hono-primitives-audit.md`, find the `hono/csrf` row's rationale text:
+
+```
+| `hono/csrf` | unused | sidestep | **keep** | Users mount `csrf()` on their `c.api` like in any other Hono app. The framework deliberately doesn't pre-decide for them. If a user wants CSRF on `/__actions/*` specifically, they wrap the handler or use middleware composition; framework auto-mounting would violate "use Hono as normal." |
+```
+
+Replace it with:
+
+```
+| `hono/csrf` | unused | sidestep | **keep** | Users mount `csrf()` on their `c.api` like in any other Hono app. The framework deliberately doesn't pre-decide for them. A user who wants CSRF on `/__actions` specifically registers `app.use('/__actions', …)` in their `api.ts`: #43 mounts the user app ahead of the reserved paths, so that middleware reaches the endpoint. Framework auto-mounting would still violate "use Hono as normal." |
+```
+
+- [ ] **Step 2: Annotate recommendation 1**
+
+Find the non-recommendation:
+
+```
+- **Do not auto-mount `hono/csrf` on `/__actions`.** Earlier draft proposed this; it violates the guiding principle.
+```
+
+Replace it with:
+
+```
+- **Do not auto-mount `hono/csrf` on `/__actions`.** Earlier draft proposed this; it violates the guiding principle. Resolved by #43 (`docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md`): the user app now mounts ahead of the reserved paths, so users compose `csrf()` themselves with no framework auto-mount.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/research/2026-05-14-hono-primitives-audit.md
+git commit -m "docs(audit): correct hono/csrf row — #43 resolved reserved-path composition"
+```
+
+---
+
+## Task 7: Full verification
+
+- [ ] **Step 1: Run the full Vite package test suite**
+
+Run: `pnpm exec vitest run packages/vite`
+Expected: PASS — all files green.
+
+- [ ] **Step 2: Run the full repository test suite**
+
+Run: `pnpm test`
+Expected: PASS — no regressions in `packages/server`, `packages/iso`, or `apps/site`.
+
+- [ ] **Step 3: Typecheck the workspace**
+
+Run: `pnpm typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Prettier check on touched files**
+
+Run: `pnpm exec prettier --check "packages/vite/src/server-entry.ts" "packages/vite/src/__tests__/server-entry.test.ts" "apps/site/src/pages/docs/csrf.mdx"`
+Expected: "All matched files use Prettier code style!" — if not, run `prettier --write` on the reported files and amend the relevant commit.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec part 1 (entry reordering) → Task 1.
+- Spec part 2 (shadow detection: severity table, `.on()` fix, rename) → Tasks 3 and 4.
+- Spec part 3 (docs) → Task 5.
+- Spec part 4 (audit correction) → Task 6.
+- Spec "Verification" (Hono mount-order semantics) → Task 2 (composition test) covers cases 1, 3, 5 behaviorally.
+- Spec "Testing" (entry order, detection error cases, csrf integration) → Tasks 1, 3, 4, 2.
+- Spec acceptance checklist → all five items map to Tasks 1, 3/4, 5, 6, and 7.
+
+**Type consistency:** `ApiShadowingRoute` (Task 3) is consumed by `buildStart` in Task 4 — kinds `wildcard` / `reserved` / `notFound` and the `severity` field match between the type definition, the `walk` pushes, and the `buildStart` switch. `findApiShadowingRoutes` is the single name used in the function definition (Task 3), the test import (Task 3 Step 2), and the `buildStart` caller (Task 4).
+
+**No placeholders:** every step shows exact code or exact commands with expected output.

--- a/docs/superpowers/research/2026-05-14-hono-primitives-audit.md
+++ b/docs/superpowers/research/2026-05-14-hono-primitives-audit.md
@@ -63,7 +63,7 @@ Status legend:
 | `hono/html` | unused | sidestep | **keep** | We have a full Preact pipeline; raw HTML template strings would compete with `prerender()`. Users wanting raw HTML responses can import `hono/html` for non-page Hono routes. |
 | `hono/context-storage` | unused | **replace** | **keep our `runRequestScope`** | Hono's helper only stashes `c`; we need a per-request `Map<unknown, unknown>` for loader-cache memoization, and our store has to be isomorphic (server + browser via a same-shape no-op on the client). See `packages/iso/src/cache.ts:32-63`. Documented decision from PR #41 prework. |
 | `hono/cors` | unused | sidestep | **keep, document** | Per-route CORS policy is opinionated; mounting it framework-wide would push a default users would have to undo. Worth a "recommended Hono middleware" docs page. |
-| `hono/csrf` | unused | sidestep | **keep** | Users mount `csrf()` on their `c.api` like in any other Hono app. The framework deliberately doesn't pre-decide for them. If a user wants CSRF on `/__actions/*` specifically, they wrap the handler or use middleware composition; framework auto-mounting would violate "use Hono as normal." |
+| `hono/csrf` | unused | sidestep | **keep** | Users mount `csrf()` on their `c.api` like in any other Hono app. The framework deliberately doesn't pre-decide for them. A user who wants CSRF on `/__actions` specifically registers `app.use('/__actions', …)` in their `api.ts`: #43 mounts the user app ahead of the reserved paths, so that middleware reaches the endpoint. Framework auto-mounting would still violate "use Hono as normal." |
 | `hono/secure-headers` | unused | sidestep | **keep, document** | Recommend in docs; default policy is user-specific. |
 | `hono/cache` | unused | sidestep | **keep** | Page-level HTTP caching is a render-side concern that interacts badly with our streaming responses. Loader-side caching is already in-process via `runRequestScope`. |
 | `hono/etag` | unused | sidestep | **keep** | SSR-streamed responses can't be ETag'd cleanly. Out of hot path. |
@@ -174,7 +174,7 @@ None of these block v0.1; all are docs / examples that reinforce the "use Hono a
 
 Two non-recommendations explicitly recorded:
 
-- **Do not auto-mount `hono/csrf` on `/__actions`.** Earlier draft proposed this; it violates the guiding principle.
+- **Do not auto-mount `hono/csrf` on `/__actions`.** Earlier draft proposed this; it violates the guiding principle. Resolved by #43 (`docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md`): the user app now mounts ahead of the reserved paths, so users compose `csrf()` themselves with no framework auto-mount.
 - **Do not ship a framework `serverTiming()` helper that auto-mounts `hono/timing`.** If we later expose timing marks at SSR seams, expose them as opt-in primitives users wire into their own `hono/timing` middleware, not as a framework-managed default.
 
 ---

--- a/docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md
+++ b/docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md
@@ -1,0 +1,193 @@
+# Reserved-path middleware: mount the user app on top
+
+**Date:** 2026-05-17
+**Status:** design, approved
+**Issue:** [#43](https://github.com/sbesh91/hono-preact/issues/43)
+**Audit ancestry:** `docs/superpowers/research/2026-05-14-hono-primitives-audit.md` (`hono/csrf` row, recommendation 1)
+**Related:** #44 (per-loader/action middleware — orthogonal, the RPC layer below HTTP dispatch)
+
+---
+
+## Problem
+
+Users cannot apply HTTP-layer middleware to the framework's reserved paths,
+`POST /__loaders` and `POST /__actions`. The motivating case is `hono/csrf`: an
+app whose threat model needs explicit origin checking on `/__actions` has no way
+to add it.
+
+The generated server entry (`packages/vite/src/server-entry.ts`) registers the
+reserved paths first, then mounts the user's app:
+
+```ts
+new Hono()
+  .post('/__loaders', loadersHandler(serverModules, handlerOpts))
+  .post('/__actions', actionsHandler(serverModules, handlerOpts))
+  .route('/', userApp)          // user's api.ts
+  .get('*', (c) => renderPage(c, ...));
+```
+
+The #36 audit and issue #43 attributed the gap to Hono "sub-app scoping." That
+is imprecise. `app.route('/', userApp)` copies every route in `userApp` —
+including `.use('*', …)` middleware, which is just an ALL-method route — onto
+the parent at the mount path. Hono then matches **all** routes for a path and
+composes the matched handlers **in registration order**.
+
+So `csrf()` registered inside `api.ts` fails to protect `/__actions` purely
+because of **order**: `/__actions` is registered first, so for a
+`POST /__actions` the composed chain is `[actionsHandler, csrf]`. The actions
+handler returns a `Response` without calling `next()`, and `csrf` never runs.
+
+Verified against `hono@4.12.14` (five cases, see "Verification" below).
+
+## Decision
+
+**Mount the user app above the framework's handlers.** Flip the generated entry
+so `api.ts` is registered before the reserved paths and the SSR catch-all. Then
+`app.use('*', csrf())` in `api.ts` composes ahead of the reserved-path handlers
+and protects them, by ordinary Hono semantics. No new framework API, no
+auto-mounted default, no middleware-slot config.
+
+This was chosen over two alternatives:
+
+- **Auto-mount a default origin check on the reserved paths.** Rejected: it
+  reverses the #36 audit's "do not pre-decide for the user" principle, and the
+  audit recorded that decision explicitly three times. The reframe below honors
+  the principle instead of overturning it.
+- **A handler factory + bring-your-own-entry.** Rejected as #43's answer: it
+  adds public API surface to solve a problem the reordering makes disappear. The
+  existing `entry` plugin option remains as a separate full-BYO escape hatch for
+  power users; it is not this issue's mechanism.
+
+### Trade-off accepted
+
+Reserved-paths-first was a structural guarantee that user code in `api.ts`
+**cannot shadow** `/__loaders`, `/__actions`, or the SSR handler. Mounting the
+user app on top removes that guarantee: a catch-all or a literal reserved-path
+registration in `api.ts` now composes ahead of the framework handler and can
+shadow it (verified, case 4).
+
+We replace the structural guarantee with **build-time detection that fails the
+build** for the unambiguous cases (see part 2). Dynamically-computed routes that
+happen to collide remain a static-analysis blind spot; this is judged
+acceptable because such routes are exotic and the deliberate cases are caught
+hard.
+
+### Bonus: app-wide middleware
+
+Because `api.ts` now sits ahead of the SSR `GET *` handler too, a `.use('*', …)`
+there runs on SSR page responses as well as RPC (verified, case 5). This
+resolves, for free, the "app-wide middleware" need (`hono/secure-headers`,
+`hono/logger`, request-id over the whole site) that the #43 investigation had
+set aside as a separate concern. No separate mechanism is needed.
+
+## Design
+
+### 1. Entry reordering
+
+In `generateServerEntrySource` (`packages/vite/src/server-entry.ts`), emit the
+`api.ts` mount before the reserved paths:
+
+```ts
+export const app = new Hono()
+  .route('/', userApp)          // emitted only when api.ts exists
+  .post('/__loaders', loadersHandler(serverModules, handlerOpts))
+  .post('/__actions', actionsHandler(serverModules, handlerOpts))
+  .get('*', (c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes })))));
+```
+
+When no `api.ts` is present, output is unchanged (there is no `userApp` to
+mount). This is the entire runtime change.
+
+### 2. Shadow detection (`findApiCatchAllRoutes`, runs in `buildStart`)
+
+Today the walker emits `this.warn` for catch-alls and `app.notFound()`. New
+behavior:
+
+| Pattern in `api.ts`                                              | Post-flip consequence                          | Severity                |
+| ---------------------------------------------------------------- | ---------------------------------------------- | ----------------------- |
+| Catch-all route — `get/post/put/patch/delete/options/head/all/on` with path `'*'` or `'/*'` | Composes ahead of reserved paths and/or SSR; shadows them | **build error** (`this.error`) |
+| Literal `'/__loaders'` or `'/__actions'` registration, any method | Directly shadows the framework RPC handler     | **build error**         |
+| `app.notFound(...)`                                              | Won't fire — the `GET *` SSR handler matches everything first; does not shadow RPC | **warning** (unchanged) |
+
+`notFound()` stays a warning: a not-found handler only runs when no route
+matches, and `renderPage` always matches, so it cannot break RPC. It silently
+won't fire — the same advisory as today.
+
+Two corrections to the walker while it is being changed:
+
+- **`.on()` argument bug.** The walker inspects `arguments[0]` for the wildcard
+  pattern. For `app.on(method, path, …)` the path is `arguments[1]`, so `.on()`
+  catch-alls are currently missed. Detect the path at the correct index for
+  `on` (it accepts `on(method, path, …)` and `on(method, path[], …)`).
+- The warning/error message wording is updated: catch-alls and literal reserved
+  paths now break RPC and/or SSR, not just "shadow renderPage."
+
+`findApiCatchAllRoutes` is renamed to reflect the broader responsibility
+(`findApiShadowingRoutes`); the `CatchAllWarning` type is renamed accordingly
+and gains a `severity: 'error' | 'warning'` field, which the `buildStart`
+caller switches on between `this.error(...)` and `this.warn(...)`.
+
+### 3. Documentation
+
+- **Actions / CSRF docs:** the origin-check recipe is `app.use('*', csrf())` in
+  `api.ts`. Show it.
+- **Reserved paths:** document `/__loaders` and `/__actions` as reserved, and
+  the now load-bearing rule — do not register catch-alls or those literal paths
+  in `api.ts`; the build will reject them.
+- **App-wide middleware:** state explicitly that `api.ts` middleware runs ahead
+  of both RPC and SSR, so `.use('*', …)` there is effectively app-wide.
+
+### 4. Audit correction
+
+Update `docs/superpowers/research/2026-05-14-hono-primitives-audit.md`:
+
+- The `hono/csrf` row claims users can already "wrap the handler or use
+  middleware composition" for `/__actions`. That was false when written. Replace
+  it with the now-true mechanism: `app.use('*', csrf())` in `api.ts`.
+- Recommendation 1 ("Do not auto-mount `hono/csrf` on `/__actions`") stands —
+  add a note that #43 resolved the underlying gap by reordering, with no
+  auto-mount, preserving the guiding principle.
+
+## Out of scope
+
+- **Per-loader / per-action middleware** (auth, validation, per-action rate
+  limiting). That is the RPC layer, tracked in #44.
+- **A handler factory or `createHandlers`-style API.** Not needed.
+- **An auto-mounted default origin check.** Explicitly rejected (see Decision).
+- **A new convention filename for a user-authored entry.** The existing `entry`
+  plugin option is retained unchanged as the full-BYO escape hatch.
+
+## Verification
+
+Hono mount-order semantics, confirmed against `hono@4.12.14`:
+
+1. User `.use('*')` mounted first → runs before a later-registered reserved
+   path handler.
+2. Reserved path first (today) → user `.use('*')` does not run for it.
+3. A rejecting middleware (csrf-like) mounted first → returns 403, the
+   reserved-path handler never runs.
+4. A user catch-all mounted first → shadows the reserved path entirely.
+5. User `.use('*')` mounted first → runs ahead of the `GET *` SSR handler.
+
+## Testing
+
+- `generateServerEntrySource`: asserts `.route('/', userApp)` is emitted before
+  the `.post('/__loaders')` / `.post('/__actions')` lines; unchanged output when
+  no `api.ts`.
+- Shadow detection: build error for a catch-all (`all('*')`, `get('/*')`), for a
+  literal `'/__actions'` / `'/__loaders'` registration, and for an `.on()`
+  catch-all; `notFound()` still a warning.
+- Integration: an `api.ts` with `app.use('*', csrf())`, a cross-origin
+  `POST /__actions` is rejected with 403 and the action handler does not run; a
+  same-origin `POST /__actions` succeeds.
+
+## Acceptance
+
+- [ ] Generated entry mounts `userApp` before the reserved paths and SSR
+      catch-all.
+- [ ] `api.ts` catch-alls and literal reserved-path registrations fail the
+      build; `.on()` catch-alls detected; `notFound()` remains a warning.
+- [ ] Docs cover the `csrf()` recipe, the reserved-path rule, and the app-wide
+      reach of `api.ts` middleware.
+- [ ] The #36 audit's `hono/csrf` row and recommendation 1 are corrected.
+- [ ] Tests above pass.

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -49,6 +49,7 @@
     "vite": ">=5.0.0"
   },
   "devDependencies": {
+    "hono": "^4.12.14",
     "preact": "^10.29.1",
     "preact-iso": "github:preactjs/preact-iso#v3",
     "typescript": "*",

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import {
   GENERATED_SERVER_ENTRY_RELATIVE,
-  findApiCatchAllRoutes,
+  findApiShadowingRoutes,
   generateServerEntrySource,
   generatedServerEntryAbsPath,
   serverEntryPlugin,
@@ -95,45 +95,107 @@ describe('generateServerEntrySource', () => {
   });
 });
 
-describe('findApiCatchAllRoutes', () => {
-  it('flags literal "*" on any HTTP method', () => {
+describe('findApiShadowingRoutes', () => {
+  it('flags literal "*" on any HTTP method as an error', () => {
     const src = `
       import { Hono } from 'hono';
       export default new Hono().get('*', (c) => c.text('catch'));
     `;
-    const warnings = findApiCatchAllRoutes(src);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toMatchObject({
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
       kind: 'wildcard',
       method: 'get',
       pattern: '*',
+      severity: 'error',
     });
   });
 
-  it('flags literal "/*"', () => {
+  it('flags literal "/*" as an error', () => {
     const src = `
       import { Hono } from 'hono';
       export default new Hono().all('/*', (c) => c.text('catch'));
     `;
-    const warnings = findApiCatchAllRoutes(src);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toMatchObject({
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
       kind: 'wildcard',
       method: 'all',
       pattern: '/*',
+      severity: 'error',
     });
   });
 
-  it('flags app.notFound(...)', () => {
+  it('flags an app.on() catch-all (path is the second argument)', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().on('GET', '*', (c) => c.text('catch'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'wildcard',
+      method: 'on',
+      pattern: '*',
+      severity: 'error',
+    });
+  });
+
+  it('flags a literal /__actions registration as a reserved-path error', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().post('/__actions', (c) => c.text('mine'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'reserved',
+      method: 'post',
+      pattern: '/__actions',
+      severity: 'error',
+    });
+  });
+
+  it('flags a literal /__loaders registration as a reserved-path error', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().get('/__loaders', (c) => c.text('mine'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'reserved',
+      method: 'get',
+      pattern: '/__loaders',
+      severity: 'error',
+    });
+  });
+
+  it('flags an app.on() registration of a reserved path (path is the second argument)', () => {
+    const src = `
+      import { Hono } from 'hono';
+      export default new Hono().on('POST', '/__actions', (c) => c.text('mine'));
+    `;
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      kind: 'reserved',
+      method: 'on',
+      pattern: '/__actions',
+      severity: 'error',
+    });
+  });
+
+  it('flags app.notFound(...) as a warning, not an error', () => {
     const src = `
       import { Hono } from 'hono';
       const app = new Hono();
       app.notFound((c) => c.text('nope', 404));
       export default app;
     `;
-    const warnings = findApiCatchAllRoutes(src);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toMatchObject({ kind: 'notFound' });
+    const found = findApiShadowingRoutes(src);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ kind: 'notFound', severity: 'warning' });
   });
 
   it('does not flag variable-arg routes', () => {
@@ -142,7 +204,7 @@ describe('findApiCatchAllRoutes', () => {
       const path = '/api/foo';
       export default new Hono().get(path, (c) => c.text('ok'));
     `;
-    expect(findApiCatchAllRoutes(src)).toEqual([]);
+    expect(findApiShadowingRoutes(src)).toEqual([]);
   });
 
   it('does not flag pathless app.use(...) middleware', () => {
@@ -150,7 +212,7 @@ describe('findApiCatchAllRoutes', () => {
       import { Hono } from 'hono';
       export default new Hono().use((c, next) => next());
     `;
-    expect(findApiCatchAllRoutes(src)).toEqual([]);
+    expect(findApiShadowingRoutes(src)).toEqual([]);
   });
 
   it('does not flag a specific path on a chained call', () => {
@@ -160,10 +222,10 @@ describe('findApiCatchAllRoutes', () => {
         .get('/api/watched/:id/photo', (c) => c.text('ok'))
         .post('/api/watched', (c) => c.text('ok'));
     `;
-    expect(findApiCatchAllRoutes(src)).toEqual([]);
+    expect(findApiShadowingRoutes(src)).toEqual([]);
   });
 
-  it('returns multiple warnings if multiple catchalls are present', () => {
+  it('returns multiple entries if multiple shadowing routes are present', () => {
     const src = `
       import { Hono } from 'hono';
       const app = new Hono();
@@ -171,8 +233,7 @@ describe('findApiCatchAllRoutes', () => {
       app.notFound((c) => c.text('b'));
       export default app;
     `;
-    const warnings = findApiCatchAllRoutes(src);
-    expect(warnings).toHaveLength(2);
+    expect(findApiShadowingRoutes(src)).toHaveLength(2);
   });
 
   it('does not flag c.notFound() inside a handler body', () => {
@@ -184,7 +245,7 @@ describe('findApiCatchAllRoutes', () => {
         return c.text('ok');
       });
     `;
-    expect(findApiCatchAllRoutes(src)).toEqual([]);
+    expect(findApiShadowingRoutes(src)).toEqual([]);
   });
 });
 
@@ -233,11 +294,15 @@ describe('serverEntryPlugin', () => {
     // configResolved alone should NOT have written anything.
     expect(fs.existsSync(outputPath)).toBe(false);
 
-    (
-      plugin as {
-        buildStart?: (this: { warn: (m: string) => void }) => void;
-      }
-    ).buildStart?.call({ warn: () => {} });
+    const ctx = {
+      warn: () => {},
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+      ctx
+    );
 
     expect(fs.existsSync(outputPath)).toBe(true);
     const code = fs.readFileSync(outputPath, 'utf8');
@@ -278,11 +343,15 @@ describe('serverEntryPlugin', () => {
     ).configResolved?.({
       root: tmp,
     });
-    (
-      plugin as {
-        buildStart?: (this: { warn: (m: string) => void }) => void;
-      }
-    ).buildStart?.call({ warn: () => {} });
+    const ctx = {
+      warn: () => {},
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+      ctx
+    );
 
     const code = fs.readFileSync(outputPath, 'utf8');
     expect(code).toContain(
@@ -293,7 +362,7 @@ describe('serverEntryPlugin', () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it('buildStart emits this.warn for catchall routes in api.ts', () => {
+  it('buildStart throws via this.error for a catch-all route in api.ts', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
     fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
     fs.writeFileSync(
@@ -306,7 +375,6 @@ describe('serverEntryPlugin', () => {
       'hono-preact',
       'server-entry.tsx'
     );
-
     const plugin = serverEntryPlugin({
       layout: 'src/Layout.tsx',
       routes: 'src/routes.ts',
@@ -315,21 +383,99 @@ describe('serverEntryPlugin', () => {
     });
     (
       plugin as { configResolved?: (c: { root: string }) => void }
-    ).configResolved?.({
-      root: tmp,
+    ).configResolved?.({ root: tmp });
+
+    // Rollup's this.error throws; mimic that.
+    const ctx = {
+      warn: () => {},
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    expect(() =>
+      (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+        ctx
+      )
+    ).toThrow(/catch-all/);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('buildStart throws via this.error for a literal /__actions registration', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'src', 'api.ts'),
+      `import { Hono } from 'hono';\nexport default new Hono().post('/__actions', (c) => c.text('mine'));\n`
+    );
+    const outputPath = path.join(
+      tmp,
+      '.vite',
+      'hono-preact',
+      'server-entry.tsx'
+    );
+    const plugin = serverEntryPlugin({
+      layout: 'src/Layout.tsx',
+      routes: 'src/routes.ts',
+      api: 'src/api.ts',
+      outputPath,
     });
+    (
+      plugin as { configResolved?: (c: { root: string }) => void }
+    ).configResolved?.({ root: tmp });
+
+    const ctx = {
+      warn: () => {},
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    expect(() =>
+      (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+        ctx
+      )
+    ).toThrow(/reserved/);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('buildStart warns (does not throw) for app.notFound in api.ts', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
+    fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'src', 'api.ts'),
+      `import { Hono } from 'hono';\nconst app = new Hono();\napp.notFound((c) => c.text('nope', 404));\nexport default app;\n`
+    );
+    const outputPath = path.join(
+      tmp,
+      '.vite',
+      'hono-preact',
+      'server-entry.tsx'
+    );
+    const plugin = serverEntryPlugin({
+      layout: 'src/Layout.tsx',
+      routes: 'src/routes.ts',
+      api: 'src/api.ts',
+      outputPath,
+    });
+    (
+      plugin as { configResolved?: (c: { root: string }) => void }
+    ).configResolved?.({ root: tmp });
 
     const warnings: string[] = [];
-    const ctx = { warn: (msg: string) => warnings.push(msg) };
-    (
-      plugin as {
-        buildStart?: (this: { warn: (m: string) => void }) => void;
-      }
-    ).buildStart?.call(ctx);
-
+    const ctx = {
+      warn: (m: string) => warnings.push(m),
+      error: (m: unknown) => {
+        throw new Error(typeof m === 'string' ? m : String(m));
+      },
+    };
+    expect(() =>
+      (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
+        ctx
+      )
+    ).not.toThrow();
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain(`src/api.ts`);
-    expect(warnings[0]).toContain(`catch-all`);
+    expect(warnings[0]).toContain('notFound');
 
     fs.rmSync(tmp, { recursive: true, force: true });
   });
@@ -345,12 +491,10 @@ describe('mount-order composition (why api.ts is mounted first)', () => {
     userApp.use('*', csrf({ origin: 'https://example.com' }));
 
     // Mirrors the order generateServerEntrySource emits: userApp first.
-    const app = new Hono()
-      .route('/', userApp)
-      .post('/__actions', (c) => {
-        actionRan = true;
-        return c.json({ ok: true });
-      });
+    const app = new Hono().route('/', userApp).post('/__actions', (c) => {
+      actionRan = true;
+      return c.json({ ok: true });
+    });
 
     // Cross-origin form post: csrf rejects before the action handler runs.
     const blocked = await app.request('https://example.com/__actions', {

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -71,7 +71,7 @@ describe('generateServerEntrySource', () => {
     expect(src).not.toContain('<Layout');
   });
 
-  it('emits the api import and mount when apiAbsPath is provided, before the catchall', () => {
+  it('emits the api import and mounts userApp before the reserved paths and catchall', () => {
     const src = generateServerEntrySource({
       layoutAbsPath: '/proj/src/Layout.tsx',
       routesAbsPath: '/proj/src/routes.ts',
@@ -81,11 +81,17 @@ describe('generateServerEntrySource', () => {
     expect(src).toContain(`import userApp from '/proj/src/api.ts';`);
     expect(src).toContain(`.route('/', userApp)`);
 
-    // The user's app must be mounted BEFORE the catchall.
+    // The user's app must be mounted BEFORE the reserved paths so that
+    // middleware registered in api.ts composes ahead of loadersHandler /
+    // actionsHandler. See docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md
     const apiIdx = src.indexOf(`.route('/', userApp)`);
+    const loadersIdx = src.indexOf(`'/__loaders'`);
+    const actionsIdx = src.indexOf(`'/__actions'`);
     const catchallIdx = src.indexOf(`.get('*'`);
     expect(apiIdx).toBeGreaterThan(-1);
-    expect(catchallIdx).toBeGreaterThan(apiIdx);
+    expect(loadersIdx).toBeGreaterThan(apiIdx);
+    expect(actionsIdx).toBeGreaterThan(loadersIdx);
+    expect(catchallIdx).toBeGreaterThan(actionsIdx);
   });
 });
 

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -334,3 +334,46 @@ describe('serverEntryPlugin', () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 });
+
+describe('mount-order composition (why api.ts is mounted first)', () => {
+  it('middleware in the user app guards the reserved /__actions path', async () => {
+    const { Hono } = await import('hono');
+    const { csrf } = await import('hono/csrf');
+
+    let actionRan = false;
+    const userApp = new Hono();
+    userApp.use('*', csrf({ origin: 'https://example.com' }));
+
+    // Mirrors the order generateServerEntrySource emits: userApp first.
+    const app = new Hono()
+      .route('/', userApp)
+      .post('/__actions', (c) => {
+        actionRan = true;
+        return c.json({ ok: true });
+      });
+
+    // Cross-origin form post: csrf rejects before the action handler runs.
+    const blocked = await app.request('https://example.com/__actions', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://evil.example',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'x=1',
+    });
+    expect(blocked.status).toBe(403);
+    expect(actionRan).toBe(false);
+
+    // Same-origin form post: passes csrf, reaches the action handler.
+    const ok = await app.request('https://example.com/__actions', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://example.com',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'x=1',
+    });
+    expect(ok.status).toBe(200);
+    expect(actionRan).toBe(true);
+  });
+});

--- a/packages/vite/src/server-entry.ts
+++ b/packages/vite/src/server-entry.ts
@@ -50,14 +50,27 @@ export function generateServerEntrySource(
   );
 }
 
-export type CatchAllWarning =
+export type ApiShadowingRoute =
   | {
       kind: 'wildcard';
       method: string;
       pattern: string;
       line: number | undefined;
+      severity: 'error';
     }
-  | { kind: 'notFound'; line: number | undefined };
+  | {
+      kind: 'reserved';
+      method: string;
+      pattern: string;
+      line: number | undefined;
+      severity: 'error';
+    }
+  | { kind: 'notFound'; line: number | undefined; severity: 'warning' };
+
+// Framework-reserved request paths. A literal registration of either in
+// api.ts shadows the framework's RPC handler now that the user app mounts
+// ahead of them.
+const RESERVED_PATHS = new Set(['/__loaders', '/__actions']);
 
 const HONO_METHODS = new Set([
   'get',
@@ -84,8 +97,8 @@ const FUNCTION_BODY_PARENTS = new Set([
   'ClassMethod',
 ]);
 
-export function findApiCatchAllRoutes(source: string): CatchAllWarning[] {
-  const warnings: CatchAllWarning[] = [];
+export function findApiShadowingRoutes(source: string): ApiShadowingRoute[] {
+  const found: ApiShadowingRoute[] = [];
 
   let ast: ReturnType<typeof parse>;
   try {
@@ -97,25 +110,25 @@ export function findApiCatchAllRoutes(source: string): CatchAllWarning[] {
   } catch (err) {
     // If api.ts won't parse, the build will fail elsewhere with a clearer
     // error. Surface a note so the framework user can correlate a missing
-    // catch-all warning with a parse-time syntax issue rather than wondering
+    // shadowing warning with a parse-time syntax issue rather than wondering
     // why nothing was reported.
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(
-      `[hono-preact] Failed to parse api.ts for catch-all route detection: ${msg}. ` +
+      `[hono-preact] Failed to parse api.ts for shadowing-route detection: ${msg}. ` +
         `The build will surface the real syntax error; this warning explains why ` +
-        `route-overlap warnings may be missing.`
+        `route-overlap diagnostics may be missing.`
     );
-    return warnings;
+    return found;
   }
 
-  walk(ast.program, warnings);
-  return warnings;
+  walk(ast.program, found);
+  return found;
 }
 
-function walk(node: unknown, warnings: CatchAllWarning[]): void {
+function walk(node: unknown, found: ApiShadowingRoute[]): void {
   if (!node || typeof node !== 'object') return;
   if (Array.isArray(node)) {
-    for (const child of node) walk(child, warnings);
+    for (const child of node) walk(child, found);
     return;
   }
 
@@ -139,20 +152,32 @@ function walk(node: unknown, warnings: CatchAllWarning[]): void {
     const line = n.loc?.start?.line;
 
     if (method === 'notFound') {
-      warnings.push({ kind: 'notFound', line });
+      found.push({ kind: 'notFound', line, severity: 'warning' });
     } else if (HONO_METHODS.has(method)) {
-      const firstArg = n.arguments?.[0];
+      // `app.on(method, path, ...)` puts the path at argument index 1;
+      // every other Hono routing method takes the path as argument 0.
+      const pathArg = n.arguments?.[method === 'on' ? 1 : 0];
       if (
-        firstArg?.type === 'StringLiteral' &&
-        typeof firstArg.value === 'string' &&
-        WILDCARD_PATTERNS.has(firstArg.value)
+        pathArg?.type === 'StringLiteral' &&
+        typeof pathArg.value === 'string'
       ) {
-        warnings.push({
-          kind: 'wildcard',
-          method,
-          pattern: firstArg.value,
-          line,
-        });
+        if (WILDCARD_PATTERNS.has(pathArg.value)) {
+          found.push({
+            kind: 'wildcard',
+            method,
+            pattern: pathArg.value,
+            line,
+            severity: 'error',
+          });
+        } else if (RESERVED_PATHS.has(pathArg.value)) {
+          found.push({
+            kind: 'reserved',
+            method,
+            pattern: pathArg.value,
+            line,
+            severity: 'error',
+          });
+        }
       }
     }
   }
@@ -168,7 +193,7 @@ function walk(node: unknown, warnings: CatchAllWarning[]): void {
     )
       continue;
     if (isFunctionParent && key === 'body') continue;
-    walk((node as Record<string, unknown>)[key], warnings);
+    walk((node as Record<string, unknown>)[key], found);
   }
 }
 
@@ -245,22 +270,35 @@ export function serverEntryPlugin(opts: ServerEntryPluginOptions): Plugin {
 
       if (!apiAbsPath) return;
       const apiSource = fs.readFileSync(apiAbsPath, 'utf8');
-      const warnings = findApiCatchAllRoutes(apiSource);
-      for (const w of warnings) {
-        const where = `${apiAbsPath}${w.line != null ? `:${w.line}` : ''}`;
-        if (w.kind === 'notFound') {
+      const shadowing = findApiShadowingRoutes(apiSource);
+      const errors: string[] = [];
+      for (const r of shadowing) {
+        const where = `${apiAbsPath}${r.line != null ? `:${r.line}` : ''}`;
+        if (r.kind === 'notFound') {
           this.warn(
-            `[hono-preact] ${where}: app.notFound(...) acts as a catch-all and ` +
-              `will be shadowed by the framework's renderPage handler. ` +
-              `Move the behavior to a more specific path, or accept that it won't fire.`
+            `[hono-preact] ${where}: app.notFound(...) will not fire — the ` +
+              `framework's renderPage handler matches every unmatched request. ` +
+              `Move the behavior to a specific path, or accept that it won't fire.`
+          );
+        } else if (r.kind === 'wildcard') {
+          errors.push(
+            `${where}: app.${r.method}('${r.pattern}', ...) is a catch-all route`
           );
         } else {
-          this.warn(
-            `[hono-preact] ${where}: app.${w.method}('${w.pattern}', ...) is a ` +
-              `catch-all route and will be shadowed by the framework's renderPage ` +
-              `handler. Move it to a more specific path, or accept that it won't fire.`
+          errors.push(
+            `${where}: app.${r.method}('${r.pattern}', ...) registers the ` +
+              `framework-reserved path '${r.pattern}'`
           );
         }
+      }
+      if (errors.length > 0) {
+        this.error(
+          `[hono-preact] api.ts registers routes that shadow framework handlers:\n` +
+            errors.map((e) => `  - ${e}`).join('\n') +
+            `\nThe framework mounts your app ahead of its reserved paths ` +
+            `(/__loaders, /__actions) and the SSR handler, so these routes break ` +
+            `loaders/actions and/or page rendering. Use specific, non-wildcard paths.`
+        );
       }
     },
   };

--- a/packages/vite/src/server-entry.ts
+++ b/packages/vite/src/server-entry.ts
@@ -41,9 +41,9 @@ export function generateServerEntrySource(
     `const handlerOpts = { dev: import.meta.env.DEV };\n` +
     `\n` +
     `export const app = new Hono()\n` +
+    apiMount +
     `  .post('/__loaders', loadersHandler(serverModules, handlerOpts))\n` +
     `  .post('/__actions', actionsHandler(serverModules, handlerOpts))\n` +
-    apiMount +
     `  .get('*', (c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes })))));\n` +
     `\n` +
     `export default app;\n`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
         specifier: ^0.30.21
         version: 0.30.21
     devDependencies:
+      hono:
+        specifier: ^4.12.14
+        version: 4.12.14
       preact:
         specifier: ^10.29.1
         version: 10.29.1


### PR DESCRIPTION
## Summary

Closes #43. Lets users apply HTTP middleware (e.g. `csrf()`) to the framework's reserved RPC paths.

The generated server entry used to register `POST /__loaders` and `POST /__actions` *before* mounting the user's `api.ts` app. Hono composes matched handlers in registration order, so middleware in `api.ts` could never run before the framework's RPC handlers. This flips the order — the user app mounts first — so `app.use('/__actions', csrf())` (and `app.use('*', …)` app-wide) composes ahead of the framework handlers.

To replace the lost "user code cannot shadow reserved paths" structural guarantee, the Vite plugin's static `api.ts` analyzer (`findApiCatchAllRoutes` → `findApiShadowingRoutes`) now **fails the build** (`this.error`) on catch-all routes and literal `/__loaders` / `/__actions` registrations, while still only **warning** on `app.notFound`. A latent `app.on(method, path, …)` argument-index bug is fixed along the way.

Honors the #36 audit's "use Hono as normal" principle by making the framework composable rather than auto-mounting a default; the audit's now-stale `hono/csrf` claim is corrected.

Design: `docs/superpowers/specs/2026-05-17-reserved-path-middleware-design.md`.

## Changes

- `packages/vite/src/server-entry.ts` — reorder the generated entry; rename + extend the shadow detector with a `severity`-bearing `ApiShadowingRoute` union and reserved-path detection; `buildStart` fails the build on errors.
- `packages/vite/src/__tests__/server-entry.test.ts` — order assertion, mount-order composition regression test, detector + `buildStart` error/warn coverage.
- `apps/site/src/pages/docs/csrf.mdx` — explain the mount order; clarify `app.use('*', …)` middleware is safe vs. catch-all routes.
- `docs/superpowers/research/2026-05-14-hono-primitives-audit.md` — correct the `hono/csrf` row and recommendation 1.

## Test Plan

- [x] `pnpm test` — 547/547 pass
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] New tests: entry order, mount-order composition (`csrf()` 403s a cross-origin `POST /__actions`), catch-all/reserved-path build errors, `.on()` catch-all detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)