### PR TITLE
feat: Node deployment adapter (Plan B)

### DIFF
--- a/apps/example-node/package.json
+++ b/apps/example-node/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "example-node",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "node dist/server/server-entry.js"
+  },
+  "dependencies": {
+    "hono-preact": "workspace:*",
+    "hono": "^4.12.14",
+    "preact": "^10.29.1",
+    "preact-iso": "github:preactjs/preact-iso#v3"
+  },
+  "devDependencies": {
+    "@hono/node-server": "^1.19.14",
+    "@hono/node-ws": "^1.3.1",
+    "@preact/preset-vite": "^2.10.5",
+    "preact-render-to-string": "^6.6.7",
+    "typescript": "*",
+    "vite": "*"
+  }
+}

--- a/apps/example-node/src/Layout.tsx
+++ b/apps/example-node/src/Layout.tsx
@@ -1,0 +1,14 @@
+import { ClientScript, Head } from 'hono-preact';
+import type { ComponentChildren } from 'preact';
+
+export default function Layout({ children }: { children: ComponentChildren }) {
+  return (
+    <html>
+      <Head defaultTitle="example-node" />
+      <body>
+        <main id="app">{children}</main>
+        <ClientScript />
+      </body>
+    </html>
+  );
+}

--- a/apps/example-node/src/api.ts
+++ b/apps/example-node/src/api.ts
@@ -1,0 +1,17 @@
+import { Hono } from 'hono';
+import { createNodeWebSocket } from '@hono/node-ws';
+
+const app = new Hono();
+const { upgradeWebSocket, injectWebSocket } = createNodeWebSocket({ app });
+
+app.get(
+  '/ws',
+  upgradeWebSocket(() => ({
+    onMessage(event, ws) {
+      ws.send(`echo: ${event.data}`);
+    },
+  }))
+);
+
+export { injectWebSocket };
+export default app;

--- a/apps/example-node/src/pages/about.tsx
+++ b/apps/example-node/src/pages/about.tsx
@@ -1,0 +1,11 @@
+import type { FunctionComponent } from 'preact';
+
+const About: FunctionComponent = () => (
+  <section>
+    <h1>About example-node</h1>
+    <a href="/">Home</a>
+  </section>
+);
+About.displayName = 'About';
+
+export default About;

--- a/apps/example-node/src/pages/home.server.ts
+++ b/apps/example-node/src/pages/home.server.ts
@@ -1,0 +1,14 @@
+import { defineLoader, defineAction } from 'hono-preact';
+
+export const serverLoaders = {
+  default: defineLoader(async () => ({
+    message: 'Hello from the Node adapter loader',
+    renderedAt: new Date().toISOString(),
+  })),
+};
+
+export const serverActions = {
+  echo: defineAction<{ text: string }, { echoed: string }>(
+    async (_ctx, input) => ({ echoed: input.text })
+  ),
+};

--- a/apps/example-node/src/pages/home.tsx
+++ b/apps/example-node/src/pages/home.tsx
@@ -1,0 +1,23 @@
+import { definePage } from 'hono-preact';
+import type { FunctionComponent } from 'preact';
+import { serverLoaders } from './home.server.js';
+
+const homeLoader = serverLoaders.default;
+
+const HomePage: FunctionComponent = () => {
+  const { message } = homeLoader.useData();
+  return (
+    <section>
+      <h1>example-node</h1>
+      <p>{message}</p>
+      <a href="/about">About</a>
+    </section>
+  );
+};
+HomePage.displayName = 'HomePage';
+
+const HomeView = homeLoader.View(() => <HomePage />, {
+  fallback: <p>Loading...</p>,
+});
+
+export default definePage(HomeView, {});

--- a/apps/example-node/src/routes.ts
+++ b/apps/example-node/src/routes.ts
@@ -1,0 +1,10 @@
+import { defineRoutes } from 'hono-preact';
+
+export default defineRoutes([
+  {
+    path: '/',
+    view: () => import('./pages/home.js'),
+    server: () => import('./pages/home.server.js'),
+  },
+  { path: '/about', view: () => import('./pages/about.js') },
+]);

--- a/apps/example-node/tsconfig.json
+++ b/apps/example-node/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["vite/client", "@testing-library/jest-dom"]
+  },
+  "exclude": ["node_modules/**/*"],
+  "include": [
+    "./src/**/*.tsx",
+    "./src/**/*.ts",
+    "./src/**/*.json",
+    "./src/**/*.mdx",
+    "./vite.config.ts"
+  ]
+}

--- a/apps/example-node/vite.config.ts
+++ b/apps/example-node/vite.config.ts
@@ -1,0 +1,23 @@
+import { honoPreact } from 'hono-preact/vite';
+import { nodeAdapter } from 'hono-preact/adapter-node';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: 'hono-preact/internal', replacement: resolve(__dirname, '../../packages/hono-preact/src/internal.ts') },
+      { find: 'hono-preact/server', replacement: resolve(__dirname, '../../packages/hono-preact/src/server.ts') },
+      { find: 'hono-preact/vite', replacement: resolve(__dirname, '../../packages/hono-preact/src/vite.ts') },
+      { find: 'hono-preact/adapter-node', replacement: resolve(__dirname, '../../packages/hono-preact/src/adapter-node.ts') },
+      { find: 'hono-preact', replacement: resolve(__dirname, '../../packages/hono-preact/src/index.ts') },
+      { find: '@hono-preact/iso/internal', replacement: resolve(__dirname, '../../packages/iso/src/internal.ts') },
+      { find: '@hono-preact/iso', replacement: resolve(__dirname, '../../packages/iso/src/index.ts') },
+      { find: '@hono-preact/server', replacement: resolve(__dirname, '../../packages/server/src/index.ts') },
+    ],
+  },
+  plugins: [honoPreact({ adapter: nodeAdapter() })],
+});

