### PR TITLE
docs(site): document adapter option and Node target

### DIFF
--- a/apps/site/src/pages/docs/deployment.mdx
+++ b/apps/site/src/pages/docs/deployment.mdx
@@ -1,6 +1,27 @@
 # Build & Deploy
 
-## Development
+## Adapters
+
+The framework targets whichever adapter you choose. Two adapters ship today:
+`cloudflareAdapter()` from `hono-preact/adapter-cloudflare` and `nodeAdapter()`
+from `hono-preact/adapter-node`. You select one in `vite.config.ts` by passing
+it to the framework plugin: `honoPreact({ adapter: ... })`. An adapter is
+required.
+
+Dev, build, and deploy all behave per-adapter. The rest of this page covers
+both flows.
+
+## Cloudflare Workers
+
+This section assumes a `cloudflareAdapter()` in `vite.config.ts`:
+
+```ts
+import { cloudflareAdapter } from 'hono-preact/adapter-cloudflare';
+// ...
+plugins: [honoPreact({ adapter: cloudflareAdapter() })],
+```
+
+### Development
 
 ```bash
 npm run dev
@@ -12,7 +33,7 @@ so development mirrors production: Cloudflare bindings, the SSR runtime, and
 WebSocket upgrades all behave the same as a deployed Worker. Hot module
 replacement works for both client components and server code.
 
-## Production build
+### Production build
 
 ```bash
 npm run build
@@ -40,7 +61,7 @@ dist/
 The Worker directory name is derived from the `name` field in `wrangler.jsonc`
 (hyphens become underscores), so `hono-preact` produces `dist/hono_preact/`.
 
-## Local preview
+### Local preview
 
 ```bash
 npm run preview
@@ -48,7 +69,7 @@ npm run preview
 
 Runs `vite preview`, which serves the production build through `workerd` again.
 
-## Configuring `wrangler.jsonc`
+### Configuring `wrangler.jsonc`
 
 `wrangler.jsonc` is the source of truth `@cloudflare/vite-plugin` reads:
 
@@ -72,7 +93,7 @@ source is never exposed through the asset store. The build also writes a
 `.assetsignore` into `dist/client/` that excludes the generated config from the
 asset upload.
 
-## Deploy
+### Deploy
 
 ```bash
 npm run deploy
@@ -81,3 +102,51 @@ npm run deploy
 This runs `wrangler deploy` against the generated config in the Worker output
 directory (`dist/hono_preact/wrangler.json`), which references the built Worker
 and the `dist/client/` assets. Run `npm run build` first so the output exists.
+
+## Node.js
+
+### Setup
+
+Register the Node adapter in `vite.config.ts`:
+
+```ts
+import { honoPreact } from 'hono-preact/vite';
+import { nodeAdapter } from 'hono-preact/adapter-node';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [honoPreact({ adapter: nodeAdapter() })],
+});
+```
+
+`@hono/node-server` is a peer dependency, so install it alongside the
+framework: `npm install @hono/node-server`. `@hono/node-ws` is an optional peer
+if you need WebSocket upgrades.
+
+### Development
+
+```bash
+npm run dev
+```
+
+Starts the Vite dev server. The Node adapter handles SSR through Vite's SSR
+module runner, so HMR works for both client and server code.
+
+### Production build and start
+
+`vite build` emits a server entry at `dist/server/server-entry.js` and the
+client bundle under `dist/client/`. Start production with:
+
+```bash
+node dist/server/server-entry.js
+```
+
+The server listens on `PORT` (default 3000).
+
+### Deploying
+
+Deploy the same way you would any Node server: a container image (Docker),
+a system service (systemd), or a PaaS that runs Node processes. Static assets
+must be served from `dist/client/`; the Node adapter serves them in-process
+when you run the bundled server, so a single `node` process handles both
+assets and SSR.

--- a/apps/site/src/pages/docs/guards.mdx
+++ b/apps/site/src/pages/docs/guards.mdx
@@ -88,7 +88,32 @@ Both factories take a function that receives:
 - `location`: the current `RouteHook` (`path`, `pathParams`, `searchParams`).
 - `next()`: call and **return** this to pass control downstream (`return next()`, not `await next()`).
 
