### PR TITLE
fix(server): backpressure-aware multi-loader HTML stream

### DIFF
--- a/packages/server/src/__tests__/render-stream.test.tsx
+++ b/packages/server/src/__tests__/render-stream.test.tsx
@@ -297,6 +297,57 @@ describe('renderPage: streaming SSR', () => {
     expect(accumulated).toMatch(/"n":2/);
   });
 
+  it('pauses production when the HTML consumer is slow (backpressure)', async () => {
+    // Mirror of sse-backpressure.test.ts:117 but for the HTML streaming
+    // path in `render.tsx`. A loader yields in a tight loop while the
+    // consumer reads exactly one chunk and stalls. With backpressure the
+    // pump should be ahead by at most a small constant (the chunks buffered
+    // in the response stream's internal queue). Without backpressure the
+    // Promise.all-driven loader loop in `render.tsx` races unboundedly,
+    // buffering every yield into the ReadableStream queue.
+    // Capped so a broken backpressure path fails the assertion instead of
+    // OOM-ing the worker. 5000 is far above the with-backpressure ceiling
+    // (≈1–2) and far below a heap-exhausting count.
+    const CAP = 5000;
+    let produced = 0;
+    const loader = defineLoader<{ n: number }>(async function* () {
+      while (produced < CAP) {
+        produced += 1;
+        yield { n: produced };
+      }
+    });
+    const app = new Hono();
+    app.get('/', (c) =>
+      renderPage(
+        c,
+        <Loader loader={loader} location={loc}>
+          <p>streaming</p>
+        </Loader>
+      )
+    );
+
+    const res = await app.request('/');
+    expect(res.body).not.toBeNull();
+    const reader = res.body!.getReader();
+
+    // Read one chunk so the stream is actively running.
+    await reader.read();
+    // Yield the event loop for a stretch. With backpressure honored the
+    // loader stays parked at its yield point until the consumer reads;
+    // without it, the loop runs as fast as the microtask queue allows.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Backpressure cap: bounded by the ReadableStream queue. Without
+    // backpressure, `produced` reaches thousands within 50ms.
+    // With backpressure honored, `produced` should be ~2 (one yield consumed
+    // by prerender, one chunk buffered in the TransformStream). A small
+    // upper bound keeps the test sensitive to regressions while leaving
+    // headroom for microtask scheduling differences across runtimes.
+    expect(produced).toBeLessThan(5);
+
+    await reader.cancel();
+  });
+
   it('aborts cleanly on client cancel: no synthetic error chunks, no enqueue-after-close throws', async () => {
     // Loader that yields one chunk then awaits forever; cancel mid-stream.
     let releaseSecondYield: (() => void) | null = null;

--- a/packages/server/src/render.tsx
+++ b/packages/server/src/render.tsx
@@ -293,78 +293,116 @@ export async function renderPage(
   // chunk that nobody can read anyway).
   let aborted = false;
 
-  const responseStream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      // Re-enter the captured request scope so generator continuations and
-      // anything they touch (e.g. `getRequestHonoContext`, per-request loader
-      // caches) see the same per-request store the initial prerender saw.
-      return bindRequestScope(async () => {
-        try {
-          if (aborted) return;
-          controller.enqueue(
-            encoder.encode(`<!doctype html>${beforeBody}\n${bootstrap}\n`)
-          );
+  // Multi-producer backpressure via TransformStream. Each loader pump writes
+  // to a shared `writer`, awaiting `writer.ready` before each write so that
+  // the per-loader iteration is paced by the consumer's read rate (not by
+  // however fast the generator yields). Without this, a tight-loop streaming
+  // loader would buffer chunks into the ReadableStream queue unbounded; see
+  // render-stream.test.tsx "pauses production when the HTML consumer is
+  // slow (backpressure)".
+  const { writable, readable: responseStream } = new TransformStream<
+    Uint8Array,
+    Uint8Array
+  >();
+  const writer = writable.getWriter();
 
-          // Yield one microtask before advancing any loader generator past
-          // its first yield. `renderPage` is still on the synchronous frame
-          // that constructs this response (`new ReadableStream(...)` returns,
-          // then `c.body(...)` runs and commits the headers). Resuming a
-          // generator can call `setCookie(ctx.c, ...)`, which mutates Hono's
-          // prepared headers; deferring the pump guarantees the response is
-          // built first, so post-first-yield header writes are consistently
-          // excluded rather than racing construction. Cookies must be set
-          // before the loader's first yield to reach the streamed response.
-          await Promise.resolve();
+  // When the consumer cancels the readable side (e.g. Hono drops the response,
+  // or the runtime tears down the request), the writable side transitions to
+  // an errored state and `writer.closed` rejects. Propagate to the loader
+  // generators symmetrically with the request-signal abort path below. The
+  // `aborted` guard makes the self-triggered case (`writer.abort()` in our
+  // own finally) a no-op.
+  writer.closed.catch(() => {
+    if (aborted) return;
+    aborted = true;
+    for (const { gen } of streamingLoaders) {
+      gen.return(undefined).catch(() => {
+        /* swallow */
+      });
+    }
+  });
 
-          // Drive each pending generator in parallel; emit script tags per chunk.
-          await Promise.all(
-            streamingLoaders.map(async ({ loaderId, gen }) => {
-              try {
-                while (!aborted) {
-                  const step = await gen.next();
-                  if (aborted) return;
-                  if (step.done) {
-                    controller.enqueue(
-                      encoder.encode(
-                        `<script>window.__HP_STREAM__.end(${jsonForScript(loaderId)});document.currentScript.remove()</script>\n`
-                      )
-                    );
-                    return;
-                  }
-                  controller.enqueue(
-                    encoder.encode(
-                      `<script>window.__HP_STREAM__.push(${jsonForScript(loaderId)},${jsonForScript(step.value)});document.currentScript.remove()</script>\n`
-                    )
-                  );
-                }
-              } catch (err) {
-                if (aborted) return;
-                const message =
-                  err instanceof Error ? err.message : String(err);
-                const name = err instanceof Error ? err.name : 'Error';
-                controller.enqueue(
+  // Re-enter the captured request scope so generator continuations and
+  // anything they touch (e.g. `getRequestHonoContext`, per-request loader
+  // caches) see the same per-request store the initial prerender saw.
+  void bindRequestScope(async () => {
+    // Yield one microtask before doing anything else. `renderPage` is still
+    // on the synchronous frame that constructs this response (TransformStream
+    // is created, then `c.body(...)` runs and commits the headers). Resuming
+    // a generator can call `setCookie(ctx.c, ...)`, which mutates Hono's
+    // prepared headers; deferring the pump guarantees the response is built
+    // first, so post-first-yield header writes are consistently excluded
+    // rather than racing construction. Cookies must be set before the
+    // loader's first yield to reach the streamed response.
+    await Promise.resolve();
+
+    try {
+      if (aborted) return;
+      await writer.ready;
+      if (aborted) return;
+      await writer.write(
+        encoder.encode(`<!doctype html>${beforeBody}\n${bootstrap}\n`)
+      );
+
+      // Drive each pending generator in parallel; emit script tags per chunk.
+      await Promise.all(
+        streamingLoaders.map(async ({ loaderId, gen }) => {
+          try {
+            while (!aborted) {
+              const step = await gen.next();
+              if (aborted) return;
+              await writer.ready;
+              if (aborted) return;
+              if (step.done) {
+                await writer.write(
                   encoder.encode(
-                    `<script>window.__HP_STREAM__.error(${jsonForScript(loaderId)},${jsonForScript({ message, name })});document.currentScript.remove()</script>\n`
+                    `<script>window.__HP_STREAM__.end(${jsonForScript(loaderId)});document.currentScript.remove()</script>\n`
                   )
                 );
+                return;
               }
-            })
-          );
+              await writer.write(
+                encoder.encode(
+                  `<script>window.__HP_STREAM__.push(${jsonForScript(loaderId)},${jsonForScript(step.value)});document.currentScript.remove()</script>\n`
+                )
+              );
+            }
+          } catch (err) {
+            if (aborted) return;
+            const message = err instanceof Error ? err.message : String(err);
+            const name = err instanceof Error ? err.name : 'Error';
+            try {
+              await writer.ready;
+              if (aborted) return;
+              await writer.write(
+                encoder.encode(
+                  `<script>window.__HP_STREAM__.error(${jsonForScript(loaderId)},${jsonForScript({ message, name })});document.currentScript.remove()</script>\n`
+                )
+              );
+            } catch {
+              /* swallow: writable side closed/errored */
+            }
+          }
+        })
+      );
 
-          if (!aborted) controller.enqueue(encoder.encode(afterBody));
-        } finally {
-          if (!aborted) controller.close();
-        }
-      });
-    },
-    cancel() {
-      aborted = true;
-      for (const { gen } of streamingLoaders) {
-        gen.return(undefined).catch(() => {
+      if (!aborted) {
+        await writer.ready;
+        if (!aborted) await writer.write(encoder.encode(afterBody));
+      }
+    } catch {
+      /* swallow: writable side closed/errored mid-pump */
+    } finally {
+      if (aborted) {
+        writer.abort().catch(() => {
+          /* swallow */
+        });
+      } else {
+        writer.close().catch(() => {
           /* swallow */
         });
       }
-    },
+    }
   });
 
   requestSignal.addEventListener('abort', () => {
@@ -374,6 +412,9 @@ export async function renderPage(
         /* swallow */
       });
     }
+    writer.abort().catch(() => {
+      /* swallow */
+    });
   });
 
   // Route through `c.body()` rather than `new Response(...)` so Hono merges


### PR DESCRIPTION
## Summary

- Streaming-SSR path in `render.tsx` previously built a single `ReadableStream` and drove N loader generators with `Promise.all` + `controller.enqueue`, never consulting `desiredSize`. A tight-loop streaming loader raced ahead of the consumer and buffered chunks unbounded into the stream's internal queue (V8 heap exhaustion on a 1-loader repro within ~12s).
- Swap to a `TransformStream` + `writer.ready` shape so each per-loader producer pauses on backpressure. Same idiom `sse.ts` already uses; consumer's read rate paces production.
- Cancellation propagates via `writer.closed.catch(...)`; `transformer.cancel` is in the WHATWG spec but TS's lib.dom `Transformer` type doesn't include it, and casting is the wrong shape per `CLAUDE.md`.
- Add a regression test mirroring `sse-backpressure.test.ts:117` for the HTML stream, capped at 5000 yields so a regression fails the assertion instead of OOMing the worker. Pre-fix: cap hit in 50ms. Post-fix: `produced` stays at 2.

Context: review of <https://frontendmasters.com/blog/your-node-js-streams-arent-backpressuring-theyre-silently-eating-your-memory/> in relation to our streaming setup. The article is mostly about `node:stream`, which we don't use; the rest of our streaming (SSE pump, SSE decoder, loader streams) was already correct. This was the one Web Streams analog of the article's footgun.

## Test plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (795/795 incl. new backpressure test)
- [x] `pnpm test:integration` (4/4)
- [x] `pnpm --filter site build`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)