--- a/docs/superpowers/plans/2026-05-18-multi-cloud-adapters-plan-b.md
+++ b/docs/superpowers/plans/2026-05-18-multi-cloud-adapters-plan-b.md
@@ -1,0 +1,648 @@
+# Multi-Cloud Adapters — Plan B (Node adapter) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Node deployment adapter for `hono-preact`, built on Vite's native Environment API (no `@hono/vite-*` tooling), plus a minimal `apps/example-node` app and WebSocket-in-dev verification on both the Node and Cloudflare adapters.
+
+**Architecture:** `nodeAdapter()` implements the existing `HonoPreactAdapter` interface (shipped in Plan A). Its `vitePlugins()` contributes a `config`-hook plugin that defines the server (`ssr`) build environment and a `builder` so one `vite build` emits both the browser bundle and the Node server bundle, plus a dev plugin whose `configureServer` hook runs the server via Vite's SSR module runner and wires the HTTP `upgrade` event for WebSockets. Its `wrapEntry()` composes an outer Hono app (`serveStatic` for `dist/client`, then the core app) booted with `@hono/node-server`'s `serve()`.
+
+**Tech Stack:** TypeScript, Vite 8 Environment API, `@hono/node-server`, `@hono/node-ws`, Vitest, pnpm workspaces. Spec: `docs/superpowers/specs/2026-05-17-multi-cloud-adapter-architecture-design.md`.
+
+**Builds on Plan A (merged):** the `HonoPreactAdapter` interface (`packages/vite/src/adapter.ts`), the core-app-module / entry-wrapper split (`server-entry.ts`), `honoPreact()` requiring an `adapter`, and `configPlugin` owning the `client` build environment config. Plan B does not change any of that; it adds a second adapter alongside `cloudflareAdapter()`.
+
+**Lessons from Plan A carried in:**
+- A consuming app's `vite.config.ts` imports `honoPreact` from the *built* umbrella `dist/`. After changing framework source, always run `pnpm --filter '@hono-preact/*' --filter hono-preact build` before building a consuming app, or the change will not take effect.
+- The generated entry wrapper must exist on disk before the build/dev plugins resolve config; `serverEntryPlugin` already writes it in its `config` hook. The Node adapter's plugins must not assume an earlier time.
+- The `client` build environment is already configured by `configPlugin` (Plan A). The Node adapter only configures the *server* environment.
+
+---
+
+## File Structure
+
+**Created:**
+- `packages/vite/src/adapter-node.ts` — `nodeAdapter()` factory: `vitePlugins()`, `wrapEntry()`. Standalone module, NOT re-exported by `index.ts` (importing `hono-preact/vite` must not pull in `@hono/node-server`).
+- `packages/vite/src/node-dev-server.ts` — the dev plugin (`configureServer` middleware + WebSocket `upgrade` wiring). Kept separate from `adapter-node.ts` so the adapter factory stays small and the dev server is independently testable.
+- `packages/hono-preact/src/adapter-node.ts` — umbrella subpath re-export.
+- `apps/example-node/` — minimal Node-target app: `package.json`, `vite.config.ts`, `tsconfig.json`, `src/Layout.tsx`, `src/routes.ts`, `src/api.ts`, two page components, one `.server.ts` loader, one action, one `/ws` WebSocket route.
+- `docs/superpowers/research/2026-05-18-node-environment-api-spike.md` — Task 0 findings.
+- Tests: `packages/vite/src/__tests__/adapter-node.test.ts`, `packages/vite/src/__tests__/node-dev-server.test.ts`, `packages/vite/src/__tests__/websocket-dev.test.ts`.
+
+**Modified:**
+- `packages/vite/package.json` — add `./adapter-node` export; add `@hono/node-server` + `@hono/node-ws` as optional peer deps and as devDependencies (for tests).
+- `packages/hono-preact/package.json` — add `./adapter-node` export; add the two peers.
+- `packages/hono-preact/scripts/consolidate.mjs` — teach it the `@hono-preact/vite/adapter-node` specifier.
+
+**Untouched:** `adapter.ts`, `hono-preact.ts`, `server-entry.ts`, `adapter-cloudflare.ts`, `apps/site`. Plan B is purely additive.
+
+---
+
+## Task 0: Node Environment-API spike (implementation gate)
+
+No production code is committed. This task validates the three mechanisms the Node adapter depends on, none of which Plan A's spike exercised. If any fails, STOP and revisit the spec's Node-adapter / D2 section.
+
+**Files:**
+- Create: `docs/superpowers/research/2026-05-18-node-environment-api-spike.md`
+
+- [ ] **Step 1: Scaffold a throwaway project**
+
+Outside the repo (e.g. `/tmp/node-env-spike`): `npm init -y`; install `vite@8.0.8`, `hono`, `@hono/node-server`, `@hono/node-ws`. Create a trivial Hono app module and a `vite.config.ts`.
+
+- [ ] **Step 2: Validate a multi-environment build**
+
+Configure a `client` environment and an `ssr` environment plus `builder.buildApp`, so a single `vite build` emits a browser bundle and a Node-runnable server bundle. Run `npx vite build`. Record: does one `vite build` produce both; what is the output layout; does the server bundle run under `node`.
+
+- [ ] **Step 3: Validate an SSR dev middleware**
+
+In a `configureServer` hook, create a module runner against the `ssr` environment (`createServerModuleRunner` or `server.environments.ssr` runner), load the server entry, and add a Connect middleware that converts the Node request to a `Request`, calls the app's `fetch`, and writes the `Response` back. Run `npx vite dev`, confirm `GET /` is served by the SSR app, and confirm editing a server module hot-reloads.
+
+- [ ] **Step 4: Validate WebSocket upgrade wiring**
+
+Using `@hono/node-ws`'s `createNodeWebSocket` / `injectWebSocket`, attach an `upgrade` listener to the Vite dev server's `httpServer` in `configureServer`. Confirm a WebSocket client connecting to a `/ws` route during `vite dev` reaches the handler (open/message/close run).
+
+- [ ] **Step 5: Write findings and commit**
+
+Write `docs/superpowers/research/2026-05-18-node-environment-api-spike.md`: the working `environments` + `builder` config shape, the working module-runner dev-middleware shape, the working `upgrade`-wiring shape, the build output layout, resolved `@hono/node-server` and `@hono/node-ws` versions, and any Vite-8 API specifics (exact import names for the module runner). Commit only that file:
+
+```bash
+git add docs/superpowers/research/2026-05-18-node-environment-api-spike.md
+git commit -m "research: Node Environment-API spike for the Node adapter"
+```
+
+- [ ] **Step 6: Go/no-go**
+
+If Steps 2-4 all succeed, proceed. If any fails, STOP and report — the D2 "framework-owned Node dev middleware" decision must be reconsidered (fallback: reintroduce `@hono/vite-dev-server` for the Node dev path only).
+
+> The concrete code in Tasks 2 and 3 below is written from the spec's intended design. Where the spike's findings differ (exact module-runner API, config shape), the spike findings win — adjust those tasks to match the committed spike doc.
+
+---
+
+## Task 1: Node adapter skeleton and `wrapEntry()`
+
+**Files:**
+- Create: `packages/vite/src/adapter-node.ts`
+- Modify: `packages/vite/package.json` (devDependencies)
+- Test: `packages/vite/src/__tests__/adapter-node.test.ts`
+
+- [ ] **Step 1: Add `@hono/node-server` and `@hono/node-ws` as devDependencies**
+
+`adapter-node.ts` and its tests import these. Add to `packages/vite/package.json` `devDependencies` at the versions Task 0's spike resolved (use the spike's exact versions):
+
+```json
+    "@hono/node-server": "^1.19.0",
+    "@hono/node-ws": "^1.2.0",
+```
+
+Run `pnpm install`. Expected: clean.
+
+- [ ] **Step 2: Write the failing test**
+
+`vitePlugins()` is exercised by Task 5's example-app build/dev, not unit-tested here (it constructs dev/build plugins). This test covers the pure surface.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { nodeAdapter } from '../adapter-node.js';
+
+const ctx = {
+  root: '/p',
+  coreAppModuleId: '/p/node_modules/.vite/hono-preact/core-app.tsx',
+  entryWrapperId: '/p/node_modules/.vite/hono-preact/server-entry.tsx',
+};
+
+describe('nodeAdapter', () => {
+  it('is named "node"', () => {
+    expect(nodeAdapter().name).toBe('node');
+  });
+
+  it('wrapEntry composes an outer app: static assets, core app, serve()', () => {
+    const tail = nodeAdapter().wrapEntry(ctx);
+    expect(tail).toContain("from '@hono/node-server'");
+    expect(tail).toContain('serveStatic');
+    expect(tail).toContain(ctx.coreAppModuleId);
+    expect(tail).toContain('serve(');
+  });
+
+  it('exposes a vitePlugins function', () => {
+    expect(typeof nodeAdapter().vitePlugins).toBe('function');
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/adapter-node.test.ts`
+Expected: FAIL — cannot find module `../adapter-node.js`.
+
+- [ ] **Step 4: Implement the adapter skeleton**
+
+```ts
+// packages/vite/src/adapter-node.ts
+//
+// Standalone module. NOT re-exported by index.ts: importing `hono-preact/vite`
+// must never pull in `@hono/node-server`. Only importing
+// `hono-preact/adapter-node` loads this file.
+import type { Plugin } from 'vite';
+import type { HonoPreactAdapter, HonoPreactAdapterContext } from './adapter.js';
+import { nodeBuildPlugin, nodeDevServerPlugin } from './node-dev-server.js';
+
+export function nodeAdapter(): HonoPreactAdapter {
+  return {
+    name: 'node',
+    vitePlugins(ctx: HonoPreactAdapterContext): Plugin[] {
+      return [nodeBuildPlugin(ctx), nodeDevServerPlugin(ctx)];
+    },
+    wrapEntry(ctx: HonoPreactAdapterContext): string {
+      // Node has no CDN asset layer, so the entry composes an outer Hono app:
+      // static files first, then the framework's core app, booted with a
+      // Node HTTP listener. `serveStatic` root is the client build output.
+      return (
+        `import { serve } from '@hono/node-server';\n` +
+        `import { serveStatic } from '@hono/node-server/serve-static';\n` +
+        `import { Hono } from 'hono';\n` +
+        `import coreApp from ${JSON.stringify(ctx.coreAppModuleId)};\n` +
+        `\n` +
+        `const app = new Hono()\n` +
+        `  .use('/static/*', serveStatic({ root: './dist/client' }))\n` +
+        `  .route('/', coreApp);\n` +
+        `\n` +
+        `const port = Number(process.env.PORT) || 3000;\n` +
+        `serve({ fetch: app.fetch, port });\n` +
+        `console.log('hono-preact (node) listening on :' + port);\n` +
+        `\n` +
+        `export default app;\n`
+      );
+    },
+  };
+}
+```
+
+`nodeBuildPlugin` and `nodeDevServerPlugin` are created in Tasks 2 and 3. To make this task compile and its test pass on its own, first create `packages/vite/src/node-dev-server.ts` with two stub exports:
+
+```ts
+// packages/vite/src/node-dev-server.ts
+import type { Plugin } from 'vite';
+import type { HonoPreactAdapterContext } from './adapter.js';
+
+export function nodeBuildPlugin(_ctx: HonoPreactAdapterContext): Plugin {
+  return { name: 'hono-preact:node-build' };
+}
+
+export function nodeDevServerPlugin(_ctx: HonoPreactAdapterContext): Plugin {
+  return { name: 'hono-preact:node-dev-server' };
+}
+```
+
+Tasks 2 and 3 fill these in.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/adapter-node.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/vite/src/adapter-node.ts packages/vite/src/node-dev-server.ts packages/vite/package.json packages/vite/src/__tests__/adapter-node.test.ts pnpm-lock.yaml
+git commit -m "feat(vite): add Node adapter skeleton and wrapEntry"
+```
+
+---
+
+## Task 2: Node build environment config (`nodeBuildPlugin`)
+
+Fill in `nodeBuildPlugin` so one `vite build` emits the Node server bundle alongside the client bundle. The exact `environments` / `builder` shape is governed by Task 0's spike findings — implement to match the committed spike doc.
+
+**Files:**
+- Modify: `packages/vite/src/node-dev-server.ts`
+- Test: `packages/vite/src/__tests__/node-dev-server.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { nodeBuildPlugin } from '../node-dev-server.js';
+
+const ctx = {
+  root: '/p',
+  coreAppModuleId: '/p/node_modules/.vite/hono-preact/core-app.tsx',
+  entryWrapperId: '/p/node_modules/.vite/hono-preact/server-entry.tsx',
+};
+
+describe('nodeBuildPlugin', () => {
+  it('contributes an ssr build environment whose input is the entry wrapper', () => {
+    const plugin = nodeBuildPlugin(ctx);
+    const cfg = (plugin.config as Function)(
+      {},
+      { command: 'build', mode: 'production' }
+    ) as {
+      environments: { ssr: { build: { rollupOptions: { input: string[] } } } };
+    };
+    expect(cfg.environments.ssr.build.rollupOptions.input).toEqual([
+      ctx.entryWrapperId,
+    ]);
+  });
+
+  it('builds the app via a builder.buildApp orchestrator', () => {
+    const plugin = nodeBuildPlugin(ctx);
+    const cfg = (plugin.config as Function)(
+      {},
+      { command: 'build', mode: 'production' }
+    ) as { builder: { buildApp: unknown } };
+    expect(typeof cfg.builder.buildApp).toBe('function');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/node-dev-server.test.ts`
+Expected: FAIL — the stub `nodeBuildPlugin` returns no `config`.
+
+- [ ] **Step 3: Implement `nodeBuildPlugin`**
+
+Replace the `nodeBuildPlugin` stub in `packages/vite/src/node-dev-server.ts`. The plugin's `config` hook defines the `ssr` environment (entry = the framework's generated entry wrapper, Node platform, no externalization of the framework runtime) and a `builder.buildApp` that builds the `client` environment then the `ssr` environment. Use the exact `environments` / `builder` shape the Task 0 spike recorded as working; the structure is:
+
+```ts
+export function nodeBuildPlugin(ctx: HonoPreactAdapterContext): Plugin {
+  return {
+    name: 'hono-preact:node-build',
+    config() {
+      return {
+        environments: {
+          ssr: {
+            build: {
+              outDir: 'dist/server',
+              rollupOptions: { input: [ctx.entryWrapperId] },
+            },
+          },
+        },
+        builder: {
+          async buildApp(builder) {
+            await builder.build(builder.environments.client);
+            await builder.build(builder.environments.ssr);
+          },
+        },
+      };
+    },
+  };
+}
+```
+
+> **Spike dependency:** if Task 0 found a different working shape (e.g. `ssr` must set `ssr: true` / a specific `consumer`, or the server bundle needs `build.ssr` rather than `rollupOptions.input`, or the Node bundle must not be code-split), adopt the spike's shape and update the Step 1 test assertions to match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/node-dev-server.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/node-dev-server.ts packages/vite/src/__tests__/node-dev-server.test.ts
+git commit -m "feat(vite): Node adapter build environment config"
+```
+
+---
+
+## Task 3: Node dev server middleware (`nodeDevServerPlugin`)
+
+Fill in `nodeDevServerPlugin`: a `configureServer` hook that serves the SSR app in dev via Vite's module runner and wires the WebSocket `upgrade` event. The concrete module-runner API and middleware shape come from Task 0's spike doc.
+
+**Files:**
+- Modify: `packages/vite/src/node-dev-server.ts`
+- Test: `packages/vite/src/__tests__/node-dev-server.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+A full dev-server integration test belongs in Task 6 (it needs a running server). Here, assert the plugin's shape only:
+
+```ts
+import { nodeDevServerPlugin } from '../node-dev-server.js';
+
+describe('nodeDevServerPlugin', () => {
+  it('is a serve-only plugin with a configureServer hook', () => {
+    const plugin = nodeDevServerPlugin({
+      root: '/p',
+      coreAppModuleId: '/p/a.tsx',
+      entryWrapperId: '/p/b.tsx',
+    });
+    expect(plugin.name).toBe('hono-preact:node-dev-server');
+    expect(plugin.apply).toBe('serve');
+    expect(typeof plugin.configureServer).toBe('function');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/node-dev-server.test.ts`
+Expected: FAIL — the stub has no `apply` / `configureServer`.
+
+- [ ] **Step 3: Implement `nodeDevServerPlugin`**
+
+Replace the `nodeDevServerPlugin` stub. The `configureServer` hook: (a) loads the generated entry wrapper through Vite's SSR module runner so the Hono app and its server modules are HMR-aware; (b) returns a post-middleware that converts the Node request to a `Request`, calls the app's `fetch`, and streams the `Response` back; (c) attaches an `upgrade` listener to `server.httpServer` via `@hono/node-ws`'s `injectWebSocket`. Implement to the shape the Task 0 spike recorded. Skeleton:
+
+```ts
+export function nodeDevServerPlugin(ctx: HonoPreactAdapterContext): Plugin {
+  return {
+    name: 'hono-preact:node-dev-server',
+    apply: 'serve',
+    configureServer(server) {
+      // Module runner for the `ssr` environment — loads the entry wrapper
+      // with HMR so server-code edits hot-reload. Exact API per spike.
+      // WebSocket: createNodeWebSocket({ app }).injectWebSocket(httpServer)
+      // wired against server.httpServer for `upgrade` events.
+      // Request path: return a post-hook middleware that runs app.fetch.
+      return () => {
+        server.middlewares.use(async (req, res) => {
+          // build Request -> app.fetch -> write Response (per spike)
+        });
+      };
+    },
+  };
+}
+```
+
+> **Spike dependency:** this is the task most governed by Task 0. Use the spike doc's verified module-runner code, request/response conversion, and `upgrade`-wiring verbatim. If the spike could not get HMR or the `upgrade` event working, STOP and escalate before writing a partial implementation.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/node-dev-server.test.ts`
+Expected: PASS (shape test). End-to-end dev verification is Task 6.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/node-dev-server.ts packages/vite/src/__tests__/node-dev-server.test.ts
+git commit -m "feat(vite): Node adapter dev server middleware"
+```
+
+---
+
+## Task 4: Umbrella `hono-preact/adapter-node` subpath
+
+Mirrors Plan A's Task 7 (the Cloudflare subpath), which is the reference for every step here.
+
+**Files:**
+- Modify: `packages/vite/package.json`
+- Create: `packages/hono-preact/src/adapter-node.ts`
+- Modify: `packages/hono-preact/package.json`
+- Modify: `packages/hono-preact/scripts/consolidate.mjs`
+
+- [ ] **Step 1: Add the `./adapter-node` export to the vite package**
+
+In `packages/vite/package.json` `exports`, add after the `./adapter-cloudflare` entry:
+
+```json
+    "./adapter-node": {
+      "types": "./dist/adapter-node.d.ts",
+      "import": "./dist/adapter-node.js"
+    },
+```
+
+- [ ] **Step 2: Create the umbrella re-export module**
+
+```ts
+// packages/hono-preact/src/adapter-node.ts
+export * from '@hono-preact/vite/adapter-node';
+```
+
+- [ ] **Step 3: Add the umbrella `./adapter-node` export and peer deps**
+
+In `packages/hono-preact/package.json`: add to `exports` after `./adapter-cloudflare`:
+
+```json
+    "./adapter-node": {
+      "types": "./dist/adapter-node.d.ts",
+      "import": "./dist/adapter-node.js"
+    },
+```
+
+Add `@hono/node-server` and `@hono/node-ws` to `peerDependencies` (at the spike's resolved versions) and mark both optional in `peerDependenciesMeta`:
+
+```json
+    "@hono/node-server": "^1.19.0",
+    "@hono/node-ws": "^1.2.0",
+```
+
+```json
+    "@hono/node-server": { "optional": true },
+    "@hono/node-ws": { "optional": true },
+```
+
+- [ ] **Step 4: Add `@hono/node-server` and `@hono/node-ws` as optional peers of the vite package**
+
+In `packages/vite/package.json`, add the two packages to `peerDependencies` and mark them optional in `peerDependenciesMeta` (they are already devDependencies from Task 1; this declares the consumer-facing peer contract).
+
+- [ ] **Step 5: Teach `consolidate.mjs` the new specifier**
+
+In `packages/hono-preact/scripts/consolidate.mjs`, add to `DIST_PATHS` after the `'@hono-preact/vite/adapter-cloudflare'` line:
+
+```js
+  '@hono-preact/vite/adapter-node': 'vite/adapter-node.js',
+```
+
+Update the rewrite regex to include `vite/adapter-node` in the alternation (longest-match-first, before `vite`):
+
+```js
+    /(['"])(@hono-preact\/(?:iso\/internal|iso|server|vite\/adapter-cloudflare|vite\/adapter-node|vite))(['"])/g,
+```
+
+- [ ] **Step 6: Verify the umbrella builds and consolidates**
+
+Run: `pnpm --filter '@hono-preact/*' --filter hono-preact build`
+Expected: completes; `packages/hono-preact/dist/adapter-node.js` exists and its `@hono-preact/vite/adapter-node` import is rewritten to `./vite/adapter-node.js`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/vite/package.json packages/hono-preact/src/adapter-node.ts packages/hono-preact/package.json packages/hono-preact/scripts/consolidate.mjs pnpm-lock.yaml
+git commit -m "feat(hono-preact): expose hono-preact/adapter-node subpath"
+```
+
+---
+
+## Task 5: `apps/example-node` example app
+
+A minimal Node-target app that exercises the adapter end to end and serves as the Node docs reference.
+
+**Files:**
+- Create: `apps/example-node/package.json`, `apps/example-node/tsconfig.json`, `apps/example-node/vite.config.ts`
+- Create: `apps/example-node/src/Layout.tsx`, `src/routes.ts`, `src/api.ts`, `src/pages/home.tsx`, `src/pages/about.tsx`, `src/pages/data.server.ts` (a loader), and an action
+- Create: `apps/example-node/src/pages/ws.ts` (a WebSocket route, registered in `api.ts`)
+
+- [ ] **Step 1: Create `package.json`**
+
+```json
+{
+  "name": "example-node",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "node dist/server/server-entry.js"
+  },
+  "dependencies": {
+    "hono-preact": "workspace:*",
+    "hono": "^4.12.14",
+    "preact": "^10.29.1",
+    "preact-iso": "github:preactjs/preact-iso#v3"
+  },
+  "devDependencies": {
+    "@hono/node-server": "^1.19.0",
+    "@hono/node-ws": "^1.2.0",
+    "@preact/preset-vite": "^2.10.5",
+    "preact-render-to-string": "^6.6.7",
+    "typescript": "*",
+    "vite": "*"
+  }
+}
+```
+
+- [ ] **Step 2: Create `vite.config.ts`**
+
+Mirror `apps/site/vite.config.ts` but with `nodeAdapter()` and only the umbrella source aliases (no MDX, no visualizer):
+
+```ts
+import { honoPreact } from 'hono-preact/vite';
+import { nodeAdapter } from 'hono-preact/adapter-node';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: 'hono-preact/internal', replacement: resolve(__dirname, '../../packages/hono-preact/src/internal.ts') },
+      { find: 'hono-preact/server', replacement: resolve(__dirname, '../../packages/hono-preact/src/server.ts') },
+      { find: 'hono-preact/vite', replacement: resolve(__dirname, '../../packages/hono-preact/src/vite.ts') },
+      { find: 'hono-preact/adapter-node', replacement: resolve(__dirname, '../../packages/hono-preact/src/adapter-node.ts') },
+      { find: 'hono-preact', replacement: resolve(__dirname, '../../packages/hono-preact/src/index.ts') },
+      { find: '@hono-preact/iso/internal', replacement: resolve(__dirname, '../../packages/iso/src/internal.ts') },
+      { find: '@hono-preact/iso', replacement: resolve(__dirname, '../../packages/iso/src/index.ts') },
+      { find: '@hono-preact/server', replacement: resolve(__dirname, '../../packages/server/src/index.ts') },
+    ],
+  },
+  plugins: [honoPreact({ adapter: nodeAdapter() })],
+});
+```
+
+> Note: the consuming app's `vite.config.ts` imports `honoPreact` from the *built* umbrella `dist/`. Run `pnpm --filter '@hono-preact/*' --filter hono-preact build` before the first `vite build`/`dev` here, and after any framework change.
+
+- [ ] **Step 3: Create the app source**
+
+Create `tsconfig.json` (copy `apps/site/tsconfig.json`), `src/Layout.tsx`, `src/routes.ts` (two routes: `/` → home, `/about` → about), `src/pages/home.tsx`, `src/pages/about.tsx`, `src/pages/data.server.ts` (one `defineLoader` returning a value the home page renders), and one action. Keep each file minimal — this app exists to exercise the adapter, not to demo features. Model the file shapes on `apps/site/src/`.
+
+- [ ] **Step 4: Create the WebSocket route**
+
+`src/api.ts` exports a Hono app with a `/ws` route using `@hono/node-ws`'s `upgradeWebSocket` (echo server: `onMessage` sends back `echo: <data>`). `api.ts` is mounted by the framework ahead of the reserved RPC paths.
+
+- [ ] **Step 5: Build and run**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm --filter example-node build
+pnpm --filter example-node start
+```
+
+Expected: build emits `dist/client/` and `dist/server/`; `node` boots the server; `curl localhost:3000/` returns SSR HTML; `/about` works; the loader-backed value renders.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/example-node pnpm-lock.yaml
+git commit -m "feat(example-node): minimal Node-target example app"
+```
+
+---
+
+## Task 6: WebSocket verification (both adapters)
+
+**Files:**
+- Create: `packages/vite/src/__tests__/websocket-dev.test.ts`
+- Modify: `apps/site/src/api.ts` is NOT touched; the Cloudflare WS test uses a fixture.
+
+- [ ] **Step 1: Write the Node WebSocket dev-server test**
+
+An integration test that starts `apps/example-node` under `vite dev` (programmatically via Vite's `createServer`), connects a WebSocket client to `/ws`, sends a message, and asserts the echo reply. This proves the Node adapter's `upgrade` wiring (Task 3).
+
+```ts
+import { describe, it, expect } from 'vitest';
+// Start example-node's vite dev server, connect ws://.../ws, assert echo.
+// Use Vite's createServer API + the `ws` client (a dev dependency).
+```
+
+Write the full test body using the dev-server start pattern Task 0's spike validated.
+
+- [ ] **Step 2: Run it — verify Node WS works**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/websocket-dev.test.ts`
+Expected: PASS — the upgrade reaches the handler and the echo returns.
+
+- [ ] **Step 3: Add the Cloudflare WebSocket dev-server test**
+
+In the same file, a second test boots the `@cloudflare/vite-plugin` dev server (a small fixture worker with a `hono/cloudflare-workers` `upgradeWebSocket` `/ws` route) and connects a WebSocket client. This confirms the spec's claim that Cloudflare WS works in dev for free.
+
+- [ ] **Step 4: Run the file — both tests pass**
+
+Run: `pnpm vitest run packages/vite/src/__tests__/websocket-dev.test.ts`
+Expected: PASS (Node and Cloudflare).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/__tests__/websocket-dev.test.ts
+git commit -m "test(vite): WebSocket-in-dev verification for both adapters"
+```
+
+---
+
+## Task 7: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Rebuild the umbrella, then run the whole test suite**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm test
+```
+
+Expected: PASS. Investigate any failure before proceeding.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Format check**
+
+Run: `pnpm format:check`
+Expected: PASS. If it fails, `pnpm format` and commit.
+
+- [ ] **Step 4: Build both example apps**
+
+```bash
+pnpm --filter site build
+pnpm --filter example-node build
+```
+
+Expected: both succeed; `apps/site/dist/client/static/client.js` and `apps/example-node/dist/server/` are present.
+
+- [ ] **Step 5: Final commit if needed**
+
+```bash
+git add -A
+git commit -m "chore: typecheck and format fixes for the Node adapter"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Plan B covers the spec's Node-adapter section — Environment-API build (Task 2), framework-owned dev middleware with WebSocket support (Task 3), the `serveStatic` + `serve()` `wrapEntry` (Task 1), optional peer deps and the umbrella subpath (Task 4), the `apps/example-node` reference app (Task 5), and WebSocket verification on both adapters (Task 6). The spec's "Node adapter uses no `@hono/vite-*` tooling" is satisfied — only `@hono/node-server` and `@hono/node-ws` (runtime deps) are added.
+- **Spike-dependent tasks:** Tasks 2 and 3 carry explicit "Spike dependency" notes. Their concrete code is the spec's intended shape; Task 0's findings override where they differ. This is deliberate — the Vite-native Node dev middleware was never exercised before this plan.
+- **Isolation:** `adapter-node.ts` is not re-exported by `index.ts`, mirroring `adapter-cloudflare.ts`, so `hono-preact/vite` stays free of `@hono/node-server`.
+- **Out of scope:** Bun and Deno adapters; converting `apps/site` to be adapter-swappable; any change to the Cloudflare adapter or Plan A code.

--- a/docs/superpowers/research/2026-05-18-node-environment-api-spike.md
+++ b/docs/superpowers/research/2026-05-18-node-environment-api-spike.md
@@ -1,0 +1,284 @@
+# Node Environment-API spike for the Node adapter
+
+Date: 2026-05-18
+Task: Task 0 of the Node adapter (Plan B) implementation plan; implementation gate.
+
+## Outcome: GO
+
+All three mechanisms the Node adapter depends on were validated against a
+throwaway project (`/tmp/node-env-spike`) with real `vite build`, `vite dev`,
+HTTP requests, and a `ws` WebSocket client.
+
+| Step | Mechanism | Result |
+|------|-----------|--------|
+| 2 | Multi-environment build (`client` + `ssr` + `builder.buildApp`) | GO |
+| 3 | SSR dev middleware via `createServerModuleRunner` (incl. HMR) | GO |
+| 4 | WebSocket `upgrade` wiring with `@hono/node-ws` in dev | GO |
+
+## Resolved versions
+
+Installed with plain `npm` on Node v24.10.0, `vite@8.0.8` pinned.
+
+| Package | Resolved version |
+|---------|------------------|
+| `vite` | 8.0.8 |
+| `hono` | 4.12.19 |
+| `@hono/node-server` | 1.19.14 |
+| `@hono/node-ws` | 1.3.1 |
+| `ws` (transitive of node-ws; also used for the test client) | 8.20.1 |
+
+## Vite 8 API specifics (verified by inspecting `vite`'s exports)
+
+The module runner for the SSR environment is created with:
+
+```ts
+import { createServerModuleRunner } from 'vite';
+// ...
+const runner = createServerModuleRunner(server.environments.ssr);
+const mod = await runner.import('/src/server.ts'); // path is root-relative
+```
+
+`createServerModuleRunner` is a **named export of `vite`** (not `vite/module-runner`).
+Other relevant runner/environment exports present in `vite@8.0.8`:
+`createBuilder`, `DevEnvironment`, `BuildEnvironment`,
+`createRunnableDevEnvironment`, `createFetchableDevEnvironment`,
+`isRunnableDevEnvironment`, `createServerModuleRunnerTransport`,
+`moduleRunnerTransform`, `runnerImport`.
+
+`runner.import()` re-evaluates the module on HMR, so re-importing on every
+request always yields the latest app. No manual cache invalidation needed.
+
+## Step 2: multi-environment build config (verified)
+
+One `npx vite build` emits both bundles. `builder.buildApp` drives both
+environments sequentially.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  environments: {
+    client: {
+      build: {
+        outDir: 'dist/client',
+        rollupOptions: { input: 'src/client.ts' },
+      },
+    },
+    ssr: {
+      build: {
+        outDir: 'dist/server',
+        ssr: true,
+        // The adapter generates a prod entry that imports the user app and
+        // calls serve()/injectWebSocket; that file is the input here.
+        rollupOptions: { input: 'src/prod-entry.ts' },
+      },
+    },
+  },
+  builder: {
+    async buildApp(builder) {
+      await builder.build(builder.environments.client);
+      await builder.build(builder.environments.ssr);
+    },
+  },
+});
+```
+
+### Build output layout (verified)
+
+```
+dist/client/assets/client-<hash>.js   # browser bundle (hashed)
+dist/server/prod-entry.js             # Node-runnable server bundle (un-hashed)
+```
+
+The `ssr` environment bundle **externalizes** `hono`, `@hono/node-server`,
+`@hono/node-ws` (they appear as bare `import` statements). The bundle is plain
+ESM and runs under `node dist/server/prod-entry.js` directly, provided those
+deps are installed in the deployed `node_modules`.
+
+### Prod entry shape the build plugin must generate (verified runnable)
+
+```ts
+import { serve } from '@hono/node-server';
+import { app, injectWebSocket } from './server.ts';
+
+const server = serve({ fetch: app.fetch, port: 3456 }, (info) => {
+  console.log(`listening on http://localhost:${info.port}`);
+});
+injectWebSocket(server);
+```
+
+`node dist/server/prod-entry.js` served `GET /`, `GET /api/ping`, and a full
+WebSocket open/message(echo)/close cycle.
+
+## Step 3: SSR dev middleware (verified, incl. HMR)
+
+```ts
+// inside a Plugin's configureServer(server: ViteDevServer)
+import { createServerModuleRunner } from 'vite';
+
+const runner = createServerModuleRunner(server.environments.ssr);
+
+async function getServerModule() {
+  return runner.import('/src/server.ts'); // re-import reflects HMR
+}
+
+// IMPORTANT: register the SSR middleware DIRECTLY in configureServer,
+// NOT via the returned post hook `return () => { ... }`.
+// The post hook runs AFTER Vite's spaFallback/html middlewares, which
+// rewrite req.url to "/index.html" -- the SSR app then never sees the
+// real path and 404s. Registering directly puts our middleware first.
+server.middlewares.use(async (req, res, next) => {
+  try {
+    const { app } = await getServerModule();
+
+    const url = `http://${req.headers.host}${req.url}`;
+    const method = req.method ?? 'GET';
+    const headers = new Headers();
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (typeof v === 'string') headers.set(k, v);
+      else if (Array.isArray(v)) v.forEach((vv) => headers.append(k, vv));
+    }
+    let body: BodyInit | undefined;
+    if (method !== 'GET' && method !== 'HEAD') {
+      const chunks: Buffer[] = [];
+      for await (const c of req) chunks.push(c as Buffer);
+      body = chunks.length ? Buffer.concat(chunks) : undefined;
+    }
+
+    const request = new Request(url, { method, headers, body });
+    const response = await app.fetch(request);
+
+    res.statusCode = response.status;
+    response.headers.forEach((value, key) => res.setHeader(key, value));
+    if (response.body) {
+      const reader = response.body.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(value);
+      }
+    }
+    res.end();
+  } catch (err) {
+    next(err as Error);
+  }
+});
+```
+
+Verified: `GET /` and `GET /api/ping` are served by the SSR app under
+`vite dev`. Editing `src/server.ts` (changing the `/` response body) was
+reflected on the next request with no server restart -- HMR confirmed.
+
+### Gotcha for Task 3 (load-bearing)
+
+`server.middlewares` is a Connect stack. Registering via the
+`configureServer` return value (`return () => { server.middlewares.use(...) }`)
+places the middleware **after** Vite's internal middlewares. Vite's
+`spaFallbackMiddleware` rewrites `req.url` to `/index.html`, so the SSR app
+receives the wrong path and returns 404. Register the SSR catch-all middleware
+**directly inside `configureServer`** (synchronously, before the function
+returns) so it runs ahead of Vite's HTML/SPA middlewares.
+
+## Step 4: WebSocket upgrade wiring (verified)
+
+### How `@hono/node-ws` actually works (from reading `dist/index.cjs`)
+
+`createNodeWebSocket({ app })` returns `{ wss, injectWebSocket, upgradeWebSocket }`.
+The three share **closure state** (`wss`, a `waiterMap`). Therefore:
+
+- `upgradeWebSocket` (used in route handlers) and `injectWebSocket` (used to
+  attach the upgrade listener) **must come from the same
+  `createNodeWebSocket()` call**. A fresh `createNodeWebSocket()` per request
+  has an empty `waiterMap` and the upgrade silently fails.
+- `injectWebSocket(target)` does exactly one thing:
+  `target.on('upgrade', handler)`. It does not need a real `http.Server`; any
+  object with an `on` method works.
+
+So the SSR server module owns one `createNodeWebSocket({ app })` call and
+exports both `app` and `injectWebSocket` (or the whole node-ws result).
+
+### Prod: pass the real server (verified)
+
+```ts
+const server = serve({ fetch: app.fetch });
+injectWebSocket(server); // attaches `upgrade` listener to the http server
+```
+
+### Dev: forward the dev server's `upgrade` event (verified)
+
+In dev, the user app must register its `upgrade` handler on the *Vite dev
+server's* `httpServer`. Because `injectWebSocket` only calls
+`target.on('upgrade', fn)`, capture that `fn` via a shim and forward each real
+upgrade event to it. Re-import per upgrade so HMR is respected.
+
+```ts
+// inside configureServer(server: ViteDevServer)
+server.httpServer?.on('upgrade', async (req, socket, head) => {
+  try {
+    const { injectWebSocket } = await getServerModule();
+    let handler:
+      | ((req: unknown, socket: unknown, head: unknown) => void)
+      | undefined;
+    // injectWebSocket(target) === target.on('upgrade', handler)
+    injectWebSocket({
+      on(event: string, fn: typeof handler) {
+        if (event === 'upgrade') handler = fn;
+      },
+    });
+    handler?.(req, socket, head);
+  } catch (err) {
+    console.error('[ws] dev upgrade error', err);
+    socket.destroy();
+  }
+});
+```
+
+Verified: a `ws` client connecting to `ws://localhost:<port>/ws` during
+`vite dev` reached the handler -- `onOpen`, `onMessage` (echoed back), and
+`onClose` all ran (confirmed in both the dev server log and the client).
+
+## SSR server module shape (used by all steps)
+
+The user/framework server entry must construct node-ws once and export the
+app plus `injectWebSocket` so prod and dev share the same wiring:
+
+```ts
+import { Hono } from 'hono';
+import { createNodeWebSocket } from '@hono/node-ws';
+
+const app = new Hono();
+const { injectWebSocket, upgradeWebSocket } = createNodeWebSocket({ app });
+
+app.get('/', (c) => c.html('<h1>...</h1>'));
+app.get('/ws', upgradeWebSocket(() => ({
+  onOpen() {}, onMessage(evt, ws) { ws.send(`echo:${evt.data}`); }, onClose() {},
+})));
+
+export { app, injectWebSocket };
+export default app;
+```
+
+## Concerns / notes for Tasks 2 and 3
+
+1. **Middleware ordering (Task 3):** must register the SSR middleware
+   synchronously in `configureServer`, not in the returned post hook (see
+   Step 3 gotcha). This is the single most likely thing to get wrong.
+2. **SSR externals (Task 2):** `hono`, `@hono/node-server`, `@hono/node-ws`
+   are externalized in the `ssr` bundle. The deploy target needs them in
+   `node_modules`, or the build config must mark them `noExternal` if a
+   fully self-contained bundle is wanted. Decide deliberately.
+3. **`ws` peer dep:** `ws@8.20.1` comes in transitively via `@hono/node-ws`;
+   no need to declare it directly for the adapter runtime. (It was installed
+   explicitly in the spike only for the test client.)
+4. **Static assets:** not exercised in this spike. Prod serving of
+   `dist/client/*` will need `serveStatic` from `@hono/node-server/serve-static`
+   wired into the generated prod entry; verify in Task 2/3.
+5. **Dev WS per-upgrade re-import:** re-importing the module on every upgrade
+   is correct for HMR but creates a new `createNodeWebSocket` closure each
+   time. Fine for short-lived upgrade negotiation; the resulting `WebSocket`
+   connection is held by `ws`'s `WebSocketServer` independently, so this is
+   safe. No connection leak observed.
+6. The dev server prints `[vite] connected.` before its banner; cosmetic, not
+   an error.
+```

--- a/packages/hono-preact/package.json
+++ b/packages/hono-preact/package.json
@@ -48,6 +48,10 @@
       "types": "./dist/adapter-cloudflare.d.ts",
       "import": "./dist/adapter-cloudflare.js"
     },
+    "./adapter-node": {
+      "types": "./dist/adapter-node.d.ts",
+      "import": "./dist/adapter-node.js"
+    },
     "./internal": {
       "types": "./dist/internal.d.ts",
       "import": "./dist/internal.js"
@@ -66,6 +70,8 @@
   },
   "peerDependencies": {
     "@cloudflare/vite-plugin": "^1.37.1",
+    "@hono/node-server": "^1.19.14",
+    "@hono/node-ws": "^1.3.1",
     "hono": ">=4.0.0",
     "hoofd": ">=1.0.0",
     "preact": ">=10.0.0",
@@ -76,6 +82,12 @@
   },
   "peerDependenciesMeta": {
     "@cloudflare/vite-plugin": {
+      "optional": true
+    },
+    "@hono/node-server": {
+      "optional": true
+    },
+    "@hono/node-ws": {
       "optional": true
     },
     "wrangler": {

--- a/packages/hono-preact/scripts/consolidate.mjs
+++ b/packages/hono-preact/scripts/consolidate.mjs
@@ -51,6 +51,7 @@ const DIST_PATHS = {
   '@hono-preact/server': 'server/index.js',
   '@hono-preact/vite': 'vite/index.js',
   '@hono-preact/vite/adapter-cloudflare': 'vite/adapter-cloudflare.js',
+  '@hono-preact/vite/adapter-node': 'vite/adapter-node.js',
 };
 
 async function copyTree(src, dest) {
@@ -96,7 +97,7 @@ async function rewriteImports(filePath) {
   const isTypeFile = filePath.endsWith('.d.ts');
 
   let rewritten = original.replace(
-    /(['"])(@hono-preact\/(?:iso\/internal|iso|server|vite\/adapter-cloudflare|vite))(['"])/g,
+    /(['"])(@hono-preact\/(?:iso\/internal|iso|server|vite\/adapter-cloudflare|vite\/adapter-node|vite))(['"])/g,
     (match, q1, source, q2) => {
       const distRel = DIST_PATHS[source];
       if (!distRel) return match;

--- a/packages/hono-preact/src/adapter-node.ts
+++ b/packages/hono-preact/src/adapter-node.ts
@@ -1,0 +1,2 @@
+// packages/hono-preact/src/adapter-node.ts
+export * from '@hono-preact/vite/adapter-node';

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -34,6 +34,10 @@
     "./adapter-cloudflare": {
       "types": "./dist/adapter-cloudflare.d.ts",
       "import": "./dist/adapter-cloudflare.js"
+    },
+    "./adapter-node": {
+      "types": "./dist/adapter-node.d.ts",
+      "import": "./dist/adapter-node.js"
     }
   },
   "scripts": {
@@ -48,12 +52,20 @@
   },
   "peerDependencies": {
     "@cloudflare/vite-plugin": "^1.37.1",
+    "@hono/node-server": "^1.19.14",
+    "@hono/node-ws": "^1.3.1",
     "@preact/preset-vite": "^2.10.5",
     "vite": ">=6.0.0",
     "wrangler": "^4.92.0"
   },
   "peerDependenciesMeta": {
     "@cloudflare/vite-plugin": {
+      "optional": true
+    },
+    "@hono/node-server": {
+      "optional": true
+    },
+    "@hono/node-ws": {
       "optional": true
     },
     "wrangler": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -62,6 +62,8 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.37.1",
+    "@hono/node-server": "^1.19.14",
+    "@hono/node-ws": "^1.3.1",
     "hono": "^4.12.14",
     "preact": "^10.29.1",
     "preact-iso": "github:preactjs/preact-iso#v3",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -76,10 +76,12 @@
     "@cloudflare/vite-plugin": "^1.37.1",
     "@hono/node-server": "^1.19.14",
     "@hono/node-ws": "^1.3.1",
+    "@types/ws": "^8.5.0",
     "hono": "^4.12.14",
     "preact": "^10.29.1",
     "preact-iso": "github:preactjs/preact-iso#v3",
     "typescript": "*",
-    "vite": "*"
+    "vite": "*",
+    "ws": "^8.18.0"
   }
 }

--- a/packages/vite/src/__tests__/adapter-node.test.ts
+++ b/packages/vite/src/__tests__/adapter-node.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { nodeAdapter } from '../adapter-node.js';
+
+const ctx = {
+  root: '/p',
+  coreAppModuleId: '/p/node_modules/.vite/hono-preact/core-app.tsx',
+  entryWrapperId: '/p/node_modules/.vite/hono-preact/server-entry.tsx',
+};
+
+describe('nodeAdapter', () => {
+  it('is named "node"', () => {
+    expect(nodeAdapter().name).toBe('node');
+  });
+
+  it('wrapEntry composes an outer app: static assets, core app, serve()', () => {
+    const tail = nodeAdapter().wrapEntry(ctx);
+    expect(tail).toContain("from '@hono/node-server'");
+    expect(tail).toContain('serveStatic');
+    expect(tail).toContain(ctx.coreAppModuleId);
+    expect(tail).toContain('serve(');
+  });
+
+  it('exposes a vitePlugins function', () => {
+    expect(typeof nodeAdapter().vitePlugins).toBe('function');
+  });
+
+  it('wrapEntry re-exports injectWebSocket when an api module is present', () => {
+    const tail = nodeAdapter().wrapEntry({ ...ctx, apiModuleId: '/p/src/api.ts' });
+    expect(tail).toContain('/p/src/api.ts');
+    expect(tail).toContain('injectWebSocket');
+  });
+
+  it('wrapEntry omits the api import when there is no api module', () => {
+    const tail = nodeAdapter().wrapEntry(ctx);
+    expect(tail).not.toContain('injectWebSocket');
+  });
+
+  it('guards serve() so dev module-runner loads do not start a server', () => {
+    const tail = nodeAdapter().wrapEntry(ctx);
+    expect(tail).toContain('import.meta.env.PROD');
+  });
+});

--- a/packages/vite/src/__tests__/adapter-node.test.ts
+++ b/packages/vite/src/__tests__/adapter-node.test.ts
@@ -25,7 +25,10 @@ describe('nodeAdapter', () => {
   });
 
   it('wrapEntry re-exports injectWebSocket when an api module is present', () => {
-    const tail = nodeAdapter().wrapEntry({ ...ctx, apiModuleId: '/p/src/api.ts' });
+    const tail = nodeAdapter().wrapEntry({
+      ...ctx,
+      apiModuleId: '/p/src/api.ts',
+    });
     expect(tail).toContain('/p/src/api.ts');
     expect(tail).toContain('injectWebSocket');
   });

--- a/packages/vite/src/__tests__/fixtures/cf-ws/src/worker.ts
+++ b/packages/vite/src/__tests__/fixtures/cf-ws/src/worker.ts
@@ -1,0 +1,15 @@
+import { Hono } from 'hono';
+import { upgradeWebSocket } from 'hono/cloudflare-workers';
+
+const app = new Hono();
+
+app.get(
+  '/ws',
+  upgradeWebSocket(() => ({
+    onMessage(event, ws) {
+      ws.send(`echo: ${event.data}`);
+    },
+  }))
+);
+
+export default app;

--- a/packages/vite/src/__tests__/fixtures/cf-ws/vite.config.ts
+++ b/packages/vite/src/__tests__/fixtures/cf-ws/vite.config.ts
@@ -1,0 +1,4 @@
+import { cloudflare } from '@cloudflare/vite-plugin';
+import { defineConfig } from 'vite';
+
+export default defineConfig({ plugins: [cloudflare()] });

--- a/packages/vite/src/__tests__/fixtures/cf-ws/wrangler.jsonc
+++ b/packages/vite/src/__tests__/fixtures/cf-ws/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+  "name": "cf-ws",
+  "main": "src/worker.ts",
+  "compatibility_date": "2024-12-01"
+}

--- a/packages/vite/src/__tests__/node-dev-server.test.ts
+++ b/packages/vite/src/__tests__/node-dev-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { nodeBuildPlugin } from '../node-dev-server.js';
+import { nodeBuildPlugin, nodeDevServerPlugin } from '../node-dev-server.js';
 
 const ctx = {
   root: '/p',
@@ -32,5 +32,18 @@ describe('nodeBuildPlugin', () => {
       { command: 'build', mode: 'production' }
     ) as { builder: { buildApp: unknown } };
     expect(typeof cfg.builder.buildApp).toBe('function');
+  });
+});
+
+describe('nodeDevServerPlugin', () => {
+  it('is a serve-only plugin with a configureServer hook', () => {
+    const plugin = nodeDevServerPlugin({
+      root: '/p',
+      coreAppModuleId: '/p/a.tsx',
+      entryWrapperId: '/p/b.tsx',
+    });
+    expect(plugin.name).toBe('hono-preact:node-dev-server');
+    expect(plugin.apply).toBe('serve');
+    expect(typeof plugin.configureServer).toBe('function');
   });
 });

--- a/packages/vite/src/__tests__/node-dev-server.test.ts
+++ b/packages/vite/src/__tests__/node-dev-server.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { nodeBuildPlugin } from '../node-dev-server.js';
+
+const ctx = {
+  root: '/p',
+  coreAppModuleId: '/p/node_modules/.vite/hono-preact/core-app.tsx',
+  entryWrapperId: '/p/node_modules/.vite/hono-preact/server-entry.tsx',
+};
+
+describe('nodeBuildPlugin', () => {
+  it('configures client and ssr build environments', () => {
+    const plugin = nodeBuildPlugin(ctx);
+    const cfg = (plugin.config as Function)(
+      {},
+      { command: 'build', mode: 'production' }
+    ) as {
+      environments: {
+        client: { build: { outDir: string } };
+        ssr: { build: { outDir: string; ssr: boolean; rollupOptions: { input: string[] } } };
+      };
+    };
+    expect(cfg.environments.client.build.outDir).toBe('dist/client');
+    expect(cfg.environments.ssr.build.outDir).toBe('dist/server');
+    expect(cfg.environments.ssr.build.ssr).toBe(true);
+    expect(cfg.environments.ssr.build.rollupOptions.input).toEqual([ctx.entryWrapperId]);
+  });
+
+  it('builds the app via a builder.buildApp orchestrator', () => {
+    const plugin = nodeBuildPlugin(ctx);
+    const cfg = (plugin.config as Function)(
+      {},
+      { command: 'build', mode: 'production' }
+    ) as { builder: { buildApp: unknown } };
+    expect(typeof cfg.builder.buildApp).toBe('function');
+  });
+});

--- a/packages/vite/src/__tests__/node-dev-server.test.ts
+++ b/packages/vite/src/__tests__/node-dev-server.test.ts
@@ -16,13 +16,21 @@ describe('nodeBuildPlugin', () => {
     ) as {
       environments: {
         client: { build: { outDir: string } };
-        ssr: { build: { outDir: string; ssr: boolean; rollupOptions: { input: string[] } } };
+        ssr: {
+          build: {
+            outDir: string;
+            ssr: boolean;
+            rollupOptions: { input: string[] };
+          };
+        };
       };
     };
     expect(cfg.environments.client.build.outDir).toBe('dist/client');
     expect(cfg.environments.ssr.build.outDir).toBe('dist/server');
     expect(cfg.environments.ssr.build.ssr).toBe(true);
-    expect(cfg.environments.ssr.build.rollupOptions.input).toEqual([ctx.entryWrapperId]);
+    expect(cfg.environments.ssr.build.rollupOptions.input).toEqual([
+      ctx.entryWrapperId,
+    ]);
   });
 
   it('builds the app via a builder.buildApp orchestrator', () => {

--- a/packages/vite/src/__tests__/websocket-dev.test.ts
+++ b/packages/vite/src/__tests__/websocket-dev.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type ViteDevServer } from 'vite';
+import { WebSocket } from 'ws';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const exampleNodeRoot = resolve(here, '../../../../apps/example-node');
+const cfWsRoot = resolve(here, 'fixtures/cf-ws');
+
+// Generous timeouts: starting a real Vite dev server (and, for the Cloudflare
+// case, workerd) takes noticeably longer than an in-memory unit test.
+
+function serverPort(server: ViteDevServer): number {
+  const addr = server.httpServer!.address();
+  return typeof addr === 'object' && addr ? addr.port : 0;
+}
+
+function echoOverWs(port: number, message: string): Promise<string> {
+  return new Promise<string>((res, rej) => {
+    const ws = new WebSocket(`ws://localhost:${port}/ws`);
+    const timer = setTimeout(() => {
+      ws.close();
+      rej(new Error('ws timeout'));
+    }, 15_000);
+    ws.on('open', () => ws.send(message));
+    ws.on('message', (data) => {
+      clearTimeout(timer);
+      ws.close();
+      res(data.toString());
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      rej(err);
+    });
+  });
+}
+
+describe('Node adapter: WebSocket in dev', () => {
+  let server: ViteDevServer;
+
+  beforeAll(async () => {
+    server = await createServer({ root: exampleNodeRoot, server: { port: 0 } });
+    await server.listen();
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it('echoes a message over /ws', async () => {
+    const reply = await echoOverWs(serverPort(server), 'hello');
+    expect(reply).toBe('echo: hello');
+  }, 20_000);
+});
+
+describe('Cloudflare adapter: WebSocket in dev', () => {
+  let server: ViteDevServer;
+
+  beforeAll(async () => {
+    server = await createServer({ root: cfWsRoot, server: { port: 0 } });
+    await server.listen();
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it('echoes a message over /ws', async () => {
+    const reply = await echoOverWs(serverPort(server), 'hello');
+    expect(reply).toBe('echo: hello');
+  }, 20_000);
+});

--- a/packages/vite/src/adapter-node.ts
+++ b/packages/vite/src/adapter-node.ts
@@ -1,0 +1,60 @@
+// packages/vite/src/adapter-node.ts
+//
+// Standalone module. NOT re-exported by index.ts: importing `hono-preact/vite`
+// must never pull in `@hono/node-server`. Only importing
+// `hono-preact/adapter-node` loads this file.
+import type { HonoPreactAdapter, HonoPreactAdapterContext } from './adapter.js';
+import { nodeBuildPlugin, nodeDevServerPlugin } from './node-dev-server.js';
+
+export function nodeAdapter(): HonoPreactAdapter {
+  return {
+    name: 'node',
+    vitePlugins(ctx: HonoPreactAdapterContext) {
+      return [nodeBuildPlugin(ctx), nodeDevServerPlugin(ctx)];
+    },
+    wrapEntry(ctx) {
+      const hasApi = ctx.apiModuleId != null;
+
+      const apiImport = hasApi
+        ? `import * as __api from ${JSON.stringify(ctx.apiModuleId)};\n`
+        : '';
+      const injectExport = hasApi
+        ? `export const injectWebSocket = __api.injectWebSocket;\n`
+        : '';
+      const injectBoot = hasApi
+        ? `  if (__api.injectWebSocket) __api.injectWebSocket(server);\n`
+        : '';
+
+      // The outer app serves built client assets under /static/* and mounts
+      // the framework's core Hono app at the root.
+      //
+      // The serve() boot is guarded by `import.meta.env.PROD`. In `vite dev`
+      // the Node dev plugin loads this wrapper through the SSR module runner
+      // purely to obtain `app` (and `injectWebSocket`); PROD is false there so
+      // no rogue HTTP server starts. In the production build it constant-folds
+      // to true and the bundle boots a real server.
+      return (
+        `import { serve } from '@hono/node-server';\n` +
+        `import { serveStatic } from '@hono/node-server/serve-static';\n` +
+        `import { Hono } from 'hono';\n` +
+        `import coreApp from ${JSON.stringify(ctx.coreAppModuleId)};\n` +
+        apiImport +
+        `\n` +
+        `const app = new Hono()\n` +
+        `  .use('/static/*', serveStatic({ root: './dist/client' }))\n` +
+        `  .route('/', coreApp);\n` +
+        `\n` +
+        `export { app };\n` +
+        `export default app;\n` +
+        injectExport +
+        `\n` +
+        `if (import.meta.env.PROD) {\n` +
+        `  const port = Number(process.env.PORT) || 3000;\n` +
+        `  const server = serve({ fetch: app.fetch, port });\n` +
+        `  console.log(\`hono-preact: listening on http://localhost:\${port}\`);\n` +
+        injectBoot +
+        `}\n`
+      );
+    },
+  };
+}

--- a/packages/vite/src/adapter.ts
+++ b/packages/vite/src/adapter.ts
@@ -14,6 +14,10 @@ export interface HonoPreactAdapterContext {
   coreAppModuleId: string;
   /** Absolute path where the adapter's wrapEntry() output is written. */
   entryWrapperId: string;