-`defineServerGuard` additionally receives `ctx.c`, the request's Hono `Context`. That gives a guard everything it needs to enforce auth using Hono's helpers directly. Below is a guard that reads a signed cookie and redirects on failure:
+### Context shapes
+
+The two factories accept different context shapes. Server guards receive both the Hono `Context` and the current location:
+
+```ts
+defineServerGuard(({ c, location }, next) => {
+  // c: typed Hono Context (cookies, headers, KV/D1/env bindings, request)
+  // location: current RouteHook
+  return next();
+});
+```
+
+Client guards receive only the location:
+
+```ts
+defineClientGuard(({ location }, next) => {
+  // no `c` here. Hono Context is request-bound and only exists server-side.
+  return next();
+});
+```
+
+If you need request data (cookies, headers, `Bindings`), the guard must be a server guard. A guard that needs both server- and client-side logic is two declarations: `defineServerGuard(...)` plus `defineClientGuard(...)` in the same `guards` list.
+
+### Reading the Hono `Context` in a server guard
+
+`ctx.c` gives a server guard everything it needs to enforce auth using Hono's helpers directly. Below is a guard that reads a signed cookie and redirects on failure:
 
 ```ts
 import { defineServerGuard } from 'hono-preact';
@@ -104,8 +129,6 @@ export const requireSession = defineServerGuard(async (ctx, next) => {
   return next();
 });
 ```
-
-Client guards receive only `{ location }`; cookies, headers, and `Bindings` are server-only. A guard that needs both server- and client-side logic is two declarations: `defineServerGuard(...)` plus `defineClientGuard(...)` in the same `guards` list.
 
 ## Same logic in both environments
 

--- a/apps/site/src/pages/docs/loaders.mdx
+++ b/apps/site/src/pages/docs/loaders.mdx
@@ -113,6 +113,34 @@ export const serverLoaders = {
 };
 ```
 
+### The loader context
+
+Every loader is called with a single context argument with the same three fields, regardless of whether it returns a value or streams:
+
+```ts
+type LoaderCtx = {
+  c: Context; // typed Hono Context, always available
+  location: RouteHook; // route-change location info
+  signal: AbortSignal; // aborts when the user navigates away
+};
+```
+
+| Field      | Description                                                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `c`        | The request's Hono `Context`. Use it for headers, cookies, KV/D1/env `Bindings`, the request URL, etc. With typed `Bindings`, narrow inside the function body. |
+| `location` | Current route navigation info (the same shape as `useLocation()`). Carries `pathParams`, `searchParams`, the resolved path, and the route's metadata. |
+| `signal`   | An `AbortSignal` that aborts when the user navigates away mid-load. Forward it to `fetch` and any cancellable server work to short-circuit on navigation. |
+
+Destructure whichever fields a loader needs:
+
+```ts
+defineLoader(async ({ c, location, signal }) => {
+  const token = getCookie(c, 'session');
+  const res = await fetch(`/api/movies/${location.pathParams.id}`, { signal });
+  return res.json();
+});
+```
+
 `ctx.c` is the request's Hono `Context`. A server loader can read cookies (`getCookie(ctx.c, …)`), reach app `Bindings` (`ctx.c.env.MY_KV`), or set a response header before yielding. The shape is `Context`; users with typed `Bindings` can narrow inside the function body.
 
 By convention, loaders read; actions write. Setting cookies/headers from a loader is allowed but discouraged.
@@ -186,9 +214,11 @@ const StatsView = statsLoader.View(
 );
 ```
 
-## Multi-loader pages
+## Composing multiple loaders per route
 
-A page can declare any number of loaders in one `serverLoaders` container. Each loader gets its own independent Suspense boundary, error boundary, and streaming section:
+This is the supported pattern when a route needs more than one data source. Declare each source as its own loader in the same `serverLoaders` container; the framework wires each one independently. There is no separate "parallel fetch" or "loader group" API; composition is just adding another key.
+
+Each loader gets its own independent Suspense boundary, error boundary, cache key, and streaming section, so a slow or failing source never blocks the rest of the page:
 
 ```ts
 // src/pages/movie.server.ts

--- a/apps/site/src/pages/docs/loaders.mdx
+++ b/apps/site/src/pages/docs/loaders.mdx
@@ -125,11 +125,11 @@ type LoaderCtx = {
 };
 ```
 
-| Field      | Description                                                                                                                                |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Field      | Description                                                                                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `c`        | The request's Hono `Context`. Use it for headers, cookies, KV/D1/env `Bindings`, the request URL, etc. With typed `Bindings`, narrow inside the function body. |
-| `location` | Current route navigation info (the same shape as `useLocation()`). Carries `pathParams`, `searchParams`, the resolved path, and the route's metadata. |
-| `signal`   | An `AbortSignal` that aborts when the user navigates away mid-load. Forward it to `fetch` and any cancellable server work to short-circuit on navigation. |
+| `location` | Current route navigation info (the same shape as `useLocation()`). Carries `pathParams`, `searchParams`, the resolved path, and the route's metadata.          |
+| `signal`   | An `AbortSignal` that aborts when the user navigates away mid-load. Forward it to `fetch` and any cancellable server work to short-circuit on navigation.      |
 
 Destructure whichever fields a loader needs:
 

