### PR TITLE
Multi-cloud adapter architecture (Plan A): Cloudflare adapter

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -6,8 +6,8 @@
     "build": "NODE_ENV=production vite build",
     "visualize": "NODE_ENV=production VISUALIZE=1 vite build --mode client",
     "updates": "npx npm-check-updates -i --format group",
-    "deploy": "wrangler deploy",
-    "deploy:upload": "wrangler versions upload",
+    "deploy": "wrangler deploy -c dist/hono_preact/wrangler.json",
+    "deploy:upload": "wrangler versions upload -c dist/hono_preact/wrangler.json",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -45,6 +45,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "*",
     "vite": "*",
-    "wrangler": "^4.83.0"
+    "wrangler": "^4.92.0"
   }
 }

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -3,12 +3,12 @@
   "type": "module",
   "scripts": {
     "dev": "NODE_ENV=development vite --force",
-    "build": "NODE_ENV=production vite build --mode client && vite build",
+    "build": "NODE_ENV=production vite build",
     "visualize": "NODE_ENV=production VISUALIZE=1 vite build --mode client",
     "updates": "npx npm-check-updates -i --format group",
     "deploy": "wrangler deploy",
     "deploy:upload": "wrangler versions upload",
-    "preview": "npm run build && wrangler dev"
+    "preview": "vite preview"
   },
   "dependencies": {
     "hono-preact": "workspace:*",
@@ -27,15 +27,13 @@
     "@babel/types": "^7.29.0",
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",
+    "@cloudflare/vite-plugin": "^1.37.1",
     "@hono/node-server": "^1.19.14",
-    "@hono/vite-build": "^1.11.1",
-    "@hono/vite-dev-server": "^0.25.1",
     "@mdx-js/rollup": "^3.1.1",
     "@preact/preset-vite": "^2.10.5",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^25.6.0",
     "magic-string": "^0.30.21",
-    "miniflare": "^4.20260415.0",
     "postcss": "^8.5.10",
     "preact-render-to-string": "^6.6.7",
     "prettier": "^3.8.3",

--- a/apps/site/src/pages/docs/deployment.mdx
+++ b/apps/site/src/pages/docs/deployment.mdx
@@ -6,33 +6,39 @@
 npm run dev
 ```
 
-Starts the Vite dev server (`NODE_ENV=development vite --force`) with the `@hono/vite-dev-server` Cloudflare adapter. Hot module replacement works for both client components and server code. The `--force` flag disables Vite's dependency cache, which prevents stale module resolution issues during development.
+Starts the Vite dev server. The Cloudflare adapter runs your worker inside
+`workerd` (the real Cloudflare Workers runtime) via `@cloudflare/vite-plugin`,
+so development mirrors production: Cloudflare bindings, the SSR runtime, and
+WebSocket upgrades all behave the same as a deployed Worker. Hot module
+replacement works for both client components and server code.
 
-## Two-pass production build
+## Production build
 
 ```bash
 npm run build
 ```
 
-This runs two Vite builds sequentially:
+A single `vite build`. Vite's Environment API builds the browser bundle and the
+Worker bundle together; there is no separate client pass. The `serverOnlyPlugin`
+still replaces every `*.server.*` import with a no-op stub so server code never
+enters the browser bundle.
 
-**Pass 1: client bundle** (`vite build --mode client`):
-
-Produces the browser bundle in `dist/static/`. The `serverOnlyPlugin` replaces all `*.server.*` imports with no-op stubs so server code never enters the browser bundle.
-
-Output:
+Output is split into two directories so worker source can never be served as a
+static asset:
 
 ```
-dist/static/client.js        # main client entry
-dist/static/<name>-<hash>.js # lazy page chunks
-dist/static/<name>-<hash>.css
+dist/
+  client/                      # static assets, served from Cloudflare's CDN
+    static/client.js            #   client entry
+    static/<name>-<hash>.js     #   lazy route chunks
+    static/<name>-<hash>.css
+  hono_preact/                 # the Worker bundle
+    index.js                    #   bundled Worker
+    wrangler.json               #   generated deploy config
 ```
 
-**Pass 2: Worker bundle** (`vite build`):
-
-Produces the Cloudflare Workers bundle at `dist/index.js`. The `@hono/vite-build` plugin handles bundling for the Workers runtime. Client assets from Pass 1 are included in `dist/` so the Worker can serve them.
-
-The two-pass approach is necessary because the client and server targets have different runtimes (browser vs. Workers edge runtime) and different Vite plugin configurations.
+The Worker directory name is derived from the `name` field in `wrangler.jsonc`
+(hyphens become underscores), so `hono-preact` produces `dist/hono_preact/`.
 
 ## Local preview
 
@@ -40,25 +46,31 @@ The two-pass approach is necessary because the client and server targets have di
 npm run preview
 ```
 
-Runs the full production build then starts Wrangler's local dev mode. This is closer to the real Cloudflare environment than the Vite dev server and is the right tool for testing production behaviour locally.
+Runs `vite preview`, which serves the production build through `workerd` again.
 
 ## Configuring `wrangler.jsonc`
 
-Before deploying, update `wrangler.jsonc`:
+`wrangler.jsonc` is the source of truth `@cloudflare/vite-plugin` reads:
 
 ```jsonc
 {
-  "name": "your-app-name", // ← change this to your Worker name
-  "main": "dist/index.js",
+  "name": "your-app-name", // also names the dist/<name>/ worker directory
+  "main": "node_modules/.vite/hono-preact/server-entry.tsx",
   "compatibility_date": "2026-02-22",
-  "assets": {
-    "directory": "./dist", // serves dist/static/* as static assets
-  },
   "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": "./dist/client",
+  },
 }
 ```
 
-`assets.directory` points Cloudflare to `dist/` so static files (JS chunks, CSS) are served automatically from the CDN alongside the Worker. The Worker itself handles all HTML responses via the catch-all route.
+`main` points at the server entry the framework generates into the Vite cache
+directory; the framework writes that file before the build starts. `assets`
+points at the client build output. No `run_worker_first` list is needed: the
+client assets and the Worker bundle land in separate directories, so the Worker
+source is never exposed through the asset store. The build also writes a
+`.assetsignore` into `dist/client/` that excludes the generated config from the
+asset upload.
 
 ## Deploy
 
@@ -66,4 +78,6 @@ Before deploying, update `wrangler.jsonc`:
 npm run deploy
 ```
 
-Runs `wrangler deploy`, which uploads `dist/index.js` as the Worker script and the contents of `dist/` as static assets to Cloudflare's global network.
+This runs `wrangler deploy` against the generated config in the Worker output
+directory (`dist/hono_preact/wrangler.json`), which references the built Worker
+and the `dist/client/` assets. Run `npm run build` first so the output exists.

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -1,4 +1,5 @@
 import { honoPreact } from 'hono-preact/vite';
+import { cloudflareAdapter } from 'hono-preact/adapter-cloudflare';
 import mdx, { type Options as MdxOptions } from '@mdx-js/rollup';
 import remarkGfm from 'remark-gfm';
 import rehypeShiki from '@shikijs/rehype';
@@ -43,6 +44,10 @@ export default defineConfig((env) => ({
         replacement: resolve(__dirname, '../../packages/hono-preact/src/vite.ts'),
       },
       {
+        find: 'hono-preact/adapter-cloudflare',
+        replacement: resolve(__dirname, '../../packages/hono-preact/src/adapter-cloudflare.ts'),
+      },
+      {
         find: 'hono-preact',
         replacement: resolve(__dirname, '../../packages/hono-preact/src/index.ts'),
       },
@@ -67,7 +72,7 @@ export default defineConfig((env) => ({
     sourcemap: visualize && env.mode === 'client',
   },
   plugins: [
-    honoPreact(),
+    honoPreact({ adapter: cloudflareAdapter() }),
     Object.assign(mdx(mdxOptions), { enforce: 'pre' as const }),
     ...(visualize && env.mode === 'client'
       ? [

--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -1,23 +1,9 @@
 {
   "name": "hono-preact",
-  "main": "dist/index.js",
+  "main": "node_modules/.vite/hono-preact/server-entry.tsx",
   "compatibility_date": "2026-02-22",
   "assets": {
-    "directory": "./dist",
-    // The build emits the Worker entry alongside the static client assets in
-    // ./dist (Vite's outDir, also the site's `main`). Workers Static Assets
-    // does NOT exclude `main` from the uploaded asset manifest, so without
-    // this list a request to `/index.js` (or `/tsconfig.tsbuildinfo` from an
-    // incremental typecheck) would be served as a public static file and
-    // leak the Worker source. Force those routes through the Worker; the
-    // catch-all SSR handler will respond, never the asset server.
-    //
-    // Adding new server-only artifacts? Either ensure they're emitted
-    // outside ./dist or extend this list.
-    "run_worker_first": [
-      "/index.js",
-      "/tsconfig.tsbuildinfo",
-    ],
+    "directory": "./dist/client",
   },
   "compatibility_flags": ["nodejs_compat"],
   "preview_urls": true,

--- a/docs/superpowers/research/2026-05-17-cloudflare-vite-plugin-spike.md
+++ b/docs/superpowers/research/2026-05-17-cloudflare-vite-plugin-spike.md
@@ -1,0 +1,178 @@
+# @cloudflare/vite-plugin Vite 8 Compatibility Spike
+
+**Date:** 2026-05-17  
+**Status:** PASS — plan proceeds
+
+## Summary
+
+`@cloudflare/vite-plugin` works correctly on `vite@8.0.8`. Both `vite dev` and
+`vite build` succeed without errors or Vite-8-specific warnings. The go/no-go
+gate is cleared.
+
+## Resolved Versions
+
+| Package                    | Version  |
+|----------------------------|----------|
+| `vite`                     | 8.0.8    |
+| `@cloudflare/vite-plugin`  | 1.37.1   |
+| `wrangler`                 | 4.92.0   |
+| `hono`                     | 4.12.19  |
+
+Installed via `npm install vite@8.0.8 @cloudflare/vite-plugin wrangler hono`
+in a fresh throwaway project at `/tmp/cf-spike`.
+
+## Step 2: Dev Server
+
+`vite dev` boots in ~430-600 ms. `GET /` returns `200 ok` from workerd. No
+Vite-8 incompatibility errors.
+
+```
+  VITE v8.0.8  ready in 432 ms
+
+  ➜  Local:   http://localhost:7777/
+  ➜  Network: use --host to expose
+  ➜  Debug:   http://localhost:7777/__debug
+```
+
+```
+curl http://localhost:7777/
+ok
+```
+
+## Step 3: Build Output Layout
+
+Running `vite build` on a project with both a worker entry and a client-side
+HTML/JS entry produces the following tree under `dist/`:
+
+```
+dist/
+  cf_spike/              <- worker environment output
+    .vite/
+      manifest.json
+    index.js             <- bundled worker (53 kB, hono included)
+    wrangler.json        <- generated wrangler config for deployment
+  client/                <- client environment output
+    .assetsignore        <- contains "wrangler.json\n.dev.vars"
+    index.html
+    assets/
+      index-BgOb5xxM.js  <- hashed client bundle
+```
+
+The generated `dist/cf_spike/wrangler.json` sets:
+
+```json
+{
+  "main": "index.js",
+  "assets": { "directory": "../client" },
+  "no_bundle": true
+}
+```
+
+Key observations:
+
+- Worker output goes to `dist/<env-name>/` (environment name derived from the
+  `wrangler.jsonc` `name` field, with hyphens converted to underscores).
+- Client assets go to `dist/client/`.
+- The plugin generates a `wrangler.json` inside the worker directory that
+  references `../client` for the assets directory. The `wrangler deploy` command
+  is meant to run from `dist/cf_spike/`.
+- `dist/client/.assetsignore` explicitly excludes `wrangler.json` and
+  `.dev.vars` from the assets upload, preventing worker-source leakage to the
+  static asset store.
+- Worker source (`index.js`) lives in a separate directory from client assets.
+  There is no structural overlap.
+
+## Step 4: Integration Questions
+
+### Q1: Does the plugin accept a `.tsx` file as `wrangler.jsonc` `main`?
+
+**Yes.** Setting `"main": "src/worker.tsx"` in `wrangler.jsonc` works for both
+`vite dev` and `vite build` without any special configuration. The plugin
+resolves and transforms `.tsx` entries the same as `.ts`.
+
+### Q2: When does the plugin read `main`, and must the file exist before startup?
+
+**The file must exist on disk before `vite dev` / `vite build` is invoked.**
+
+The plugin validates `main` during Vite's `config` hook (the earliest hook,
+runs during config resolution before the server or build pipeline starts).
+Specifically, `resolvePluginConfig` calls `resolveWorkerConfig`, which calls
+`maybeResolveMain`, which checks `fs.existsSync` on the resolved path. If the
+file is absent, startup aborts with:
+
+```
+Error: The provided Wrangler config main field (/path/to/src/worker.tsx)
+       doesn't point to an existing file
+    at maybeResolveMain (.../index.mjs:41319:44)
+    at resolveWorkerConfig (.../index.mjs:41289:23)
+    at resolvePluginConfig (.../index.mjs:41429:36)
+    at BasicMinimalPluginContext.config (.../index.mjs:54044:33)
+    at runConfigHook (vite/dist/node/chunks/node.js:34709:42)
+```
+
+This error is the same for both `vite dev` and `vite build`.
+
+**Implication for the framework:** The framework's generated server-entry file
+(e.g. `.vite/hono-preact/server-entry.tsx`) must be written to disk before
+`@cloudflare/vite-plugin` initialises. It cannot be a virtual module referenced
+from `main`. See the reference note in project memory
+(`@hono/vite-build entry resolution gotcha`) — the same constraint applies here.
+
+### Q3: Are client assets and the worker emitted into separate directories?
+
+**Yes, fully separated.** Worker output goes to `dist/<worker-name>/` and
+client assets go to `dist/client/`. There is no path overlap.
+
+Worker-source-leak protection is layered:
+
+1. **Separate directories:** client assets cannot accidentally include the
+   worker bundle because they live under a different top-level subdirectory.
+2. **`.assetsignore`:** the plugin writes `dist/client/.assetsignore` containing
+   `wrangler.json` and `.dev.vars`. Even if wrangler deployment were pointed at
+   the client directory directly, those files would be excluded from the upload.
+3. **`no_bundle: true`** in the generated `wrangler.json`: wrangler will not
+   re-bundle `index.js`, relying on the already-bundled output from vite.
+
+The `wrangler deploy` surface is `dist/cf_spike/` (worker bundle + generated
+wrangler config); the `assets.directory` points up to `../client`.
+
+### Q4: Does a WebSocket `GET` with `Upgrade: websocket` reach worker code under `vite dev`?
+
+**Yes.** A `GET /ws` request with `Upgrade: websocket` headers reaches the hono
+`upgradeWebSocket` handler and returns `101 Switching Protocols`. The worker
+runs inside workerd under `vite dev`, so the full WebSocket lifecycle runs
+through workerd's WebSocket API.
+
+Test:
+
+```bash
+curl -sv \
+  -H "Upgrade: websocket" \
+  -H "Connection: Upgrade" \
+  -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+  -H "Sec-WebSocket-Version: 13" \
+  http://localhost:7780/ws
+```
+
+Response:
+
+```
+< HTTP/1.1 101 Switching Protocols
+< Upgrade: websocket
+< Connection: Upgrade
+< Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+```
+
+The worker log also emitted `WebSocket closed` when curl disconnected, confirming
+the `onClose` handler ran.
+
+## Go/No-Go Decision
+
+**GO.** Both `vite dev` and `vite build` succeed on `vite@8.0.8` with
+`@cloudflare/vite-plugin@1.37.1`. The plan proceeds.
+
+The one notable constraint to carry forward: the file referenced by
+`wrangler.jsonc` `main` must exist on disk before the plugin's `config` hook
+runs. For the framework's virtual server-entry pattern, this means writing the
+entry file to disk during a Vite plugin's own `config` hook (before
+`@cloudflare/vite-plugin` reads it), or generating it in a pre-build step.

--- a/packages/hono-preact/package.json
+++ b/packages/hono-preact/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"
     },
+    "./adapter-cloudflare": {
+      "types": "./dist/adapter-cloudflare.d.ts",
+      "import": "./dist/adapter-cloudflare.js"
+    },
     "./internal": {
       "types": "./dist/internal.d.ts",
       "import": "./dist/internal.js"
@@ -57,18 +61,22 @@
   "dependencies": {
     "@babel/parser": "^7.29.2",
     "@babel/types": "^7.29.0",
-    "@hono/vite-build": "^1.11.1",
-    "@hono/vite-dev-server": "^0.25.1",
     "@preact/preset-vite": "^2.10.5",
     "magic-string": "^0.30.21"
   },
   "peerDependencies": {
+    "@cloudflare/vite-plugin": "^1.37.1",
     "hono": ">=4.0.0",
     "hoofd": ">=1.0.0",
     "preact": ">=10.0.0",
     "preact-iso": ">=2.11.0",
     "preact-render-to-string": ">=6.0.0",
-    "vite": ">=5.0.0"
+    "vite": ">=6.0.0",
+    "wrangler": "^4.92.0"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/vite-plugin": { "optional": true },
+    "wrangler": { "optional": true }
   },
   "devDependencies": {
     "@hono-preact/iso": "workspace:*",

--- a/packages/hono-preact/package.json
+++ b/packages/hono-preact/package.json
@@ -75,8 +75,12 @@
     "wrangler": "^4.92.0"
   },
   "peerDependenciesMeta": {
-    "@cloudflare/vite-plugin": { "optional": true },
-    "wrangler": { "optional": true }
+    "@cloudflare/vite-plugin": {
+      "optional": true
+    },
+    "wrangler": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@hono-preact/iso": "workspace:*",

--- a/packages/hono-preact/scripts/consolidate.mjs
+++ b/packages/hono-preact/scripts/consolidate.mjs
@@ -50,6 +50,7 @@ const DIST_PATHS = {
   '@hono-preact/iso': 'iso/index.js',
   '@hono-preact/server': 'server/index.js',
   '@hono-preact/vite': 'vite/index.js',
+  '@hono-preact/vite/adapter-cloudflare': 'vite/adapter-cloudflare.js',
 };
 
 async function copyTree(src, dest) {
@@ -95,7 +96,7 @@ async function rewriteImports(filePath) {
   const isTypeFile = filePath.endsWith('.d.ts');
 
   let rewritten = original.replace(
-    /(['"])(@hono-preact\/(?:iso\/internal|iso|server|vite))(['"])/g,
+    /(['"])(@hono-preact\/(?:iso\/internal|iso|server|vite\/adapter-cloudflare|vite))(['"])/g,
     (match, q1, source, q2) => {
       const distRel = DIST_PATHS[source];
       if (!distRel) return match;

--- a/packages/hono-preact/src/adapter-cloudflare.ts
+++ b/packages/hono-preact/src/adapter-cloudflare.ts
@@ -1,0 +1,2 @@
+// packages/hono-preact/src/adapter-cloudflare.ts
+export * from '@hono-preact/vite/adapter-cloudflare';

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -30,6 +30,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./adapter-cloudflare": {
+      "types": "./dist/adapter-cloudflare.d.ts",
+      "import": "./dist/adapter-cloudflare.js"
     }
   },
   "scripts": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -49,6 +49,7 @@
     "vite": ">=5.0.0"
   },
   "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.37.1",
     "hono": "^4.12.14",
     "preact": "^10.29.1",
     "preact-iso": "github:preactjs/preact-iso#v3",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -43,10 +43,14 @@
     "magic-string": "^0.30.21"
   },
   "peerDependencies": {
-    "@hono/vite-build": "^1.11.1",
-    "@hono/vite-dev-server": "^0.25.1",
+    "@cloudflare/vite-plugin": "^1.37.1",
     "@preact/preset-vite": "^2.10.5",
-    "vite": ">=5.0.0"
+    "vite": ">=6.0.0",
+    "wrangler": "^4.92.0"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/vite-plugin": { "optional": true },
+    "wrangler": { "optional": true }
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.37.1",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -53,8 +53,12 @@
     "wrangler": "^4.92.0"
   },
   "peerDependenciesMeta": {
-    "@cloudflare/vite-plugin": { "optional": true },
-    "wrangler": { "optional": true }
+    "@cloudflare/vite-plugin": {
+      "optional": true
+    },
+    "wrangler": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.37.1",

--- a/packages/vite/src/__tests__/adapter-cloudflare.test.ts
+++ b/packages/vite/src/__tests__/adapter-cloudflare.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { cloudflareAdapter } from '../adapter-cloudflare.js';
+
+const ctx = {
+  root: '/p',
+  coreAppModuleId: '/p/node_modules/.vite/hono-preact/core-app.tsx',
+  entryWrapperId: '/p/node_modules/.vite/hono-preact/server-entry.tsx',
+};
+
+describe('cloudflareAdapter', () => {
+  it('is named "cloudflare"', () => {
+    expect(cloudflareAdapter().name).toBe('cloudflare');
+  });
+
+  it('wrapEntry re-exports the core app module default', () => {
+    const tail = cloudflareAdapter().wrapEntry(ctx);
+    expect(tail).toBe(
+      `export { default } from "/p/node_modules/.vite/hono-preact/core-app.tsx";\n`
+    );
+  });
+
+  it('exposes a vitePlugins function', () => {
+    expect(typeof cloudflareAdapter().vitePlugins).toBe('function');
+  });
+});

--- a/packages/vite/src/__tests__/adapter.test.ts
+++ b/packages/vite/src/__tests__/adapter.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import type { HonoPreactAdapter, HonoPreactAdapterContext } from '../adapter.js';
+
+describe('HonoPreactAdapter interface', () => {
+  it('a conforming object satisfies the interface and produces an entry tail', () => {
+    const ctx: HonoPreactAdapterContext = {
+      root: '/project',
+      coreAppModuleId: '/project/node_modules/.vite/hono-preact/core-app.tsx',
+      entryWrapperId: '/project/node_modules/.vite/hono-preact/server-entry.tsx',
+    };
+    const adapter: HonoPreactAdapter = {
+      name: 'fake',
+      vitePlugins: () => [],
+      wrapEntry: (c) => `export { default } from ${JSON.stringify(c.coreAppModuleId)};\n`,
+    };
+    expect(adapter.name).toBe('fake');
+    expect(adapter.vitePlugins(ctx)).toEqual([]);
+    expect(adapter.wrapEntry(ctx)).toContain('core-app.tsx');
+  });
+});

--- a/packages/vite/src/__tests__/adapter.test.ts
+++ b/packages/vite/src/__tests__/adapter.test.ts
@@ -1,17 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import type { HonoPreactAdapter, HonoPreactAdapterContext } from '../adapter.js';
+import type {
+  HonoPreactAdapter,
+  HonoPreactAdapterContext,
+} from '../adapter.js';
 
 describe('HonoPreactAdapter interface', () => {
   it('a conforming object satisfies the interface and produces an entry tail', () => {
     const ctx: HonoPreactAdapterContext = {
       root: '/project',
       coreAppModuleId: '/project/node_modules/.vite/hono-preact/core-app.tsx',
-      entryWrapperId: '/project/node_modules/.vite/hono-preact/server-entry.tsx',
+      entryWrapperId:
+        '/project/node_modules/.vite/hono-preact/server-entry.tsx',
     };
     const adapter: HonoPreactAdapter = {
       name: 'fake',
       vitePlugins: () => [],
-      wrapEntry: (c) => `export { default } from ${JSON.stringify(c.coreAppModuleId)};\n`,
+      wrapEntry: (c) =>
+        `export { default } from ${JSON.stringify(c.coreAppModuleId)};\n`,
     };
     expect(adapter.name).toBe('fake');
     expect(adapter.vitePlugins(ctx)).toEqual([]);

--- a/packages/vite/src/__tests__/client-shim.test.ts
+++ b/packages/vite/src/__tests__/client-shim.test.ts
@@ -26,11 +26,10 @@ function makePlugin(entry = './src/client.tsx', root = '/repo'): ShimPlugin {
 }
 
 describe('clientShimPlugin', () => {
-  it('runs in dev (serve) and in client builds, but not in SSR builds', () => {
+  it('runs in dev (serve) and in builds', () => {
     const apply = (clientShimPlugin('./src/client.tsx') as ShimPlugin).apply!;
     expect(apply({}, { command: 'serve', mode: 'development' })).toBe(true);
-    expect(apply({}, { command: 'build', mode: 'client' })).toBe(true);
-    expect(apply({}, { command: 'build', mode: 'production' })).toBe(false);
+    expect(apply({}, { command: 'build', mode: 'production' })).toBe(true);
   });
 
   it('resolves the virtual id to a private resolved id', () => {
@@ -82,6 +81,20 @@ describe('clientShimPlugin', () => {
     const plugin = makePlugin('./src/client.tsx', '/repo');
     const result = plugin.transform('// other', '/repo/src/iso.tsx');
     expect(result).toBeUndefined();
+  });
+});
+
+describe('clientShimPlugin apply gate', () => {
+  it('applies during serve', () => {
+    const p = clientShimPlugin('virtual:hono-preact/client');
+    const apply = p.apply as Function;
+    expect(apply({}, { command: 'serve', mode: 'development' })).toBe(true);
+  });
+
+  it('applies during a unified build (no client mode)', () => {
+    const p = clientShimPlugin('virtual:hono-preact/client');
+    const apply = p.apply as Function;
+    expect(apply({}, { command: 'build', mode: 'production' })).toBe(true);
   });
 });
 

--- a/packages/vite/src/__tests__/hono-preact.test.ts
+++ b/packages/vite/src/__tests__/hono-preact.test.ts
@@ -6,7 +6,8 @@ function fakeAdapter(): HonoPreactAdapter {
   return {
     name: 'fake',
     vitePlugins: () => [{ name: 'fake-adapter:plugin' }],
-    wrapEntry: (c) => `export { default } from ${JSON.stringify(c.coreAppModuleId)};\n`,
+    wrapEntry: (c) =>
+      `export { default } from ${JSON.stringify(c.coreAppModuleId)};\n`,
   };
 }
 
@@ -71,8 +72,14 @@ describe('honoPreact config plugin', () => {
   it('does not branch on mode (no client-only rollupOptions)', () => {
     const plugins = honoPreact({ adapter: fakeAdapter() });
     const cfg = plugins.find((p) => p.name === 'hono-preact:config');
-    const a = (cfg!.config as Function)({}, { command: 'build', mode: 'client' });
-    const b = (cfg!.config as Function)({}, { command: 'build', mode: 'production' });
+    const a = (cfg!.config as Function)(
+      {},
+      { command: 'build', mode: 'client' }
+    );
+    const b = (cfg!.config as Function)(
+      {},
+      { command: 'build', mode: 'production' }
+    );
     expect(a).toEqual(b);
   });
 

--- a/packages/vite/src/__tests__/hono-preact.test.ts
+++ b/packages/vite/src/__tests__/hono-preact.test.ts
@@ -1,218 +1,34 @@
 import { describe, it, expect } from 'vitest';
 import { honoPreact } from '../hono-preact.js';
+import type { HonoPreactAdapter } from '../adapter.js';
 
-function findConfigPlugin(plugins: ReturnType<typeof honoPreact>) {
-  const configPlugin = plugins.find(
-    (p) => 'config' in p && typeof p.config === 'function'
-  );
-  if (!configPlugin || typeof configPlugin.config !== 'function') {
-    throw new Error('config plugin not found');
-  }
-  return configPlugin.config as (config: unknown, env: unknown) => unknown;
-}
-
-function getClientConfig(
-  plugins: ReturnType<typeof honoPreact>,
-  userConfig = {}
-) {
-  return findConfigPlugin(plugins)(userConfig, {
-    mode: 'client',
-    command: 'build',
-  });
-}
-
-function getServerConfig(
-  plugins: ReturnType<typeof honoPreact>,
-  userConfig = {}
-) {
-  return findConfigPlugin(plugins)(userConfig, {
-    mode: 'production',
-    command: 'build',
-  });
-}
-
-describe('honoPreact rollupOptions merge', () => {
-  it('uses framework defaults when no clientBuild.rollupOptions provided', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' });
-    const config = getClientConfig(plugins);
-    expect(config).toBeTruthy();
-    const rollup = (
-      config as {
-        build: {
-          rollupOptions: {
-            input: string[];
-            output: { entryFileNames: string };
-          };
-        };
-      }
-    ).build.rollupOptions;
-    expect(rollup.input).toEqual(['virtual:hono-preact/client']);
-    expect(rollup.output.entryFileNames).toBe('static/client.js');
-  });
-
-  it('merges user output fields without losing framework defaults', () => {
-    const plugins = honoPreact({
-      entry: './src/server.tsx',
-      clientBuild: {
-        rollupOptions: {
-          output: { entryFileNames: 'custom/entry.js' },
-        },
-      },
-    });
-    const config = getClientConfig(plugins);
-    const rollup = (
-      config as {
-        build: {
-          rollupOptions: {
-            output: { entryFileNames: string; chunkFileNames: string };
-          };
-        };
-      }
-    ).build.rollupOptions;
-    expect(rollup.output.entryFileNames).toBe('custom/entry.js');
-    expect(rollup.output.chunkFileNames).toBe('static/[name]-[hash].js');
-  });
-
-  it('ignores array-form output and keeps framework defaults', () => {
-    const plugins = honoPreact({
-      entry: './src/server.tsx',
-      clientBuild: {
-        rollupOptions: {
-          output: [{ entryFileNames: 'ignored.js' }],
-        },
-      },
-    });
-    const config = getClientConfig(plugins);
-    const rollup = (
-      config as {
-        build: { rollupOptions: { output: { entryFileNames: string } } };
-      }
-    ).build.rollupOptions;
-    expect(rollup.output.entryFileNames).toBe('static/client.js');
-  });
-});
-
-describe('honoPreact server build config', () => {
-  type ServerCfg = {
-    ssr: { noExternal: string[] };
-    build: Record<string, unknown> & { target: string; assetsDir: string };
+function fakeAdapter(): HonoPreactAdapter {
+  return {
+    name: 'fake',
+    vitePlugins: () => [{ name: 'fake-adapter:plugin' }],
+    wrapEntry: (c) => `export { default } from ${JSON.stringify(c.coreAppModuleId)};\n`,
   };
+}
 
-  it('declares the framework SSR noExternal list', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' });
-    const config = getServerConfig(plugins) as ServerCfg;
-    expect(config.ssr.noExternal).toEqual([
-      'preact-render-to-string',
-      'preact-iso',
-      'hono-preact',
-    ]);
+type NamedPlugin = { name?: string };
+
+describe('honoPreact adapter requirement', () => {
+  it('throws when called without an adapter', () => {
+    // @ts-expect-error - exercising the runtime guard
+    expect(() => honoPreact({})).toThrow(/adapter/i);
   });
 
-  it('preserves shared build defaults on the server config', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' });
-    const config = getServerConfig(plugins) as ServerCfg;
-    expect(config.build.target).toBe('esnext');
-    expect(config.build.assetsDir).toBe('static');
-    expect(config.build.ssrEmitAssets).toBe(true);
-  });
-
-  it('merges user serverBuild fields over framework defaults', () => {
-    const plugins = honoPreact({
-      entry: './src/server.tsx',
-      serverBuild: { outDir: 'custom-server-out', minify: false },
-    });
-    const config = getServerConfig(plugins) as ServerCfg;
-    expect(config.build.outDir).toBe('custom-server-out');
-    expect(config.build.minify).toBe(false);
-    // Shared defaults survive what the user didn't override.
-    expect(config.build.assetsDir).toBe('static');
-  });
-
-  it('uses inline sourcemaps on server so SSR stacks point at user source', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' });
-    const config = getServerConfig(plugins) as ServerCfg & {
-      build: { sourcemap?: unknown };
-    };
-    // The Worker bundle inlines sourcemaps because Workers tooling won't
-    // follow a sibling .map file. See hono-preact.ts for the rationale.
-    expect(config.build.sourcemap).toBe('inline');
-  });
-
-  it('does not include client-only build fields (cssCodeSplit, rollupOptions)', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' });
-    const config = getServerConfig(plugins) as ServerCfg & {
-      build: { cssCodeSplit?: unknown; rollupOptions?: unknown };
-    };
-    expect(config.build.cssCodeSplit).toBeUndefined();
-    expect(config.build.rollupOptions).toBeUndefined();
-  });
-
-  it('lets serverBuild.sourcemap override the inline default (e.g. false to disable)', () => {
-    const plugins = honoPreact({
-      entry: './src/server.tsx',
-      serverBuild: { sourcemap: false },
-    });
-    const config = getServerConfig(plugins) as ServerCfg & {
-      build: { sourcemap?: unknown };
-    };
-    expect(config.build.sourcemap).toBe(false);
-  });
-
-  it('honors sharedBuild on both client and server configs', () => {
-    const plugins = honoPreact({
-      entry: './src/server.tsx',
-      sharedBuild: { reportCompressedSize: false },
-    });
-    const client = getClientConfig(plugins) as {
-      build: { reportCompressedSize?: boolean };
-    };
-    const server = getServerConfig(plugins) as {
-      build: { reportCompressedSize?: boolean };
-    };
-    expect(client.build.reportCompressedSize).toBe(false);
-    expect(server.build.reportCompressedSize).toBe(false);
+  it('throws when called with no options at all', () => {
+    // @ts-expect-error - exercising the runtime guard
+    expect(() => honoPreact()).toThrow(/adapter/i);
   });
 });
 
 describe('honoPreact plugin assembly', () => {
-  type NamedPlugin = { name?: string; apply?: unknown };
-
-  it('emits the framework plugins in the documented pipeline order', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' }) as NamedPlugin[];
+  it('emits the framework plugins in pipeline order, then the adapter plugins, then preact', () => {
+    const plugins = honoPreact({ adapter: fakeAdapter() }) as NamedPlugin[];
     const names = plugins.map((p) => p.name);
-    // The first six entries are the framework plugins; the remaining are
-    // upstream plugin instances (vite-build, vite-dev-server) whose names
-    // we don't lock to keep this test resilient to upstream renames.
-    expect(names.slice(0, 6)).toEqual([
-      'hono-preact:config',
-      'hono-preact:client-shim',
-      'hono-preact:client-entry',
-      'server-loader-validation',
-      'module-key',
-      'server-only',
-    ]);
-  });
-
-  it('emits at least eight framework-owned plugins when entry is provided', () => {
-    // 8 framework plugins (config, client-shim, client-entry, validation,
-    // module-key, server-only, build, dev-server) plus an unknown number of
-    // preact preset plugins.
-    const plugins = honoPreact({ entry: './src/server.tsx' });
-    expect(plugins.length).toBeGreaterThanOrEqual(8);
-  });
-
-  it('adds exactly one more framework-owned plugin in the zero-arg path (server-entry)', () => {
-    const withEntry = honoPreact({ entry: './src/server.tsx' });
-    const zeroArg = honoPreact();
-    expect(zeroArg.length).toBe(withEntry.length + 1);
-  });
-
-  it('emits the documented pipeline order in the zero-arg path', () => {
-    const plugins = honoPreact() as NamedPlugin[];
-    const names = plugins.map((p) => p.name);
-    // client-entry slots in after client-shim; server-entry slots in after
-    // client-entry, before validation/module-key/server-only.
-    expect(names.slice(0, 7)).toEqual([
+    expect(names.slice(0, 8)).toEqual([
       'hono-preact:config',
       'hono-preact:client-shim',
       'hono-preact:client-entry',
@@ -220,93 +36,43 @@ describe('honoPreact plugin assembly', () => {
       'server-loader-validation',
       'module-key',
       'server-only',
+      'hono-preact:guard-strip',
     ]);
   });
 
-  it('gates the build plugin to non-client build commands', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' }) as NamedPlugin[];
-    const buildPlugin = plugins[7];
-    expect(typeof buildPlugin.apply).toBe('function');
-    const apply = buildPlugin.apply as (
-      _: unknown,
-      env: { command: string; mode: string }
-    ) => boolean;
-    expect(apply({}, { command: 'build', mode: 'production' })).toBe(true);
-    expect(apply({}, { command: 'build', mode: 'client' })).toBe(false);
-    expect(apply({}, { command: 'serve', mode: 'production' })).toBe(false);
+  it('splices the adapter-contributed plugins into the chain', () => {
+    const plugins = honoPreact({ adapter: fakeAdapter() }) as NamedPlugin[];
+    expect(plugins.map((p) => p.name)).toContain('fake-adapter:plugin');
   });
 
-  it('gates the dev-server plugin to serve only', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' }) as NamedPlugin[];
-    const devPlugin = plugins[8];
-    expect(devPlugin.apply).toBe('serve');
+  it('includes the preact preset plugins', () => {
+    const plugins = honoPreact({ adapter: fakeAdapter() }) as NamedPlugin[];
+    expect(plugins.map((p) => p.name)).toContain('vite:preact-jsx');
   });
 });
 
-describe('honoPreact zero-arg path', () => {
-  type NamedPlugin = { name?: string; apply?: unknown };
-
-  it('accepts no arguments and includes the server-entry plugin', () => {
-    const plugins = honoPreact() as NamedPlugin[];
-    const names = plugins.map((p) => p.name);
-    expect(names).toContain('hono-preact:server-entry');
-  });
-
-  it('omits the server-entry plugin when entry is provided', () => {
-    const plugins = honoPreact({ entry: './src/server.tsx' }) as NamedPlugin[];
-    const names = plugins.map((p) => p.name);
-    expect(names).not.toContain('hono-preact:server-entry');
-  });
-
-  it('places server-entry early in the pipeline (before module-key) so its virtual id resolves first', () => {
-    const plugins = honoPreact() as NamedPlugin[];
-    const names = plugins.map((p) => p.name);
-    const seIdx = names.indexOf('hono-preact:server-entry');
-    const mkIdx = names.indexOf('module-key');
-    expect(seIdx).toBeGreaterThan(-1);
-    expect(mkIdx).toBeGreaterThan(-1);
-    expect(seIdx).toBeLessThan(mkIdx);
-  });
-});
-
-describe('honoPreact preact() auto-inclusion', () => {
-  type NamedPlugin = { name?: string };
-
-  it('includes the preact preset plugins by name', () => {
-    const plugins = honoPreact() as NamedPlugin[];
-    const names = plugins.map((p) => p.name);
-    // @preact/preset-vite returns multiple named plugins; the JSX-transform
-    // plugin is the most stable name to assert on.
-    expect(names).toContain('vite:preact-jsx');
-  });
-});
-
-describe('honoPreact client-entry wiring', () => {
-  type NamedPlugin = { name?: string };
-
-  it('includes the client-entry plugin', () => {
-    const plugins = honoPreact() as NamedPlugin[];
-    const names = plugins.map((p) => p.name);
-    expect(names).toContain('hono-preact:client-entry');
-  });
-
-  it('defaults the client build input to the virtual client entry', () => {
-    const plugins = honoPreact();
-    const config = getClientConfig(plugins) as {
-      build: { rollupOptions: { input: string[] } };
+describe('honoPreact config plugin', () => {
+  it('contributes only shared config: preact dedupe, esnext target, static assetsDir', () => {
+    const plugins = honoPreact({ adapter: fakeAdapter() });
+    const cfg = plugins.find((p) => p.name === 'hono-preact:config');
+    if (!cfg || typeof cfg.config !== 'function') {
+      throw new Error('config plugin not found');
+    }
+    const result = cfg.config({}, { command: 'build', mode: 'production' }) as {
+      resolve: { dedupe: string[] };
+      build: { target: string; assetsDir: string };
     };
-    expect(config.build.rollupOptions.input).toEqual([
-      'virtual:hono-preact/client',
-    ]);
+    expect(result.resolve.dedupe).toContain('preact');
+    expect(result.resolve.dedupe).toContain('preact-iso');
+    expect(result.build.target).toBe('esnext');
+    expect(result.build.assetsDir).toBe('static');
   });
 
-  it('honors a user-provided clientEntry override', () => {
-    const plugins = honoPreact({ clientEntry: './src/custom-client.tsx' });
-    const config = getClientConfig(plugins) as {
-      build: { rollupOptions: { input: string[] } };
-    };
-    expect(config.build.rollupOptions.input).toEqual([
-      './src/custom-client.tsx',
-    ]);
+  it('does not branch on mode (no client-only rollupOptions)', () => {
+    const plugins = honoPreact({ adapter: fakeAdapter() });
+    const cfg = plugins.find((p) => p.name === 'hono-preact:config');
+    const a = (cfg!.config as Function)({}, { command: 'build', mode: 'client' });
+    const b = (cfg!.config as Function)({}, { command: 'build', mode: 'production' });
+    expect(a).toEqual(b);
   });
 });

--- a/packages/vite/src/__tests__/hono-preact.test.ts
+++ b/packages/vite/src/__tests__/hono-preact.test.ts
@@ -52,7 +52,7 @@ describe('honoPreact plugin assembly', () => {
 });
 
 describe('honoPreact config plugin', () => {
-  it('contributes only shared config: preact dedupe, esnext target, static assetsDir', () => {
+  it('contributes shared config: preact dedupe, esnext target, static assetsDir', () => {
     const plugins = honoPreact({ adapter: fakeAdapter() });
     const cfg = plugins.find((p) => p.name === 'hono-preact:config');
     if (!cfg || typeof cfg.config !== 'function') {
@@ -74,5 +74,29 @@ describe('honoPreact config plugin', () => {
     const a = (cfg!.config as Function)({}, { command: 'build', mode: 'client' });
     const b = (cfg!.config as Function)({}, { command: 'build', mode: 'production' });
     expect(a).toEqual(b);
+  });
+
+  it('configures the client build environment input to the client entry', () => {
+    const plugins = honoPreact({ adapter: fakeAdapter() });
+    const cfg = plugins.find((p) => p.name === 'hono-preact:config');
+    const result = (cfg!.config as Function)(
+      {},
+      { command: 'build', mode: 'production' }
+    ) as {
+      environments: {
+        client: {
+          build: {
+            rollupOptions: {
+              input: string[];
+              output: { entryFileNames: string; chunkFileNames: string };
+            };
+          };
+        };
+      };
+    };
+    const ro = result.environments.client.build.rollupOptions;
+    expect(ro.input).toEqual(['virtual:hono-preact/client']);
+    expect(ro.output.entryFileNames).toBe('static/client.js');
+    expect(ro.output.chunkFileNames).toBe('static/[name]-[hash].js');
   });
 });

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -368,6 +368,10 @@ describe('serverEntryPlugin', () => {
 
     expect(fs.existsSync(coreAppPath)).toBe(true);
     expect(fs.existsSync(entryWrapperPath)).toBe(true);
+    // The entry wrapper is the adapter's wrapEntry() output, importing the
+    // core app module by its absolute path.
+    const wrapperCode = fs.readFileSync(entryWrapperPath, 'utf8');
+    expect(wrapperCode).toContain(`export { default } from '${coreAppPath}';`);
     const code = fs.readFileSync(coreAppPath, 'utf8');
     expect(code).toContain(
       `import Layout from '${path.join(tmp, 'src', 'Layout.tsx')}';`

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -3,16 +3,48 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import {
-  GENERATED_SERVER_ENTRY_RELATIVE,
+  GENERATED_CORE_APP_RELATIVE,
+  GENERATED_ENTRY_WRAPPER_RELATIVE,
   findApiShadowingRoutes,
-  generateServerEntrySource,
-  generatedServerEntryAbsPath,
+  generateCoreAppModule,
+  generatedCoreAppAbsPath,
+  generatedEntryWrapperAbsPath,
   serverEntryPlugin,
 } from '../server-entry.js';
 
-describe('generateServerEntrySource', () => {
+// Minimal adapter stub for plugin tests that only check file-writing behavior.
+const stubAdapter = {
+  name: 'stub',
+  vitePlugins: () => [],
+  wrapEntry: ({ coreAppModuleId }: { root: string; coreAppModuleId: string; entryWrapperId: string }) =>
+    `// stub wrapper\nexport { default } from '${coreAppModuleId}';\n`,
+};
+
+describe('generateCoreAppModule', () => {
+  it('emits the Hono app with loaders, actions, renderPage and a default export', () => {
+    const src = generateCoreAppModule({
+      layoutAbsPath: '/p/src/Layout.tsx',
+      routesAbsPath: '/p/src/routes.ts',
+      apiAbsPath: undefined,
+    });
+    expect(src).toContain("loadersHandler");
+    expect(src).toContain("actionsHandler");
+    expect(src).toContain("renderPage");
+    expect(src).toContain('export default app;');
+  });
+
+  it('mounts the user api app when apiAbsPath is provided', () => {
+    const src = generateCoreAppModule({
+      layoutAbsPath: '/p/src/Layout.tsx',
+      routesAbsPath: '/p/src/routes.ts',
+      apiAbsPath: '/p/src/api.ts',
+    });
+    expect(src).toContain("import userApp from '/p/src/api.ts'");
+    expect(src).toContain(".route('/', userApp)");
+  });
+
   it('emits the framework imports, mounts loaders/actions/catchall, omits api when not provided', () => {
-    const src = generateServerEntrySource({
+    const src = generateCoreAppModule({
       layoutAbsPath: '/proj/src/Layout.tsx',
       routesAbsPath: '/proj/src/routes.ts',
       apiAbsPath: undefined,
@@ -72,7 +104,7 @@ describe('generateServerEntrySource', () => {
   });
 
   it('emits the api import and mounts userApp before the reserved paths and catchall', () => {
-    const src = generateServerEntrySource({
+    const src = generateCoreAppModule({
       layoutAbsPath: '/proj/src/Layout.tsx',
       routesAbsPath: '/proj/src/routes.ts',
       apiAbsPath: '/proj/src/api.ts',
@@ -92,6 +124,51 @@ describe('generateServerEntrySource', () => {
     expect(loadersIdx).toBeGreaterThan(apiIdx);
     expect(actionsIdx).toBeGreaterThan(loadersIdx);
     expect(catchallIdx).toBeGreaterThan(actionsIdx);
+  });
+});
+
+describe('generated entry paths', () => {
+  it('core app and entry wrapper resolve to distinct files under the vite cache', () => {
+    const core = generatedCoreAppAbsPath('/p');
+    const wrapper = generatedEntryWrapperAbsPath('/p');
+    expect(core).toContain('node_modules/.vite/hono-preact/');
+    expect(wrapper).toContain('node_modules/.vite/hono-preact/');
+    expect(core).not.toBe(wrapper);
+  });
+
+  it('GENERATED_ENTRY_WRAPPER_RELATIVE is the documented project-relative entry path', () => {
+    expect(GENERATED_ENTRY_WRAPPER_RELATIVE).toBe(
+      'node_modules/.vite/hono-preact/server-entry.tsx'
+    );
+  });
+
+  it('GENERATED_CORE_APP_RELATIVE is distinct from the entry wrapper', () => {
+    expect(GENERATED_CORE_APP_RELATIVE).toBe(
+      'node_modules/.vite/hono-preact/core-app.tsx'
+    );
+    expect(GENERATED_CORE_APP_RELATIVE).not.toBe(GENERATED_ENTRY_WRAPPER_RELATIVE);
+  });
+
+  it('generatedEntryWrapperAbsPath() resolves against cwd by default', () => {
+    const p = generatedEntryWrapperAbsPath();
+    expect(path.isAbsolute(p)).toBe(true);
+    expect(p.endsWith(GENERATED_ENTRY_WRAPPER_RELATIVE)).toBe(true);
+
+    const overridden = generatedEntryWrapperAbsPath('/some/other/root');
+    expect(overridden).toBe(
+      path.join('/some/other/root', GENERATED_ENTRY_WRAPPER_RELATIVE)
+    );
+  });
+
+  it('generatedCoreAppAbsPath() resolves against cwd by default', () => {
+    const p = generatedCoreAppAbsPath();
+    expect(path.isAbsolute(p)).toBe(true);
+    expect(p.endsWith(GENERATED_CORE_APP_RELATIVE)).toBe(true);
+
+    const overridden = generatedCoreAppAbsPath('/some/other/root');
+    expect(overridden).toBe(
+      path.join('/some/other/root', GENERATED_CORE_APP_RELATIVE)
+    );
   });
 });
 
@@ -250,31 +327,21 @@ describe('findApiShadowingRoutes', () => {
 });
 
 describe('serverEntryPlugin', () => {
-  it('GENERATED_SERVER_ENTRY_RELATIVE is the documented project-relative entry path', () => {
-    expect(GENERATED_SERVER_ENTRY_RELATIVE).toBe(
-      'node_modules/.vite/hono-preact/server-entry.tsx'
-    );
-  });
-
-  it('generatedServerEntryAbsPath() resolves against cwd by default', () => {
-    const p = generatedServerEntryAbsPath();
-    expect(path.isAbsolute(p)).toBe(true);
-    expect(p.endsWith(GENERATED_SERVER_ENTRY_RELATIVE)).toBe(true);
-
-    const overridden = generatedServerEntryAbsPath('/some/other/root');
-    expect(overridden).toBe(
-      path.join('/some/other/root', GENERATED_SERVER_ENTRY_RELATIVE)
-    );
-  });
-
-  // The disk write happens in buildStart (not configResolved) so config-only
-  // Vite invocations (IDE probes, vitest loading the config, dependency
-  // optimizer cold runs) don't side-effect the cache directory. These tests
-  // drive both lifecycle hooks in order.
-  it('buildStart writes the generated entry to outputPath (no api file)', () => {
+  // The disk write happens in config (the earliest Vite hook) so the entry
+  // wrapper exists before @cloudflare/vite-plugin's own `config` hook does
+  // fs.existsSync on wrangler.jsonc `main`. These tests drive config + buildStart.
+  it('config writes the core app module and entry wrapper (no api file)', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
-    const outputPath = path.join(
+    const coreAppPath = path.join(
       tmp,
+      'node_modules',
+      '.vite',
+      'hono-preact',
+      'core-app.tsx'
+    );
+    const entryWrapperPath = path.join(
+      tmp,
+      'node_modules',
       '.vite',
       'hono-preact',
       'server-entry.tsx'
@@ -284,28 +351,19 @@ describe('serverEntryPlugin', () => {
       layout: 'src/Layout.tsx',
       routes: 'src/routes.ts',
       api: 'src/api.ts', // configured but does not exist on disk
-      outputPath,
+      adapter: stubAdapter,
+      coreAppPath,
+      entryWrapperPath,
     });
     (
-      plugin as { configResolved?: (c: { root: string }) => void }
-    ).configResolved?.({
+      plugin as { config?: (c: { root: string }) => void }
+    ).config?.({
       root: tmp,
     });
-    // configResolved alone should NOT have written anything.
-    expect(fs.existsSync(outputPath)).toBe(false);
 
-    const ctx = {
-      warn: () => {},
-      error: (m: unknown) => {
-        throw new Error(typeof m === 'string' ? m : String(m));
-      },
-    };
-    (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
-      ctx
-    );
-
-    expect(fs.existsSync(outputPath)).toBe(true);
-    const code = fs.readFileSync(outputPath, 'utf8');
+    expect(fs.existsSync(coreAppPath)).toBe(true);
+    expect(fs.existsSync(entryWrapperPath)).toBe(true);
+    const code = fs.readFileSync(coreAppPath, 'utf8');
     expect(code).toContain(
       `import Layout from '${path.join(tmp, 'src', 'Layout.tsx')}';`
     );
@@ -318,15 +376,23 @@ describe('serverEntryPlugin', () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  it('buildStart writes an entry that includes api when the file exists', () => {
+  it('config writes a core app that includes api when the file exists', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hp-server-entry-'));
     fs.mkdirSync(path.join(tmp, 'src'), { recursive: true });
     fs.writeFileSync(
       path.join(tmp, 'src', 'api.ts'),
       `import { Hono } from 'hono';\nexport default new Hono().get('/api/x', (c) => c.text('ok'));\n`
     );
-    const outputPath = path.join(
+    const coreAppPath = path.join(
       tmp,
+      'node_modules',
+      '.vite',
+      'hono-preact',
+      'core-app.tsx'
+    );
+    const entryWrapperPath = path.join(
+      tmp,
+      'node_modules',
       '.vite',
       'hono-preact',
       'server-entry.tsx'
@@ -336,24 +402,17 @@ describe('serverEntryPlugin', () => {
       layout: 'src/Layout.tsx',
       routes: 'src/routes.ts',
       api: 'src/api.ts',
-      outputPath,
+      adapter: stubAdapter,
+      coreAppPath,
+      entryWrapperPath,
     });
     (
-      plugin as { configResolved?: (c: { root: string }) => void }
-    ).configResolved?.({
+      plugin as { config?: (c: { root: string }) => void }
+    ).config?.({
       root: tmp,
     });
-    const ctx = {
-      warn: () => {},
-      error: (m: unknown) => {
-        throw new Error(typeof m === 'string' ? m : String(m));
-      },
-    };
-    (plugin as { buildStart?: (this: typeof ctx) => void }).buildStart?.call(
-      ctx
-    );
 
-    const code = fs.readFileSync(outputPath, 'utf8');
+    const code = fs.readFileSync(coreAppPath, 'utf8');
     expect(code).toContain(
       `import userApp from '${path.join(tmp, 'src', 'api.ts')}';`
     );
@@ -369,8 +428,16 @@ describe('serverEntryPlugin', () => {
       path.join(tmp, 'src', 'api.ts'),
       `import { Hono } from 'hono';\nexport default new Hono().get('*', (c) => c.text('catch'));\n`
     );
-    const outputPath = path.join(
+    const coreAppPath = path.join(
       tmp,
+      'node_modules',
+      '.vite',
+      'hono-preact',
+      'core-app.tsx'
+    );
+    const entryWrapperPath = path.join(
+      tmp,
+      'node_modules',
       '.vite',
       'hono-preact',
       'server-entry.tsx'
@@ -379,11 +446,11 @@ describe('serverEntryPlugin', () => {
       layout: 'src/Layout.tsx',
       routes: 'src/routes.ts',
       api: 'src/api.ts',
-      outputPath,
+      adapter: stubAdapter,
+      coreAppPath,
+      entryWrapperPath,
     });
-    (
-      plugin as { configResolved?: (c: { root: string }) => void }
-    ).configResolved?.({ root: tmp });
+    (plugin as { config?: (c: { root: string }) => void }).config?.({ root: tmp });
 
     // Rollup's this.error throws; mimic that.
     const ctx = {
@@ -408,8 +475,16 @@ describe('serverEntryPlugin', () => {
       path.join(tmp, 'src', 'api.ts'),
       `import { Hono } from 'hono';\nexport default new Hono().post('/__actions', (c) => c.text('mine'));\n`
     );
-    const outputPath = path.join(
+    const coreAppPath = path.join(
       tmp,
+      'node_modules',
+      '.vite',
+      'hono-preact',
+      'core-app.tsx'
+    );
+    const entryWrapperPath = path.join(
+      tmp,
+      'node_modules',
       '.vite',
       'hono-preact',
       'server-entry.tsx'
@@ -418,11 +493,11 @@ describe('serverEntryPlugin', () => {
       layout: 'src/Layout.tsx',
       routes: 'src/routes.ts',
       api: 'src/api.ts',
-      outputPath,
+      adapter: stubAdapter,
+      coreAppPath,
+      entryWrapperPath,
     });
-    (
-      plugin as { configResolved?: (c: { root: string }) => void }
-    ).configResolved?.({ root: tmp });
+    (plugin as { config?: (c: { root: string }) => void }).config?.({ root: tmp });
 
     const ctx = {
       warn: () => {},
@@ -446,8 +521,16 @@ describe('serverEntryPlugin', () => {
       path.join(tmp, 'src', 'api.ts'),
       `import { Hono } from 'hono';\nconst app = new Hono();\napp.notFound((c) => c.text('nope', 404));\nexport default app;\n`
     );
-    const outputPath = path.join(
+    const coreAppPath = path.join(
       tmp,
+      'node_modules',
+      '.vite',
+      'hono-preact',
+      'core-app.tsx'
+    );
+    const entryWrapperPath = path.join(
+      tmp,
+      'node_modules',
       '.vite',
       'hono-preact',
       'server-entry.tsx'
@@ -456,11 +539,11 @@ describe('serverEntryPlugin', () => {
       layout: 'src/Layout.tsx',
       routes: 'src/routes.ts',
       api: 'src/api.ts',
-      outputPath,
+      adapter: stubAdapter,
+      coreAppPath,
+      entryWrapperPath,
     });
-    (
-      plugin as { configResolved?: (c: { root: string }) => void }
-    ).configResolved?.({ root: tmp });
+    (plugin as { config?: (c: { root: string }) => void }).config?.({ root: tmp });
 
     const warnings: string[] = [];
     const ctx = {
@@ -490,7 +573,7 @@ describe('mount-order composition (why api.ts is mounted first)', () => {
     const userApp = new Hono();
     userApp.use('*', csrf({ origin: 'https://example.com' }));
 
-    // Mirrors the order generateServerEntrySource emits: userApp first.
+    // Mirrors the order generateCoreAppModule emits: userApp first.
     const app = new Hono().route('/', userApp).post('/__actions', (c) => {
       actionRan = true;
       return c.json({ ok: true });

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -16,8 +16,13 @@ import {
 const stubAdapter = {
   name: 'stub',
   vitePlugins: () => [],
-  wrapEntry: ({ coreAppModuleId }: { root: string; coreAppModuleId: string; entryWrapperId: string }) =>
-    `// stub wrapper\nexport { default } from '${coreAppModuleId}';\n`,
+  wrapEntry: ({
+    coreAppModuleId,
+  }: {
+    root: string;
+    coreAppModuleId: string;
+    entryWrapperId: string;
+  }) => `// stub wrapper\nexport { default } from '${coreAppModuleId}';\n`,
 };
 
 describe('generateCoreAppModule', () => {
@@ -27,9 +32,9 @@ describe('generateCoreAppModule', () => {
       routesAbsPath: '/p/src/routes.ts',
       apiAbsPath: undefined,
     });
-    expect(src).toContain("loadersHandler");
-    expect(src).toContain("actionsHandler");
-    expect(src).toContain("renderPage");
+    expect(src).toContain('loadersHandler');
+    expect(src).toContain('actionsHandler');
+    expect(src).toContain('renderPage');
     expect(src).toContain('export default app;');
   });
 
@@ -146,7 +151,9 @@ describe('generated entry paths', () => {
     expect(GENERATED_CORE_APP_RELATIVE).toBe(
       'node_modules/.vite/hono-preact/core-app.tsx'
     );
-    expect(GENERATED_CORE_APP_RELATIVE).not.toBe(GENERATED_ENTRY_WRAPPER_RELATIVE);
+    expect(GENERATED_CORE_APP_RELATIVE).not.toBe(
+      GENERATED_ENTRY_WRAPPER_RELATIVE
+    );
   });
 
   it('generatedEntryWrapperAbsPath() resolves against cwd by default', () => {
@@ -355,9 +362,7 @@ describe('serverEntryPlugin', () => {
       coreAppPath,
       entryWrapperPath,
     });
-    (
-      plugin as { config?: (c: { root: string }) => void }
-    ).config?.({
+    (plugin as { config?: (c: { root: string }) => void }).config?.({
       root: tmp,
     });
 
@@ -406,9 +411,7 @@ describe('serverEntryPlugin', () => {
       coreAppPath,
       entryWrapperPath,
     });
-    (
-      plugin as { config?: (c: { root: string }) => void }
-    ).config?.({
+    (plugin as { config?: (c: { root: string }) => void }).config?.({
       root: tmp,
     });
 
@@ -450,7 +453,9 @@ describe('serverEntryPlugin', () => {
       coreAppPath,
       entryWrapperPath,
     });
-    (plugin as { config?: (c: { root: string }) => void }).config?.({ root: tmp });
+    (plugin as { config?: (c: { root: string }) => void }).config?.({
+      root: tmp,
+    });
 
     // Rollup's this.error throws; mimic that.
     const ctx = {
@@ -497,7 +502,9 @@ describe('serverEntryPlugin', () => {
       coreAppPath,
       entryWrapperPath,
     });
-    (plugin as { config?: (c: { root: string }) => void }).config?.({ root: tmp });
+    (plugin as { config?: (c: { root: string }) => void }).config?.({
+      root: tmp,
+    });
 
     const ctx = {
       warn: () => {},
@@ -543,7 +550,9 @@ describe('serverEntryPlugin', () => {
       coreAppPath,
       entryWrapperPath,
     });
-    (plugin as { config?: (c: { root: string }) => void }).config?.({ root: tmp });
+    (plugin as { config?: (c: { root: string }) => void }).config?.({
+      root: tmp,
+    });
 
     const warnings: string[] = [];
     const ctx = {

--- a/packages/vite/src/adapter-cloudflare.ts
+++ b/packages/vite/src/adapter-cloudflare.ts
@@ -1,0 +1,28 @@
+// packages/vite/src/adapter-cloudflare.ts
+//
+// Standalone module. NOT re-exported by index.ts: importing `hono-preact/vite`
+// must never pull in `@cloudflare/vite-plugin`. Only importing
+// `hono-preact/adapter-cloudflare` loads this file.
+import { cloudflare } from '@cloudflare/vite-plugin';
+import type { Plugin } from 'vite';
+import type { HonoPreactAdapter } from './adapter.js';
+
+export function cloudflareAdapter(): HonoPreactAdapter {
+  return {
+    name: 'cloudflare',
+    vitePlugins() {
+      // `@cloudflare/vite-plugin` drives both workerd dev and the build via
+      // the Environment API, and reads the worker entry from wrangler.jsonc
+      // `main`. It needs no entry argument from the framework.
+      // `cloudflare()` may return a single plugin or an array; normalize so
+      // the HonoPreactAdapter contract (a flat Plugin[]) holds either way.
+      const produced = cloudflare() as Plugin | Plugin[];
+      return Array.isArray(produced) ? produced : [produced];
+    },
+    wrapEntry(ctx) {
+      // A Hono app's default export is already a valid Workers fetch handler,
+      // so the platform tail is a bare re-export of the core app module.
+      return `export { default } from ${JSON.stringify(ctx.coreAppModuleId)};\n`;
+    },
+  };
+}

--- a/packages/vite/src/adapter.ts
+++ b/packages/vite/src/adapter.ts
@@ -1,0 +1,28 @@
+// packages/vite/src/adapter.ts
+import type { Plugin } from 'vite';
+
+/**
+ * Static context the framework hands an adapter. `command` and `outDir`
+ * are intentionally absent: they are not known when honoPreact() builds its
+ * plugin array. Adapters that need them read them from their own plugin
+ * hooks (config / configResolved).
+ */
+export interface HonoPreactAdapterContext {
+  /** Vite project root (process.cwd() when honoPreact() is called). */
+  root: string;
+  /** Absolute path of the framework-generated core Hono app module. */
+  coreAppModuleId: string;
+  /** Absolute path where the adapter's wrapEntry() output is written. */
+  entryWrapperId: string;
+}
+
+/**
+ * A deployment target. `vitePlugins()` contributes the terminal build/dev
+ * plugins; `wrapEntry()` returns the platform tail that imports the core
+ * Hono app module and adapts it to the runtime.
+ */
+export interface HonoPreactAdapter {
+  name: string;
+  vitePlugins(ctx: HonoPreactAdapterContext): Plugin[];
+  wrapEntry(ctx: HonoPreactAdapterContext): string;
+}

--- a/packages/vite/src/client-shim.ts
+++ b/packages/vite/src/client-shim.ts
@@ -21,10 +21,11 @@ export function clientShimPlugin(clientEntry: string): Plugin {
   return {
     name: 'hono-preact:client-shim',
     enforce: 'pre',
-    apply(_, { command, mode }) {
-      // Inject during dev (`vite serve`) and the client build only. The SSR
-      // build runs in Node/Workers and does not need the shim.
-      return command === 'serve' || (command === 'build' && mode === 'client');
+    apply(_, { command }) {
+      // The shim is needed for dev and for the build. The `transform` hook
+      // below self-gates to the client entry module, so it never injects
+      // into SSR/worker code regardless of build environment.
+      return command === 'serve' || command === 'build';
     },
     configResolved(config) {
       resolvedEntry = path.resolve(config.root, clientEntry);

--- a/packages/vite/src/hono-preact.ts
+++ b/packages/vite/src/hono-preact.ts
@@ -25,6 +25,10 @@ export interface HonoPreactOptions {
 }
 
 export function honoPreact(options: HonoPreactOptions): Plugin[] {
+  // `?? {}` is deliberate: TypeScript types `options` as required, but a
+  // zero-arg `honoPreact()` call still reaches here at runtime. Without the
+  // fallback, destructuring `undefined` throws a cryptic TypeError; with it,
+  // the friendly `adapter`-required guard below fires instead.
   const {
     adapter,
     layout = 'src/Layout.tsx',

--- a/packages/vite/src/hono-preact.ts
+++ b/packages/vite/src/hono-preact.ts
@@ -49,8 +49,13 @@ export function honoPreact(options: HonoPreactOptions): Plugin[] {
     entryWrapperId: entryWrapperPath,
   };
 
-  // Only genuinely platform-agnostic config lives here. Client-vs-server
-  // build config is owned by the adapter's plugins (Environment API).
+  // Shared config plus the `client` build environment's input. The worker
+  // environment is configured by the adapter's plugins; the `client`
+  // environment's entry is framework-owned (every adapter needs the same
+  // browser bundle) so it lives here. Without it, the client environment has
+  // no input and `vite build` emits no client JavaScript. The
+  // `static/client.js` entry name is the URL the SSR layer references and
+  // must stay stable.
   const configPlugin: Plugin = {
     name: 'hono-preact:config',
     config() {
@@ -61,6 +66,20 @@ export function honoPreact(options: HonoPreactOptions): Plugin[] {
         build: {
           target: 'esnext' as const,
           assetsDir: 'static',
+        },
+        environments: {
+          client: {
+            build: {
+              rollupOptions: {
+                input: [clientEntry],
+                output: {
+                  entryFileNames: 'static/client.js',
+                  chunkFileNames: 'static/[name]-[hash].js',
+                  assetFileNames: 'static/[name]-[hash].[ext]',
+                },
+              },
+            },
+          },
         },
       };
     },

--- a/packages/vite/src/hono-preact.ts
+++ b/packages/vite/src/hono-preact.ts
@@ -1,8 +1,5 @@
-import build from '@hono/vite-build/cloudflare-workers';
-import devServer, { defaultOptions } from '@hono/vite-dev-server';
-import cloudflareAdapter from '@hono/vite-dev-server/cloudflare';
 import preact from '@preact/preset-vite';
-import { type BuildEnvironmentOptions, type Plugin } from 'vite';
+import { type Plugin } from 'vite';
 import { clientShimPlugin } from './client-shim.js';
 import { clientEntryPlugin, VIRTUAL_CLIENT_ENTRY_ID } from './client-entry.js';
 import { serverLoaderValidationPlugin } from './server-loader-validation.js';
@@ -10,102 +7,60 @@ import { moduleKeyPlugin } from './module-key-plugin.js';
 import { serverOnlyPlugin } from './server-only.js';
 import { guardStripPlugin } from './guard-strip.js';
 import {
-  GENERATED_SERVER_ENTRY_RELATIVE,
-  generatedServerEntryAbsPath,
+  generatedCoreAppAbsPath,
+  generatedEntryWrapperAbsPath,
   serverEntryPlugin,
 } from './server-entry.js';
+import type { HonoPreactAdapter, HonoPreactAdapterContext } from './adapter.js';
 
 export interface HonoPreactOptions {
-  // Source paths (for the generated server entry). All optional.
+  /** Deployment target. Required. See hono-preact/adapter-cloudflare. */
+  adapter: HonoPreactAdapter;
+
+  // Source paths (for the generated core app module). All optional.
   layout?: string; // default 'src/Layout.tsx'
   routes?: string; // default 'src/routes.ts'
   api?: string; // default 'src/api.ts' (only loaded if file exists)
   clientEntry?: string; // default 'virtual:hono-preact/client'
-
-  // Server entry. Defaults to a generated file the framework writes into the
-  // Vite cache directory. Rare override.
-  entry?: string;
-
-  // Build-tuning escape hatches (preserved).
-  clientBuild?: BuildEnvironmentOptions;
-  serverBuild?: BuildEnvironmentOptions;
-  sharedBuild?: BuildEnvironmentOptions;
 }
 
-export function honoPreact(options: HonoPreactOptions = {}): Plugin[] {
+export function honoPreact(options: HonoPreactOptions): Plugin[] {
   const {
+    adapter,
     layout = 'src/Layout.tsx',
     routes = 'src/routes.ts',
     api = 'src/api.ts',
     clientEntry = VIRTUAL_CLIENT_ENTRY_ID,
-    entry,
-    clientBuild = {},
-    serverBuild = {},
-    sharedBuild = {},
-  } = options;
+  } = options ?? {};
 
-  const useGeneratedEntry = entry === undefined;
-  const resolvedEntry = entry ?? GENERATED_SERVER_ENTRY_RELATIVE;
+  if (!adapter) {
+    throw new Error(
+      '[hono-preact] honoPreact() requires an `adapter` option. ' +
+        "Import one, e.g. `import { cloudflareAdapter } from 'hono-preact/adapter-cloudflare'`, " +
+        'and pass `honoPreact({ adapter: cloudflareAdapter() })`.'
+    );
+  }
 
+  const coreAppPath = generatedCoreAppAbsPath();
+  const entryWrapperPath = generatedEntryWrapperAbsPath();
+  const ctx: HonoPreactAdapterContext = {
+    root: process.cwd(),
+    coreAppModuleId: coreAppPath,
+    entryWrapperId: entryWrapperPath,
+  };
+
+  // Only genuinely platform-agnostic config lives here. Client-vs-server
+  // build config is owned by the adapter's plugins (Environment API).
   const configPlugin: Plugin = {
     name: 'hono-preact:config',
-    config(_, { mode }) {
-      const shared = {
+    config() {
+      return {
         resolve: {
           dedupe: ['preact', 'preact/compat', 'preact/hooks', 'preact-iso'],
         },
         build: {
           target: 'esnext' as const,
           assetsDir: 'static',
-          ssrEmitAssets: true,
-          minify: true,
-          ...sharedBuild,
-        },
-      };
-
-      if (mode === 'client') {
-        const { rollupOptions: userRollup, ...restClientBuild } = clientBuild;
-        return {
-          ...shared,
-          build: {
-            ...shared.build,
-            sourcemap: true,
-            cssCodeSplit: true,
-            copyPublicDir: false,
-            ...restClientBuild,
-            rollupOptions: {
-              input: userRollup?.input ?? [clientEntry],
-              output: {
-                entryFileNames: 'static/client.js',
-                chunkFileNames: 'static/[name]-[hash].js',
-                assetFileNames: 'static/[name]-[hash].[ext]',
-                // Array-form output is not supported; use an OutputOptions object to
-                // override individual fields (entryFileNames, chunkFileNames, etc.).
-                ...(userRollup?.output && !Array.isArray(userRollup.output)
-                  ? userRollup.output
-                  : {}),
-              },
-            },
-          },
-        };
-      }
-
-      return {
-        ...shared,
-        ssr: {
-          noExternal: ['preact-render-to-string', 'preact-iso', 'hono-preact'],
-        },
-        build: {
-          ...shared.build,
-          // Inline sourcemaps so SSR error stacks point at user source
-          // (e.g. `pages/issue.server.ts:42`) instead of the rolled-up
-          // Worker chunk. We pick `inline` over a separate .map file because
-          // SSR is a single bundle and Workers tooling will not look at a
-          // sibling .map. Bundle size grows; for typical app server bundles
-          // this is a few hundred KB at most and is worth the debuggability.
-          // Users can override by passing `serverBuild.sourcemap: false`.
-          sourcemap: 'inline' as const,
-          ...serverBuild,
         },
       };
     },
@@ -115,40 +70,19 @@ export function honoPreact(options: HonoPreactOptions = {}): Plugin[] {
     configPlugin,
     clientShimPlugin(clientEntry),
     clientEntryPlugin({ routes }),
-    ...(useGeneratedEntry
-      ? [
-          serverEntryPlugin({
-            layout,
-            routes,
-            api,
-            outputPath: generatedServerEntryAbsPath(),
-          }),
-        ]
-      : []),
+    serverEntryPlugin({
+      layout,
+      routes,
+      api,
+      adapter,
+      coreAppPath,
+      entryWrapperPath,
+    }),
     serverLoaderValidationPlugin(),
     moduleKeyPlugin(),
     serverOnlyPlugin(),
     guardStripPlugin(),
-    Object.assign(build({ entry: resolvedEntry }), {
-      apply: (
-        _: unknown,
-        { command, mode }: { command: string; mode: string }
-      ) => command === 'build' && mode !== 'client',
-    }),
-    Object.assign(
-      devServer({
-        entry: resolvedEntry,
-        exclude: [
-          ...defaultOptions.exclude,
-          /\.scss/,
-          /\.css/,
-          /\?url/,
-          /\?inline/,
-        ],
-        adapter: cloudflareAdapter,
-      }),
-      { apply: 'serve' as const }
-    ),
+    ...adapter.vitePlugins(ctx),
     ...preact(),
   ];
 }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -3,9 +3,12 @@ export { serverLoaderValidationPlugin } from './server-loader-validation.js';
 export { serverOnlyPlugin, VITE_ROOT_ACCESSOR } from './server-only.js';
 export { moduleKeyPlugin } from './module-key-plugin.js';
 export {
-  GENERATED_SERVER_ENTRY_RELATIVE,
-  generatedServerEntryAbsPath,
+  GENERATED_CORE_APP_RELATIVE,
+  GENERATED_ENTRY_WRAPPER_RELATIVE,
+  generatedCoreAppAbsPath,
+  generatedEntryWrapperAbsPath,
   serverEntryPlugin,
 } from './server-entry.js';
+export type { HonoPreactAdapter, HonoPreactAdapterContext } from './adapter.js';
 export { clientEntryPlugin, VIRTUAL_CLIENT_ENTRY_ID } from './client-entry.js';
 export { guardStripPlugin } from './guard-strip.js';

--- a/packages/vite/src/server-entry.ts
+++ b/packages/vite/src/server-entry.ts
@@ -3,15 +3,16 @@ import * as fs from 'node:fs';
 import { parse } from '@babel/parser';
 import type { Plugin } from 'vite';
 import { BABEL_PARSER_PLUGINS } from './parser-options.js';
+import type { HonoPreactAdapter } from './adapter.js';
 
-export interface GenerateServerEntrySourceOptions {
+export interface GenerateCoreAppModuleOptions {
   layoutAbsPath: string;
   routesAbsPath: string;
   apiAbsPath: string | undefined;
 }
 
-export function generateServerEntrySource(
-  opts: GenerateServerEntrySourceOptions
+export function generateCoreAppModule(
+  opts: GenerateCoreAppModuleOptions
 ): string {
   const { layoutAbsPath, routesAbsPath, apiAbsPath } = opts;
 
@@ -197,77 +198,76 @@ function walk(node: unknown, found: ApiShadowingRoute[]): void {
   }
 }
 
-// Project-relative path of the on-disk file the plugin writes during
-// configResolved. We use a relative path because @hono/vite-build prepends
-// `/` to the entry when constructing its `import.meta.glob([...])`, and
-// absolute paths produce a `//Users/...` double-slash that's brittle in the
-// Cloudflare Workers runtime. Project-relative keeps the resulting glob
-// pattern (`/node_modules/.vite/hono-preact/server-entry.tsx`) clean.
-//
-// We write to disk rather than register a virtual module because
-// @hono/vite-build resolves its entry via `import.meta.glob([entry])`, which
-// cannot match a `virtual:*` id. The Cloudflare Workers runtime then fails
-// with "Can't import modules from ['/virtual:...']" when it tries to load the
-// generated bundle.
-export const GENERATED_SERVER_ENTRY_RELATIVE =
+// Both generated files live in the Vite cache dir. The wrapper keeps the
+// `server-entry.tsx` name because that is the file the adapter's build/dev
+// plugins (and wrangler.jsonc `main`) point at; the core app module is a
+// separate file the wrapper imports.
+export const GENERATED_CORE_APP_RELATIVE =
+  'node_modules/.vite/hono-preact/core-app.tsx';
+export const GENERATED_ENTRY_WRAPPER_RELATIVE =
   'node_modules/.vite/hono-preact/server-entry.tsx';
 
-export function generatedServerEntryAbsPath(
+export function generatedCoreAppAbsPath(cwd: string = process.cwd()): string {
+  return path.resolve(cwd, GENERATED_CORE_APP_RELATIVE);
+}
+
+export function generatedEntryWrapperAbsPath(
   cwd: string = process.cwd()
 ): string {
-  return path.resolve(cwd, GENERATED_SERVER_ENTRY_RELATIVE);
+  return path.resolve(cwd, GENERATED_ENTRY_WRAPPER_RELATIVE);
 }
 
 export interface ServerEntryPluginOptions {
   layout: string; // project-relative or absolute
   routes: string;
   api: string; // project-relative or absolute; absence treated as "no api"
-  outputPath: string; // absolute path to write the generated entry file
+  adapter: HonoPreactAdapter;
+  coreAppPath: string; // absolute path to write the core app module
+  entryWrapperPath: string; // absolute path to write the adapter wrapper
 }
 
 export function serverEntryPlugin(opts: ServerEntryPluginOptions): Plugin {
-  // Paths resolved during configResolved (cheap) — actual disk write
-  // happens in buildStart so config-only Vite invocations (IDE probes,
-  // typecheck-only runs, dependency-optimizer cold runs) don't side-effect
-  // the cache directory. Writing on every config resolution was a tax that
-  // showed up when integration tests loaded vite.config.ts to inspect the
-  // plugin chain.
-  let layoutAbsPath: string | undefined;
-  let routesAbsPath: string | undefined;
   let apiAbsPath: string | undefined;
 
   return {
     name: 'hono-preact:server-entry',
     enforce: 'pre',
-    configResolved(config) {
-      layoutAbsPath = path.isAbsolute(opts.layout)
+    // Write generated files in `config` -- the earliest hook -- so the entry
+    // wrapper exists before @cloudflare/vite-plugin's own `config` hook does
+    // fs.existsSync on wrangler.jsonc `main`.
+    config(userConfig) {
+      const root = userConfig.root
+        ? path.resolve(userConfig.root)
+        : process.cwd();
+      const layoutAbsPath = path.isAbsolute(opts.layout)
         ? opts.layout
-        : path.resolve(config.root, opts.layout);
-      routesAbsPath = path.isAbsolute(opts.routes)
+        : path.resolve(root, opts.layout);
+      const routesAbsPath = path.isAbsolute(opts.routes)
         ? opts.routes
-        : path.resolve(config.root, opts.routes);
+        : path.resolve(root, opts.routes);
       const candidateApi = path.isAbsolute(opts.api)
         ? opts.api
-        : path.resolve(config.root, opts.api);
+        : path.resolve(root, opts.api);
       apiAbsPath = fs.existsSync(candidateApi) ? candidateApi : undefined;
-    },
-    buildStart() {
-      // configResolved must have run first. Bail loudly if not — silent
-      // emission of a stub would be much harder to debug.
-      if (!layoutAbsPath || !routesAbsPath) {
-        throw new Error(
-          '[hono-preact] server-entry buildStart fired before configResolved; ' +
-            'layout/routes paths were never resolved.'
-        );
-      }
-      const source = generateServerEntrySource({
+
+      const source = generateCoreAppModule({
         layoutAbsPath,
         routesAbsPath,
         apiAbsPath,
       });
-      fs.mkdirSync(path.dirname(opts.outputPath), { recursive: true });
-      fs.writeFileSync(opts.outputPath, source, 'utf8');
+      fs.mkdirSync(path.dirname(opts.coreAppPath), { recursive: true });
+      fs.writeFileSync(opts.coreAppPath, source, 'utf8');
 
+      const wrapper = opts.adapter.wrapEntry({
+        root,
+        coreAppModuleId: opts.coreAppPath,
+        entryWrapperId: opts.entryWrapperPath,
+      });
+      fs.writeFileSync(opts.entryWrapperPath, wrapper, 'utf8');
+    },
+    buildStart() {
+      // The api.ts shadowing diagnostic stays in buildStart: it needs
+      // this.warn / this.error, which the `config` hook context lacks.
       if (!apiAbsPath) return;
       const apiSource = fs.readFileSync(apiAbsPath, 'utf8');
       const shadowing = findApiShadowingRoutes(apiSource);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@babel/types':
         specifier: ^7.29.0
         version: 7.29.0
+      '@cloudflare/vite-plugin':
+        specifier: ^1.37.1
+        version: 1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)
       '@emnapi/core':
         specifier: ^1.10.0
         version: 1.10.0
@@ -80,12 +83,6 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.14
         version: 1.19.14(hono@4.12.14)
-      '@hono/vite-build':
-        specifier: ^1.11.1
-        version: 1.11.1(hono@4.12.14)
-      '@hono/vite-dev-server':
-        specifier: ^0.25.1
-        version: 0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.92.0)
       '@mdx-js/rollup':
         specifier: ^3.1.1
         version: 3.1.1(rollup@4.60.2)
@@ -101,9 +98,6 @@ importers:
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
-      miniflare:
-        specifier: ^4.20260415.0
-        version: 4.20260415.0
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -143,12 +137,9 @@ importers:
       '@babel/types':
         specifier: ^7.29.0
         version: 7.29.0
-      '@hono/vite-build':
-        specifier: ^1.11.1
-        version: 1.11.1(hono@4.12.14)
-      '@hono/vite-dev-server':
-        specifier: ^0.25.1
-        version: 0.25.1(hono@4.12.14)(miniflare@4.20260515.0)(wrangler@4.92.0)
+      '@cloudflare/vite-plugin':
+        specifier: ^1.37.1
+        version: 1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))
@@ -173,6 +164,9 @@ importers:
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0)
+      wrangler:
+        specifier: ^4.92.0
+        version: 4.92.0
     devDependencies:
       '@hono-preact/iso':
         specifier: workspace:*
@@ -400,22 +394,10 @@ packages:
       vite: ^8.0.8
       wrangler: ^4.92.0
 
-  '@cloudflare/workerd-darwin-64@1.20260415.1':
-    resolution: {integrity: sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
   '@cloudflare/workerd-darwin-64@1.20260515.1':
     resolution: {integrity: sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==}
     engines: {node: '>=16'}
     cpu: [x64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
-    resolution: {integrity: sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
     os: [darwin]
 
   '@cloudflare/workerd-darwin-arm64@1.20260515.1':
@@ -424,22 +406,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260415.1':
-    resolution: {integrity: sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
   '@cloudflare/workerd-linux-64@1.20260515.1':
     resolution: {integrity: sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==}
     engines: {node: '>=16'}
     cpu: [x64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-arm64@1.20260415.1':
-    resolution: {integrity: sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
     os: [linux]
 
   '@cloudflare/workerd-linux-arm64@1.20260515.1':
@@ -447,12 +417,6 @@ packages:
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
-
-  '@cloudflare/workerd-windows-64@1.20260415.1':
-    resolution: {integrity: sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
 
   '@cloudflare/workerd-windows-64@1.20260515.1':
     resolution: {integrity: sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==}
@@ -796,25 +760,6 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
-
-  '@hono/vite-build@1.11.1':
-    resolution: {integrity: sha512-EQJmFL7G+71MXZQ/mmywNl4qW6DSyjTdC30cq7mlDS451a1/jE86old0M2DCWzNGCO50sv7CzQDYkz4L5dq5VQ==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: '*'
-
-  '@hono/vite-dev-server@0.25.1':
-    resolution: {integrity: sha512-H6EqoPtCV+uH1fu8nKyRy5Wh3LU012QxloEYMlUcyMjjEfVFiRXPjHx/0TQiiRi140Vu8San5A4XQWyElKFKaw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: '*'
-      miniflare: '*'
-      wrangler: '*'
-    peerDependenciesMeta:
-      miniflare:
-        optional: true
-      wrangler:
-        optional: true
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1635,9 +1580,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
@@ -1648,9 +1590,6 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -2440,19 +2379,10 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  miniflare@4.20260415.0:
-    resolution: {integrity: sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
   miniflare@4.20260515.0:
     resolution: {integrity: sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3086,11 +3016,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  workerd@1.20260415.1:
-    resolution: {integrity: sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-
   workerd@1.20260515.1:
     resolution: {integrity: sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==}
     engines: {node: '>=16'}
@@ -3327,31 +3252,16 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/workerd-darwin-64@1.20260415.1':
-    optional: true
-
   '@cloudflare/workerd-darwin-64@1.20260515.1':
-    optional: true
-
-  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260415.1':
-    optional: true
-
   '@cloudflare/workerd-linux-64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260415.1':
-    optional: true
-
   '@cloudflare/workerd-linux-arm64@1.20260515.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260415.1':
     optional: true
 
   '@cloudflare/workerd-windows-64@1.20260515.1':
@@ -3544,28 +3454,6 @@ snapshots:
   '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
-
-  '@hono/vite-build@1.11.1(hono@4.12.14)':
-    dependencies:
-      hono: 4.12.14
-
-  '@hono/vite-dev-server@0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.92.0)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.14)
-      hono: 4.12.14
-      minimatch: 9.0.9
-    optionalDependencies:
-      miniflare: 4.20260415.0
-      wrangler: 4.92.0
-
-  '@hono/vite-dev-server@0.25.1(hono@4.12.14)(miniflare@4.20260515.0)(wrangler@4.92.0)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.14)
-      hono: 4.12.14
-      minimatch: 9.0.9
-    optionalDependencies:
-      miniflare: 4.20260515.0
-      wrangler: 4.92.0
 
   '@img/colour@1.1.0': {}
 
@@ -4294,17 +4182,11 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   baseline-browser-mapping@2.10.20: {}
 
   blake3-wasm@2.1.5: {}
 
   boolbase@1.0.0: {}
-
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
 
   browserslist@4.28.2:
     dependencies:
@@ -5438,18 +5320,6 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  miniflare@4.20260415.0:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.34.5
-      undici: 7.24.8
-      workerd: 1.20260415.1
-      ws: 8.18.0
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   miniflare@4.20260515.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -5461,10 +5331,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.0
 
   ms@2.1.3: {}
 
@@ -6191,14 +6057,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  workerd@1.20260415.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260415.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260415.1
-      '@cloudflare/workerd-linux-64': 1.20260415.1
-      '@cloudflare/workerd-linux-arm64': 1.20260415.1
-      '@cloudflare/workerd-windows-64': 1.20260415.1
 
   workerd@1.20260515.1:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,18 +239,15 @@ importers:
       '@babel/types':
         specifier: ^7.29.0
         version: 7.29.0
-      '@hono/vite-build':
-        specifier: ^1.11.1
-        version: 1.11.1(hono@4.12.14)
-      '@hono/vite-dev-server':
-        specifier: ^0.25.1
-        version: 0.25.1(hono@4.12.14)(miniflare@4.20260515.0)(wrangler@4.92.0)
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
+      wrangler:
+        specifier: ^4.92.0
+        version: 4.92.0
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.37.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 1.11.1(hono@4.12.14)
       '@hono/vite-dev-server':
         specifier: ^0.25.1
-        version: 0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.83.0)
+        version: 0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.92.0)
       '@mdx-js/rollup':
         specifier: ^3.1.1
         version: 3.1.1(rollup@4.60.2)
@@ -132,8 +132,8 @@ importers:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0)
       wrangler:
-        specifier: ^4.83.0
-        version: 4.83.0
+        specifier: ^4.92.0
+        version: 4.92.0
 
   packages/hono-preact:
     dependencies:
@@ -148,7 +148,7 @@ importers:
         version: 1.11.1(hono@4.12.14)
       '@hono/vite-dev-server':
         specifier: ^0.25.1
-        version: 0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.83.0)
+        version: 0.25.1(hono@4.12.14)(miniflare@4.20260515.0)(wrangler@4.92.0)
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))
@@ -244,7 +244,7 @@ importers:
         version: 1.11.1(hono@4.12.14)
       '@hono/vite-dev-server':
         specifier: ^0.25.1
-        version: 0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.83.0)
+        version: 0.25.1(hono@4.12.14)(miniflare@4.20260515.0)(wrangler@4.92.0)
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))
@@ -252,6 +252,9 @@ importers:
         specifier: ^0.30.21
         version: 0.30.21
     devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.37.1
+        version: 1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -381,21 +384,33 @@ packages:
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
 
-  '@cloudflare/kv-asset-handler@0.4.2':
-    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
-    engines: {node: '>=18.0.0'}
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
 
-  '@cloudflare/unenv-preset@2.16.0':
-    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
       unenv: 2.0.0-rc.24
-      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
+      workerd: '>1.20260305.0 <2.0.0-0'
     peerDependenciesMeta:
       workerd:
         optional: true
 
+  '@cloudflare/vite-plugin@1.37.1':
+    resolution: {integrity: sha512-FldhsmkXyLsX3yI+p0aJDo/kGyY69pDdynz2JjcuH3eCiQ+G9XaY3CrN+UYEfCbWv8CiR2wL95lNg0fT/HfwWA==}
+    peerDependencies:
+      vite: ^8.0.8
+      wrangler: ^4.92.0
+
   '@cloudflare/workerd-darwin-64@1.20260415.1':
     resolution: {integrity: sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
+    resolution: {integrity: sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -406,8 +421,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    resolution: {integrity: sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@cloudflare/workerd-linux-64@1.20260415.1':
     resolution: {integrity: sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260515.1':
+    resolution: {integrity: sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -418,8 +445,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    resolution: {integrity: sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260415.1':
     resolution: {integrity: sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260515.1':
+    resolution: {integrity: sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2409,6 +2448,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  miniflare@4.20260515.0:
+    resolution: {integrity: sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3050,12 +3094,17 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.83.0:
-    resolution: {integrity: sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==}
-    engines: {node: '>=20.3.0'}
+  workerd@1.20260515.1:
+    resolution: {integrity: sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.92.0:
+    resolution: {integrity: sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260415.1
+      '@cloudflare/workers-types': ^4.20260515.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -3260,27 +3309,55 @@ snapshots:
 
   '@bufbuild/protobuf@2.11.0': {}
 
-  '@cloudflare/kv-asset-handler@0.4.2': {}
+  '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260415.1
+      workerd: 1.20260515.1
+
+  '@cloudflare/vite-plugin@1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)
+      miniflare: 4.20260515.0
+      unenv: 2.0.0-rc.24
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0)
+      wrangler: 4.92.0
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - workerd
 
   '@cloudflare/workerd-darwin-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260415.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260515.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260415.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260515.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -3475,14 +3552,23 @@ snapshots:
     dependencies:
       hono: 4.12.14
 
-  '@hono/vite-dev-server@0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.83.0)':
+  '@hono/vite-dev-server@0.25.1(hono@4.12.14)(miniflare@4.20260415.0)(wrangler@4.92.0)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.14)
       hono: 4.12.14
       minimatch: 9.0.9
     optionalDependencies:
       miniflare: 4.20260415.0
-      wrangler: 4.83.0
+      wrangler: 4.92.0
+
+  '@hono/vite-dev-server@0.25.1(hono@4.12.14)(miniflare@4.20260515.0)(wrangler@4.92.0)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      hono: 4.12.14
+      minimatch: 9.0.9
+    optionalDependencies:
+      miniflare: 4.20260515.0
+      wrangler: 4.92.0
 
   '@img/colour@1.1.0': {}
 
@@ -5367,6 +5453,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@4.20260515.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260515.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
@@ -6105,16 +6203,24 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260415.1
       '@cloudflare/workerd-windows-64': 1.20260415.1
 
-  wrangler@4.83.0:
+  workerd@1.20260515.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260515.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260515.1
+      '@cloudflare/workerd-linux-64': 1.20260515.1
+      '@cloudflare/workerd-linux-arm64': 1.20260515.1
+      '@cloudflare/workerd-windows-64': 1.20260515.1
+
+  wrangler@4.92.0:
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260415.0
+      miniflare: 4.20260515.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260415.1
+      workerd: 1.20260515.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Plan A of the multi-cloud adapter architecture. Replaces the framework's hardcoded Cloudflare build/dev toolchain (`@hono/vite-build` + `@hono/vite-dev-server`) with a deployment-adapter abstraction, and ships the Cloudflare adapter built on `@cloudflare/vite-plugin` (workerd dev + build via Vite's Environment API).

- **`HonoPreactAdapter` interface** (`packages/vite/src/adapter.ts`) — `{ name, vitePlugins(ctx), wrapEntry(ctx) }`. `honoPreact()` now requires an `adapter` option and splices `adapter.vitePlugins()` into its plugin chain.
- **Server-entry split** — the framework generates a platform-agnostic core Hono app module; the adapter's `wrapEntry()` produces the platform tail. Both are written in `serverEntryPlugin`'s `config` hook so the wrapper exists before `@cloudflare/vite-plugin` reads `wrangler.jsonc` `main`.
- **Cloudflare adapter** exposed as the `hono-preact/adapter-cloudflare` umbrella subpath; `@cloudflare/vite-plugin` / `wrangler` are optional peer deps so non-Cloudflare installs stay lean.
- **`apps/site` migrated** to the Cloudflare adapter: single-pass `vite build`, `vite preview`, `run_worker_first` hack removed, deployment docs rewritten.
- Spec/plan: `docs/superpowers/specs/2026-05-17-multi-cloud-adapter-architecture-design.md`, `docs/superpowers/plans/2026-05-17-multi-cloud-adapters-plan-a.md` (these live on `main`, not this branch).

Plan B (Node adapter, example app, WebSocket verification) is a follow-up.

## Test plan

- [x] `pnpm test` — 543 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm --filter site build` — client bundle in `dist/client/`, worker in `dist/hono_preact/`, no fallback entry
- [x] `pnpm --filter site dev` — boots in workerd, SSRs
- [ ] `wrangler deploy` against a real Cloudflare account (not verified locally — deploy is an external action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)