+  /** Absolute path of the user's api module, if it exists. Used by adapters
+   *  that need to reach api-module exports (e.g. the Node adapter's
+   *  WebSocket `injectWebSocket`). Undefined when the project has no api.ts. */
+  apiModuleId?: string;
 }
 
 /**

--- a/packages/vite/src/node-dev-server.ts
+++ b/packages/vite/src/node-dev-server.ts
@@ -1,4 +1,5 @@
-import type { Plugin, ViteBuilder } from 'vite';
+import type { Plugin, ViteBuilder, ViteDevServer } from 'vite';
+import { createServerModuleRunner } from 'vite';
 import type { HonoPreactAdapterContext } from './adapter.js';
 
 export function nodeBuildPlugin(ctx: HonoPreactAdapterContext): Plugin {
@@ -34,6 +35,94 @@ export function nodeBuildPlugin(ctx: HonoPreactAdapterContext): Plugin {
   };
 }
 
-export function nodeDevServerPlugin(_ctx: HonoPreactAdapterContext): Plugin {
-  return { name: 'hono-preact:node-dev-server' };
+export function nodeDevServerPlugin(ctx: HonoPreactAdapterContext): Plugin {
+  return {
+    name: 'hono-preact:node-dev-server',
+    apply: 'serve',
+    configureServer(server: ViteDevServer) {
+      const runner = createServerModuleRunner(server.environments.ssr);
+
+      // Wire the WebSocket upgrade. @hono/node-ws's injectWebSocket(target)
+      // just calls target.on('upgrade', fn); we pass a shim that captures
+      // that handler so we can invoke it with Node's real upgrade args.
+      // Multiple 'upgrade' listeners coexist fine with Vite's own HMR one.
+      server.httpServer?.on('upgrade', async (req, socket, head) => {
+        try {
+          const { injectWebSocket } = await runner.import(ctx.entryWrapperId);
+          if (!injectWebSocket) return;
+          let handler:
+            | ((req: unknown, socket: unknown, head: unknown) => void)
+            | undefined;
+          (injectWebSocket as (target: unknown) => void)({
+            on(event: string, fn: (req: unknown, socket: unknown, head: unknown) => void) {
+              if (event === 'upgrade') handler = fn;
+            },
+          });
+          handler?.(req, socket, head);
+        } catch (err) {
+          console.error('[hono-preact] dev ws upgrade error', err);
+          socket.destroy();
+        }
+      });
+
+      // Register the SSR middleware synchronously (not via the returned post
+      // hook). The post hook runs after Vite's spaFallbackMiddleware, which
+      // rewrites req.url to /index.html and makes the SSR app 404. Synchronous
+      // registration puts this ahead of Vite's HTML/SPA middlewares.
+      server.middlewares.use(async (req, res, next) => {
+        try {
+          // Vite-internal requests (its HMR client, source modules under
+          // /@fs and /@id, optimized deps) must reach Vite's later
+          // middlewares, or client hydration and HMR break. The SSR app only
+          // owns application routes, so pass these through. Same model as
+          // @hono/vite-dev-server's `exclude` option.
+          const path = (req.url ?? '').split('?')[0];
+          if (path.startsWith('/@') || path.startsWith('/node_modules/')) {
+            return next();
+          }
+
+          const { default: app } = (await runner.import(
+            ctx.entryWrapperId
+          )) as { default: { fetch: (request: Request) => Promise<Response> } };
+
+          const url = `http://${req.headers.host}${req.url}`;
+          const method = req.method ?? 'GET';
+          const headers = new Headers();
+          for (const [k, v] of Object.entries(req.headers)) {
+            if (typeof v === 'string') headers.set(k, v);
+            else if (Array.isArray(v)) v.forEach((vv) => headers.append(k, vv));
+          }
+          let body: ArrayBuffer | undefined;
+          if (method !== 'GET' && method !== 'HEAD') {
+            const chunks: Buffer[] = [];
+            for await (const c of req) chunks.push(c as Buffer);
+            if (chunks.length) {
+              const buf = Buffer.concat(chunks);
+              // Copy into a fresh ArrayBuffer: BodyInit accepts ArrayBuffer,
+              // and this sidesteps Buffer<ArrayBufferLike> typing friction.
+              body = buf.buffer.slice(
+                buf.byteOffset,
+                buf.byteOffset + buf.byteLength
+              ) as ArrayBuffer;
+            }
+          }
+          const request = new Request(url, { method, headers, body });
+          const response = await app.fetch(request);
+          res.statusCode = response.status;
+          response.headers.forEach((value, key) => res.setHeader(key, value));
+          if (response.body) {
+            const reader = response.body.getReader();
+            for (;;) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              res.write(value);
+            }
+          }
+          res.end();
+        } catch (err) {
+          next(err);
+        }
+      });
+    },
+  };
 }

--- a/packages/vite/src/node-dev-server.ts
+++ b/packages/vite/src/node-dev-server.ts
@@ -54,7 +54,10 @@ export function nodeDevServerPlugin(ctx: HonoPreactAdapterContext): Plugin {
             | ((req: unknown, socket: unknown, head: unknown) => void)
             | undefined;
           (injectWebSocket as (target: unknown) => void)({
-            on(event: string, fn: (req: unknown, socket: unknown, head: unknown) => void) {
+            on(
+              event: string,
+              fn: (req: unknown, socket: unknown, head: unknown) => void
+            ) {
               if (event === 'upgrade') handler = fn;
             },
           });

--- a/packages/vite/src/node-dev-server.ts
+++ b/packages/vite/src/node-dev-server.ts
@@ -1,0 +1,10 @@
+import type { Plugin } from 'vite';
+import type { HonoPreactAdapterContext } from './adapter.js';
+
+export function nodeBuildPlugin(_ctx: HonoPreactAdapterContext): Plugin {
+  return { name: 'hono-preact:node-build' };
+}
+
+export function nodeDevServerPlugin(_ctx: HonoPreactAdapterContext): Plugin {
+  return { name: 'hono-preact:node-dev-server' };
+}

--- a/packages/vite/src/node-dev-server.ts
+++ b/packages/vite/src/node-dev-server.ts
@@ -1,8 +1,37 @@
-import type { Plugin } from 'vite';
+import type { Plugin, ViteBuilder } from 'vite';
 import type { HonoPreactAdapterContext } from './adapter.js';
 
-export function nodeBuildPlugin(_ctx: HonoPreactAdapterContext): Plugin {
-  return { name: 'hono-preact:node-build' };
+export function nodeBuildPlugin(ctx: HonoPreactAdapterContext): Plugin {
+  return {
+    name: 'hono-preact:node-build',
+    config() {
+      return {
+        environments: {
+          // The Node target has no Cloudflare-style plugin to set the client
+          // outDir, so set it here. wrapEntry()'s serveStatic expects the
+          // client bundle at dist/client.
+          client: {
+            build: { outDir: 'dist/client' },
+          },
+          ssr: {
+            build: {
+              outDir: 'dist/server',
+              ssr: true,
+              rollupOptions: {
+                input: [ctx.entryWrapperId],
+              },
+            },
+          },
+        },
+        builder: {
+          async buildApp(builder: ViteBuilder) {
+            await builder.build(builder.environments.client);
+            await builder.build(builder.environments.ssr);
+          },
+        },
+      };
+    },
+  };
 }
 
 export function nodeDevServerPlugin(_ctx: HonoPreactAdapterContext): Plugin {

--- a/packages/vite/src/server-entry.ts
+++ b/packages/vite/src/server-entry.ts
@@ -262,6 +262,7 @@ export function serverEntryPlugin(opts: ServerEntryPluginOptions): Plugin {
         root,
         coreAppModuleId: opts.coreAppPath,
         entryWrapperId: opts.entryWrapperPath,
+        apiModuleId: apiAbsPath,
       });
       fs.writeFileSync(opts.entryWrapperPath, wrapper, 'utf8');
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,12 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.37.1
         version: 1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.14)
+      '@hono/node-ws':
+        specifier: ^1.3.1
+        version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)
       '@preact/preset-vite':
         specifier: ^2.10.5
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,12 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.37.1
         version: 1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.14)
+      '@hono/node-ws':
+        specifier: ^1.3.1
+        version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -760,6 +766,13 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hono/node-ws@1.3.1':
+    resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      '@hono/node-server': ^1.19.11
+      hono: ^4.6.0
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3454,6 +3467,15 @@ snapshots:
   '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
+
+  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      hono: 4.12.14
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@img/colour@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,40 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))
 
+  apps/example-node:
+    dependencies:
+      hono:
+        specifier: ^4.12.14
+        version: 4.12.14
+      hono-preact:
+        specifier: workspace:*
+        version: link:../../packages/hono-preact
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+      preact-iso:
+        specifier: github:preactjs/preact-iso#v3
+        version: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+    devDependencies:
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.14)
+      '@hono/node-ws':
+        specifier: ^1.3.1
+        version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)
+      '@preact/preset-vite':
+        specifier: ^2.10.5
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))
+      preact-render-to-string:
+        specifier: ^6.6.7
+        version: 6.6.7(preact@10.29.1)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0)
+
   apps/site:
     dependencies:
       '@shikijs/rehype':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       '@hono/node-ws':
         specifier: ^1.3.1
         version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)
+      '@types/ws':
+        specifier: ^8.5.0
+        version: 8.18.1
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -307,6 +310,9 @@ importers:
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0)
+      ws:
+        specifier: ^8.18.0
+        version: 8.20.0
 
 packages:
 


### PR DESCRIPTION
## Summary

Ships a Node deployment adapter for `hono-preact`, built on Vite 8's native Environment API (no `@hono/vite-*` tooling), plus a reference example app and WebSocket-in-dev verification for both adapters.

- **`nodeAdapter()`** (`hono-preact/adapter-node`): a `config`-hook plugin defining the `client` + `ssr` build environments and a `builder` so one `vite build` emits both bundles; a dev plugin whose `configureServer` hook serves the SSR app through Vite's SSR module runner (with HMR) and wires the HTTP `upgrade` event for WebSockets; `wrapEntry()` composes an outer Hono app (`serveStatic` for `dist/client`, then the core app) booted with `@hono/node-server`'s `serve()`.
- **Umbrella subpath** `hono-preact/adapter-node` with `@hono/node-server` and `@hono/node-ws` as optional peer dependencies.
- **`apps/example-node`**: a minimal Node-target app (SSR pages, a loader, an action, a `/ws` WebSocket route) that exercises the adapter end to end.
- **WebSocket-in-dev tests** for both the Node and Cloudflare adapters.

Plan B is purely additive: the Cloudflare adapter and Plan A code are unchanged. One spike-driven deviation from the plan: `HonoPreactAdapterContext` gained an additive, type-only optional `apiModuleId` field so the generated entry wrapper can re-export `injectWebSocket` for WebSocket-in-dev.

Implemented task-by-task per `docs/superpowers/plans/2026-05-18-multi-cloud-adapters-plan-b.md`, with the Task 0 spike findings in `docs/superpowers/research/2026-05-18-node-environment-api-spike.md`.

## Test plan

- [x] `pnpm test` (554 tests pass, including new adapter + WebSocket-dev tests)
- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `pnpm --filter site build` and `pnpm --filter example-node build`
- [x] `apps/example-node` boots under `node dist/server/server-entry.js`; `/` and `/about` return SSR HTML
- [x] WebSocket echo round-trips over `/ws` in `vite dev` for both adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)