### PR TITLE
feat: loader/action timeouts, useOptimistic view transitions, URL.parse adoption

### DIFF
--- a/apps/site/src/pages/demo/login.tsx
+++ b/apps/site/src/pages/demo/login.tsx
@@ -16,7 +16,7 @@ const LoginPage: FunctionComponent = () => {
       }
       window.location.assign('/demo/projects');
     },
-    onError: (e) => setError(e.message),
+    onError: (e: Error) => setError(e.message),
   });
 
   return (

--- a/apps/site/src/pages/docs/actions.mdx
+++ b/apps/site/src/pages/docs/actions.mdx
@@ -315,6 +315,41 @@ export const serverActions = {
 
 For module-wide gating (every action plus every loader), export `pageUse` from the `.server.ts` file instead. See [Middleware](/docs/middleware) for the full chain model.
 
+## Timeouts
+
+Actions get a deadline. By default every call has 30 seconds to finish; the
+deadline starts when the handler receives the request. Pass `timeoutMs` on
+`defineAction` to override:
+
+```ts
+export const slowExport = defineAction<{ id: string }, { ok: boolean }>(
+  async (_ctx, { id }) => {
+    /* ... */
+  },
+  { timeoutMs: 60_000 }
+);
+```
+
+Pass `timeoutMs: false` to opt out entirely (useful for streaming actions):
+
+```ts
+export const longRunningStream = defineAction<{ url: string }, never>(
+  async (_ctx, { url }) => {
+    /* returns a ReadableStream that may run for minutes */
+  },
+  { timeoutMs: false }
+);
+```
+
+When a deadline fires, the action's `ctx.signal` aborts with reason
+`DOMException('TimeoutError')`. The server responds with status 504 and a
+`{ __outcome: 'timeout', timeoutMs }` envelope. On the client, the failure
+surfaces as a `TimeoutError` instance (with `kind: 'timeout'` and the original
+`timeoutMs` as class properties).
+
+The framework default is configurable per handler via
+`actionsHandler(glob, { defaultTimeoutMs })`.
+
 ## The server/client boundary
 
 `serverOnlyPlugin` rewrites `serverActions` imports in the client bundle with a Proxy: each property access returns an `ActionStub` with the module and action name. Any imported `pageUse` / `loaderUse` / `actionUse` named exports become empty arrays on the client. `serverLoaderValidationPlugin` enforces that `.server.*` files only export `serverLoaders`, `serverActions`, or the recognized `use` exports. See [Overview: The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.

--- a/apps/site/src/pages/docs/loaders.mdx
+++ b/apps/site/src/pages/docs/loaders.mdx
@@ -483,6 +483,41 @@ const { mutate } = useAction(serverActions.addReview, {
 
 `invalidate` accepts an array of loader refs, so a single action can refresh multiple targets: `invalidate: [moviesLoader, ratingsLoader]`. Use `'auto'` instead of an array to invalidate the current page's loader only.
 
+## Timeouts
+
+Loaders get a deadline. By default every call has 30 seconds to finish; the
+deadline starts when the handler receives the request. Pass `timeoutMs` on
+`defineLoader` to override:
+
+```ts
+export const slowReport = defineLoader(
+  async () => {
+    /* ... */
+  },
+  { timeoutMs: 60_000 }
+);
+```
+
+Pass `timeoutMs: false` to opt out entirely (useful for long-running streams):
+
+```ts
+export const longLivedStream = defineLoader(
+  async function* () {
+    /* yields indefinitely */
+  },
+  { timeoutMs: false }
+);
+```
+
+When a deadline fires, the loader's `ctx.signal` aborts with reason
+`DOMException('TimeoutError')`. The server responds with status 504 and a
+`{ __outcome: 'timeout', timeoutMs }` envelope. On the client, the failure
+surfaces as a `TimeoutError` instance (with `kind: 'timeout'` and the original
+`timeoutMs` as class properties).
+
+The framework default is configurable per handler via
+`loadersHandler(glob, { defaultTimeoutMs })`.
+
 ## The server/client boundary
 
 Two Vite plugins enforce that `.server.*` code never reaches the browser. `serverOnlyPlugin` rewrites `*.server.*` imports in the client bundle: the `serverLoaders` named export becomes a Proxy whose `get(_, name)` returns a fresh `LoaderRef` stub for that name. Any imported `serverActions` becomes a Proxy of action stubs; imported `pageUse` / `loaderUse` / `actionUse` become empty arrays. `serverLoaderValidationPlugin` fails the build if a `.server.*` file has unrecognised named exports. See [Overview: The server/client boundary](/docs#the-serverclient-boundary) for the full explanation.

--- a/apps/site/src/pages/docs/optimistic-ui.mdx
+++ b/apps/site/src/pages/docs/optimistic-ui.mdx
@@ -182,3 +182,22 @@ const MoviesPage = ({ pendingAdds }) => (
 | `pending` | `A[]`                       | Pending actions to project. Defaults to `[]`.                                        |
 
 Prefer `useOptimistic` or `useOptimisticAction` when the optimistic state is local to the component that owns the mutation. Reach for `<OptimisticOverlay>` when the optimistic projection needs to flow through `loader.useData()` for descendants you don't want to thread props through.
+
+## View Transitions
+
+`useOptimistic` and `useOptimisticAction` accept `{ transition: true }` to
+wrap settle and revert state changes in
+[`document.startViewTransition`](https://developer.mozilla.org/en-US/docs/Web/API/Document/startViewTransition).
+The initial optimistic update is never wrapped so it paints in the same
+frame. When `startViewTransition` is not available (older browsers or SSR),
+the option is a no-op.
+
+```ts
+const [count, addOptimistic] = useOptimistic(serverCount, reducer, {
+  transition: true,
+});
+```
+
+Style transitions with `::view-transition-old(*)` and `::view-transition-new(*)`
+CSS pseudo-elements, or attach `view-transition-name` to specific elements
+for element-level animations.

--- a/docs/superpowers/plans/2026-05-23-spec-a-platform-hygiene.md
+++ b/docs/superpowers/plans/2026-05-23-spec-a-platform-hygiene.md
@@ -69,7 +69,7 @@ import { timeoutOutcome, isTimeout, isOutcome } from '../outcomes.js';
 describe('timeoutOutcome', () => {
   it('constructs a timeout outcome with the given timeoutMs', () => {
     const o = timeoutOutcome(30000);
-    expect(o).toEqual({ __outcome: 'timeout', kind: 'timeout', timeoutMs: 30000 });
+    expect(o).toEqual({ __outcome: 'timeout', timeoutMs: 30000 });
   });
 
   it('isTimeout narrows correctly', () => {
@@ -98,7 +98,6 @@ In `packages/iso/src/outcomes.ts`, after the `RenderOutcome` declaration, add:
 ```ts
 export type TimeoutOutcome = {
   __outcome: 'timeout';
-  kind: 'timeout';
   timeoutMs: number;
 };
 ```
@@ -124,7 +123,7 @@ Append at the bottom of the file:
 
 ```ts
 export function timeoutOutcome(timeoutMs: number): TimeoutOutcome {
-  return { __outcome: 'timeout', kind: 'timeout', timeoutMs };
+  return { __outcome: 'timeout', timeoutMs };
 }
 
 export function isTimeout(value: unknown): value is TimeoutOutcome {
@@ -604,7 +603,7 @@ function translateOutcomeForLoader(c: Context, outcome: Outcome): Response {
   }
   if (outcome.__outcome === 'timeout') {
     return c.json(
-      { __outcome: 'timeout', kind: 'timeout', timeoutMs: outcome.timeoutMs },
+      { __outcome: 'timeout', timeoutMs: outcome.timeoutMs },
       504
     );
   }
@@ -850,7 +849,7 @@ import {
 ```ts
   if (outcome.__outcome === 'timeout') {
     return c.json(
-      { __outcome: 'timeout', kind: 'timeout', timeoutMs: outcome.timeoutMs },
+      { __outcome: 'timeout', timeoutMs: outcome.timeoutMs },
       504
     );
   }
@@ -1018,7 +1017,6 @@ describe('sse mid-stream timeout', () => {
     const timeoutEvent = events.find((e) => e.event === 'timeout');
     expect(timeoutEvent).toBeDefined();
     expect(JSON.parse(timeoutEvent!.data)).toMatchObject({
-      kind: 'timeout',
       timeoutMs: 75,
     });
   });
@@ -1043,7 +1041,7 @@ export type SseGeneratorOptions = {
    * The composed signal whose `reason` is inspected in the catch path to
    * distinguish a deadline-driven abort from a generic throw. When the
    * signal has aborted with a `TimeoutError` DOMException, the pump emits
-   * `event: timeout` with `{ kind: 'timeout', timeoutMs }` instead of the
+   * `event: timeout` with `{ timeoutMs }` instead of the
    * generic `event: error` frame.
    */
   signal?: AbortSignal;
@@ -1077,10 +1075,7 @@ Update the `catch (err) {` block inside `sseGeneratorResponse` to emit a `timeou
       if (isTimeoutAbort(options.signal) && typeof options.timeoutMs === 'number') {
         await stream.writeSSE({
           event: 'timeout',
-          data: JSON.stringify({
-            kind: 'timeout',
-            timeoutMs: options.timeoutMs,
-          }),
+          data: JSON.stringify({ timeoutMs: options.timeoutMs }),
         });
       } else {
         await stream.writeSSE({
@@ -1171,7 +1166,7 @@ describe('useAction timeout handling', () => {
 
     global.fetch = vi.fn().mockResolvedValue(
       new Response(
-        JSON.stringify({ __outcome: 'timeout', kind: 'timeout', timeoutMs: 5000 }),
+        JSON.stringify({ __outcome: 'timeout', timeoutMs: 5000 }),
         { status: 504, headers: { 'Content-Type': 'application/json' } }
       )
     );
@@ -1373,7 +1368,7 @@ describe('fetchLoaderData timeout handling', () => {
   it('throws TimeoutError when the server returns a 504 timeout outcome', async () => {
     global.fetch = vi.fn().mockResolvedValue(
       new Response(
-        JSON.stringify({ __outcome: 'timeout', kind: 'timeout', timeoutMs: 7000 }),
+        JSON.stringify({ __outcome: 'timeout', timeoutMs: 7000 }),
         { status: 504, headers: { 'Content-Type': 'application/json' } }
       )
     );
@@ -1983,8 +1978,8 @@ Insert a section into the loader docs (or a new `timeouts.mdx` page, depending o
 - `timeoutMs` option on `defineLoader` / `defineAction`.
 - Default of 30000 ms.
 - `timeoutMs: false` opts out.
-- Server returns 504 with `{ __outcome: 'timeout', kind: 'timeout', timeoutMs }`.
-- Client surfaces `TimeoutError` (with `kind: 'timeout'`, `timeoutMs` properties).
+- Server returns 504 with `{ __outcome: 'timeout', timeoutMs }`.
+- Client surfaces `TimeoutError` (with `kind: 'timeout'` and `timeoutMs` class properties).
 - Streaming loaders: timeout applies to total stream completion, not first chunk; opt out with `timeoutMs: false` for long streams.
 
 Describe current behavior only; no migration breadcrumbs.
@@ -2020,9 +2015,9 @@ export const longLivedStream = defineLoader(
 
 When a deadline fires, the loader's `ctx.signal` aborts with reason
 `DOMException('TimeoutError')`. The server responds with status 504 and a
-`{ __outcome: 'timeout', kind: 'timeout', timeoutMs }` envelope. The client
-hook (`useData()`, `useAction()`) exposes the failure as a `TimeoutError`
-with `kind === 'timeout'` and the original `timeoutMs` attached.
+`{ __outcome: 'timeout', timeoutMs }` envelope. The client hook
+(`useData()`, `useAction()`) exposes the failure as a `TimeoutError`
+instance carrying `kind === 'timeout'` and the original `timeoutMs`.
 
 The framework default is configurable per handler via
 `loadersHandler(glob, { defaultTimeoutMs })` and
@@ -2104,7 +2099,7 @@ gh pr create --title "feat: loader/action timeouts, useOptimistic view transitio
 
 Spec A, PR1 of 2. Adopts three web-standard APIs as user-facing additions:
 
-- Loader/action timeouts via `AbortSignal.any` + `AbortSignal.timeout`, with a new `TimeoutOutcome` variant (`{ __outcome: 'timeout', kind: 'timeout', timeoutMs }`) and a `TimeoutError` class on the client.
+- Loader/action timeouts via `AbortSignal.any` + `AbortSignal.timeout`, with a new `TimeoutOutcome` variant (`{ __outcome: 'timeout', timeoutMs }`) and a `TimeoutError` class on the client.
 - Opt-in View Transitions in `useOptimistic` / `useOptimisticAction` (settle + revert only; initial mutate paints same-frame).
 - `URL.parse()` at recoverable parse sites.
 
@@ -2291,7 +2286,7 @@ export function sseGeneratorResponse(
       if (isTimeoutAbort(signal) && typeof timeoutMs === 'number') {
         yield {
           event: 'timeout',
-          data: JSON.stringify({ kind: 'timeout', timeoutMs }),
+          data: JSON.stringify({ timeoutMs }),
         };
       } else {
         yield { event: 'error', data: encodeErrorPayload(err) };
@@ -2407,7 +2402,7 @@ export function sseReadableStreamResponse(
       if (isTimeoutAbort(signal) && typeof timeoutMs === 'number') {
         yield {
           event: 'timeout',
-          data: JSON.stringify({ kind: 'timeout', timeoutMs }),
+          data: JSON.stringify({ timeoutMs }),
         };
       } else {
         yield { event: 'error', data: encodeErrorPayload(err) };

--- a/docs/superpowers/specs/2026-05-23-spec-a-platform-hygiene-design.md
+++ b/docs/superpowers/specs/2026-05-23-spec-a-platform-hygiene-design.md
@@ -31,7 +31,7 @@ No new subsystem. Two of the four changes (1, 2) add opt-in API surface; the oth
 
 Two themes:
 
-1. **Cancellation and time pressure** are made explicit and observable. Loaders and actions get composed `AbortSignal`s with a default 30 s deadline, exposed to user code through the existing `ctx.signal`. Timeouts surface as a structured outcome through the same path that already carries `redirect` / `deny`, so consumers branch on `error.kind === 'timeout'` instead of inferring from message strings.
+1. **Cancellation and time pressure** are made explicit and observable. Loaders and actions get composed `AbortSignal`s with a default 30 s deadline, exposed to user code through the existing `ctx.signal`. Timeouts surface as a structured outcome through the same path that already carries `redirect` / `deny`. On the client the failure arrives as a `TimeoutError` class instance, so consumers branch on `error instanceof TimeoutError` (or its `error.kind === 'timeout'` class property) instead of inferring from message strings.
 
 2. **The framework stops paraphrasing the platform.** `URL.parse()` replaces try/catch around `new URL` wherever the framework parses recoverable input. `TransformStream` + `TextDecoderStream` replace the hand-rolled SSE codec; `hono/streaming` stops being a dependency on the loader/action stream path. `document.startViewTransition` becomes an opt-in pass-through wrapper for `useOptimistic` settle/revert.
 
@@ -56,7 +56,7 @@ defineAction(fn, { timeoutMs?: number | false, /* existing options */ })
 **Outcome envelope grows one variant** in `packages/iso/src/outcomes.ts`:
 
 ```ts
-type TimeoutOutcome = { __outcome: 'timeout', kind: 'timeout', timeoutMs: number };
+type TimeoutOutcome = { __outcome: 'timeout', timeoutMs: number };
 export function isTimeout(o: unknown): o is TimeoutOutcome;
 ```
 

--- a/packages/iso/src/__tests__/action.test.tsx
+++ b/packages/iso/src/__tests__/action.test.tsx
@@ -151,7 +151,7 @@ describe('useAction', () => {
 
     await screen.findByText('has-data');
     expect(screen.getByTestId('data')).toHaveTextContent('has-data');
-    expect(onSuccess).toHaveBeenCalledWith({ ok: true }, undefined);
+    expect(onSuccess).toHaveBeenCalledWith({ ok: true });
   });
 
   it('passes snapshot from onMutate to onSuccess', async () => {

--- a/packages/iso/src/__tests__/define-action-timeout.test.ts
+++ b/packages/iso/src/__tests__/define-action-timeout.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { defineAction } from '../action.js';
+
+describe('defineAction timeoutMs', () => {
+  it('does not attach timeoutMs when option is omitted', () => {
+    const stub = defineAction(async (_ctx, _payload) => 1);
+    expect((stub as { timeoutMs?: unknown }).timeoutMs).toBeUndefined();
+  });
+
+  it('attaches timeoutMs as a non-enumerable property', () => {
+    const stub = defineAction(async (_ctx, _payload) => 1, { timeoutMs: 5000 });
+    expect((stub as { timeoutMs?: unknown }).timeoutMs).toBe(5000);
+    const desc = Object.getOwnPropertyDescriptor(stub, 'timeoutMs');
+    expect(desc?.enumerable).toBe(false);
+  });
+
+  it('accepts false to disable', () => {
+    const stub = defineAction(async (_ctx, _payload) => 1, { timeoutMs: false });
+    expect((stub as { timeoutMs?: unknown }).timeoutMs).toBe(false);
+  });
+});

--- a/packages/iso/src/__tests__/define-action-timeout.test.ts
+++ b/packages/iso/src/__tests__/define-action-timeout.test.ts
@@ -26,4 +26,29 @@ describe('defineAction timeoutMs', () => {
     const stub = defineAction(async (_ctx, _payload) => 1, { timeoutMs: false });
     expect(readAmbient(stub, 'timeoutMs')).toBe(false);
   });
+
+  it('accepts 0', () => {
+    const stub = defineAction(async (_ctx, _payload) => 1, { timeoutMs: 0 });
+    expect(readAmbient(stub, 'timeoutMs')).toBe(0);
+  });
+
+  it('rejects negative numbers', () => {
+    expect(() =>
+      defineAction(async (_ctx, _payload) => 1, { timeoutMs: -5 })
+    ).toThrow(RangeError);
+  });
+
+  it('rejects NaN', () => {
+    expect(() =>
+      defineAction(async (_ctx, _payload) => 1, { timeoutMs: Number.NaN })
+    ).toThrow(RangeError);
+  });
+
+  it('rejects Infinity', () => {
+    expect(() =>
+      defineAction(async (_ctx, _payload) => 1, {
+        timeoutMs: Number.POSITIVE_INFINITY,
+      })
+    ).toThrow(RangeError);
+  });
 });

--- a/packages/iso/src/__tests__/define-action-timeout.test.ts
+++ b/packages/iso/src/__tests__/define-action-timeout.test.ts
@@ -1,21 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import { defineAction } from '../action.js';
 
+// `timeoutMs` is attached as ambient non-enumerable metadata, not on the
+// public `ActionStub` type. Reading it through the property descriptor keeps
+// the assertion honest about what the implementation does (and avoids
+// asserting against a phantom field on the typed surface).
+function readAmbient(stub: object, key: string): unknown {
+  return Object.getOwnPropertyDescriptor(stub, key)?.value;
+}
+
 describe('defineAction timeoutMs', () => {
   it('does not attach timeoutMs when option is omitted', () => {
     const stub = defineAction(async (_ctx, _payload) => 1);
-    expect((stub as { timeoutMs?: unknown }).timeoutMs).toBeUndefined();
+    expect(readAmbient(stub, 'timeoutMs')).toBeUndefined();
   });
 
   it('attaches timeoutMs as a non-enumerable property', () => {
     const stub = defineAction(async (_ctx, _payload) => 1, { timeoutMs: 5000 });
-    expect((stub as { timeoutMs?: unknown }).timeoutMs).toBe(5000);
     const desc = Object.getOwnPropertyDescriptor(stub, 'timeoutMs');
+    expect(desc?.value).toBe(5000);
     expect(desc?.enumerable).toBe(false);
   });
 
   it('accepts false to disable', () => {
     const stub = defineAction(async (_ctx, _payload) => 1, { timeoutMs: false });
-    expect((stub as { timeoutMs?: unknown }).timeoutMs).toBe(false);
+    expect(readAmbient(stub, 'timeoutMs')).toBe(false);
   });
 });

--- a/packages/iso/src/__tests__/define-action-timeout.test.ts
+++ b/packages/iso/src/__tests__/define-action-timeout.test.ts
@@ -23,7 +23,9 @@ describe('defineAction timeoutMs', () => {
   });
 
   it('accepts false to disable', () => {
-    const stub = defineAction(async (_ctx, _payload) => 1, { timeoutMs: false });
+    const stub = defineAction(async (_ctx, _payload) => 1, {
+      timeoutMs: false,
+    });
     expect(readAmbient(stub, 'timeoutMs')).toBe(false);
   });
 

--- a/packages/iso/src/__tests__/define-loader-timeout.test.ts
+++ b/packages/iso/src/__tests__/define-loader-timeout.test.ts
@@ -16,4 +16,27 @@ describe('defineLoader timeoutMs', () => {
     const ref = defineLoader(async () => 1, { timeoutMs: false });
     expect(ref.timeoutMs).toBe(false);
   });
+
+  it('accepts 0 (fires immediately at request time)', () => {
+    const ref = defineLoader(async () => 1, { timeoutMs: 0 });
+    expect(ref.timeoutMs).toBe(0);
+  });
+
+  it('rejects negative numbers', () => {
+    expect(() => defineLoader(async () => 1, { timeoutMs: -1 })).toThrow(
+      RangeError
+    );
+  });
+
+  it('rejects NaN', () => {
+    expect(() =>
+      defineLoader(async () => 1, { timeoutMs: Number.NaN })
+    ).toThrow(RangeError);
+  });
+
+  it('rejects Infinity', () => {
+    expect(() =>
+      defineLoader(async () => 1, { timeoutMs: Number.POSITIVE_INFINITY })
+    ).toThrow(RangeError);
+  });
 });

--- a/packages/iso/src/__tests__/define-loader-timeout.test.ts
+++ b/packages/iso/src/__tests__/define-loader-timeout.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { defineLoader } from '../define-loader.js';
+
+describe('defineLoader timeoutMs', () => {
+  it('defaults timeoutMs to undefined when not specified', () => {
+    const ref = defineLoader(async () => 1);
+    expect(ref.timeoutMs).toBeUndefined();
+  });
+
+  it('stores the provided timeoutMs on the ref', () => {
+    const ref = defineLoader(async () => 1, { timeoutMs: 5000 });
+    expect(ref.timeoutMs).toBe(5000);
+  });
+
+  it('accepts false to disable', () => {
+    const ref = defineLoader(async () => 1, { timeoutMs: false });
+    expect(ref.timeoutMs).toBe(false);
+  });
+});

--- a/packages/iso/src/__tests__/optimistic-action-transition.test.ts
+++ b/packages/iso/src/__tests__/optimistic-action-transition.test.ts
@@ -19,7 +19,8 @@ describe('useOptimisticAction transition forwarding', () => {
   });
   afterEach(() => {
     if (originalSVT === undefined) {
-      delete (document as { startViewTransition?: unknown }).startViewTransition;
+      delete (document as { startViewTransition?: unknown })
+        .startViewTransition;
     } else {
       document.startViewTransition = originalSVT;
     }

--- a/packages/iso/src/__tests__/optimistic-action-transition.test.ts
+++ b/packages/iso/src/__tests__/optimistic-action-transition.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { defineAction } from '../action.js';
+import { useOptimisticAction } from '../optimistic-action.js';
+
+const originalFetch = global.fetch;
+
+describe('useOptimisticAction transition forwarding', () => {
+  let originalSVT: typeof document.startViewTransition | undefined;
+  beforeEach(() => {
+    originalSVT = document.startViewTransition;
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+  afterEach(() => {
+    if (originalSVT === undefined) {
+      delete (document as { startViewTransition?: unknown }).startViewTransition;
+    } else {
+      document.startViewTransition = originalSVT;
+    }
+    global.fetch = originalFetch;
+  });
+
+  it('wraps settle in startViewTransition when transition: true', async () => {
+    const spy = vi.fn((cb: () => void) => {
+      cb();
+      return { finished: Promise.resolve() };
+    });
+    document.startViewTransition = spy as never;
+
+    const stub = defineAction(async () => ({ ok: true })) as ReturnType<typeof defineAction>;
+    (stub as unknown as { __module: string; __action: string }).__module = 'm';
+    (stub as unknown as { __module: string; __action: string }).__action = 'a';
+
+    const { result } = renderHook(() =>
+      useOptimisticAction<{}, { ok: true }, number>(stub, {
+        base: 0,
+        apply: (acc) => acc + 1,
+        transition: true,
+      })
+    );
+
+    await act(async () => {
+      await result.current.mutate({});
+    });
+    // Initial mutate: no transition. onSuccess -> settle: one transition.
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/iso/src/__tests__/optimistic-action-transition.test.ts
+++ b/packages/iso/src/__tests__/optimistic-action-transition.test.ts
@@ -33,9 +33,10 @@ describe('useOptimisticAction transition forwarding', () => {
     });
     document.startViewTransition = spy as never;
 
-    const stub = defineAction(async () => ({ ok: true })) as ReturnType<typeof defineAction>;
-    (stub as unknown as { __module: string; __action: string }).__module = 'm';
-    (stub as unknown as { __module: string; __action: string }).__action = 'a';
+    const stub = defineAction(async () => ({ ok: true }), {
+      __module: 'm',
+      __action: 'a',
+    });
 
     const { result } = renderHook(() =>
       useOptimisticAction<{}, { ok: true }, number>(stub, {

--- a/packages/iso/src/__tests__/optimistic-ssr.test.ts
+++ b/packages/iso/src/__tests__/optimistic-ssr.test.ts
@@ -13,9 +13,13 @@ describe('useOptimistic SSR with transition: true', () => {
 
     // Component that uses useOptimistic with transition: true.
     function Component() {
-      const [value] = useOptimistic([1, 2, 3], (current: number[], p: number) => [...current, p], {
-        transition: true,
-      });
+      const [value] = useOptimistic(
+        [1, 2, 3],
+        (current: number[], p: number) => [...current, p],
+        {
+          transition: true,
+        }
+      );
       return h('span', null, String(value.length));
     }
 
@@ -37,9 +41,13 @@ describe('useOptimistic SSR with transition: true', () => {
     expect(typeof document).toBe('undefined');
 
     function Component() {
-      const [value] = useOptimistic([0], (current: number[], p: number) => [...current, p], {
-        transition: true,
-      });
+      const [value] = useOptimistic(
+        [0],
+        (current: number[], p: number) => [...current, p],
+        {
+          transition: true,
+        }
+      );
       return h('div', null, h('span', null, String(value[0])));
     }
 

--- a/packages/iso/src/__tests__/optimistic-ssr.test.ts
+++ b/packages/iso/src/__tests__/optimistic-ssr.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { h } from 'preact';
+import { prerender } from 'preact-iso/prerender';
+import { useOptimistic } from '../optimistic.js';
+
+describe('useOptimistic SSR with transition: true', () => {
+  it('renders without throwing when transition: true in SSR (node) environment', async () => {
+    // Critical assertion: prove document is undefined in the node environment.
+    // This demonstrates that the feature-detection guard in runWithTransition
+    // (typeof document !== 'undefined') is genuinely being exercised.
+    expect(typeof document).toBe('undefined');
+
+    // Component that uses useOptimistic with transition: true.
+    function Component() {
+      const [value] = useOptimistic([1, 2, 3], (current: number[], p: number) => [...current, p], {
+        transition: true,
+      });
+      return h('span', null, String(value.length));
+    }
+
+    // Prerender the component in a node environment. This exercises the
+    // useOptimistic hook with transition: true while document is undefined.
+    // If the feature detection guard were broken, prerender would throw
+    // a ReferenceError when the hook tries to access document.
+    const result = await prerender(h(Component, null));
+
+    // The prerender result should contain the rendered HTML.
+    expect(result.html).toContain('<span>3</span>');
+  });
+
+  it('transition: true with manual settle/revert in prerender context', async () => {
+    // In SSR, event handlers that call settle/revert typically don't execute
+    // during prerender (no user interaction). However, we can test that the
+    // hook's runWithTransition guard is properly set up by verifying the
+    // component renders successfully.
+    expect(typeof document).toBe('undefined');
+
+    function Component() {
+      const [value] = useOptimistic([0], (current: number[], p: number) => [...current, p], {
+        transition: true,
+      });
+      return h('div', null, h('span', null, String(value[0])));
+    }
+
+    const result = await prerender(h(Component, null));
+    expect(result.html).toContain('<span>0</span>');
+  });
+});

--- a/packages/iso/src/__tests__/optimistic-transition.test.ts
+++ b/packages/iso/src/__tests__/optimistic-transition.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useOptimistic } from '../optimistic.js';
+
+declare global {
+  interface Document {
+    startViewTransition?: (cb: () => void) => { finished: Promise<void> };
+  }
+}
+
+describe('useOptimistic transition option', () => {
+  let originalSVT: typeof document.startViewTransition | undefined;
+
+  beforeEach(() => {
+    originalSVT = document.startViewTransition;
+  });
+  afterEach(() => {
+    if (originalSVT === undefined) {
+      delete (document as { startViewTransition?: unknown }).startViewTransition;
+    } else {
+      document.startViewTransition = originalSVT;
+    }
+  });
+
+  it('does not wrap settle/revert when transition is omitted (default)', () => {
+    const spy = vi.fn((cb: () => void) => {
+      cb();
+      return { finished: Promise.resolve() };
+    });
+    document.startViewTransition = spy as never;
+
+    const { result } = renderHook(() =>
+      useOptimistic<number, number>(0, (acc, p) => acc + p)
+    );
+    let handle!: ReturnType<typeof result.current[1]>;
+    act(() => {
+      handle = result.current[1](5);
+    });
+    act(() => handle.settle());
+    act(() => {
+      result.current[1](2).revert();
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('wraps settle and revert when transition is true, but not the initial mutate', () => {
+    const spy = vi.fn((cb: () => void) => {
+      cb();
+      return { finished: Promise.resolve() };
+    });
+    document.startViewTransition = spy as never;
+
+    const { result } = renderHook(() =>
+      useOptimistic<number, number>(0, (acc, p) => acc + p, { transition: true })
+    );
+    let handle!: ReturnType<typeof result.current[1]>;
+    act(() => {
+      handle = result.current[1](5);
+    });
+    // mutate path: no transition
+    expect(spy).not.toHaveBeenCalled();
+    act(() => handle.settle());
+    expect(spy).toHaveBeenCalledTimes(1);
+    act(() => {
+      const handle2 = result.current[1](3);
+      handle2.revert();
+    });
+    // mutate (no), revert (yes) => one more call
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('no-ops gracefully when startViewTransition is unavailable', () => {
+    delete (document as { startViewTransition?: unknown }).startViewTransition;
+    const { result } = renderHook(() =>
+      useOptimistic<number, number>(0, (acc, p) => acc + p, { transition: true })
+    );
+    let handle!: ReturnType<typeof result.current[1]>;
+    act(() => {
+      handle = result.current[1](5);
+    });
+    act(() => handle.settle());
+    expect(result.current[0]).toBe(5);
+  });
+});

--- a/packages/iso/src/__tests__/optimistic-transition.test.ts
+++ b/packages/iso/src/__tests__/optimistic-transition.test.ts
@@ -17,7 +17,8 @@ describe('useOptimistic transition option', () => {
   });
   afterEach(() => {
     if (originalSVT === undefined) {
-      delete (document as { startViewTransition?: unknown }).startViewTransition;
+      delete (document as { startViewTransition?: unknown })
+        .startViewTransition;
     } else {
       document.startViewTransition = originalSVT;
     }
@@ -33,7 +34,7 @@ describe('useOptimistic transition option', () => {
     const { result } = renderHook(() =>
       useOptimistic<number, number>(0, (acc, p) => acc + p)
     );
-    let handle!: ReturnType<typeof result.current[1]>;
+    let handle!: ReturnType<(typeof result.current)[1]>;
     act(() => {
       handle = result.current[1](5);
     });
@@ -52,9 +53,11 @@ describe('useOptimistic transition option', () => {
     document.startViewTransition = spy as never;
 
     const { result } = renderHook(() =>
-      useOptimistic<number, number>(0, (acc, p) => acc + p, { transition: true })
+      useOptimistic<number, number>(0, (acc, p) => acc + p, {
+        transition: true,
+      })
     );
-    let handle!: ReturnType<typeof result.current[1]>;
+    let handle!: ReturnType<(typeof result.current)[1]>;
     act(() => {
       handle = result.current[1](5);
     });
@@ -73,9 +76,11 @@ describe('useOptimistic transition option', () => {
   it('no-ops gracefully when startViewTransition is unavailable', () => {
     delete (document as { startViewTransition?: unknown }).startViewTransition;
     const { result } = renderHook(() =>
-      useOptimistic<number, number>(0, (acc, p) => acc + p, { transition: true })
+      useOptimistic<number, number>(0, (acc, p) => acc + p, {
+        transition: true,
+      })
     );
-    let handle!: ReturnType<typeof result.current[1]>;
+    let handle!: ReturnType<(typeof result.current)[1]>;
     act(() => {
       handle = result.current[1](5);
     });

--- a/packages/iso/src/__tests__/outcomes-timeout.test.ts
+++ b/packages/iso/src/__tests__/outcomes-timeout.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { timeoutOutcome, isTimeout, isOutcome } from '../outcomes.js';
+
+describe('timeoutOutcome', () => {
+  it('constructs a timeout outcome with the given timeoutMs', () => {
+    const o = timeoutOutcome(30000);
+    expect(o).toEqual({ __outcome: 'timeout', timeoutMs: 30000 });
+  });
+
+  it('isTimeout narrows correctly', () => {
+    const o: unknown = timeoutOutcome(5000);
+    expect(isTimeout(o)).toBe(true);
+    expect(isTimeout({ __outcome: 'deny' })).toBe(false);
+    expect(isTimeout(null)).toBe(false);
+    expect(isTimeout(undefined)).toBe(false);
+  });
+
+  it('isOutcome recognizes timeout', () => {
+    expect(isOutcome(timeoutOutcome(1000))).toBe(true);
+  });
+});

--- a/packages/iso/src/__tests__/use-action-timeout.test.ts
+++ b/packages/iso/src/__tests__/use-action-timeout.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/preact';
-import { defineAction, useAction } from '../action.js';
+import { defineAction, TimeoutError, useAction } from '../action.js';
 
 const originalFetch = global.fetch;
 
@@ -10,10 +10,8 @@ describe('useAction timeout handling', () => {
     global.fetch = originalFetch;
   });
 
-  it('surfaces a timeout envelope (504 with __outcome: timeout) as an error tagged kind: timeout', async () => {
-    const stub = defineAction(async () => 1) as ReturnType<typeof defineAction>;
-    (stub as unknown as { __module: string; __action: string }).__module = 'm';
-    (stub as unknown as { __module: string; __action: string }).__action = 'a';
+  it('surfaces a timeout envelope (504 with __outcome: timeout) as a TimeoutError', async () => {
+    const stub = defineAction(async () => 1, { __module: 'm', __action: 'a' });
 
     global.fetch = vi.fn().mockResolvedValue(
       new Response(
@@ -29,16 +27,16 @@ describe('useAction timeout handling', () => {
     });
     expect(mutated!.ok).toBe(false);
     if (!mutated!.ok) {
-      expect(mutated!.error.name).toBe('TimeoutError');
-      expect((mutated!.error as Error & { kind?: string; timeoutMs?: number }).kind).toBe('timeout');
-      expect((mutated!.error as Error & { timeoutMs?: number }).timeoutMs).toBe(5000);
+      expect(mutated!.error).toBeInstanceOf(TimeoutError);
+      if (mutated!.error instanceof TimeoutError) {
+        expect(mutated!.error.kind).toBe('timeout');
+        expect(mutated!.error.timeoutMs).toBe(5000);
+      }
     }
   });
 
   it('surfaces an SSE event: timeout frame as a TimeoutError', async () => {
-    const stub = defineAction(async () => 1) as ReturnType<typeof defineAction>;
-    (stub as unknown as { __module: string; __action: string }).__module = 'm';
-    (stub as unknown as { __module: string; __action: string }).__action = 'a';
+    const stub = defineAction(async () => 1, { __module: 'm', __action: 'a' });
 
     const body =
       'event: message\ndata: "tick"\n\n' +
@@ -57,9 +55,11 @@ describe('useAction timeout handling', () => {
     });
     expect(mutated!.ok).toBe(false);
     if (!mutated!.ok) {
-      expect(mutated!.error.name).toBe('TimeoutError');
-      expect((mutated!.error as Error & { kind?: string }).kind).toBe('timeout');
-      expect((mutated!.error as Error & { timeoutMs?: number }).timeoutMs).toBe(75);
+      expect(mutated!.error).toBeInstanceOf(TimeoutError);
+      if (mutated!.error instanceof TimeoutError) {
+        expect(mutated!.error.kind).toBe('timeout');
+        expect(mutated!.error.timeoutMs).toBe(75);
+      }
     }
   });
 });

--- a/packages/iso/src/__tests__/use-action-timeout.test.ts
+++ b/packages/iso/src/__tests__/use-action-timeout.test.ts
@@ -13,12 +13,14 @@ describe('useAction timeout handling', () => {
   it('surfaces a timeout envelope (504 with __outcome: timeout) as a TimeoutError', async () => {
     const stub = defineAction(async () => 1, { __module: 'm', __action: 'a' });
 
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({ __outcome: 'timeout', timeoutMs: 5000 }),
-        { status: 504, headers: { 'Content-Type': 'application/json' } }
-      )
-    );
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ __outcome: 'timeout', timeoutMs: 5000 }),
+          { status: 504, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
 
     const { result } = renderHook(() => useAction(stub));
     let mutated: Awaited<ReturnType<typeof result.current.mutate>>;

--- a/packages/iso/src/__tests__/use-action-timeout.test.ts
+++ b/packages/iso/src/__tests__/use-action-timeout.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { defineAction, useAction } from '../action.js';
+
+const originalFetch = global.fetch;
+
+describe('useAction timeout handling', () => {
+  beforeEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('surfaces a timeout envelope (504 with __outcome: timeout) as an error tagged kind: timeout', async () => {
+    const stub = defineAction(async () => 1) as ReturnType<typeof defineAction>;
+    (stub as unknown as { __module: string; __action: string }).__module = 'm';
+    (stub as unknown as { __module: string; __action: string }).__action = 'a';
+
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ __outcome: 'timeout', timeoutMs: 5000 }),
+        { status: 504, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const { result } = renderHook(() => useAction(stub));
+    let mutated: Awaited<ReturnType<typeof result.current.mutate>>;
+    await act(async () => {
+      mutated = await result.current.mutate({});
+    });
+    expect(mutated!.ok).toBe(false);
+    if (!mutated!.ok) {
+      expect(mutated!.error.name).toBe('TimeoutError');
+      expect((mutated!.error as Error & { kind?: string; timeoutMs?: number }).kind).toBe('timeout');
+      expect((mutated!.error as Error & { timeoutMs?: number }).timeoutMs).toBe(5000);
+    }
+  });
+
+  it('surfaces an SSE event: timeout frame as a TimeoutError', async () => {
+    const stub = defineAction(async () => 1) as ReturnType<typeof defineAction>;
+    (stub as unknown as { __module: string; __action: string }).__module = 'm';
+    (stub as unknown as { __module: string; __action: string }).__action = 'a';
+
+    const body =
+      'event: message\ndata: "tick"\n\n' +
+      'event: timeout\ndata: {"timeoutMs":75}\n\n';
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    );
+
+    const { result } = renderHook(() => useAction(stub));
+    let mutated: Awaited<ReturnType<typeof result.current.mutate>>;
+    await act(async () => {
+      mutated = await result.current.mutate({});
+    });
+    expect(mutated!.ok).toBe(false);
+    if (!mutated!.ok) {
+      expect(mutated!.error.name).toBe('TimeoutError');
+      expect((mutated!.error as Error & { kind?: string }).kind).toBe('timeout');
+      expect((mutated!.error as Error & { timeoutMs?: number }).timeoutMs).toBe(75);
+    }
+  });
+});

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -42,6 +42,16 @@ export type DefineActionOpts<TChunk = never, TResult = unknown> = {
   timeoutMs?: number | false;
 };
 
+export class TimeoutError extends Error {
+  readonly kind = 'timeout' as const;
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs}ms`);
+    this.name = 'TimeoutError';
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export function defineAction<TPayload, TResult, TChunk = never>(
   fn: ActionFn<TPayload, TResult, TChunk>,
   opts?: DefineActionOpts<TChunk, TResult>
@@ -208,7 +218,14 @@ export function useAction<
             error?: string;
             __outcome?: string;
             message?: string;
+            timeoutMs?: number;
           };
+          if (
+            body.__outcome === 'timeout' &&
+            typeof body.timeoutMs === 'number'
+          ) {
+            throw new TimeoutError(body.timeoutMs);
+          }
           // Deny outcomes carry `message` instead of the legacy `error`
           // field; prefer the descriptive message when present. The deny()
           // constructor defaults the message for first-party callers, but a
@@ -283,6 +300,15 @@ export function useAction<
               } catch (e) {
                 streamError = new Error(
                   `Malformed result event in stream: ${e instanceof Error ? e.message : String(e)}`
+                );
+              }
+            } else if (ev.event === 'timeout') {
+              try {
+                const parsed = JSON.parse(ev.data) as { timeoutMs?: number };
+                streamError = new TimeoutError(parsed.timeoutMs ?? 0);
+              } catch (e) {
+                streamError = new Error(
+                  `Malformed timeout event in stream: ${e instanceof Error ? e.message : String(e)}`
                 );
               }
             } else if (ev.event === 'error') {

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -66,10 +66,17 @@ export function defineAction<TPayload, TResult, TChunk = never>(
   fn: ActionFn<TPayload, TResult, TChunk>,
   opts?: DefineActionOpts<TChunk, TResult>
 ): ActionStub<TPayload, TResult, TChunk> {
-  // Returns `fn` masquerading as `ActionStub`. The `ActionStub` interface
-  // describes the consumer contract; the runtime is the function itself with
-  // optional non-enumerable metadata attached. The dispatcher reads this
-  // metadata through the typed `ActionEntry` map built at module-load time.
+  // SHAPE NOTE: `ActionStub` describes the CLIENT-side shape produced by the
+  // Vite plugin (`packages/vite/src/server-only.ts`) — an object with
+  // `__module`, `__action`, and a `useAction` method. `defineAction` runs on
+  // the SERVER side and returns the raw function with metadata attached via
+  // `Object.defineProperty`. These are two different runtime shapes unified
+  // under one type so consumers can import a server action and use it
+  // identically on both sides; the plugin handles the substitution at the
+  // value level. The `as unknown as` cast at the return is the single
+  // bounded acknowledgement of this dual-shape contract. A future cleanup
+  // could split into `ServerActionImpl` / `ActionStub` types if the lie
+  // starts to bite, but for now it's localized and documented.
   //
   // `Object.defineProperty` is used instead of direct assignment so a frozen
   // module export (strict ESM, HMR-frozen modules) does not throw.
@@ -111,8 +118,16 @@ export type UseActionOptions<
   invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
   onMutate?: (payload: TPayload) => TSnapshot;
   onChunk?: (chunk: TChunk) => void;
-  onError?: (err: Error, snapshot: TSnapshot) => void;
-  onSuccess?: (data: TResult, snapshot: TSnapshot) => void;
+  /**
+   * `snapshot` is the value returned by `onMutate` for this mutation.
+   * It is `undefined` when `onMutate` was not provided.
+   */
+  onError?: (err: Error, snapshot: TSnapshot | undefined) => void;
+  /**
+   * `snapshot` is the value returned by `onMutate` for this mutation.
+   * It is `undefined` when `onMutate` was not provided.
+   */
+  onSuccess?: (data: TResult, snapshot: TSnapshot | undefined) => void;
 };
 
 /**
@@ -177,22 +192,18 @@ export function useAction<
 
       const currentStub = stubRef.current;
       const currentOptions = optionsRef.current;
-      let snapshot: unknown;
+      let snapshot: TSnapshot | undefined;
       if (currentOptions?.onMutate) {
         snapshot = currentOptions.onMutate(payload);
       }
 
       let finalResult: TResult | undefined;
       try {
-        const stub = currentStub as unknown as {
-          __module: string;
-          __action: string;
-        };
         let response: Response;
         if (hasFileValues(payload)) {
           const fd = new FormData();
-          fd.append('__module', stub.__module);
-          fd.append('__action', stub.__action);
+          fd.append('__module', currentStub.__module);
+          fd.append('__action', currentStub.__action);
           for (const [key, value] of Object.entries(
             payload as Record<string, unknown>
           )) {
@@ -211,8 +222,8 @@ export function useAction<
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              module: stub.__module,
-              action: stub.__action,
+              module: currentStub.__module,
+              action: currentStub.__action,
               payload,
             }),
           });
@@ -337,12 +348,12 @@ export function useAction<
           }
           if (resultValue !== undefined) {
             setData(resultValue);
-            currentOptions?.onSuccess?.(resultValue, snapshot as TSnapshot);
+            currentOptions?.onSuccess?.(resultValue, snapshot);
             finalResult = resultValue;
           } else {
             currentOptions?.onSuccess?.(
               undefined as unknown as TResult,
-              snapshot as TSnapshot
+              snapshot
             );
             // Streaming actions with no `result` event resolve with undefined.
             // Consumers should type `TResult = void` (or include `undefined`)
@@ -352,7 +363,7 @@ export function useAction<
         } else {
           const result = (await response.json()) as TResult;
           setData(result);
-          currentOptions?.onSuccess?.(result, snapshot as TSnapshot);
+          currentOptions?.onSuccess?.(result, snapshot);
           finalResult = result;
         }
 
@@ -377,7 +388,7 @@ export function useAction<
       } catch (err) {
         const e = err instanceof Error ? err : new Error(String(err));
         setError(e);
-        currentOptions?.onError?.(e, snapshot as TSnapshot);
+        currentOptions?.onError?.(e, snapshot);
         setPending(false);
         return { ok: false, error: e };
       }

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -30,8 +30,9 @@ export type ActionFn<TPayload, TResult, TChunk = never> =
 export type DefineActionOpts<TChunk = never, TResult = unknown> = {
   /**
    * Per-action middleware and (for streaming actions) stream observers.
-   * Attached to the function as a non-enumerable-feeling property; the
-   * actions-handler reads it via the dispatcher (Task 18).
+   * Attached to the function as a non-enumerable property; the
+   * actions-handler reads it through the typed `ActionEntry` map built at
+   * module-load time (`packages/server/src/actions-handler.ts`).
    */
   use?: ActionUse<TChunk, TResult, boolean>;
   /**
@@ -40,6 +41,15 @@ export type DefineActionOpts<TChunk = never, TResult = unknown> = {
    * this action.
    */
   timeoutMs?: number | false;
+  /**
+   * The module key the client-side `useAction` hook will reference in its
+   * RPC envelope. Production wires this through the Vite plugin's
+   * client-stub emission; test code can pass it directly to construct a
+   * properly-shaped stub without bypassing the type system.
+   */
+  __module?: string;
+  /** The action name the client-side `useAction` hook will reference. */
+  __action?: string;
 };
 
 export class TimeoutError extends Error {
@@ -56,30 +66,25 @@ export function defineAction<TPayload, TResult, TChunk = never>(
   fn: ActionFn<TPayload, TResult, TChunk>,
   opts?: DefineActionOpts<TChunk, TResult>
 ): ActionStub<TPayload, TResult, TChunk> {
-  // Runtime no-op for the call itself: returns fn as-is. The ActionStub type
-  // is enforced only by TypeScript and the Vite plugin. The dispatcher reads
-  // `use` off the function-as-stub when running the chain.
+  // Returns `fn` masquerading as `ActionStub`. The `ActionStub` interface
+  // describes the consumer contract; the runtime is the function itself with
+  // optional non-enumerable metadata attached. The dispatcher reads this
+  // metadata through the typed `ActionEntry` map built at module-load time.
   //
-  // Use `Object.defineProperty` instead of direct assignment so a frozen
-  // module export (strict ESM, HMR-frozen modules) doesn't throw. The
-  // actions-handler reads via `(fn as { use?: ReadonlyArray<unknown> }).use`,
-  // which works whether the property was set by assignment or defineProperty.
-  if (opts?.use) {
-    Object.defineProperty(fn, 'use', {
-      value: opts.use,
+  // `Object.defineProperty` is used instead of direct assignment so a frozen
+  // module export (strict ESM, HMR-frozen modules) does not throw.
+  const attach = (key: string, value: unknown) => {
+    Object.defineProperty(fn, key, {
+      value,
       configurable: true,
       writable: true,
       enumerable: false,
     });
-  }
-  if (opts?.timeoutMs !== undefined) {
-    Object.defineProperty(fn, 'timeoutMs', {
-      value: opts.timeoutMs,
-      configurable: true,
-      writable: true,
-      enumerable: false,
-    });
-  }
+  };
+  if (opts?.use) attach('use', opts.use);
+  if (opts?.timeoutMs !== undefined) attach('timeoutMs', opts.timeoutMs);
+  if (opts?.__module !== undefined) attach('__module', opts.__module);
+  if (opts?.__action !== undefined) attach('__action', opts.__action);
   return fn as unknown as ActionStub<TPayload, TResult, TChunk>;
 }
 

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -62,10 +62,23 @@ export class TimeoutError extends Error {
   }
 }
 
+function validateTimeoutMs(
+  value: number | false | undefined,
+  context: string
+): void {
+  if (value === undefined || value === false) return;
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(
+      `${context}: timeoutMs must be a non-negative finite number or false, got ${String(value)}`
+    );
+  }
+}
+
 export function defineAction<TPayload, TResult, TChunk = never>(
   fn: ActionFn<TPayload, TResult, TChunk>,
   opts?: DefineActionOpts<TChunk, TResult>
 ): ActionStub<TPayload, TResult, TChunk> {
+  validateTimeoutMs(opts?.timeoutMs, 'defineAction');
   // SHAPE NOTE: `ActionStub` describes the CLIENT-side shape produced by the
   // Vite plugin (`packages/vite/src/server-only.ts`) — an object with
   // `__module`, `__action`, and a `useAction` method. `defineAction` runs on
@@ -95,12 +108,7 @@ export function defineAction<TPayload, TResult, TChunk = never>(
   return fn as unknown as ActionStub<TPayload, TResult, TChunk>;
 }
 
-export type UseActionOptions<
-  TPayload,
-  TResult,
-  TChunk = never,
-  TSnapshot = unknown,
-> = {
+type UseActionOptionsCommon<TChunk = never> = {
   /**
    * How to update loader caches after the action commits. Three modes:
    *
@@ -116,38 +124,59 @@ export type UseActionOptions<
    * See `/docs/reloading` for the full mental model.
    */
   invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
-  onMutate?: (payload: TPayload) => TSnapshot;
   onChunk?: (chunk: TChunk) => void;
-  /**
-   * `snapshot` is the value returned by `onMutate` for this mutation.
-   * It is `undefined` when `onMutate` was not provided.
-   */
-  onError?: (err: Error, snapshot: TSnapshot | undefined) => void;
-  /**
-   * `snapshot` is the value returned by `onMutate` for this mutation.
-   * It is `undefined` when `onMutate` was not provided.
-   */
-  onSuccess?: (data: TResult, snapshot: TSnapshot | undefined) => void;
 };
+
+/**
+ * Options when `onMutate` is provided. `onSuccess` / `onError` receive the
+ * value `onMutate` returned for this specific mutation as the second
+ * parameter, so concurrent calls can be paired with their own snapshot.
+ */
+type UseActionWithMutate<TPayload, TResult, TChunk, TSnapshot> =
+  UseActionOptionsCommon<TChunk> & {
+    onMutate: (payload: TPayload) => TSnapshot;
+    onError?: (err: Error, snapshot: TSnapshot) => void;
+    onSuccess?: (data: TResult, snapshot: TSnapshot) => void;
+  };
+
+/**
+ * Options when `onMutate` is not provided. `onSuccess` / `onError` take
+ * only the result / error — there is no snapshot to thread through.
+ */
+type UseActionWithoutMutate<TResult, TChunk> =
+  UseActionOptionsCommon<TChunk> & {
+    onMutate?: undefined;
+    onError?: (err: Error) => void;
+    onSuccess?: (data: TResult) => void;
+  };
+
+/**
+ * Discriminated by `onMutate`. Providing `onMutate` requires the
+ * `onSuccess` / `onError` callbacks to accept the snapshot; omitting
+ * `onMutate` types those callbacks as single-argument.
+ */
+export type UseActionOptions<
+  TPayload,
+  TResult,
+  TChunk = never,
+  TSnapshot = unknown,
+> =
+  | UseActionWithMutate<TPayload, TResult, TChunk, TSnapshot>
+  | UseActionWithoutMutate<TResult, TChunk>;
 
 /**
  * The value `mutate` resolves to. A discriminated union so callers can
  * chain on success without awaiting then probing the hook's `data`/`error`
  * state, and without leaking unhandled rejections in fire-and-forget callers.
  *
- * - Success: `{ ok: true, data }`. For streaming actions that emit no
- *   `result` SSE event, `data` is `undefined`; declare `TResult = void` (or
- *   include `undefined` in its union) if your action doesn't emit a result.
+ * - Success: `{ ok: true, data }`. `data` is `undefined` for streaming
+ *   actions that close without emitting a `result` SSE event (the type
+ *   reflects this honestly: callers must narrow before using `data`).
  * - Failure: `{ ok: false, error }`. The same `Error` instance is also
  *   written to the hook's `error` state and passed to `onError`.
- *
- * Returning a union (rather than throwing) keeps `mutate(...)` ergonomic
- * for non-awaiting call sites — the existing `error` state field is the
- * idiomatic way to render an error UI — while still letting awaiting
- * callers do `if (result.ok) navigate(...)`.
  */
 export type MutateResult<TResult> =
-  | { ok: true; data: TResult }
+  | { ok: true; data: TResult | undefined }
   | { ok: false; error: Error };
 
 export type UseActionResult<TPayload, TResult> = {
@@ -192,10 +221,51 @@ export function useAction<
 
       const currentStub = stubRef.current;
       const currentOptions = optionsRef.current;
-      let snapshot: TSnapshot | undefined;
-      if (currentOptions?.onMutate) {
-        snapshot = currentOptions.onMutate(payload);
-      }
+
+      // Resolve the callback discriminant once for this mutation. The runtime
+      // value `callbacks` carries the typed onSuccess/onError handlers plus
+      // the snapshot (when onMutate is set) so subsequent invokeSuccess /
+      // invokeError calls don't need to re-narrow currentOptions.
+      type Callbacks =
+        | {
+            kind: 'with-mutate';
+            snapshot: TSnapshot;
+            onSuccess?: (data: TResult, snapshot: TSnapshot) => void;
+            onError?: (err: Error, snapshot: TSnapshot) => void;
+          }
+        | {
+            kind: 'without-mutate';
+            onSuccess?: (data: TResult) => void;
+            onError?: (err: Error) => void;
+          };
+
+      const callbacks: Callbacks = currentOptions?.onMutate
+        ? {
+            kind: 'with-mutate',
+            snapshot: currentOptions.onMutate(payload),
+            onSuccess: currentOptions.onSuccess,
+            onError: currentOptions.onError,
+          }
+        : {
+            kind: 'without-mutate',
+            onSuccess: currentOptions?.onSuccess,
+            onError: currentOptions?.onError,
+          };
+
+      const invokeSuccess = (data: TResult) => {
+        if (callbacks.kind === 'with-mutate') {
+          callbacks.onSuccess?.(data, callbacks.snapshot);
+        } else {
+          callbacks.onSuccess?.(data);
+        }
+      };
+      const invokeError = (err: Error) => {
+        if (callbacks.kind === 'with-mutate') {
+          callbacks.onError?.(err, callbacks.snapshot);
+        } else {
+          callbacks.onError?.(err);
+        }
+      };
 
       let finalResult: TResult | undefined;
       try {
@@ -348,22 +418,20 @@ export function useAction<
           }
           if (resultValue !== undefined) {
             setData(resultValue);
-            currentOptions?.onSuccess?.(resultValue, snapshot);
+            invokeSuccess(resultValue);
             finalResult = resultValue;
           } else {
-            currentOptions?.onSuccess?.(
-              undefined as unknown as TResult,
-              snapshot
-            );
-            // Streaming actions with no `result` event resolve with undefined.
-            // Consumers should type `TResult = void` (or include `undefined`)
-            // when their action doesn't emit a result.
-            finalResult = undefined as unknown as TResult;
+            // Streaming action closed without emitting a `result` event;
+            // resolve with `data: undefined`. `onSuccess` is not called
+            // in this branch since there is no result value to deliver
+            // (matches the static-action path where onSuccess only fires
+            // with a real value).
+            finalResult = undefined;
           }
         } else {
           const result = (await response.json()) as TResult;
           setData(result);
-          currentOptions?.onSuccess?.(result, snapshot);
+          invokeSuccess(result);
           finalResult = result;
         }
 
@@ -388,12 +456,12 @@ export function useAction<
       } catch (err) {
         const e = err instanceof Error ? err : new Error(String(err));
         setError(e);
-        currentOptions?.onError?.(e, snapshot);
+        invokeError(e);
         setPending(false);
         return { ok: false, error: e };
       }
       setPending(false);
-      return { ok: true, data: finalResult as TResult };
+      return { ok: true, data: finalResult };
     },
     []
   );

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -34,6 +34,12 @@ export type DefineActionOpts<TChunk = never, TResult = unknown> = {
    * actions-handler reads it via the dispatcher (Task 18).
    */
   use?: ActionUse<TChunk, TResult, boolean>;
+  /**
+   * Per-action timeout in milliseconds. When omitted, the handler applies
+   * its configured default (30s). Pass `false` to disable the timeout for
+   * this action.
+   */
+  timeoutMs?: number | false;
 };
 
 export function defineAction<TPayload, TResult, TChunk = never>(
@@ -51,6 +57,14 @@ export function defineAction<TPayload, TResult, TChunk = never>(
   if (opts?.use) {
     Object.defineProperty(fn, 'use', {
       value: opts.use,
+      configurable: true,
+      writable: true,
+      enumerable: false,
+    });
+  }
+  if (opts?.timeoutMs !== undefined) {
+    Object.defineProperty(fn, 'timeoutMs', {
+      value: opts.timeoutMs,
       configurable: true,
       writable: true,
       enumerable: false,

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -145,7 +145,7 @@ function ViewRenderer<T>({
   const error = loaderRef.useError();
   const reloadCtx = useContext(ReloadContext);
   const reload = reloadCtx?.reload ?? (() => {});
-  return render({ data, error, reload, ...props }) as any;
+  return render({ data, error, reload, ...props });
 }
 
 export function defineLoader<T>(
@@ -212,34 +212,30 @@ export function defineLoader<T>(
     invalidate() {
       cache!.invalidate();
     },
-    Boundary: null as never,
-    View: null as never,
+    // `Boundary` and `View` close over `ref`. The captures are by reference
+    // and only deref at call time (component render), so the cycle is safe;
+    // both are fully initialized before any consumer can invoke them.
+    Boundary: ({ fallback, errorFallback, children }) =>
+      h(LoaderHost<T>, {
+        loader: ref,
+        fallback,
+        errorFallback,
+        children,
+      }),
+    View: (render, viewOpts) => {
+      const Wrapped: FunctionComponent<any> = (props) =>
+        h(ref.Boundary, {
+          fallback: viewOpts?.fallback,
+          errorFallback: viewOpts?.errorFallback,
+          children: h(ViewRenderer<T>, {
+            loaderRef: ref,
+            props,
+            render,
+          }),
+        });
+      return Wrapped;
+    },
   };
-
-  const Boundary: LoaderRef<T>['Boundary'] = ({
-    fallback,
-    errorFallback,
-    children,
-  }) => {
-    return h(LoaderHost as any, {
-      loader: ref,
-      fallback,
-      errorFallback,
-      children,
-    });
-  };
-  ref.Boundary = Boundary;
-
-  const View: LoaderRef<T>['View'] = (render, viewOpts) => {
-    const Wrapped: FunctionComponent<any> = (props) =>
-      h(ref.Boundary, {
-        fallback: viewOpts?.fallback,
-        errorFallback: viewOpts?.errorFallback,
-        children: h(ViewRenderer<T> as any, { loaderRef: ref, props, render }),
-      });
-    return Wrapped;
-  };
-  ref.View = View;
 
   return ref;
 }

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -148,10 +148,23 @@ function ViewRenderer<T>({
   return render({ data, error, reload, ...props });
 }
 
+function validateTimeoutMs(
+  value: number | false | undefined,
+  context: string
+): void {
+  if (value === undefined || value === false) return;
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(
+      `${context}: timeoutMs must be a non-negative finite number or false, got ${String(value)}`
+    );
+  }
+}
+
 export function defineLoader<T>(
   fn: Loader<T>,
   opts?: DefineLoaderOpts<T>
 ): LoaderRef<T> {
+  validateTimeoutMs(opts?.timeoutMs, 'defineLoader');
   const idKey = opts?.__moduleKey
     ? opts.__loaderName
       ? `${opts.__moduleKey}::${opts.__loaderName}`

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -34,6 +34,12 @@ export interface LoaderRef<T> {
   readonly cache: LoaderCache<T>;
   readonly params: string[] | '*';
   /**
+   * Raw value as authored on `defineLoader({ timeoutMs })`. `undefined`
+   * means "use the handler's configured default"; `false` means "no
+   * timeout, only the request signal aborts".
+   */
+  readonly timeoutMs?: number | false;
+  /**
    * Per-loader middleware and (for streaming loaders) stream observers,
    * exactly as authored on `defineLoader({ use })`. The handler-side
    * dispatcher calls `partitionUse(ref.use)` to split middleware from
@@ -76,6 +82,12 @@ export type DefineLoaderOpts<T> = {
   __loaderName?: string;
   cache?: LoaderCache<T>;
   params?: string[] | '*';
+  /**
+   * Per-loader timeout in milliseconds. When omitted, the handler applies
+   * its configured default (30s). Pass `false` to disable the timeout for
+   * this loader (rely solely on the request signal).
+   */
+  timeoutMs?: number | false;
   /**
    * Per-loader middleware and (for streaming loaders) stream observers.
    * The element type LoaderUse<T, Streaming> structurally gates stream
@@ -178,6 +190,7 @@ export function defineLoader<T>(
     fn,
     cache: cache!,
     params: opts?.params ?? [],
+    timeoutMs: opts?.timeoutMs,
     // LoaderUse<T, boolean> structurally collapses to the same shape the
     // partitioner accepts; the cast hides only the generic narrowing on
     // StreamObserver's TChunk/TResult which is invariant. Identity-preserving.

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -83,16 +83,19 @@ export type { AppConfig, AppUseElement } from './define-app.js';
 export {
   redirect,
   deny,
+  timeoutOutcome,
   isOutcome,
   isRedirect,
   isDeny,
   isRender,
+  isTimeout,
 } from './outcomes.js';
 export type {
   Outcome,
   RedirectOutcome,
   DenyOutcome,
   RenderOutcome,
+  TimeoutOutcome,
   RedirectStatusCode,
   ErrorStatusCode,
 } from './outcomes.js';

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -26,7 +26,7 @@ export type {
   LoaderCtx,
   Loader as LoaderFn,
 } from './define-loader.js';
-export { defineAction, useAction } from './action.js';
+export { defineAction, useAction, TimeoutError } from './action.js';
 export type {
   ActionStub,
   UseActionOptions,

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -38,7 +38,7 @@ export type { ContentfulStatusCode } from 'hono/utils/http-status';
 // Hooks.
 export { useReload } from './reload-context.js';
 export { useOptimistic } from './optimistic.js';
-export type { OptimisticHandle } from './optimistic.js';
+export type { OptimisticHandle, UseOptimisticOptions } from './optimistic.js';
 export { useOptimisticAction } from './optimistic-action.js';
 export type {
   UseOptimisticActionOptions,

--- a/packages/iso/src/internal.ts
+++ b/packages/iso/src/internal.ts
@@ -86,3 +86,8 @@ export {
 // User code that imports them couples to plugin internals.
 
 export { __$createLoaderStub_hpiso } from './internal/loader-stub.js';
+
+// SSE decoder; useful in tests and advanced consumers that need to read
+// a streaming loader/action response as a sequence of typed SSE events.
+export { readSSE } from './internal/sse-decoder.js';
+export type { SSEEvent } from './internal/sse-decoder.js';

--- a/packages/iso/src/internal/__tests__/loader-fetch-timeout.test.ts
+++ b/packages/iso/src/internal/__tests__/loader-fetch-timeout.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchLoaderData } from '../loader-fetch.js';
+import { TimeoutError } from '../../action.js';
+
+const originalFetch = global.fetch;
+const location = { path: '/', pathParams: {}, searchParams: {} };
+const noopCallbacks = {
+  onChunk: () => {},
+  onError: () => {},
+  onEnd: () => {},
+};
+
+describe('fetchLoaderData timeout handling', () => {
+  beforeEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('throws TimeoutError when the server returns a 504 timeout envelope', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ __outcome: 'timeout', timeoutMs: 7000 }),
+        { status: 504, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const controller = new AbortController();
+    let thrown: unknown;
+    try {
+      await fetchLoaderData('m', 'l', location, controller.signal, noopCallbacks);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(TimeoutError);
+    expect((thrown as TimeoutError).timeoutMs).toBe(7000);
+    expect((thrown as TimeoutError).name).toBe('TimeoutError');
+  });
+
+  it('throws TimeoutError when the first SSE event is event: timeout', async () => {
+    const body =
+      'event: timeout\ndata: {"timeoutMs":120}\n\n';
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    );
+
+    const controller = new AbortController();
+    let thrown: unknown;
+    try {
+      await fetchLoaderData('m', 'l', location, controller.signal, noopCallbacks);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(TimeoutError);
+    expect((thrown as TimeoutError).timeoutMs).toBe(120);
+  });
+
+  it('reports TimeoutError via onError when timeout fires mid-stream (after first chunk)', async () => {
+    const body =
+      'event: message\ndata: "first"\n\n' +
+      'event: timeout\ndata: {"timeoutMs":250}\n\n';
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    );
+
+    const controller = new AbortController();
+    const onError = vi.fn();
+    const callbacks = { onChunk: () => {}, onError, onEnd: () => {} };
+    const first = await fetchLoaderData('m', 'l', location, controller.signal, callbacks);
+    expect(first).toBe('first');
+    // Wait a tick for the background consumer to drain.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onError).toHaveBeenCalledTimes(1);
+    const err = onError.mock.calls[0][0];
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect((err as TimeoutError).timeoutMs).toBe(250);
+  });
+});

--- a/packages/iso/src/internal/__tests__/loader-fetch-timeout.test.ts
+++ b/packages/iso/src/internal/__tests__/loader-fetch-timeout.test.ts
@@ -32,8 +32,10 @@ describe('fetchLoaderData timeout handling', () => {
       thrown = e;
     }
     expect(thrown).toBeInstanceOf(TimeoutError);
-    expect((thrown as TimeoutError).timeoutMs).toBe(7000);
-    expect((thrown as TimeoutError).name).toBe('TimeoutError');
+    if (thrown instanceof TimeoutError) {
+      expect(thrown.timeoutMs).toBe(7000);
+      expect(thrown.name).toBe('TimeoutError');
+    }
   });
 
   it('throws TimeoutError when the first SSE event is event: timeout', async () => {
@@ -54,7 +56,9 @@ describe('fetchLoaderData timeout handling', () => {
       thrown = e;
     }
     expect(thrown).toBeInstanceOf(TimeoutError);
-    expect((thrown as TimeoutError).timeoutMs).toBe(120);
+    if (thrown instanceof TimeoutError) {
+      expect(thrown.timeoutMs).toBe(120);
+    }
   });
 
   it('reports TimeoutError via onError when timeout fires mid-stream (after first chunk)', async () => {
@@ -78,6 +82,8 @@ describe('fetchLoaderData timeout handling', () => {
     expect(onError).toHaveBeenCalledTimes(1);
     const err = onError.mock.calls[0][0];
     expect(err).toBeInstanceOf(TimeoutError);
-    expect((err as TimeoutError).timeoutMs).toBe(250);
+    if (err instanceof TimeoutError) {
+      expect(err.timeoutMs).toBe(250);
+    }
   });
 });

--- a/packages/iso/src/internal/__tests__/loader-fetch-timeout.test.ts
+++ b/packages/iso/src/internal/__tests__/loader-fetch-timeout.test.ts
@@ -17,17 +17,25 @@ describe('fetchLoaderData timeout handling', () => {
   });
 
   it('throws TimeoutError when the server returns a 504 timeout envelope', async () => {
-    global.fetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({ __outcome: 'timeout', timeoutMs: 7000 }),
-        { status: 504, headers: { 'Content-Type': 'application/json' } }
-      )
-    );
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ __outcome: 'timeout', timeoutMs: 7000 }),
+          { status: 504, headers: { 'Content-Type': 'application/json' } }
+        )
+      );
 
     const controller = new AbortController();
     let thrown: unknown;
     try {
-      await fetchLoaderData('m', 'l', location, controller.signal, noopCallbacks);
+      await fetchLoaderData(
+        'm',
+        'l',
+        location,
+        controller.signal,
+        noopCallbacks
+      );
     } catch (e) {
       thrown = e;
     }
@@ -39,8 +47,7 @@ describe('fetchLoaderData timeout handling', () => {
   });
 
   it('throws TimeoutError when the first SSE event is event: timeout', async () => {
-    const body =
-      'event: timeout\ndata: {"timeoutMs":120}\n\n';
+    const body = 'event: timeout\ndata: {"timeoutMs":120}\n\n';
     global.fetch = vi.fn().mockResolvedValue(
       new Response(body, {
         status: 200,
@@ -51,7 +58,13 @@ describe('fetchLoaderData timeout handling', () => {
     const controller = new AbortController();
     let thrown: unknown;
     try {
-      await fetchLoaderData('m', 'l', location, controller.signal, noopCallbacks);
+      await fetchLoaderData(
+        'm',
+        'l',
+        location,
+        controller.signal,
+        noopCallbacks
+      );
     } catch (e) {
       thrown = e;
     }
@@ -75,7 +88,13 @@ describe('fetchLoaderData timeout handling', () => {
     const controller = new AbortController();
     const onError = vi.fn();
     const callbacks = { onChunk: () => {}, onError, onEnd: () => {} };
-    const first = await fetchLoaderData('m', 'l', location, controller.signal, callbacks);
+    const first = await fetchLoaderData(
+      'm',
+      'l',
+      location,
+      controller.signal,
+      callbacks
+    );
     expect(first).toBe('first');
     // Wait a tick for the background consumer to drain.
     await new Promise((r) => setTimeout(r, 10));

--- a/packages/iso/src/internal/envelope.tsx
+++ b/packages/iso/src/internal/envelope.tsx
@@ -28,14 +28,14 @@ export const Envelope: FunctionComponent<EnvelopeProps> = ({
   const dataLoader = isBrowser() ? 'null' : JSON.stringify(ctx.data ?? null);
 
   if (typeof as === 'string') {
-    const Tag = as as keyof JSX.IntrinsicElements;
-    const props = { id, 'data-loader': dataLoader } as JSX.HTMLAttributes;
+    const Tag = as;
     return (
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      <Tag {...(props as any)}>{children}</Tag>
+      <Tag id={id} data-loader={dataLoader}>
+        {children}
+      </Tag>
     );
   }
-  const Wrapper = as as ComponentType<WrapperProps>;
+  const Wrapper = as;
   return (
     <Wrapper id={id} data-loader={dataLoader}>
       {children}

--- a/packages/iso/src/internal/loader-fetch.ts
+++ b/packages/iso/src/internal/loader-fetch.ts
@@ -1,4 +1,5 @@
 import { readSSE } from './sse-decoder.js';
+import { TimeoutError } from '../action.js';
 
 export type LoaderFetchCallbacks<T> = {
   onChunk: (value: T) => void;
@@ -41,7 +42,14 @@ export async function fetchLoaderData<T>(
       error?: string;
       __outcome?: string;
       message?: string;
+      timeoutMs?: number;
     };
+    if (
+      body.__outcome === 'timeout' &&
+      typeof body.timeoutMs === 'number'
+    ) {
+      throw new TimeoutError(body.timeoutMs);
+    }
     if (body.__outcome === 'deny') {
       // The `deny()` constructor defaults `message` for first-party
       // callers, but a hand-rolled envelope from custom server middleware
@@ -121,6 +129,19 @@ export async function fetchLoaderData<T>(
       }
       break;
     }
+    if (ev.event === 'timeout') {
+      try {
+        const parsed = JSON.parse(ev.data) as { timeoutMs?: number };
+        throw new TimeoutError(parsed.timeoutMs ?? 0);
+      } catch (e) {
+        if (e instanceof TimeoutError) throw e;
+        throw new Error(
+          `Malformed timeout event in streaming loader: ${
+            e instanceof Error ? e.message : String(e)
+          }`
+        );
+      }
+    }
     if (ev.event === 'error') {
       try {
         const parsed = JSON.parse(ev.data) as {
@@ -157,6 +178,16 @@ export async function fetchLoaderData<T>(
           } catch {
             // malformed mid-stream chunk: skip
           }
+        } else if (ev.event === 'timeout') {
+          try {
+            const parsed = JSON.parse(ev.data) as { timeoutMs?: number };
+            callbacks.onError(new TimeoutError(parsed.timeoutMs ?? 0));
+          } catch {
+            callbacks.onError(
+              new Error('Malformed timeout event in streaming loader')
+            );
+          }
+          return;
         } else if (ev.event === 'error') {
           try {
             const parsed = JSON.parse(ev.data) as {

--- a/packages/iso/src/internal/loader-fetch.ts
+++ b/packages/iso/src/internal/loader-fetch.ts
@@ -112,54 +112,7 @@ export async function fetchLoaderData<T>(
   // SSE: read the first message event synchronously (await first chunk),
   // then kick off an async loop that pushes subsequent chunks to callbacks.
   const iter = readSSE(res.body);
-  let firstChunk: T | undefined;
-
-  while (true) {
-    const step = await iter.next();
-    if (step.done) {
-      // Stream closed before any data event: error
-      throw new Error('Streaming loader closed before emitting any data');
-    }
-    const ev = step.value;
-    if (ev.event === 'message') {
-      try {
-        firstChunk = JSON.parse(ev.data) as T;
-      } catch {
-        throw new Error('Malformed first chunk in streaming loader');
-      }
-      break;
-    }
-    if (ev.event === 'timeout') {
-      try {
-        const parsed = JSON.parse(ev.data) as { timeoutMs?: number };
-        throw new TimeoutError(parsed.timeoutMs ?? 0);
-      } catch (e) {
-        if (e instanceof TimeoutError) throw e;
-        throw new Error(
-          `Malformed timeout event in streaming loader: ${
-            e instanceof Error ? e.message : String(e)
-          }`
-        );
-      }
-    }
-    if (ev.event === 'error') {
-      try {
-        const parsed = JSON.parse(ev.data) as {
-          message?: string;
-          name?: string;
-        };
-        const err = new Error(parsed.message ?? 'Streamed error');
-        if (parsed.name) err.name = parsed.name;
-        throw err;
-      } catch (e) {
-        if (e instanceof Error && e.message.startsWith('Malformed')) {
-          throw new Error('Malformed error event in streaming loader');
-        }
-        throw e;
-      }
-    }
-    // Other events (result, etc.): ignore for loaders
-  }
+  const firstChunk = await readFirstChunk<T>(iter);
 
   // Continue consuming chunks in the background. Each subsequent message
   // pushes a value via onChunk. Errors fire onError. End fires onEnd.
@@ -210,5 +163,61 @@ export async function fetchLoaderData<T>(
     }
   })();
 
-  return firstChunk as T;
+  return firstChunk;
+}
+
+/**
+ * Drain the SSE stream until the first `message` event and parse it as `T`.
+ * `timeout` / `error` events before the first message reject with the
+ * appropriate error. Other event types are ignored.
+ */
+async function readFirstChunk<T>(
+  iter: AsyncGenerator<{ event: string; data: string }>
+): Promise<T> {
+  while (true) {
+    const step = await iter.next();
+    if (step.done) {
+      throw new Error('Streaming loader closed before emitting any data');
+    }
+    const ev = step.value;
+    if (ev.event === 'message') {
+      try {
+        return JSON.parse(ev.data) as T;
+      } catch {
+        throw new Error('Malformed first chunk in streaming loader');
+      }
+    }
+    if (ev.event === 'timeout') {
+      let timeoutMs = 0;
+      try {
+        const parsed = JSON.parse(ev.data) as { timeoutMs?: number };
+        timeoutMs = parsed.timeoutMs ?? 0;
+      } catch (e) {
+        throw new Error(
+          `Malformed timeout event in streaming loader: ${
+            e instanceof Error ? e.message : String(e)
+          }`
+        );
+      }
+      throw new TimeoutError(timeoutMs);
+    }
+    if (ev.event === 'error') {
+      let message = 'Streamed error';
+      let name: string | undefined;
+      try {
+        const parsed = JSON.parse(ev.data) as {
+          message?: string;
+          name?: string;
+        };
+        message = parsed.message ?? message;
+        name = parsed.name;
+      } catch {
+        throw new Error('Malformed error event in streaming loader');
+      }
+      const err = new Error(message);
+      if (name) err.name = name;
+      throw err;
+    }
+    // Other events (result, etc.): ignore for loaders
+  }
 }

--- a/packages/iso/src/internal/loader-fetch.ts
+++ b/packages/iso/src/internal/loader-fetch.ts
@@ -44,10 +44,7 @@ export async function fetchLoaderData<T>(
       message?: string;
       timeoutMs?: number;
     };
-    if (
-      body.__outcome === 'timeout' &&
-      typeof body.timeoutMs === 'number'
-    ) {
+    if (body.__outcome === 'timeout' && typeof body.timeoutMs === 'number') {
       throw new TimeoutError(body.timeoutMs);
     }
     if (body.__outcome === 'deny') {

--- a/packages/iso/src/internal/loader-runner.ts
+++ b/packages/iso/src/internal/loader-runner.ts
@@ -163,7 +163,7 @@ export function runLoader<T>(
     }
 
     const runInner = async (): Promise<unknown> => {
-      const result = await (loaderRef.fn(ctx) as Promise<unknown>);
+      const result = await loaderRef.fn(ctx);
       if (isAsyncGenerator(result)) {
         if (observers.length > 0) {
           fanStart(observers, serverCtx);

--- a/packages/iso/src/internal/loader.tsx
+++ b/packages/iso/src/internal/loader.tsx
@@ -1,4 +1,4 @@
-import type { ComponentChildren, JSX } from 'preact';
+import type { ComponentChildren } from 'preact';
 import type { RouteHook } from 'preact-iso';
 import { Suspense } from 'preact/compat';
 import { useContext, useId } from 'preact/hooks';
@@ -19,7 +19,7 @@ export { serializeLocationForCache } from './cache-key.js';
 type LoaderHostProps<T> = {
   loader: LoaderRef<T>;
   location?: RouteHook;
-  fallback?: JSX.Element;
+  fallback?: ComponentChildren;
   errorFallback?:
     | ComponentChildren
     | ((err: Error, reset: () => void) => ComponentChildren);
@@ -66,7 +66,7 @@ export function LoaderHost<T>({
         <ReloadContext.Provider value={{ reload, reloading }}>
           <LoaderErrorContext.Provider value={error}>
             {errorFallback != null ? (
-              <ErrorBoundary fallback={errorFallback as any}>
+              <ErrorBoundary fallback={errorFallback}>
                 {suspenseContent}
               </ErrorBoundary>
             ) : (

--- a/packages/iso/src/internal/route-boundary.tsx
+++ b/packages/iso/src/internal/route-boundary.tsx
@@ -1,11 +1,11 @@
 import { Component } from 'preact';
-import type { ComponentChildren, FunctionComponent, JSX } from 'preact';
+import type { ComponentChildren, FunctionComponent } from 'preact';
 import { Suspense } from 'preact/compat';
 import { isOutcome } from '../outcomes.js';
 
 type ErrorFallback =
-  | JSX.Element
-  | ((error: Error, reset: () => void) => JSX.Element);
+  | ComponentChildren
+  | ((error: Error, reset: () => void) => ComponentChildren);
 
 type ErrorBoundaryProps = {
   fallback?: ErrorFallback;
@@ -51,7 +51,7 @@ export class ErrorBoundary extends Component<
 }
 
 export const RouteBoundary: FunctionComponent<{
-  fallback?: JSX.Element;
+  fallback?: ComponentChildren;
   errorFallback?: ErrorFallback;
   children: ComponentChildren;
 }> = ({ fallback, errorFallback, children }) => (

--- a/packages/iso/src/optimistic-action.ts
+++ b/packages/iso/src/optimistic-action.ts
@@ -45,15 +45,11 @@ export function useOptimisticAction<TPayload, TResult, TBase, TChunk = never>(
     ...actionOpts,
     onMutate: (payload) => addOptimistic(payload),
     onSuccess: (data, handle) => {
-      // `onMutate` above always returns an `OptimisticHandle`, so `handle`
-      // is guaranteed defined here. The guard is a one-liner that documents
-      // the invariant for future readers; the type system cannot infer the
-      // pairing between `onMutate`'s return and these callback parameters.
-      if (handle) handle.settle();
+      handle.settle();
       onSuccess?.(data);
     },
     onError: (err, handle) => {
-      if (handle) handle.revert();
+      handle.revert();
       onError?.(err);
     },
   });

--- a/packages/iso/src/optimistic-action.ts
+++ b/packages/iso/src/optimistic-action.ts
@@ -38,7 +38,8 @@ export function useOptimisticAction<TPayload, TResult, TBase, TChunk = never>(
   stub: ActionStub<TPayload, TResult, TChunk>,
   options: UseOptimisticActionOptions<TPayload, TResult, TBase, TChunk>
 ): UseOptimisticActionResult<TPayload, TResult, TBase> {
-  const { base, apply, onSuccess, onError, transition, ...actionOpts } = options;
+  const { base, apply, onSuccess, onError, transition, ...actionOpts } =
+    options;
   const [value, addOptimistic] = useOptimistic(base, apply, { transition });
 
   const action = useAction<TPayload, TResult, TChunk, OptimisticHandle>(stub, {

--- a/packages/iso/src/optimistic-action.ts
+++ b/packages/iso/src/optimistic-action.ts
@@ -45,11 +45,15 @@ export function useOptimisticAction<TPayload, TResult, TBase, TChunk = never>(
     ...actionOpts,
     onMutate: (payload) => addOptimistic(payload),
     onSuccess: (data, handle) => {
-      handle.settle();
+      // `onMutate` above always returns an `OptimisticHandle`, so `handle`
+      // is guaranteed defined here. The guard is a one-liner that documents
+      // the invariant for future readers; the type system cannot infer the
+      // pairing between `onMutate`'s return and these callback parameters.
+      if (handle) handle.settle();
       onSuccess?.(data);
     },
     onError: (err, handle) => {
-      handle.revert();
+      if (handle) handle.revert();
       onError?.(err);
     },
   });

--- a/packages/iso/src/optimistic-action.ts
+++ b/packages/iso/src/optimistic-action.ts
@@ -21,6 +21,8 @@ export type UseOptimisticActionOptions<
   invalidate?: 'auto' | ReadonlyArray<LoaderRef<unknown>>;
   onSuccess?: (data: TResult) => void;
   onError?: (err: Error) => void;
+  /** Forwarded to the internal `useOptimistic` call. */
+  transition?: boolean;
 };
 
 export type UseOptimisticActionResult<TPayload, TResult, TBase> =
@@ -36,8 +38,8 @@ export function useOptimisticAction<TPayload, TResult, TBase, TChunk = never>(
   stub: ActionStub<TPayload, TResult, TChunk>,
   options: UseOptimisticActionOptions<TPayload, TResult, TBase, TChunk>
 ): UseOptimisticActionResult<TPayload, TResult, TBase> {
-  const { base, apply, onSuccess, onError, ...actionOpts } = options;
-  const [value, addOptimistic] = useOptimistic(base, apply);
+  const { base, apply, onSuccess, onError, transition, ...actionOpts } = options;
+  const [value, addOptimistic] = useOptimistic(base, apply, { transition });
 
   const action = useAction<TPayload, TResult, TChunk, OptimisticHandle>(stub, {
     ...actionOpts,

--- a/packages/iso/src/optimistic.ts
+++ b/packages/iso/src/optimistic.ts
@@ -45,14 +45,30 @@ export function useOptimistic<TBase, TPayload>(
   // below. Each render rebinds this function and writes the latest option
   // value into the ref; settle/revert created by the stale memoized callback
   // still see the up-to-date `transition` setting through the ref.
+  //
+  // The callback returns a promise that resolves on the next animation frame
+  // so the browser snapshots Preact's POST-render DOM as "new state". Without
+  // the rAF wait, `forceRender()` (an async dispatch through useReducer) has
+  // not yet flushed when `startViewTransition` snapshots, and the transition
+  // captures identical before/after frames with no visible animation.
   const runWithTransition = (mutator: () => void) => {
     if (
       transitionRef.current &&
       typeof document !== 'undefined' &&
       typeof document.startViewTransition === 'function'
     ) {
-      document.startViewTransition(() => {
+      document.startViewTransition(async () => {
         mutator();
+        await new Promise<void>((resolve) => {
+          if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(() => resolve());
+          } else {
+            // Non-DOM environment (shouldn't reach this branch given the
+            // outer check, but defensive). Resolve on next microtask so
+            // Preact's scheduled render runs.
+            queueMicrotask(resolve);
+          }
+        });
       });
     } else {
       mutator();

--- a/packages/iso/src/optimistic.ts
+++ b/packages/iso/src/optimistic.ts
@@ -8,14 +8,27 @@ export type OptimisticHandle = {
   revert: () => void;
 };
 
+export type UseOptimisticOptions = {
+  /**
+   * When true, the settle and revert paths are wrapped in
+   * `document.startViewTransition`. The initial optimistic update is never
+   * wrapped (it must paint same-frame). Falls back to a synchronous update
+   * when `document.startViewTransition` is unavailable.
+   */
+  transition?: boolean;
+};
+
 export function useOptimistic<TBase, TPayload>(
   base: TBase,
-  reducer: (current: TBase, payload: TPayload) => TBase
+  reducer: (current: TBase, payload: TPayload) => TBase,
+  options?: UseOptimisticOptions
 ): [TBase, (payload: TPayload) => OptimisticHandle] {
   const queueRef = useRef<Entry<TPayload>[]>([]);
   const lastBaseRef = useRef(base);
   const idRef = useRef(0);
   const [, forceRender] = useReducer<number, void>((c) => c + 1, 0);
+  const transitionRef = useRef(options?.transition === true);
+  transitionRef.current = options?.transition === true;
 
   if (!Object.is(lastBaseRef.current, base)) {
     queueRef.current = queueRef.current.filter((e) => e.status !== 'ready');
@@ -27,6 +40,25 @@ export function useOptimistic<TBase, TPayload>(
     base
   );
 
+  // Reads `transitionRef.current` at invocation time, not capture time, so it
+  // is safe to close over from the memoized `addOptimistic` (useCallback([]))
+  // below. Each render rebinds this function and writes the latest option
+  // value into the ref; settle/revert created by the stale memoized callback
+  // still see the up-to-date `transition` setting through the ref.
+  const runWithTransition = (mutator: () => void) => {
+    if (
+      transitionRef.current &&
+      typeof document !== 'undefined' &&
+      typeof document.startViewTransition === 'function'
+    ) {
+      document.startViewTransition(() => {
+        mutator();
+      });
+    } else {
+      mutator();
+    }
+  };
+
   const addOptimistic = useCallback((payload: TPayload): OptimisticHandle => {
     const id = ++idRef.current;
     queueRef.current = [...queueRef.current, { id, payload, status: 'active' }];
@@ -35,13 +67,17 @@ export function useOptimistic<TBase, TPayload>(
       settle: () => {
         const entry = queueRef.current.find((e) => e.id === id);
         if (entry && entry.status === 'active') {
-          entry.status = 'ready';
-          forceRender();
+          runWithTransition(() => {
+            entry.status = 'ready';
+            forceRender();
+          });
         }
       },
       revert: () => {
-        queueRef.current = queueRef.current.filter((e) => e.id !== id);
-        forceRender();
+        runWithTransition(() => {
+          queueRef.current = queueRef.current.filter((e) => e.id !== id);
+          forceRender();
+        });
       },
     };
   }, []);

--- a/packages/iso/src/outcomes.ts
+++ b/packages/iso/src/outcomes.ts
@@ -27,7 +27,12 @@ export type RenderOutcome = {
   Component: FunctionComponent;
 };
 
-export type Outcome = RedirectOutcome | DenyOutcome | RenderOutcome;
+export type TimeoutOutcome = {
+  __outcome: 'timeout';
+  timeoutMs: number;
+};
+
+export type Outcome = RedirectOutcome | DenyOutcome | RenderOutcome | TimeoutOutcome;
 
 type RedirectInput =
   | string
@@ -90,7 +95,7 @@ export function isOutcome(value: unknown): value is Outcome {
   if (typeof value !== 'object' || value === null) return false;
   if (!('__outcome' in value)) return false;
   const tag = (value as { __outcome: unknown }).__outcome;
-  return tag === 'redirect' || tag === 'deny' || tag === 'render';
+  return tag === 'redirect' || tag === 'deny' || tag === 'render' || tag === 'timeout';
 }
 
 export function isRedirect(value: unknown): value is RedirectOutcome {
@@ -103,4 +108,12 @@ export function isDeny(value: unknown): value is DenyOutcome {
 
 export function isRender(value: unknown): value is RenderOutcome {
   return isOutcome(value) && value.__outcome === 'render';
+}
+
+export function timeoutOutcome(timeoutMs: number): TimeoutOutcome {
+  return { __outcome: 'timeout', timeoutMs };
+}
+
+export function isTimeout(value: unknown): value is TimeoutOutcome {
+  return isOutcome(value) && value.__outcome === 'timeout';
 }

--- a/packages/iso/src/outcomes.ts
+++ b/packages/iso/src/outcomes.ts
@@ -32,7 +32,11 @@ export type TimeoutOutcome = {
   timeoutMs: number;
 };
 
-export type Outcome = RedirectOutcome | DenyOutcome | RenderOutcome | TimeoutOutcome;
+export type Outcome =
+  | RedirectOutcome
+  | DenyOutcome
+  | RenderOutcome
+  | TimeoutOutcome;
 
 type RedirectInput =
   | string
@@ -95,7 +99,12 @@ export function isOutcome(value: unknown): value is Outcome {
   if (typeof value !== 'object' || value === null) return false;
   if (!('__outcome' in value)) return false;
   const tag = (value as { __outcome: unknown }).__outcome;
-  return tag === 'redirect' || tag === 'deny' || tag === 'render' || tag === 'timeout';
+  return (
+    tag === 'redirect' ||
+    tag === 'deny' ||
+    tag === 'render' ||
+    tag === 'timeout'
+  );
 }
 
 export function isRedirect(value: unknown): value is RedirectOutcome {

--- a/packages/server/src/__tests__/actions-handler-timeout.test.ts
+++ b/packages/server/src/__tests__/actions-handler-timeout.test.ts
@@ -52,7 +52,9 @@ describe('actionsHandler timeouts', () => {
   it('uses the handler default when the action has no timeoutMs', async () => {
     const create = defineAction(async ({ signal }) => {
       await new Promise((_resolve, reject) => {
-        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        signal.addEventListener('abort', () => reject(signal.reason), {
+          once: true,
+        });
       });
       return { ok: true };
     });
@@ -110,7 +112,11 @@ describe('actionsHandler timeouts', () => {
     const res = await app.request('http://localhost/__actions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ module: 'untimed', action: 'create', payload: {} }),
+      body: JSON.stringify({
+        module: 'untimed',
+        action: 'create',
+        payload: {},
+      }),
     });
     expect(res.status).toBe(200);
   });

--- a/packages/server/src/__tests__/actions-handler-timeout.test.ts
+++ b/packages/server/src/__tests__/actions-handler-timeout.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { actionsHandler } from '../actions-handler.js';
+import { defineAction, isTimeout } from '@hono-preact/iso';
+
+function makeApp(glob: Parameters<typeof actionsHandler>[0]) {
+  const app = new Hono();
+  app.post('/__actions', actionsHandler(glob));
+  return app;
+}
+
+function post(app: Hono, body: unknown) {
+  return app.request('http://localhost/__actions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('actionsHandler timeouts', () => {
+  it('returns a timeout outcome when the action exceeds its timeoutMs', async () => {
+    const create = defineAction(
+      async ({ signal }) => {
+        await new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        });
+        return { id: 1 };
+      },
+      { timeoutMs: 50 }
+    );
+
+    const app = makeApp({
+      './pages/slow.server.ts': {
+        __moduleKey: 'slow',
+        serverActions: { create },
+      },
+    });
+
+    const res = await post(app, {
+      module: 'slow',
+      action: 'create',
+      payload: {},
+    });
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as unknown;
+    expect(isTimeout(body)).toBe(true);
+    expect((body as { timeoutMs: number }).timeoutMs).toBe(50);
+  });
+
+  it('uses the handler default when the action has no timeoutMs', async () => {
+    const create = defineAction(async ({ signal }) => {
+      await new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+      return { ok: true };
+    });
+
+    const app = new Hono();
+    app.post(
+      '/__actions',
+      actionsHandler(
+        {
+          './pages/fast.server.ts': {
+            __moduleKey: 'fast',
+            serverActions: { create },
+          },
+        },
+        { defaultTimeoutMs: 50 }
+      )
+    );
+
+    const res = await app.request('http://localhost/__actions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ module: 'fast', action: 'create', payload: {} }),
+    });
+
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as { timeoutMs: number };
+    expect(isTimeout(body)).toBe(true);
+    // Proves the default path created a timeout signal (not the per-action value)
+    expect(body.timeoutMs).toBe(50);
+  });
+
+  it('disables the timeout when timeoutMs is false (even when defaultTimeoutMs is small)', async () => {
+    const create = defineAction(
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 75));
+        return { ok: true };
+      },
+      { timeoutMs: false }
+    );
+
+    const app = new Hono();
+    app.post(
+      '/__actions',
+      actionsHandler(
+        {
+          './pages/untimed.server.ts': {
+            __moduleKey: 'untimed',
+            serverActions: { create },
+          },
+        },
+        { defaultTimeoutMs: 25 }
+      )
+    );
+
+    const res = await app.request('http://localhost/__actions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ module: 'untimed', action: 'create', payload: {} }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('signal.reason inside the action is a TimeoutError DOMException', async () => {
+    let observedReason: unknown;
+    const create = defineAction(
+      async ({ signal }) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              observedReason = signal.reason;
+              resolve();
+            },
+            { once: true }
+          );
+        });
+        return { id: 0 };
+      },
+      { timeoutMs: 50 }
+    );
+
+    const app = makeApp({
+      './pages/slow2.server.ts': {
+        __moduleKey: 'slow2',
+        serverActions: { create },
+      },
+    });
+
+    await post(app, { module: 'slow2', action: 'create', payload: {} });
+    expect(observedReason).toBeInstanceOf(DOMException);
+    expect((observedReason as DOMException).name).toBe('TimeoutError');
+  });
+});

--- a/packages/server/src/__tests__/loaders-handler-timeout.test.ts
+++ b/packages/server/src/__tests__/loaders-handler-timeout.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+import { loadersHandler } from '../loaders-handler.js';
+import { defineLoader, isTimeout } from '@hono-preact/iso';
+
+function makeApp(glob: Parameters<typeof loadersHandler>[0]) {
+  const app = new Hono();
+  app.post('/__loaders', loadersHandler(glob));
+  return app;
+}
+
+function post(app: Hono, body: unknown) {
+  return app.request('http://localhost/__loaders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const location = { path: '/', pathParams: {}, searchParams: {} };
+
+describe('loadersHandler timeouts', () => {
+  it('returns a timeout outcome when the loader exceeds its timeoutMs', async () => {
+    const ref = defineLoader(
+      async ({ signal }) => {
+        await new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+        return 'never';
+      },
+      { __moduleKey: 'slow', __loaderName: 'list', timeoutMs: 50 }
+    );
+
+    const app = makeApp({
+      './pages/slow.server.ts': {
+        __moduleKey: 'slow',
+        serverLoaders: { list: ref },
+      },
+    });
+
+    const res = await post(app, { module: 'slow', loader: 'list', location });
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as unknown;
+    expect(isTimeout(body)).toBe(true);
+    expect((body as { timeoutMs: number }).timeoutMs).toBe(50);
+  });
+
+  it('uses the handler default when timeoutMs is undefined on the loader', async () => {
+    const ref = defineLoader(
+      async ({ signal }) => {
+        await new Promise((resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
+        });
+        return 'never';
+      },
+      { __moduleKey: 'fast', __loaderName: 'list' }
+    );
+
+    const app = new Hono();
+    app.post(
+      '/__loaders',
+      loadersHandler(
+        {
+          './pages/fast.server.ts': {
+            __moduleKey: 'fast',
+            serverLoaders: { list: ref },
+          },
+        },
+        { defaultTimeoutMs: 50 }
+      )
+    );
+
+    const res = await app.request('http://localhost/__loaders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ module: 'fast', loader: 'list', location }),
+    });
+
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as { timeoutMs: number };
+    expect(isTimeout(body)).toBe(true);
+    // The reported timeoutMs MUST be the handler default, proving the
+    // resolution path fell back from `entry.timeoutMs` (undefined) to
+    // `defaultTimeoutMs` rather than skipping composition entirely.
+    expect(body.timeoutMs).toBe(50);
+  });
+
+  it('disables the timeout when timeoutMs is false (even when defaultTimeoutMs is small)', async () => {
+    let aborted = false;
+    const ref = defineLoader(
+      async ({ signal }) => {
+        await new Promise((resolve) => setTimeout(resolve, 75));
+        aborted = signal.aborted;
+        return 'ok';
+      },
+      { __moduleKey: 'untimed', __loaderName: 'list', timeoutMs: false }
+    );
+
+    const app = new Hono();
+    // Use a small default that would absolutely fire within the 75ms sleep
+    // if `false` were not honored. This makes the test discriminating against
+    // a broken implementation that ignores the `false` opt-out.
+    app.post(
+      '/__loaders',
+      loadersHandler(
+        {
+          './pages/untimed.server.ts': {
+            __moduleKey: 'untimed',
+            serverLoaders: { list: ref },
+          },
+        },
+        { defaultTimeoutMs: 25 }
+      )
+    );
+
+    const res = await app.request('http://localhost/__loaders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ module: 'untimed', loader: 'list', location }),
+    });
+    expect(res.status).toBe(200);
+    expect(aborted).toBe(false);
+  });
+
+  it('signal.reason inside the loader is a TimeoutError DOMException', async () => {
+    let observedReason: unknown;
+    const ref = defineLoader(
+      async ({ signal }) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              observedReason = signal.reason;
+              resolve();
+            },
+            { once: true }
+          );
+        });
+        return 'never';
+      },
+      { __moduleKey: 'slow2', __loaderName: 'list', timeoutMs: 50 }
+    );
+
+    const app = makeApp({
+      './pages/slow2.server.ts': {
+        __moduleKey: 'slow2',
+        serverLoaders: { list: ref },
+      },
+    });
+
+    await post(app, { module: 'slow2', loader: 'list', location });
+    expect(observedReason).toBeInstanceOf(DOMException);
+    expect((observedReason as DOMException).name).toBe('TimeoutError');
+  });
+});

--- a/packages/server/src/__tests__/loaders-handler-timeout.test.ts
+++ b/packages/server/src/__tests__/loaders-handler-timeout.test.ts
@@ -24,7 +24,9 @@ describe('loadersHandler timeouts', () => {
     const ref = defineLoader(
       async ({ signal }) => {
         await new Promise((resolve, reject) => {
-          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+          signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          });
         });
         return 'never';
       },

--- a/packages/server/src/__tests__/sse-mid-stream-timeout.test.ts
+++ b/packages/server/src/__tests__/sse-mid-stream-timeout.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { loadersHandler } from '../loaders-handler.js';
+import { defineLoader } from '@hono-preact/iso';
+import { readSSE } from '@hono-preact/iso/internal';
+
+const location = { path: '/', pathParams: {}, searchParams: {} };
+
+describe('sse mid-stream timeout', () => {
+  it('emits event: timeout when the timeout fires after the stream has started', async () => {
+    const ref = defineLoader(
+      async function* ({ signal }) {
+        yield 'first';
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        // Re-throw after abort so the SSE pump enters its catch path with
+        // the timeout reason live on the composed signal.
+        throw signal.reason;
+      },
+      { __moduleKey: 'streamy', __loaderName: 'list', timeoutMs: 75 }
+    );
+
+    const app = new Hono();
+    app.post(
+      '/__loaders',
+      loadersHandler({
+        './pages/streamy.server.ts': {
+          __moduleKey: 'streamy',
+          serverLoaders: { list: ref },
+        },
+      })
+    );
+
+    const res = await app.request('http://localhost/__loaders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ module: 'streamy', loader: 'list', location }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const events: { event: string; data: string }[] = [];
+    if (res.body) {
+      for await (const ev of readSSE(res.body)) events.push(ev);
+    }
+
+    expect(events.some((e) => e.event === 'message' && e.data === '"first"')).toBe(true);
+    const timeoutEvent = events.find((e) => e.event === 'timeout');
+    expect(timeoutEvent).toBeDefined();
+    expect(JSON.parse(timeoutEvent!.data)).toMatchObject({ timeoutMs: 75 });
+  });
+});

--- a/packages/server/src/__tests__/sse-mid-stream-timeout.test.ts
+++ b/packages/server/src/__tests__/sse-mid-stream-timeout.test.ts
@@ -46,7 +46,9 @@ describe('sse mid-stream timeout', () => {
       for await (const ev of readSSE(res.body)) events.push(ev);
     }
 
-    expect(events.some((e) => e.event === 'message' && e.data === '"first"')).toBe(true);
+    expect(
+      events.some((e) => e.event === 'message' && e.data === '"first"')
+    ).toBe(true);
     const timeoutEvent = events.find((e) => e.event === 'timeout');
     expect(timeoutEvent).toBeDefined();
     expect(JSON.parse(timeoutEvent!.data)).toMatchObject({ timeoutMs: 75 });

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -352,7 +352,7 @@ export function actionsHandler(
       });
     }
     if (result instanceof ReadableStream) {
-      return sseReadableStreamResponse(c, result as ReadableStream<unknown>, {
+      return sseReadableStreamResponse(c, result, {
         observers,
         observerCtx: ctx,
         signal: timeoutSignal,

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -325,12 +325,18 @@ export function actionsHandler(
         emitResult: true,
         observers,
         observerCtx: ctx,
+        signal: timeoutSignal,
+        timeoutMs:
+          typeof resolvedTimeoutMs === 'number' ? resolvedTimeoutMs : undefined,
       });
     }
     if (result instanceof ReadableStream) {
       return sseReadableStreamResponse(c, result as ReadableStream<unknown>, {
         observers,
         observerCtx: ctx,
+        signal: timeoutSignal,
+        timeoutMs:
+          typeof resolvedTimeoutMs === 'number' ? resolvedTimeoutMs : undefined,
       });
     }
     return c.json(result);

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from 'hono';
 import {
   isOutcome,
+  timeoutOutcome,
   type AppConfig,
   type Outcome,
   type ServerMiddleware,
@@ -77,6 +78,12 @@ function translateOutcomeForAction(c: Context, outcome: Outcome): Response {
       outcome.status
     );
   }
+  if (outcome.__outcome === 'timeout') {
+    return c.json(
+      { __outcome: 'timeout', timeoutMs: outcome.timeoutMs },
+      504
+    );
+  }
   // render outcome should never reach the action RPC.
   return c.json(
     {
@@ -121,13 +128,26 @@ export interface ActionsHandlerOptions {
   resolvePageUse?: (
     moduleKey: string
   ) => ReadonlyArray<unknown> | Promise<ReadonlyArray<unknown>>;
+  /**
+   * Default action timeout in milliseconds applied when an action does not
+   * declare its own `timeoutMs`. Defaults to 30000 (30 seconds). Pass
+   * `false` to disable the default (only action-level `timeoutMs` enforces
+   * a deadline).
+   */
+  defaultTimeoutMs?: number | false;
 }
 
 export function actionsHandler(
   glob: LazyGlob | EagerGlob,
   opts: ActionsHandlerOptions = {}
 ): MiddlewareHandler {
-  const { dev = false, onError, appConfig, resolvePageUse } = opts;
+  const {
+    dev = false,
+    onError,
+    appConfig,
+    resolvePageUse,
+    defaultTimeoutMs = 30_000,
+  } = opts;
   let cachedMapPromise: Promise<Record<string, ModuleEntry>> | null = null;
 
   return async (c) => {
@@ -219,7 +239,16 @@ export function actionsHandler(
       );
     }
 
-    const signal = c.req.raw.signal;
+    const actionTimeoutMs = (fn as { timeoutMs?: number | false }).timeoutMs;
+    const resolvedTimeoutMs =
+      actionTimeoutMs !== undefined ? actionTimeoutMs : defaultTimeoutMs;
+    const timeoutSignal =
+      resolvedTimeoutMs === false || resolvedTimeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(resolvedTimeoutMs);
+    const signal = timeoutSignal
+      ? AbortSignal.any([c.req.raw.signal, timeoutSignal])
+      : c.req.raw.signal;
     const actionCtx = { c, signal };
 
     // Chain ordering is outer -> inner: app-level middleware wraps every
@@ -276,6 +305,14 @@ export function actionsHandler(
     } catch (err) {
       if (isOutcome(err)) {
         return translateOutcomeForAction(c, err);
+      }
+      if (
+        timeoutSignal?.aborted &&
+        timeoutSignal.reason instanceof DOMException &&
+        timeoutSignal.reason.name === 'TimeoutError' &&
+        typeof resolvedTimeoutMs === 'number'
+      ) {
+        return translateOutcomeForAction(c, timeoutOutcome(resolvedTimeoutMs));
       }
       onError?.(err, { module, action });
       const message =

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -28,8 +28,16 @@ type GlobModule = {
 type LazyGlob = Record<string, () => Promise<unknown>>;
 type EagerGlob = Record<string, GlobModule>;
 
+type ActionFn = (ctx: unknown, payload: unknown) => Promise<unknown>;
+
+type ActionEntry = {
+  fn: ActionFn;
+  use: ReadonlyArray<unknown>;
+  timeoutMs?: number | false;
+};
+
 type ModuleEntry = {
-  actions: Record<string, unknown>;
+  actions: Record<string, ActionEntry>;
 };
 
 async function buildActionsMap(
@@ -42,11 +50,27 @@ async function buildActionsMap(
         ? await (moduleOrLoader as () => Promise<GlobModule>)()
         : (moduleOrLoader as GlobModule);
     const key = mod.__moduleKey;
-    if (typeof key === 'string' && mod.serverActions) {
-      result[key] = {
-        actions: mod.serverActions as Record<string, unknown>,
+    if (typeof key !== 'string' || !mod.serverActions) continue;
+
+    const actions: Record<string, ActionEntry> = {};
+    for (const [name, val] of Object.entries(mod.serverActions)) {
+      if (typeof val !== 'function') continue;
+      // `defineAction` attaches `use` and `timeoutMs` as non-enumerable
+      // properties on the function (see `packages/iso/src/action.ts`). The
+      // structural read below is the single deserialization boundary; the
+      // handler body reads `entry.fn`, `entry.use`, `entry.timeoutMs`
+      // directly through the typed `ActionEntry` shape from here on.
+      const metadata = val as {
+        use?: ReadonlyArray<unknown>;
+        timeoutMs?: number | false;
+      };
+      actions[name] = {
+        fn: val as ActionFn,
+        use: metadata.use ?? [],
+        timeoutMs: metadata.timeoutMs,
       };
     }
+    result[key] = { actions };
   }
   return result;
 }
@@ -231,15 +255,15 @@ export function actionsHandler(
       return c.json({ error: `Module '${module}' not found` }, 404);
     }
 
-    const fn = entry.actions[action];
-    if (typeof fn !== 'function') {
+    const actionEntry = entry.actions[action];
+    if (!actionEntry) {
       return c.json(
         { error: `Action '${action}' not found in module '${module}'` },
         404
       );
     }
+    const { fn, use: actionUse, timeoutMs: actionTimeoutMs } = actionEntry;
 
-    const actionTimeoutMs = (fn as { timeoutMs?: number | false }).timeoutMs;
     const resolvedTimeoutMs =
       actionTimeoutMs !== undefined ? actionTimeoutMs : defaultTimeoutMs;
     const timeoutSignal =
@@ -260,7 +284,6 @@ export function actionsHandler(
     // page-layer lookup keys by module rather than by location path.
     const rootUse = appConfig?.use ?? [];
     const pageUse = (await resolvePageUse?.(module)) ?? [];
-    const actionUse = (fn as { use?: ReadonlyArray<unknown> }).use ?? [];
     const fullUse: ReadonlyArray<Middleware | StreamObserver<unknown, never>> =
       [...rootUse, ...pageUse, ...actionUse] as ReadonlyArray<
         Middleware | StreamObserver<unknown, never>
@@ -285,9 +308,7 @@ export function actionsHandler(
           middleware: serverMw,
           ctx,
           inner: async () => {
-            const inner = await (
-              fn as (ctx: unknown, payload: unknown) => Promise<unknown>
-            )(actionCtx, payload);
+            const inner = await fn(actionCtx, payload);
             // An action that does `return redirect('/login')` instead of
             // `throw redirect('/login')` would otherwise ship the outcome
             // JSON shape as a normal 200 response and bypass envelope

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -264,10 +264,10 @@ export function actionsHandler(
     }
     const { fn, use: actionUse, timeoutMs: actionTimeoutMs } = actionEntry;
 
-    const resolvedTimeoutMs =
+    const resolvedTimeoutMs: number | false =
       actionTimeoutMs !== undefined ? actionTimeoutMs : defaultTimeoutMs;
     const timeoutSignal =
-      resolvedTimeoutMs === false || resolvedTimeoutMs === undefined
+      resolvedTimeoutMs === false
         ? undefined
         : AbortSignal.timeout(resolvedTimeoutMs);
     const signal = timeoutSignal

--- a/packages/server/src/actions-handler.ts
+++ b/packages/server/src/actions-handler.ts
@@ -103,10 +103,7 @@ function translateOutcomeForAction(c: Context, outcome: Outcome): Response {
     );
   }
   if (outcome.__outcome === 'timeout') {
-    return c.json(
-      { __outcome: 'timeout', timeoutMs: outcome.timeoutMs },
-      504
-    );
+    return c.json({ __outcome: 'timeout', timeoutMs: outcome.timeoutMs }, 504);
   }
   // render outcome should never reach the action RPC.
   return c.json(

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -171,10 +171,7 @@ function translateOutcomeForLoader(c: Context, outcome: Outcome): Response {
     );
   }
   if (outcome.__outcome === 'timeout') {
-    return c.json(
-      { __outcome: 'timeout', timeoutMs: outcome.timeoutMs },
-      504
-    );
+    return c.json({ __outcome: 'timeout', timeoutMs: outcome.timeoutMs }, 504);
   }
   // render outcome should never reach the loader RPC; this is defense in depth.
   return c.json(
@@ -326,7 +323,9 @@ export function loadersHandler(
           observerCtx: ctx,
           signal: timeoutSignal,
           timeoutMs:
-            typeof resolvedTimeoutMs === 'number' ? resolvedTimeoutMs : undefined,
+            typeof resolvedTimeoutMs === 'number'
+              ? resolvedTimeoutMs
+              : undefined,
         });
       }
       if (result instanceof ReadableStream) {
@@ -335,7 +334,9 @@ export function loadersHandler(
           observerCtx: ctx,
           signal: timeoutSignal,
           timeoutMs:
-            typeof resolvedTimeoutMs === 'number' ? resolvedTimeoutMs : undefined,
+            typeof resolvedTimeoutMs === 'number'
+              ? resolvedTimeoutMs
+              : undefined,
         });
       }
       return c.json(result);

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from 'hono';
 import {
   isOutcome,
+  timeoutOutcome,
   type AppConfig,
   type Outcome,
   type ServerMiddleware,
@@ -42,6 +43,7 @@ type LoaderFn = (props: {
 type LoaderEntry = {
   fn: LoaderFn;
   use: ReadonlyArray<unknown>;
+  timeoutMs?: number | false;
 };
 
 async function buildLoadersMap(
@@ -67,8 +69,16 @@ async function buildLoadersMap(
         if (typeof val === 'function') {
           result[`${moduleKey}::${name}`] = { fn: val as LoaderFn, use: [] };
         } else if (val && typeof (val as { fn?: unknown }).fn === 'function') {
-          const ref = val as { fn: LoaderFn; use?: ReadonlyArray<unknown> };
-          result[`${moduleKey}::${name}`] = { fn: ref.fn, use: ref.use ?? [] };
+          const ref = val as {
+            fn: LoaderFn;
+            use?: ReadonlyArray<unknown>;
+            timeoutMs?: number | false;
+          };
+          result[`${moduleKey}::${name}`] = {
+            fn: ref.fn,
+            use: ref.use ?? [],
+            timeoutMs: ref.timeoutMs,
+          };
         }
       }
     }
@@ -123,6 +133,13 @@ export interface LoadersHandlerOptions {
   resolvePageUse?: (
     path: string
   ) => ReadonlyArray<unknown> | Promise<ReadonlyArray<unknown>>;
+  /**
+   * Default loader timeout in milliseconds applied when a loader does not
+   * declare its own `timeoutMs`. Defaults to 30000 (30 seconds). Pass
+   * `false` to disable the default (only loader-level `timeoutMs` enforces
+   * a deadline).
+   */
+  defaultTimeoutMs?: number | false;
 }
 
 function translateOutcomeForLoader(c: Context, outcome: Outcome): Response {
@@ -152,6 +169,12 @@ function translateOutcomeForLoader(c: Context, outcome: Outcome): Response {
       outcome.status
     );
   }
+  if (outcome.__outcome === 'timeout') {
+    return c.json(
+      { __outcome: 'timeout', timeoutMs: outcome.timeoutMs },
+      504
+    );
+  }
   // render outcome should never reach the loader RPC; this is defense in depth.
   return c.json(
     {
@@ -166,7 +189,13 @@ export function loadersHandler(
   glob: LazyGlob | EagerGlob,
   opts: LoadersHandlerOptions = {}
 ): MiddlewareHandler {
-  const { dev = false, onError, appConfig, resolvePageUse } = opts;
+  const {
+    dev = false,
+    onError,
+    appConfig,
+    resolvePageUse,
+    defaultTimeoutMs = 30_000,
+  } = opts;
   let cachedMapPromise: Promise<Record<string, LoaderEntry>> | null = null;
 
   return async (c) => {
@@ -225,7 +254,15 @@ export function loadersHandler(
       );
     }
 
-    const signal = c.req.raw.signal;
+    const resolvedTimeoutMs =
+      entry.timeoutMs !== undefined ? entry.timeoutMs : defaultTimeoutMs;
+    const timeoutSignal =
+      resolvedTimeoutMs === false || resolvedTimeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(resolvedTimeoutMs);
+    const signal = timeoutSignal
+      ? AbortSignal.any([c.req.raw.signal, timeoutSignal])
+      : c.req.raw.signal;
 
     // Chain ordering is outer -> inner: app-level middleware wraps every
     // request, page-level wraps loaders owned by that page, and per-loader
@@ -298,6 +335,20 @@ export function loadersHandler(
     } catch (err) {
       if (isOutcome(err)) {
         return translateOutcomeForLoader(c, err);
+      }
+      // Distinguish a deadline-driven abort from any other thrown error.
+      // AbortSignal.timeout sets signal.reason to a DOMException named
+      // 'TimeoutError'; AbortSignal.any propagates that reason. Re-check the
+      // composed signal because the loader's own throw may be the
+      // *consequence* of the signal aborting (e.g. fetch rejecting with the
+      // abort reason).
+      if (
+        timeoutSignal?.aborted &&
+        timeoutSignal.reason instanceof DOMException &&
+        timeoutSignal.reason.name === 'TimeoutError' &&
+        typeof resolvedTimeoutMs === 'number'
+      ) {
+        return translateOutcomeForLoader(c, timeoutOutcome(resolvedTimeoutMs));
       }
       onError?.(err, { module, loader: loaderName });
       // In production we never leak the loader's error message: it may

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -323,12 +323,18 @@ export function loadersHandler(
           emitResult: false,
           observers,
           observerCtx: ctx,
+          signal: timeoutSignal,
+          timeoutMs:
+            typeof resolvedTimeoutMs === 'number' ? resolvedTimeoutMs : undefined,
         });
       }
       if (result instanceof ReadableStream) {
         return sseReadableStreamResponse(c, result as ReadableStream<unknown>, {
           observers,
           observerCtx: ctx,
+          signal: timeoutSignal,
+          timeoutMs:
+            typeof resolvedTimeoutMs === 'number' ? resolvedTimeoutMs : undefined,
         });
       }
       return c.json(result);

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -23,6 +23,7 @@ import {
 type GlobModule = {
   default?: unknown;
   __moduleKey?: unknown;
+  serverLoaders?: unknown;
   [key: string]: unknown;
 };
 type LazyGlob = Record<string, () => Promise<unknown>>;
@@ -58,7 +59,7 @@ async function buildLoadersMap(
     const moduleKey = mod.__moduleKey;
     if (typeof moduleKey !== 'string') continue;
 
-    const sl = (mod as any).serverLoaders;
+    const sl = mod.serverLoaders;
     if (sl && typeof sl === 'object') {
       for (const [name, val] of Object.entries(sl)) {
         // Two accepted shapes:
@@ -283,7 +284,7 @@ export function loadersHandler(
       scope: 'loader',
       c,
       signal,
-      location: validatedLocation as never,
+      location: validatedLocation,
       module,
       loader: loaderName,
     };
@@ -329,7 +330,7 @@ export function loadersHandler(
         });
       }
       if (result instanceof ReadableStream) {
-        return sseReadableStreamResponse(c, result as ReadableStream<unknown>, {
+        return sseReadableStreamResponse(c, result, {
           observers,
           observerCtx: ctx,
           signal: timeoutSignal,

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -255,10 +255,10 @@ export function loadersHandler(
       );
     }
 
-    const resolvedTimeoutMs =
+    const resolvedTimeoutMs: number | false =
       entry.timeoutMs !== undefined ? entry.timeoutMs : defaultTimeoutMs;
     const timeoutSignal =
-      resolvedTimeoutMs === false || resolvedTimeoutMs === undefined
+      resolvedTimeoutMs === false
         ? undefined
         : AbortSignal.timeout(resolvedTimeoutMs);
     const signal = timeoutSignal

--- a/packages/server/src/sse.ts
+++ b/packages/server/src/sse.ts
@@ -38,8 +38,8 @@ export type SseGeneratorOptions = {
 function isTimeoutAbort(signal?: AbortSignal): boolean {
   return Boolean(
     signal?.aborted &&
-      signal.reason instanceof DOMException &&
-      signal.reason.name === 'TimeoutError'
+    signal.reason instanceof DOMException &&
+    signal.reason.name === 'TimeoutError'
   );
 }
 
@@ -68,7 +68,13 @@ export function sseGeneratorResponse(
   gen: AsyncGenerator<unknown, unknown, unknown>,
   options: SseGeneratorOptions = {}
 ): Response {
-  const { emitResult = false, observers, observerCtx, signal: optSignal, timeoutMs: optTimeoutMs } = options;
+  const {
+    emitResult = false,
+    observers,
+    observerCtx,
+    signal: optSignal,
+    timeoutMs: optTimeoutMs,
+  } = options;
   const obs = observers ?? [];
   return streamSSE(c, async (stream) => {
     let chunks = 0;
@@ -146,7 +152,12 @@ export function sseReadableStreamResponse(
     timeoutMs?: number;
   } = {}
 ): Response {
-  const { observers, observerCtx, signal: optSignal, timeoutMs: optTimeoutMs } = options;
+  const {
+    observers,
+    observerCtx,
+    signal: optSignal,
+    timeoutMs: optTimeoutMs,
+  } = options;
   const obs = observers ?? [];
   return streamSSE(c, async (stream) => {
     const reader = source.getReader();

--- a/packages/server/src/sse.ts
+++ b/packages/server/src/sse.ts
@@ -23,7 +23,25 @@ export type SseGeneratorOptions = {
   observers?: ReadonlyArray<StreamObserver<unknown, never>>;
   /** Server-stream ctx threaded to each observer hook. */
   observerCtx?: ServerStreamCtx;
+  /**
+   * The handler's timeout signal (from `AbortSignal.timeout(timeoutMs)`),
+   * inspected in the catch path to distinguish a deadline-driven abort
+   * from a generic throw. When this signal has aborted with a
+   * `TimeoutError` DOMException, the pump emits `event: timeout` with
+   * `{ timeoutMs }` instead of the generic `event: error` frame.
+   */
+  signal?: AbortSignal;
+  /** Used only with `signal`; the timeout value reported in the frame. */
+  timeoutMs?: number;
 };
+
+function isTimeoutAbort(signal?: AbortSignal): boolean {
+  return Boolean(
+    signal?.aborted &&
+      signal.reason instanceof DOMException &&
+      signal.reason.name === 'TimeoutError'
+  );
+}
 
 function encodeErrorPayload(err: unknown): string {
   const message = err instanceof Error ? err.message : String(err);
@@ -50,7 +68,7 @@ export function sseGeneratorResponse(
   gen: AsyncGenerator<unknown, unknown, unknown>,
   options: SseGeneratorOptions = {}
 ): Response {
-  const { emitResult = false, observers, observerCtx } = options;
+  const { emitResult = false, observers, observerCtx, signal: optSignal, timeoutMs: optTimeoutMs } = options;
   const obs = observers ?? [];
   return streamSSE(c, async (stream) => {
     let chunks = 0;
@@ -95,10 +113,17 @@ export function sseGeneratorResponse(
       if (started && observerCtx) {
         fanError(obs, observerCtx, err, { chunks });
       }
-      await stream.writeSSE({
-        event: 'error',
-        data: encodeErrorPayload(err),
-      });
+      if (isTimeoutAbort(optSignal) && typeof optTimeoutMs === 'number') {
+        await stream.writeSSE({
+          event: 'timeout',
+          data: JSON.stringify({ timeoutMs: optTimeoutMs }),
+        });
+      } else {
+        await stream.writeSSE({
+          event: 'error',
+          data: encodeErrorPayload(err),
+        });
+      }
     }
   });
 }
@@ -117,9 +142,11 @@ export function sseReadableStreamResponse(
   options: {
     observers?: ReadonlyArray<StreamObserver<unknown, never>>;
     observerCtx?: ServerStreamCtx;
+    signal?: AbortSignal;
+    timeoutMs?: number;
   } = {}
 ): Response {
-  const { observers, observerCtx } = options;
+  const { observers, observerCtx, signal: optSignal, timeoutMs: optTimeoutMs } = options;
   const obs = observers ?? [];
   return streamSSE(c, async (stream) => {
     const reader = source.getReader();
@@ -151,10 +178,17 @@ export function sseReadableStreamResponse(
       if (started && observerCtx) {
         fanError(obs, observerCtx, err, { chunks });
       }
-      await stream.writeSSE({
-        event: 'error',
-        data: encodeErrorPayload(err),
-      });
+      if (isTimeoutAbort(optSignal) && typeof optTimeoutMs === 'number') {
+        await stream.writeSSE({
+          event: 'timeout',
+          data: JSON.stringify({ timeoutMs: optTimeoutMs }),
+        });
+      } else {
+        await stream.writeSSE({
+          event: 'error',
+          data: encodeErrorPayload(err),
+        });
+      }
     } finally {
       reader.cancel().catch(() => {
         /* swallow */


### PR DESCRIPTION
## Summary

Spec A, PR1 of 2. Adopts three web-standard APIs as user-facing additions:

- **Loader/action timeouts** via `AbortSignal.any` + `AbortSignal.timeout`, with a new `TimeoutOutcome` variant (`{ __outcome: 'timeout', timeoutMs }`) and a `TimeoutError` class on the client.
- **Opt-in View Transitions** in `useOptimistic` / `useOptimisticAction` (settle + revert only; initial mutate paints same-frame).
- **`URL.parse()`** audit (no recoverable-parse sites found in `packages/`, so this is a no-op for the codebase but documented as part of the spec).

No version bump; PR2 (SSE TransformStream rewrite) follows. v0.3.0 will cut after Specs B-E also land per the [roadmap](docs/superpowers/specs/2026-05-23-web-standards-adoption-roadmap.md).

Design: [docs/superpowers/specs/2026-05-23-spec-a-platform-hygiene-design.md](docs/superpowers/specs/2026-05-23-spec-a-platform-hygiene-design.md)
Plan: [docs/superpowers/plans/2026-05-23-spec-a-platform-hygiene.md](docs/superpowers/plans/2026-05-23-spec-a-platform-hygiene.md)

## Public API additions

```ts
// New per-loader/action option
defineLoader(fn, { timeoutMs?: number | false /* default 30000, false to disable */ });
defineAction(fn, { timeoutMs?: number | false });

// New handler-level default
loadersHandler(glob, { defaultTimeoutMs?: number | false });
actionsHandler(glob, { defaultTimeoutMs?: number | false });

// New outcome variant + guard
type TimeoutOutcome = { __outcome: 'timeout'; timeoutMs: number };
function timeoutOutcome(timeoutMs: number): TimeoutOutcome;
function isTimeout(value: unknown): value is TimeoutOutcome;

// New client-side error class
class TimeoutError extends Error {
  readonly kind = 'timeout' as const;
  readonly timeoutMs: number;
}

// useOptimistic / useOptimisticAction grow an optional third arg
useOptimistic(base, reducer, { transition?: boolean });
useOptimisticAction(stub, { ..., transition?: boolean });
```

## Wire format

When a deadline fires, the server returns HTTP 504 with `{ __outcome: 'timeout', timeoutMs }`. Mid-stream timeouts emit an `event: timeout` SSE frame with `{ timeoutMs }`. Client surfaces both as a `TimeoutError` instance (`error.kind === 'timeout'`, `error.timeoutMs`).

## Test plan
- [x] `pnpm test` passes on Node (734/734)
- [x] `pnpm test:integration` passes on workerd (4/4)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [ ] Manually trigger a slow loader and confirm the client sees a `TimeoutError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)