### PR TITLE
refactor: SSE codec uses TransformStream; drop hono/streaming on the stream path

### DIFF
--- a/packages/iso/src/internal/__tests__/sse-decoder-pipeline.test.ts
+++ b/packages/iso/src/internal/__tests__/sse-decoder-pipeline.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { readSSE } from '../sse-decoder.js';
+
+function asStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      // Split in odd places to exercise multi-chunk buffering.
+      controller.enqueue(bytes.slice(0, 5));
+      controller.enqueue(bytes.slice(5, 17));
+      controller.enqueue(bytes.slice(17));
+      controller.close();
+    },
+  });
+}
+
+describe('readSSE', () => {
+  it('parses event-tagged data frames split across multiple TCP-sized chunks', async () => {
+    const input =
+      'data: "first"\n\n' +
+      'event: result\ndata: "final"\n\n' +
+      'event: timeout\ndata: {"timeoutMs":75}\n\n';
+
+    const events: { event: string; data: string }[] = [];
+    for await (const ev of readSSE(asStream(input))) {
+      events.push(ev);
+    }
+    expect(events).toEqual([
+      { event: 'message', data: '"first"' },
+      { event: 'result', data: '"final"' },
+      { event: 'timeout', data: '{"timeoutMs":75}' },
+    ]);
+  });
+
+  it('ignores keepalive comments and resets event after blank line', async () => {
+    const input =
+      ': keepalive\n' + 'event: tick\ndata: 1\n\n' + 'data: 2\n\n';
+    const events: { event: string; data: string }[] = [];
+    for await (const ev of readSSE(asStream(input))) {
+      events.push(ev);
+    }
+    expect(events).toEqual([
+      { event: 'tick', data: '1' },
+      { event: 'message', data: '2' },
+    ]);
+  });
+});

--- a/packages/iso/src/internal/__tests__/sse-decoder-pipeline.test.ts
+++ b/packages/iso/src/internal/__tests__/sse-decoder-pipeline.test.ts
@@ -33,8 +33,7 @@ describe('readSSE', () => {
   });
 
   it('ignores keepalive comments and resets event after blank line', async () => {
-    const input =
-      ': keepalive\n' + 'event: tick\ndata: 1\n\n' + 'data: 2\n\n';
+    const input = ': keepalive\n' + 'event: tick\ndata: 1\n\n' + 'data: 2\n\n';
     const events: { event: string; data: string }[] = [];
     for await (const ev of readSSE(asStream(input))) {
       events.push(ev);

--- a/packages/iso/src/internal/sse-decoder.ts
+++ b/packages/iso/src/internal/sse-decoder.ts
@@ -21,9 +21,9 @@ function lineSplitTransform(): TransformStream<string, string> {
 }
 
 export async function* readSSE(
-  stream: ReadableStream<Uint8Array>
+  stream: ReadableStream<BufferSource>
 ): AsyncGenerator<SSEEvent, void, unknown> {
-  const lines = (stream as ReadableStream<BufferSource>)
+  const lines = stream
     .pipeThrough(new TextDecoderStream())
     .pipeThrough(lineSplitTransform());
 

--- a/packages/iso/src/internal/sse-decoder.ts
+++ b/packages/iso/src/internal/sse-decoder.ts
@@ -1,42 +1,56 @@
 export type SSEEvent = { event: string; data: string };
 
+function lineSplitTransform(): TransformStream<string, string> {
+  let buffer = '';
+  return new TransformStream<string, string>({
+    transform(chunk, controller) {
+      buffer += chunk;
+      let nl: number;
+      while ((nl = buffer.indexOf('\n')) !== -1) {
+        controller.enqueue(buffer.slice(0, nl).replace(/\r$/, ''));
+        buffer = buffer.slice(nl + 1);
+      }
+    },
+    flush(controller) {
+      if (buffer.length) {
+        controller.enqueue(buffer.replace(/\r$/, ''));
+        buffer = '';
+      }
+    },
+  });
+}
+
 export async function* readSSE(
   stream: ReadableStream<Uint8Array>
 ): AsyncGenerator<SSEEvent, void, unknown> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
+  const lines = (stream as ReadableStream<BufferSource>)
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(lineSplitTransform());
+
   let event = 'message';
   let dataLines: string[] = [];
-
+  const reader = (lines as ReadableStream<string>).getReader();
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value: line } = await reader.read();
       if (done) {
-        buffer += decoder.decode();
-        if (dataLines.length) yield { event, data: dataLines.join('\n') };
+        if (dataLines.length) {
+          yield { event, data: dataLines.join('\n') };
+        }
         return;
       }
-      buffer += decoder.decode(value, { stream: true });
-
-      let nl: number;
-      while ((nl = buffer.indexOf('\n')) !== -1) {
-        const line = buffer.slice(0, nl).replace(/\r$/, '');
-        buffer = buffer.slice(nl + 1);
-
-        if (line === '') {
-          if (dataLines.length) {
-            yield { event, data: dataLines.join('\n') };
-          }
-          event = 'message';
-          dataLines = [];
-        } else if (line.startsWith(':')) {
-          // SSE comment / keepalive, ignore
-        } else if (line.startsWith('event:')) {
-          event = line.slice(6).trim();
-        } else if (line.startsWith('data:')) {
-          dataLines.push(line.slice(5).replace(/^ /, ''));
+      if (line === '') {
+        if (dataLines.length) {
+          yield { event, data: dataLines.join('\n') };
         }
+        event = 'message';
+        dataLines = [];
+      } else if (line.startsWith(':')) {
+        // SSE comment / keepalive, ignore
+      } else if (line.startsWith('event:')) {
+        event = line.slice(6).trim();
+      } else if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5).replace(/^ /, ''));
       }
     }
   } finally {

--- a/packages/server/src/__tests__/sse-backpressure.test.ts
+++ b/packages/server/src/__tests__/sse-backpressure.test.ts
@@ -1,6 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Hono } from 'hono';
+import { defineStreamObserver, type ServerLoaderCtx } from '@hono-preact/iso';
 import { sseGeneratorResponse } from '../sse.js';