--- a/apps/site/src/pages/docs/quick-start.mdx
+++ b/apps/site/src/pages/docs/quick-start.mdx
@@ -10,6 +10,27 @@ Clone the starter and install dependencies:
 git clone <repo-url> my-app
 cd my-app
 pnpm install
+```
+
+## Configure Vite
+
+`honoPreact()` requires an `adapter` option; without one it throws a clear "adapter required" error at startup. A minimal `vite.config.ts` looks like:
+
+```ts
+import { honoPreact } from 'hono-preact/vite';
+import { cloudflareAdapter } from 'hono-preact/adapter-cloudflare';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [honoPreact({ adapter: cloudflareAdapter() })],
+});
+```
+
+The framework also ships a `nodeAdapter()` from `hono-preact/adapter-node` for non-Cloudflare deployments; see [Build & Deploy](./deployment) for the full picture.
+
+Now start the dev server:
+
+```bash
 pnpm dev
 ```
 

--- a/apps/site/src/pages/docs/structure.mdx
+++ b/apps/site/src/pages/docs/structure.mdx
@@ -78,7 +78,7 @@ Server-only utilities (`packages/server/`):
 
 Vite plugins for the framework (`packages/vite/`). The primary export is `honoPreact()`, which bundles all framework Vite configuration into a single plugin. See [Vite Configuration](/docs/vite-config) for usage.
 
-- **`honoPreact()`** configures resolve deduplication, SSR bundling, client/server build outputs, `@hono/vite-build`, `@hono/vite-dev-server`, and the client-shim auto-injection.
+- **`honoPreact()`** configures resolve deduplication, SSR bundling, client/server build outputs, and the client-shim auto-injection. Deployment target plugins (the worker or dev-server toolchain) come from the required `adapter` option, currently `cloudflareAdapter()` from `hono-preact/adapter-cloudflare` or `nodeAdapter()` from `hono-preact/adapter-node`.
 - **`serverOnlyPlugin`** rewrites `*.server.*` imports during the client bundle build, replacing static imports with no-op stubs and dynamic `import('./*.server.*')` calls with `Promise.resolve({})` so server code never reaches the browser.
 - **`serverLoaderValidationPlugin`** fails the build if a `.server.*` file has named exports other than `serverLoaders`, `serverActions`, or `actionGuards`.
 - **`moduleKeyPlugin`** rewrites each `.server.*` file at build time with a `__moduleKey` derived from the file path, which the loader/action handlers use to dispatch RPC requests.

--- a/apps/site/src/pages/docs/vite-config.mdx
+++ b/apps/site/src/pages/docs/vite-config.mdx
@@ -6,15 +6,16 @@ The `hono-preact/vite` subpath exports a `honoPreact()` plugin that configures V
 
 ```ts
 import { honoPreact } from 'hono-preact/vite';
+import { cloudflareAdapter } from 'hono-preact/adapter-cloudflare';
 import preact from '@preact/preset-vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [honoPreact()],
+  plugins: [honoPreact({ adapter: cloudflareAdapter() })],
 });
 ```
 
-`honoPreact()` takes no arguments in the common case; it generates the server entry as a virtual module and auto-includes `@preact/preset-vite`. `entry` is an advanced override for projects that need to author their own Hono server entry; it is optional.
+`adapter` is required; `honoPreact()` throws a clear error if it is omitted. The framework ships two adapters today: `cloudflareAdapter()` for Cloudflare Workers, imported from `hono-preact/adapter-cloudflare`, and `nodeAdapter()` for Node.js (via `@hono/node-server`), imported from `hono-preact/adapter-node`. Each adapter supplies its own Vite plugins and entry wrapper, so the framework core stays target-agnostic.
 
 ## What the plugin handles
 
@@ -26,8 +27,7 @@ export default defineConfig({
 | SSR bundling         | `ssr.noExternal` for `preact-render-to-string`, `preact-iso`, and `hono-preact`                                                                                  |
 | Client build output  | `dist/static/client.js` entry, hashed chunk and asset filenames                                                                                                  |
 | Server build output  | `esnext` target, `dist/static/` asset dir, minification                                                                                                          |
-| Worker bundling      | `@hono/vite-build` (Cloudflare Workers preset), build-only                                                                                                       |
-| Dev server           | `@hono/vite-dev-server` with Cloudflare adapter, serve-only                                                                                                      |
+| Deployment target    | Delegated to the configured adapter (Cloudflare Workers, Node.js, etc.), which supplies its own Vite plugins and entry wrapper                                   |
 | Server-only imports  | `serverOnlyPlugin` stubs static `*.server.*` imports and dynamic `() => import('./*.server.*')` calls in the client bundle                                       |
 | Loader validation    | `serverLoaderValidationPlugin` enforces `.server.*` export conventions                                                                                           |
 | Module identity      | `moduleKeyPlugin` injects a path-derived `__moduleKey` into each `.server.*` file for RPC routing                                                                |
@@ -35,10 +35,18 @@ export default defineConfig({
 
 ## Peer dependencies
 
-`@hono/vite-build` and `@hono/vite-dev-server` are peer dependencies of `hono-preact`. Install them alongside it:
+Peer deps depend on the adapter you pick. Install the ones that match your deployment target.
+
+For Cloudflare Workers:
 
 ```bash