+
+const observerCtx: ServerLoaderCtx = {
+  scope: 'loader',
+  // The SSE pump never reads through `c` / `signal` — observers only see
+  // them in onStart/onChunk/etc. via the ctx pointer. A minimal stand-in
+  // is enough for the codec-level assertions below.
+  c: {} as ServerLoaderCtx['c'],
+  signal: new AbortController().signal,
+  location: { path: '/', pathParams: {}, searchParams: {} },
+  module: 'm',
+  loader: 'l',
+};
 
 describe('SSE backpressure and abort', () => {
   it('cancels the source generator when the consumer aborts', async () => {
@@ -26,5 +39,111 @@ describe('SSE backpressure and abort', () => {
     // Give the generator a moment to observe cancellation.
     await new Promise((r) => setTimeout(r, 10));
     expect(returned).toBe(true);
+  });
+
+  it('fires onAbort when the consumer cancels mid-stream', async () => {
+    const onAbort = vi.fn();
+    const onStart = vi.fn();
+    const onChunk = vi.fn();
+    const onEnd = vi.fn();
+    const observer = defineStreamObserver({
+      onStart,
+      onChunk,
+      onEnd,
+      onAbort,
+    });
+
+    const source = (async function* () {
+      for (let i = 0; ; i++) {
+        yield i;
+      }
+    })();
+
+    const app = new Hono();
+    app.get('/', (c) =>
+      sseGeneratorResponse(c, source, {
+        observers: [observer],
+        observerCtx,
+      })
+    );
+
+    const res = await app.request('http://localhost/');
+    const reader = res.body!.getReader();
+    await reader.read();
+    await reader.read(); // pull one more frame so chunks > 0 at abort time
+    await reader.cancel();
+    // Let the cancel callback drain.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onAbort).toHaveBeenCalledTimes(1);
+    expect(onEnd).not.toHaveBeenCalled();
+    // chunks should reflect what was produced before cancellation.
+    const [, info] = onAbort.mock.calls[0];
+    expect(info.chunks).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not fire onAbort when the source completes normally', async () => {
+    const onAbort = vi.fn();
+    const onEnd = vi.fn();
+    const observer = defineStreamObserver({ onAbort, onEnd });
+
+    const source = (async function* () {
+      yield 1;
+      yield 2;
+    })();
+
+    const app = new Hono();
+    app.get('/', (c) =>
+      sseGeneratorResponse(c, source, {
+        observers: [observer],
+        observerCtx,
+      })
+    );
+
+    const res = await app.request('http://localhost/');
+    // Drain the response fully.
+    if (res.body) {
+      const reader = res.body.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    }
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onAbort).not.toHaveBeenCalled();
+  });
+
+  it('pauses production when the consumer is slow (backpressure)', async () => {
+    // The source advertises how many values have been pulled. The consumer
+    // only reads one chunk, then waits. The pump should be ahead by at most
+    // one (the chunk in the controller's queue) — not arbitrarily far.
+    let produced = 0;
+    const source = (async function* () {
+      while (true) {
+        produced += 1;
+        yield produced;
+      }
+    })();
+
+    const app = new Hono();
+    app.get('/', (c) => sseGeneratorResponse(c, source));
+
+    const res = await app.request('http://localhost/');
+    const reader = res.body!.getReader();
+
+    // Read one chunk.
+    await reader.read();
+    // Let the event loop run a bit so the pump would race ahead if
+    // backpressure were broken.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Backpressure cap. The pump's `pull` produces one frame per consumer
+    // read; the encoder TransformStream's default queue holds the frame
+    // that's been emitted but not yet consumed. So `produced` should be
+    // bounded by a small constant (typically 2) — emphatically not unbounded.
+    expect(produced).toBeLessThan(20);
+
+    await reader.cancel();
   });
 });

--- a/packages/server/src/__tests__/sse-backpressure.test.ts
+++ b/packages/server/src/__tests__/sse-backpressure.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { sseGeneratorResponse } from '../sse.js';
+
+describe('SSE backpressure and abort', () => {
+  it('cancels the source generator when the consumer aborts', async () => {
+    let returned = false;
+    const source = (async function* () {
+      try {
+        for (let i = 0; ; i++) {
+          yield i;
+        }
+      } finally {
+        returned = true;
+      }
+    })();
+
+    const app = new Hono();
+    app.get('/', (c) => sseGeneratorResponse(c, source));
+
+    const res = await app.request('http://localhost/');
+    const reader = res.body!.getReader();
+    // Read one chunk to ensure the generator has started.
+    await reader.read();
+    await reader.cancel();
+    // Give the generator a moment to observe cancellation.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(returned).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/sse-wire-snapshot.test.ts
+++ b/packages/server/src/__tests__/sse-wire-snapshot.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
-import {
-  sseGeneratorResponse,
-  sseReadableStreamResponse,
-} from '../sse.js';
+import { sseGeneratorResponse, sseReadableStreamResponse } from '../sse.js';
 
 async function bodyToString(res: Response): Promise<string> {
-  return res.body ? new TextDecoder().decode(await new Response(res.body).arrayBuffer()) : '';
+  return res.body
+    ? new TextDecoder().decode(await new Response(res.body).arrayBuffer())
+    : '';
 }
 
 describe('SSE wire format', () => {

--- a/packages/server/src/__tests__/sse-wire-snapshot.test.ts
+++ b/packages/server/src/__tests__/sse-wire-snapshot.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import {
+  sseGeneratorResponse,
+  sseReadableStreamResponse,
+} from '../sse.js';
+
+async function bodyToString(res: Response): Promise<string> {
+  return res.body ? new TextDecoder().decode(await new Response(res.body).arrayBuffer()) : '';
+}
+
+describe('SSE wire format', () => {
+  it('generator response: byte-stable for a representative stream', async () => {
+    const app = new Hono();
+    app.get('/', (c) =>
+      sseGeneratorResponse(
+        c,
+        (async function* () {
+          yield 'first';
+          yield { n: 2 };
+          return 'final';
+        })(),
+        { emitResult: true }
+      )
+    );
+
+    const res = await app.request('http://localhost/');
+    expect(res.headers.get('content-type')).toMatch(/text\/event-stream/);
+    const body = await bodyToString(res);
+    expect(body).toBe(
+      'data: "first"\n\n' +
+        'data: {"n":2}\n\n' +
+        'event: result\ndata: "final"\n\n'
+    );
+  });
+
+  it('readable-stream response: byte-stable for a representative stream', async () => {
+    const app = new Hono();
+    app.get('/', (c) => {
+      const source = new ReadableStream<unknown>({
+        start(controller) {
+          controller.enqueue('alpha');
+          controller.enqueue({ k: 'beta' });
+          controller.close();
+        },
+      });
+      return sseReadableStreamResponse(c, source);
+    });
+
+    const res = await app.request('http://localhost/');
+    const body = await bodyToString(res);
+    expect(body).toBe('data: "alpha"\n\n' + 'data: {"k":"beta"}\n\n');
+  });
+
+  it('generator error path: emits event: error frame', async () => {
+    const app = new Hono();
+    app.get('/', (c) =>
+      sseGeneratorResponse(
+        c,
+        (async function* () {
+          yield 'before';
+          throw new Error('boom');
+        })()
+      )
+    );
+
+    const res = await app.request('http://localhost/');
+    const body = await bodyToString(res);
+    expect(body).toBe(
+      'data: "before"\n\n' +
+        'event: error\ndata: {"message":"boom","name":"Error"}\n\n'
+    );
+  });
+});

--- a/packages/server/src/sse.ts
+++ b/packages/server/src/sse.ts
@@ -152,6 +152,7 @@ export function sseGeneratorResponse(
     },
     cancel() {
       pump.return(undefined).catch(() => undefined);
+      gen.return(undefined).catch(() => undefined);
     },
   }).pipeThrough(sseEncodeTransform());
 

--- a/packages/server/src/sse.ts
+++ b/packages/server/src/sse.ts
@@ -1,12 +1,10 @@
 import type { Context } from 'hono';
-import { streamSSE } from 'hono/streaming';
 import type { StreamObserver, ServerStreamCtx } from '@hono-preact/iso';
 import {
   fanStart,
   fanChunk,
   fanEnd,
   fanError,
-  fanAbort,
 } from '@hono-preact/iso/internal';
 
 export type SseGeneratorOptions = {
@@ -171,10 +169,15 @@ export function sseGeneratorResponse(
  *
  * Observer fanout mirrors `sseGeneratorResponse`: `onStart` fires before the
  * first read, `onChunk` per chunk, `onEnd` on normal completion, `onError` on
- * throw, `onAbort` when the response stream is aborted.
+ * throw.
+ *
+ * Note: `onAbort` is not called from this function. Cancellation propagates
+ * via the `ReadableStream` constructor's `cancel()` callback calling
+ * `pump.return()`; observers wanting abort notification should use a future
+ * hook added to `cancel()`.
  */
 export function sseReadableStreamResponse(
-  c: Context,
+  _c: Context,
   source: ReadableStream<unknown>,
   options: {
     observers?: ReadonlyArray<StreamObserver<unknown, never>>;
@@ -183,9 +186,10 @@ export function sseReadableStreamResponse(
     timeoutMs?: number;
   } = {}
 ): Response {
-  const { observers, observerCtx, signal: optSignal, timeoutMs: optTimeoutMs } = options;
+  const { observers, observerCtx, signal, timeoutMs } = options;
   const obs = observers ?? [];
-  return streamSSE(c, async (stream) => {
+
+  async function* framePump(): AsyncGenerator<SSEFrame, void, unknown> {
     const reader = source.getReader();
     let chunks = 0;
     let started = false;
@@ -194,7 +198,7 @@ export function sseReadableStreamResponse(
       started = true;
     }
     try {
-      while (!stream.aborted) {
+      while (true) {
         const { done, value } = await reader.read();
         if (done) {
           if (started && observerCtx) {
@@ -202,35 +206,49 @@ export function sseReadableStreamResponse(
           }
           return;
         }
-        await stream.writeSSE({ data: JSON.stringify(value) });
+        yield { data: JSON.stringify(value) };
         if (started && observerCtx) {
           fanChunk(obs, observerCtx, value, chunks);
         }
         chunks += 1;
       }
-      if (started && observerCtx) {
-        fanAbort(obs, observerCtx, { chunks });
-      }
     } catch (err) {
       if (started && observerCtx) {
         fanError(obs, observerCtx, err, { chunks });
       }
-      if (isTimeoutAbort(optSignal) && typeof optTimeoutMs === 'number') {
-        await stream.writeSSE({
+      if (isTimeoutAbort(signal) && typeof timeoutMs === 'number') {
+        yield {
           event: 'timeout',
-          data: JSON.stringify({ timeoutMs: optTimeoutMs }),
-        });
+          data: JSON.stringify({ timeoutMs }),
+        };
       } else {
-        await stream.writeSSE({
-          event: 'error',
-          data: encodeErrorPayload(err),
-        });
+        yield { event: 'error', data: encodeErrorPayload(err) };
       }
     } finally {
-      reader.cancel().catch(() => {
-        /* swallow */
-      });
+      reader.cancel().catch(() => undefined);
     }
+  }
+
+  const pump = framePump();
+  const body = new ReadableStream<SSEFrame>({
+    async pull(controller) {
+      const { value, done } = await pump.next();
+      if (done) {
+        controller.close();
+      } else {
+        controller.enqueue(value);
+      }
+    },
+    cancel() {
+      pump.return(undefined).catch(() => undefined);
+    },
+  }).pipeThrough(sseEncodeTransform());
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+    },
   });
 }
 

--- a/packages/server/src/sse.ts
+++ b/packages/server/src/sse.ts
@@ -35,11 +35,26 @@ export type SseGeneratorOptions = {
   timeoutMs?: number;
 };
 
+type SSEFrame = { event?: string; id?: string; data: string };
+
+function sseEncodeTransform(): TransformStream<SSEFrame, Uint8Array> {
+  const encoder = new TextEncoder();
+  return new TransformStream<SSEFrame, Uint8Array>({
+    transform(frame, controller) {
+      const lines: string[] = [];
+      if (frame.event) lines.push(`event: ${frame.event}`);
+      if (frame.id) lines.push(`id: ${frame.id}`);
+      lines.push(`data: ${frame.data}`);
+      controller.enqueue(encoder.encode(lines.join('\n') + '\n\n'));
+    },
+  });
+}
+
 function isTimeoutAbort(signal?: AbortSignal): boolean {
   return Boolean(
     signal?.aborted &&
-    signal.reason instanceof DOMException &&
-    signal.reason.name === 'TimeoutError'
+      signal.reason instanceof DOMException &&
+      signal.reason.name === 'TimeoutError'
   );
 }
 
@@ -56,15 +71,19 @@ function encodeErrorPayload(err: unknown): string {
  * If `emitResult` is true and the generator's return value is defined,
  * it is written as `event: result\ndata: <json>` before the stream closes.
  * If the generator throws, an `event: error\ndata: {"message","name"}` frame
- * is written and the stream closes cleanly (Hono's default error handler is
- * never invoked because we catch inside the callback).
+ * is written and the stream closes cleanly.
  *
  * When `observers` is provided, the pump fires the corresponding lifecycle
- * hooks (`onStart` / `onChunk` / `onEnd` / `onError` / `onAbort`) so
- * users can attach instrumentation via `defineStreamObserver(...)`.
+ * hooks (`onStart` / `onChunk` / `onEnd` / `onError`) so users can attach
+ * instrumentation via `defineStreamObserver(...)`.
+ *
+ * Note: `onAbort` is not called from this function. Cancellation propagates
+ * via `ReadableStream.from(gen)` calling the generator's `return()` when the
+ * client closes; observers wanting abort notification should use the readable-
+ * stream variant or a future hook added to `cancel()`.
  */
 export function sseGeneratorResponse(
-  c: Context,
+  _c: Context,
   gen: AsyncGenerator<unknown, unknown, unknown>,
   options: SseGeneratorOptions = {}
 ): Response {
@@ -72,11 +91,15 @@ export function sseGeneratorResponse(
     emitResult = false,
     observers,
     observerCtx,
-    signal: optSignal,
-    timeoutMs: optTimeoutMs,
+    signal,
+    timeoutMs,
   } = options;
   const obs = observers ?? [];
-  return streamSSE(c, async (stream) => {
+
+  // The pump generator owns the lifecycle: it adapts the user's generator
+  // into a stream of SSEFrames, calls observer hooks, and emits a trailing
+  // `result`, `timeout`, or `error` frame as needed.
+  async function* framePump(): AsyncGenerator<SSEFrame, void, unknown> {
     let chunks = 0;
     let started = false;
     if (obs.length > 0 && observerCtx) {
@@ -84,53 +107,61 @@ export function sseGeneratorResponse(
       started = true;
     }
     try {
-      while (!stream.aborted) {
+      while (true) {
         const step = await gen.next();
         if (step.done) {
           if (emitResult && step.value !== undefined) {
-            await stream.writeSSE({
-              event: 'result',
-              data: JSON.stringify(step.value),
-            });
+            yield { event: 'result', data: JSON.stringify(step.value) };
           }
           if (started && observerCtx) {
             fanEnd(obs, observerCtx, { chunks, result: step.value });
           }
           return;
         }
-        await stream.writeSSE({ data: JSON.stringify(step.value) });
+        yield { data: JSON.stringify(step.value) };
         if (started && observerCtx) {
           fanChunk(obs, observerCtx, step.value, chunks);
         }
         chunks += 1;
       }
-      // Loop exited because the response stream was aborted (typically a
-      // client disconnect). Release the generator and notify observers.
-      await gen.return(undefined).catch(() => {
-        /* swallow */
-      });
-      if (started && observerCtx) {
-        fanAbort(obs, observerCtx, { chunks });
-      }
     } catch (err) {
-      await gen.return(undefined).catch(() => {
-        /* swallow */
-      });
+      await gen.return(undefined).catch(() => undefined);
       if (started && observerCtx) {
         fanError(obs, observerCtx, err, { chunks });
       }
-      if (isTimeoutAbort(optSignal) && typeof optTimeoutMs === 'number') {
-        await stream.writeSSE({
+      if (isTimeoutAbort(signal) && typeof timeoutMs === 'number') {
+        yield {
           event: 'timeout',
-          data: JSON.stringify({ timeoutMs: optTimeoutMs }),
-        });
+          data: JSON.stringify({ timeoutMs }),
+        };
       } else {
-        await stream.writeSSE({
-          event: 'error',
-          data: encodeErrorPayload(err),
-        });
+        yield { event: 'error', data: encodeErrorPayload(err) };
       }
     }
+  }
+
+  // ReadableStream.from is not yet in the TypeScript DOM lib. The constructor
+  // form is equivalent and fully typed.
+  const pump = framePump();
+  const body = new ReadableStream<SSEFrame>({
+    async pull(controller) {
+      const { value, done } = await pump.next();
+      if (done) {
+        controller.close();
+      } else {
+        controller.enqueue(value);
+      }
+    },
+    cancel() {
+      pump.return(undefined).catch(() => undefined);
+    },
+  }).pipeThrough(sseEncodeTransform());
+
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+    },
   });
 }
 
@@ -152,12 +183,7 @@ export function sseReadableStreamResponse(
     timeoutMs?: number;
   } = {}
 ): Response {
-  const {
-    observers,
-    observerCtx,
-    signal: optSignal,
-    timeoutMs: optTimeoutMs,
-  } = options;
+  const { observers, observerCtx, signal: optSignal, timeoutMs: optTimeoutMs } = options;
   const obs = observers ?? [];
   return streamSSE(c, async (stream) => {
     const reader = source.getReader();

--- a/packages/server/src/sse.ts
+++ b/packages/server/src/sse.ts
@@ -5,18 +5,32 @@ import {
   fanChunk,
   fanEnd,
   fanError,
+  fanAbort,
 } from '@hono-preact/iso/internal';
 
-export type SseGeneratorOptions = {
-  /** When true, the generator's return value is emitted as `event: result`. */
+/**
+ * Options shared by both SSE response helpers. Encodes the lifecycle the SSE
+ * pump runs through:
+ *
+ * - Observer fanout: `onStart` fires before the first chunk, `onChunk` per
+ *   value yielded by the source, `onEnd` on normal completion, `onError` on
+ *   a thrown error, `onAbort` when the consumer cancels the response stream
+ *   before the source finishes.
+ * - Timeout discrimination: when `signal.aborted` and `signal.reason` is a
+ *   `TimeoutError` `DOMException`, the catch path emits `event: timeout`
+ *   with `{ timeoutMs }` instead of the generic `event: error` frame.
+ */
+export type SseResponseOptions = {
+  /**
+   * When true, the generator's return value (if defined) is emitted as
+   * `event: result` before the stream closes. Only meaningful for
+   * generator-sourced responses; ignored for `ReadableStream` sources.
+   */
   emitResult?: boolean;
   /**
    * Stream observers harvested from the loader/action's `use` array (the
-   * non-middleware partition). The SSE pump fires `onStart` before the
-   * first chunk, `onChunk` per yielded value, `onEnd` on clean completion,
-   * `onError` on throw, and `onAbort` when the response stream is aborted
-   * (typically because the client disconnected). Hooks are isolated: a
-   * throwing observer never corrupts the stream.
+   * non-middleware partition). Hooks are isolated: a throwing observer
+   * never corrupts the stream.
    */
   observers?: ReadonlyArray<StreamObserver<unknown, never>>;
   /** Server-stream ctx threaded to each observer hook. */
@@ -24,14 +38,15 @@ export type SseGeneratorOptions = {
   /**
    * The handler's timeout signal (from `AbortSignal.timeout(timeoutMs)`),
    * inspected in the catch path to distinguish a deadline-driven abort
-   * from a generic throw. When this signal has aborted with a
-   * `TimeoutError` DOMException, the pump emits `event: timeout` with
-   * `{ timeoutMs }` instead of the generic `event: error` frame.
+   * from a generic throw.
    */
   signal?: AbortSignal;
   /** Used only with `signal`; the timeout value reported in the frame. */
   timeoutMs?: number;
 };
+
+/** Alias retained for source compatibility with earlier code. */
+export type SseGeneratorOptions = SseResponseOptions;
 
 type SSEFrame = { event?: string; id?: string; data: string };
 
@@ -51,8 +66,8 @@ function sseEncodeTransform(): TransformStream<SSEFrame, Uint8Array> {
 function isTimeoutAbort(signal?: AbortSignal): boolean {
   return Boolean(
     signal?.aborted &&
-      signal.reason instanceof DOMException &&
-      signal.reason.name === 'TimeoutError'
+    signal.reason instanceof DOMException &&
+    signal.reason.name === 'TimeoutError'
   );
 }
 
@@ -63,27 +78,38 @@ function encodeErrorPayload(err: unknown): string {
 }
 
 /**
- * Wrap an async generator as an SSE response.
- *
- * Each yield is JSON-encoded and written as a `data:` event.
- * If `emitResult` is true and the generator's return value is defined,
- * it is written as `event: result\ndata: <json>` before the stream closes.
- * If the generator throws, an `event: error\ndata: {"message","name"}` frame
- * is written and the stream closes cleanly.
- *
- * When `observers` is provided, the pump fires the corresponding lifecycle
- * hooks (`onStart` / `onChunk` / `onEnd` / `onError`) so users can attach
- * instrumentation via `defineStreamObserver(...)`.
- *
- * Note: `onAbort` is not called from this function. Cancellation propagates
- * via `ReadableStream.from(gen)` calling the generator's `return()` when the
- * client closes; observers wanting abort notification should use the readable-
- * stream variant or a future hook added to `cancel()`.
+ * Adapt a `ReadableStream<T>` as an async generator (with no return value).
+ * The reader is released in `finally`, which fires either when the consumer
+ * stops iterating or when the source is exhausted.
  */
-export function sseGeneratorResponse(
-  _c: Context,
-  gen: AsyncGenerator<unknown, unknown, unknown>,
-  options: SseGeneratorOptions = {}
+async function* iterReadable<T>(
+  stream: ReadableStream<T>
+): AsyncGenerator<T, void, unknown> {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      yield value;
+    }
+  } finally {
+    reader.cancel().catch(() => undefined);
+  }
+}
+
+/**
+ * The shared pump implementation. Iterates `source` (a generator that may
+ * return a final value), encodes each yielded value as a JSON `data:` frame,
+ * runs the observer lifecycle, and translates errors into `event: error` or
+ * `event: timeout` frames.
+ *
+ * Observer state (`chunks`, `started`, `finished`) lives in the outer
+ * function scope so the outer ReadableStream's `cancel()` callback can fire
+ * `onAbort` when the consumer cancels mid-stream.
+ */
+function buildSseResponse(
+  source: AsyncGenerator<unknown, unknown, unknown>,
+  options: SseResponseOptions
 ): Response {
   const {
     emitResult = false,
@@ -93,20 +119,18 @@ export function sseGeneratorResponse(
     timeoutMs,
   } = options;
   const obs = observers ?? [];
+  let chunks = 0;
+  let started = false;
+  let finished = false;
 
-  // The pump generator owns the lifecycle: it adapts the user's generator
-  // into a stream of SSEFrames, calls observer hooks, and emits a trailing
-  // `result`, `timeout`, or `error` frame as needed.
   async function* framePump(): AsyncGenerator<SSEFrame, void, unknown> {
-    let chunks = 0;
-    let started = false;
     if (obs.length > 0 && observerCtx) {
       fanStart(obs, observerCtx);
       started = true;
     }
     try {
       while (true) {
-        const step = await gen.next();
+        const step = await source.next();
         if (step.done) {
           if (emitResult && step.value !== undefined) {
             yield { event: 'result', data: JSON.stringify(step.value) };
@@ -114,6 +138,7 @@ export function sseGeneratorResponse(
           if (started && observerCtx) {
             fanEnd(obs, observerCtx, { chunks, result: step.value });
           }
+          finished = true;
           return;
         }
         yield { data: JSON.stringify(step.value) };
@@ -123,23 +148,19 @@ export function sseGeneratorResponse(
         chunks += 1;
       }
     } catch (err) {
-      await gen.return(undefined).catch(() => undefined);
+      await source.return(undefined).catch(() => undefined);
       if (started && observerCtx) {
         fanError(obs, observerCtx, err, { chunks });
       }
       if (isTimeoutAbort(signal) && typeof timeoutMs === 'number') {
-        yield {
-          event: 'timeout',
-          data: JSON.stringify({ timeoutMs }),
-        };
+        yield { event: 'timeout', data: JSON.stringify({ timeoutMs }) };
       } else {
         yield { event: 'error', data: encodeErrorPayload(err) };
       }
+      finished = true;
     }
   }
 
-  // ReadableStream.from is not yet in the TypeScript DOM lib. The constructor
-  // form is equivalent and fully typed.
   const pump = framePump();
   const body = new ReadableStream<SSEFrame>({
     async pull(controller) {
@@ -151,8 +172,14 @@ export function sseGeneratorResponse(
       }
     },
     cancel() {
+      // Consumer cancelled before the pump completed. Notify observers via
+      // `onAbort` exactly when we've genuinely been aborted mid-stream
+      // (i.e. the source started but didn't finish naturally).
+      if (!finished && started && observerCtx) {
+        fanAbort(obs, observerCtx, { chunks });
+      }
       pump.return(undefined).catch(() => undefined);
-      gen.return(undefined).catch(() => undefined);
+      source.return(undefined).catch(() => undefined);
     },
   }).pipeThrough(sseEncodeTransform());
 
@@ -165,91 +192,38 @@ export function sseGeneratorResponse(
 }
 
 /**
- * Wrap a ReadableStream<T> (with T a JSON-encodable value) as an SSE response.
- * Each enqueued chunk is JSON-encoded and written as a `data:` event.
+ * Wrap an async generator as an SSE response.
  *
- * Observer fanout mirrors `sseGeneratorResponse`: `onStart` fires before the
- * first read, `onChunk` per chunk, `onEnd` on normal completion, `onError` on
- * throw.
- *
- * Note: `onAbort` is not called from this function. Cancellation propagates
- * via the `ReadableStream` constructor's `cancel()` callback calling
- * `pump.return()`; observers wanting abort notification should use a future
- * hook added to `cancel()`.
+ * Each yield is JSON-encoded and written as a `data:` event. If `emitResult`
+ * is true and the generator's return value is defined, it is written as
+ * `event: result\ndata: <json>` before the stream closes. If the generator
+ * throws, an `event: error` or `event: timeout` frame is written and the
+ * stream closes cleanly. Observer lifecycle hooks (`onStart` / `onChunk` /
+ * `onEnd` / `onError` / `onAbort`) fire from inside the pump.
+ */
+export function sseGeneratorResponse(
+  _c: Context,
+  gen: AsyncGenerator<unknown, unknown, unknown>,
+  options: SseResponseOptions = {}
+): Response {
+  return buildSseResponse(gen, options);
+}
+
+/**
+ * Wrap a `ReadableStream<T>` (with `T` a JSON-encodable value) as an SSE
+ * response. Each enqueued chunk is JSON-encoded and written as a `data:`
+ * event. Observer lifecycle hooks fire identically to `sseGeneratorResponse`;
+ * `emitResult` is not meaningful here (streams have no return value) and is
+ * ignored.
  */
 export function sseReadableStreamResponse(
   _c: Context,
   source: ReadableStream<unknown>,
-  options: {
-    observers?: ReadonlyArray<StreamObserver<unknown, never>>;
-    observerCtx?: ServerStreamCtx;
-    signal?: AbortSignal;
-    timeoutMs?: number;
-  } = {}
+  options: SseResponseOptions = {}
 ): Response {
-  const { observers, observerCtx, signal, timeoutMs } = options;
-  const obs = observers ?? [];
-
-  async function* framePump(): AsyncGenerator<SSEFrame, void, unknown> {
-    const reader = source.getReader();
-    let chunks = 0;
-    let started = false;
-    if (obs.length > 0 && observerCtx) {
-      fanStart(obs, observerCtx);
-      started = true;
-    }
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          if (started && observerCtx) {
-            fanEnd(obs, observerCtx, { chunks, result: undefined });
-          }
-          return;
-        }
-        yield { data: JSON.stringify(value) };
-        if (started && observerCtx) {
-          fanChunk(obs, observerCtx, value, chunks);
-        }
-        chunks += 1;
-      }
-    } catch (err) {
-      if (started && observerCtx) {
-        fanError(obs, observerCtx, err, { chunks });
-      }
-      if (isTimeoutAbort(signal) && typeof timeoutMs === 'number') {
-        yield {
-          event: 'timeout',
-          data: JSON.stringify({ timeoutMs }),
-        };
-      } else {
-        yield { event: 'error', data: encodeErrorPayload(err) };
-      }
-    } finally {
-      reader.cancel().catch(() => undefined);
-    }
-  }
-
-  const pump = framePump();
-  const body = new ReadableStream<SSEFrame>({
-    async pull(controller) {
-      const { value, done } = await pump.next();
-      if (done) {
-        controller.close();
-      } else {
-        controller.enqueue(value);
-      }
-    },
-    cancel() {
-      pump.return(undefined).catch(() => undefined);
-    },
-  }).pipeThrough(sseEncodeTransform());
-
-  return new Response(body, {
-    headers: {
-      'content-type': 'text/event-stream',
-      'cache-control': 'no-cache',
-    },
+  return buildSseResponse(iterReadable(source), {
+    ...options,
+    emitResult: false,
   });
 }
 


### PR DESCRIPTION
## Summary

Spec A, PR2 of 2. Replaces the hand-rolled SSE codec with a `TransformStream`-based pipeline. Wire format preserved byte-for-byte (verified by a snapshot test).

- **Server:** `sseGeneratorResponse` / `sseReadableStreamResponse` are now three-line adapters over a shared `buildSseResponse` helper that takes any `AsyncGenerator<unknown, unknown, unknown>` source, runs the observer lifecycle, encodes via a `TransformStream`, and translates errors / timeouts into structured frames. The stream variant uses a small `iterReadable` helper to present a `ReadableStream` as a generator.
- **Client:** `readSSE` pipes the response body through `TextDecoderStream` and a line-splitting `TransformStream`. Output `SSEEvent` shape unchanged.
- **`hono/streaming` removed** from `packages/server/src/sse.ts`. The stream path is now fully Web-Standards-based.
- **`onAbort` restored** for generator sources via the `ReadableStream.cancel()` callback, with outer-scope state (`chunks`, `started`, `finished`) so the callback can correctly distinguish cancellation from completion.
- **Shared `SseResponseOptions` type** (replacing the anonymous inline options on `sseReadableStreamResponse`); `SseGeneratorOptions` kept as an alias for source compatibility.

Note: previously opened as #57; auto-closed when PR1 merged and its base branch was deleted. Reopened here against `main` with identical content (rebased onto the post-merge tip).

Design: [docs/superpowers/specs/2026-05-23-spec-a-platform-hygiene-design.md](docs/superpowers/specs/2026-05-23-spec-a-platform-hygiene-design.md)
Plan: [docs/superpowers/plans/2026-05-23-spec-a-platform-hygiene.md](docs/superpowers/plans/2026-05-23-spec-a-platform-hygiene.md)

## Test plan
- [x] `pnpm test` passes (745/745)
- [x] `pnpm test:integration` passes
- [x] `pnpm typecheck` and `pnpm build` clean
- [x] SSE wire-format snapshot passes byte-for-byte against the pre-refactor encoder
- [x] Backpressure tests cover: cancellation propagation, `onAbort` fires on mid-stream cancel, `onAbort` does NOT fire on normal completion, and a slow-consumer producer cap
- [x] `grep -rn 'hono/streaming' packages/server/src packages/iso/src` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)