-npm install -D @hono/vite-build @hono/vite-dev-server
+npm install -D @cloudflare/vite-plugin wrangler
+```
+
+For Node.js (add `@hono/node-ws` if you want WebSocket support):
+
+```bash
+npm install @hono/node-server
 ```
 
 ## Adding MDX
@@ -47,12 +55,13 @@ MDX is a user-space choice and not included in the plugin. Add it alongside `hon
 
 ```ts
 import { honoPreact } from 'hono-preact/vite';
+import { cloudflareAdapter } from 'hono-preact/adapter-cloudflare';
 import mdx from '@mdx-js/rollup';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [
-    honoPreact(),
+    honoPreact({ adapter: cloudflareAdapter() }),
     Object.assign(mdx({ jsxImportSource: 'preact' }), { enforce: 'pre' }),
   ],
 });
@@ -71,7 +80,7 @@ export default defineConfig({
   resolve: {
     alias: [{ find: '@', replacement: resolve(__dirname, './src') }],
   },
-  plugins: [honoPreact()],
+  plugins: [honoPreact({ adapter: cloudflareAdapter() })],
 });
 ```
 
@@ -81,6 +90,7 @@ Pass `clientBuild`, `serverBuild`, or `sharedBuild` to extend the plugin's defau
 
 ```ts
 honoPreact({
+  adapter: cloudflareAdapter(),
   clientBuild: { sourcemap: false },
 });
 ```
@@ -93,6 +103,7 @@ The plugin defaults to the framework-generated virtual module `virtual:hono-prea
 
 ```ts
 honoPreact({
+  adapter: cloudflareAdapter(),
   clientEntry: 'src/main.tsx',
 });
 ```


### PR DESCRIPTION
## Summary

- Update docs to reflect the May 2026 adapter refactor: `honoPreact()` now requires an `adapter` option and ships `cloudflareAdapter()` (`hono-preact/adapter-cloudflare`) and `nodeAdapter()` (`hono-preact/adapter-node`).
- Add Node.js to `deployment.mdx` as a sibling section to Cloudflare Workers, covering setup, dev, prod build/start, and deploy guidance.
- Tighten ambiguous context shapes: explicit `LoaderCtx = { c, location, signal }` in `loaders.mdx`, explicit `ServerGuardContext` vs `ClientGuardContext` in `guards.mdx`.

### Files touched

- `vite-config.mdx` — minimal setup snippet uses `cloudflareAdapter()`; table drops the stale `@hono/vite-build` / `@hono/vite-dev-server` rows in favor of "Deployment target delegated to adapter"; peer deps split per adapter; the dead `entry` option reference removed.
- `quick-start.mdx` — new "Configure Vite" subsection with a working snippet and a one-line pointer to Node.
- `deployment.mdx` — restructured: `## Adapters` intro, `## Cloudflare Workers` (existing content demoted to `###`), new `## Node.js`.
- `loaders.mdx` — new `### The loader context` subsection; multi-loader section renamed and framed as the canonical composition pattern.
- `guards.mdx` — new `### Context shapes` subsection contrasting server and client guard context.
- `structure.mdx` — bullet fix removing the stale `@hono/vite-build` / `@hono/vite-dev-server` mention.

## Test plan

- [x] Docs contract tests pass (`apps/site/src/pages/docs/__tests__`, 5 tests).
- [x] `apps/site` build succeeds (all 18 MDX files bundle cleanly).
- [ ] Sanity-check the rendered pages locally on `/docs/vite-config`, `/docs/deployment`, `/docs/quick-start`, `/docs/loaders`, `/docs/guards`, `/docs/structure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)