### PR TITLE
fix(iso): avoid client-redirect double-mount by deferring initial-load middleware to post-hydration

### DIFF
--- a/packages/iso/src/internal/__tests__/page-middleware-host.test.tsx
+++ b/packages/iso/src/internal/__tests__/page-middleware-host.test.tsx
@@ -11,10 +11,17 @@ import { defineClientMiddleware } from '../../define-middleware.js';
 import { PageMiddlewareHost } from '../page-middleware-host.js';
 import { render as renderOutcome } from '../../page-only.js';
 import { redirect } from '../../outcomes.js';
+import {
+  resetHistoryShimForTesting,
+  setNavDirectionForTesting,
+} from '../history-shim.js';
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  // Redirect dispatch reads the global "have we navigated yet" signal from
+  // the history shim; reset it so tests do not leak nav state into each other.
+  resetHistoryShimForTesting();
 });
 
 const loc = {
@@ -178,13 +185,16 @@ describe('PageMiddlewareHost', () => {
   // navigation would happen during render (forbidden by Suspense semantics)
   // or never (if swallowed by the RouteBoundary fallback).
   //
-  // On the INITIAL load the redirect must be a hard navigation
+  // Before any client navigation (the document is still on its hydrated,
+  // server-rendered route) the redirect must be a hard navigation
   // (window.location.assign), not an SPA route(): an effect-driven route()
   // during hydration leaves preact-iso's Router holding the server-committed
   // DOM alongside the redirect target, double-mounting both routes in
   // <main>. A full document replacement guarantees no stale route DOM. See
   // docs/superpowers/research/2026-05-30-client-redirect-double-mount.md.
-  it('client redirect on initial load hard-navigates instead of route() (double-mount fix)', async () => {
+  it('client redirect before any navigation hard-navigates instead of route() (double-mount fix)', async () => {
+    // No navigation yet: hasClientNavigated() is false (nav direction is the
+    // default 'initial'), reset between tests by the afterEach above.
     const assignSpy = vi.fn();
     Object.defineProperty(window.location, 'assign', {
       configurable: true,
@@ -219,57 +229,42 @@ describe('PageMiddlewareHost', () => {
   });
 
   // B9b: a redirect that fires AFTER a client navigation keeps the SPA
-  // route() path. There is no server-committed-then-retained tree to leak
-  // post-navigation, and a hard nav would needlessly drop SPA state. This
-  // pins the parity half of the double-mount fix.
+  // route() path. The double-mount leak is specific to the hydration commit;
+  // post-navigation there is no server-committed-then-retained tree to leak,
+  // and a hard nav would needlessly drop SPA state. The signal is global per
+  // document load (the history shim's nav direction), not per host, so a
+  // freshly mounted host reached by navigating into a guarded route still
+  // takes the route() path. This pins the parity half of the fix.
   it('client redirect after a navigation uses SPA route(), not a hard navigation', async () => {
+    // Simulate a prior client navigation so hasClientNavigated() is true.
+    setNavDirectionForTesting('push');
+
     const assignSpy = vi.fn();
     Object.defineProperty(window.location, 'assign', {
       configurable: true,
       value: assignSpy,
     });
 
-    const locA = {
-      path: '/a',
-      url: 'http://localhost/a',
-      searchParams: {},
-      pathParams: {},
-      route: () => {},
-    } as unknown as RouteHook;
-    const locB = {
-      path: '/b',
-      url: 'http://localhost/b',
-      searchParams: {},
-      pathParams: {},
-      route: () => {},
-    } as unknown as RouteHook;
-
-    const pass = defineClientMiddleware(async (_c, next) => {
-      await next();
-    });
-    const redirecting = defineClientMiddleware(async () => {
+    const mw = defineClientMiddleware(async () => {
       throw redirect('/login');
     });
 
-    const { rerender } = rtlRender(
+    rtlRender(
       <LocationProvider>
-        <PageMiddlewareHost use={[pass]} location={locA}>
-          <div>page-a</div>
-        </PageMiddlewareHost>
-      </LocationProvider>
-    );
-    await waitFor(() => expect(screen.queryByText('page-a')).not.toBeNull());
-
-    rerender(
-      <LocationProvider>
-        <PageMiddlewareHost use={[redirecting]} location={locB}>
-          <div>page-b</div>
+        <PageMiddlewareHost use={[mw]} location={loc}>
+          <div>protected-content</div>
         </PageMiddlewareHost>
       </LocationProvider>
     );
 
-    // SPA route() moves the provider URL to the target.
+    await waitFor(() => {
+      expect(screen.queryByText('protected-content')).toBeNull();
+    });
+
+    // SPA route() moves the provider URL to the target (happy-dom updates
+    // window.location.pathname inside route()).
     await waitFor(() => expect(window.location.pathname).toBe('/login'));
+    // It must NOT have hard-navigated.
     expect(assignSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/iso/src/internal/__tests__/page-middleware-host.test.tsx
+++ b/packages/iso/src/internal/__tests__/page-middleware-host.test.tsx
@@ -173,12 +173,24 @@ describe('PageMiddlewareHost', () => {
     await waitFor(() => expect(runs).toBe(afterA + 1));
   });
 
-  // B9: client-side `route()` redirect from middleware. The effect-driven
-  // navigation must call useLocation().route with the redirect target.
-  // Without the effect path, the route() call would happen during render
-  // (forbidden by Suspense semantics) or never (if swallowed by the
-  // RouteBoundary fallback).
-  it('client redirect outcome navigates via useLocation().route in an effect', async () => {
+  // B9: client-side redirect from middleware. The effect-driven navigation
+  // must move the browser to the redirect target. Without the effect path,
+  // navigation would happen during render (forbidden by Suspense semantics)
+  // or never (if swallowed by the RouteBoundary fallback).
+  //
+  // On the INITIAL load the redirect must be a hard navigation
+  // (window.location.assign), not an SPA route(): an effect-driven route()
+  // during hydration leaves preact-iso's Router holding the server-committed
+  // DOM alongside the redirect target, double-mounting both routes in
+  // <main>. A full document replacement guarantees no stale route DOM. See
+  // docs/superpowers/research/2026-05-30-client-redirect-double-mount.md.
+  it('client redirect on initial load hard-navigates instead of route() (double-mount fix)', async () => {
+    const assignSpy = vi.fn();
+    Object.defineProperty(window.location, 'assign', {
+      configurable: true,
+      value: assignSpy,
+    });
+
     const mw = defineClientMiddleware(async () => {
       throw redirect('/login');
     });
@@ -193,17 +205,71 @@ describe('PageMiddlewareHost', () => {
 
     // After the chain resolves with a redirect outcome the consumer must
     // NOT render the children (it returns null pending the effect-scheduled
-    // nav). The route fn lives on useLocation()'s LocationProvider; the
-    // happy-dom env updates window.location synchronously inside route().
+    // nav).
     await waitFor(() => {
       expect(screen.queryByText('protected-content')).toBeNull();
     });
 
-    // The effect should have run by now. Verify the navigation target made
-    // it to the URL bar (LocationProvider.route uses history.pushState +
-    // updates window.location.pathname under happy-dom).
+    // The effect should have run by now: a hard navigation to the target.
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/login');
+      expect(assignSpy).toHaveBeenCalledWith('/login');
     });
+    // It must NOT have used SPA route(): the provider URL is unchanged.
+    expect(window.location.pathname).not.toBe('/login');
+  });
+
+  // B9b: a redirect that fires AFTER a client navigation keeps the SPA
+  // route() path. There is no server-committed-then-retained tree to leak
+  // post-navigation, and a hard nav would needlessly drop SPA state. This
+  // pins the parity half of the double-mount fix.
+  it('client redirect after a navigation uses SPA route(), not a hard navigation', async () => {
+    const assignSpy = vi.fn();
+    Object.defineProperty(window.location, 'assign', {
+      configurable: true,
+      value: assignSpy,
+    });
+
+    const locA = {
+      path: '/a',
+      url: 'http://localhost/a',
+      searchParams: {},
+      pathParams: {},
+      route: () => {},
+    } as unknown as RouteHook;
+    const locB = {
+      path: '/b',
+      url: 'http://localhost/b',
+      searchParams: {},
+      pathParams: {},
+      route: () => {},
+    } as unknown as RouteHook;
+
+    const pass = defineClientMiddleware(async (_c, next) => {
+      await next();
+    });
+    const redirecting = defineClientMiddleware(async () => {
+      throw redirect('/login');
+    });
+
+    const { rerender } = rtlRender(
+      <LocationProvider>
+        <PageMiddlewareHost use={[pass]} location={locA}>
+          <div>page-a</div>
+        </PageMiddlewareHost>
+      </LocationProvider>
+    );
+    await waitFor(() => expect(screen.queryByText('page-a')).not.toBeNull());
+
+    rerender(
+      <LocationProvider>
+        <PageMiddlewareHost use={[redirecting]} location={locB}>
+          <div>page-b</div>
+        </PageMiddlewareHost>
+      </LocationProvider>
+    );
+
+    // SPA route() moves the provider URL to the target.
+    await waitFor(() => expect(window.location.pathname).toBe('/login'));
+    expect(assignSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/iso/src/internal/__tests__/page-middleware-host.test.tsx
+++ b/packages/iso/src/internal/__tests__/page-middleware-host.test.tsx
@@ -67,7 +67,11 @@ describe('PageMiddlewareHost', () => {
     expect(screen.queryByText('page-content')).toBeNull();
   });
 
-  it('renders nothing while the chain is pending then renders children once resolved', async () => {
+  it('renders nothing while the chain is pending then renders children once resolved (post-navigation suspense path)', async () => {
+    // Post-navigation (a prior client nav happened), the host takes the
+    // Suspense path: nothing renders until the chain resolves. The
+    // deferred/initial-load path is covered separately below.
+    setNavDirectionForTesting('push');
     let resolve!: () => void;
     const mw = defineClientMiddleware(async (_c, next) => {
       await new Promise<void>((r) => {
@@ -83,6 +87,32 @@ describe('PageMiddlewareHost', () => {
       </LocationProvider>
     );
     expect(screen.queryByText('page-content')).toBeNull();
+    resolve();
+    await waitFor(() =>
+      expect(screen.queryByText('page-content')).not.toBeNull()
+    );
+  });
+
+  it('on initial load renders the server children immediately while the client chain runs (deferred path)', async () => {
+    // No navigation yet: the host renders the server-rendered children right
+    // away (matching SSR so hydration cannot orphan them) and runs the client
+    // chain post-hydration. Here the chain passes, so children stay.
+    let resolve!: () => void;
+    const mw = defineClientMiddleware(async (_c, next) => {
+      await new Promise<void>((r) => {
+        resolve = r;
+      });
+      await next();
+    });
+    rtlRender(
+      <LocationProvider>
+        <PageMiddlewareHost use={[mw]} location={loc}>
+          <div>page-content</div>
+        </PageMiddlewareHost>
+      </LocationProvider>
+    );
+    // Visible immediately, BEFORE the chain resolves (unlike the suspense path).
+    expect(screen.queryByText('page-content')).not.toBeNull();
     resolve();
     await waitFor(() =>
       expect(screen.queryByText('page-content')).not.toBeNull()
@@ -180,21 +210,19 @@ describe('PageMiddlewareHost', () => {
     await waitFor(() => expect(runs).toBe(afterA + 1));
   });
 
-  // B9: client-side redirect from middleware. The effect-driven navigation
-  // must move the browser to the redirect target. Without the effect path,
-  // navigation would happen during render (forbidden by Suspense semantics)
-  // or never (if swallowed by the RouteBoundary fallback).
-  //
-  // Before any client navigation (the document is still on its hydrated,
-  // server-rendered route) the redirect must be a hard navigation
-  // (window.location.assign), not an SPA route(): an effect-driven route()
-  // during hydration leaves preact-iso's Router holding the server-committed
-  // DOM alongside the redirect target, double-mounting both routes in
-  // <main>. A full document replacement guarantees no stale route DOM. See
-  // docs/superpowers/research/2026-05-30-client-redirect-double-mount.md.
-  it('client redirect before any navigation hard-navigates instead of route() (double-mount fix)', async () => {
-    // No navigation yet: hasClientNavigated() is false (nav direction is the
-    // default 'initial'), reset between tests by the afterEach above.
+  // B9: client-side redirect from middleware on the INITIAL document load.
+  // The host renders the server-rendered children during hydration (so the
+  // hydrated DOM matches SSR and is never orphaned), then runs the client
+  // chain post-hydration and navigates via SPA route() - NOT a hard
+  // navigation. This is the deferred fix for the double-mount: the orphan only
+  // happened because a Suspense boundary resolved to non-SSR content (null)
+  // mid-hydration; rendering the children instead removes that mismatch, so a
+  // plain route() from the fully hydrated tree is safe. The orphaned-DOM-on-
+  // mismatch is expected Preact behavior (preactjs/preact#4442), so the fix
+  // lives here on the consumer side.
+  it('client redirect on initial load renders SSR children then navigates via SPA route() (no hard nav)', async () => {
+    // No navigation yet: hasClientNavigated() is false, so the host takes the
+    // deferred path. Reset between tests by the afterEach above.
     const assignSpy = vi.fn();
     Object.defineProperty(window.location, 'assign', {
       configurable: true,
@@ -213,28 +241,24 @@ describe('PageMiddlewareHost', () => {
       </LocationProvider>
     );
 
-    // After the chain resolves with a redirect outcome the consumer must
-    // NOT render the children (it returns null pending the effect-scheduled
-    // nav).
-    await waitFor(() => {
-      expect(screen.queryByText('protected-content')).toBeNull();
-    });
+    // The server children are rendered immediately (matching SSR) while the
+    // client chain runs - they are NOT withheld.
+    expect(screen.queryByText('protected-content')).not.toBeNull();
 
-    // The effect should have run by now: a hard navigation to the target.
-    await waitFor(() => {
-      expect(assignSpy).toHaveBeenCalledWith('/login');
-    });
-    // It must NOT have used SPA route(): the provider URL is unchanged.
-    expect(window.location.pathname).not.toBe('/login');
+    // Once the chain resolves the redirect, an SPA route() moves the provider
+    // URL to the target (happy-dom updates window.location.pathname).
+    await waitFor(() => expect(window.location.pathname).toBe('/login'));
+    // It must NOT have hard-navigated.
+    expect(assignSpy).not.toHaveBeenCalled();
   });
 
-  // B9b: a redirect that fires AFTER a client navigation keeps the SPA
-  // route() path. The double-mount leak is specific to the hydration commit;
-  // post-navigation there is no server-committed-then-retained tree to leak,
-  // and a hard nav would needlessly drop SPA state. The signal is global per
-  // document load (the history shim's nav direction), not per host, so a
-  // freshly mounted host reached by navigating into a guarded route still
-  // takes the route() path. This pins the parity half of the fix.
+  // B9b: a redirect that fires AFTER a client navigation takes the Suspense
+  // path (HostConsumer) and navigates via SPA route(). Post-navigation there is
+  // no hydration to mismatch, so the host suspends on the chain and renders the
+  // redirect outcome (null) while an effect routes to the target. The signal is
+  // global per document load (the history shim's nav direction), not per host,
+  // so a freshly mounted host reached by navigating into a guarded route still
+  // takes this path. This pins the post-navigation half of the behavior.
   it('client redirect after a navigation uses SPA route(), not a hard navigation', async () => {
     // Simulate a prior client navigation so hasClientNavigated() is true.
     setNavDirectionForTesting('push');

--- a/packages/iso/src/internal/history-shim.ts
+++ b/packages/iso/src/internal/history-shim.ts
@@ -83,12 +83,13 @@ export function getNavDirection(): NavDirection {
 /**
  * True once any client-side navigation (push, replace, or popstate) has
  * occurred since the page loaded. Before the first navigation the document is
- * still showing its server-rendered, freshly hydrated route. That is the only
- * situation where a client-middleware redirect must hard-navigate: an
- * effect-driven SPA route() during hydration leaves preact-iso's Router
- * holding the server-committed DOM alongside the redirect target, mounting
- * both. `lastDirection` only ever moves away from 'initial' (never back),
- * so this is a monotonic "have we navigated yet" flag.
+ * still showing its server-rendered, freshly hydrated route. PageMiddlewareHost
+ * uses this to pick its render strategy: on the initial load it renders the
+ * server children during hydration and applies the client middleware outcome
+ * afterwards (so a Suspense boundary never resolves to non-SSR content
+ * mid-hydration, which would orphan the server route DOM); after a navigation
+ * it suspends on the chain normally. `lastDirection` only ever moves away from
+ * 'initial' (never back), so this is a monotonic "have we navigated yet" flag.
  */
 export function hasClientNavigated(): boolean {
   return lastDirection !== 'initial';

--- a/packages/iso/src/internal/history-shim.ts
+++ b/packages/iso/src/internal/history-shim.ts
@@ -80,6 +80,20 @@ export function getNavDirection(): NavDirection {
   return lastDirection;
 }
 
+/**
+ * True once any client-side navigation (push, replace, or popstate) has
+ * occurred since the page loaded. Before the first navigation the document is
+ * still showing its server-rendered, freshly hydrated route. That is the only
+ * situation where a client-middleware redirect must hard-navigate: an
+ * effect-driven SPA route() during hydration leaves preact-iso's Router
+ * holding the server-committed DOM alongside the redirect target, mounting
+ * both. `lastDirection` only ever moves away from 'initial' (never back),
+ * so this is a monotonic "have we navigated yet" flag.
+ */
+export function hasClientNavigated(): boolean {
+  return lastDirection !== 'initial';
+}
+
 /** Test-only reset. Do not call from production code. */
 export function resetHistoryShimForTesting(): void {
   if (

--- a/packages/iso/src/internal/page-middleware-host.tsx
+++ b/packages/iso/src/internal/page-middleware-host.tsx
@@ -6,7 +6,7 @@ import {
 import type { Context } from 'hono';
 import { type RouteHook, useLocation } from 'preact-iso';
 import { Suspense } from 'preact/compat';
-import { useContext, useEffect, useRef } from 'preact/hooks';
+import { useContext, useEffect, useRef, useState } from 'preact/hooks';
 import { isBrowser } from '../is-browser.js';
 import { isRedirect, isRender, type Outcome } from '../outcomes.js';
 import type {
@@ -18,7 +18,6 @@ import type { StreamObserver } from '../define-stream-observer.js';
 import { dispatchServer, dispatchClient } from './middleware-runner.js';
 import { partitionUse } from './use-partitioner.js';
 import wrapPromise from './wrap-promise.js';
-import { assignSafeRedirect } from './safe-redirect.js';
 import { hasClientNavigated } from './history-shim.js';
 import { HonoRequestContext } from './contexts.js';
 
@@ -87,6 +86,49 @@ function startChain(
 type WrappedResult = { read: () => HostResult };
 type RefValue = { current: WrappedResult | null };
 
+/**
+ * Applies a settled host outcome to the rendered tree. Shared rendering logic
+ * for both host strategies (Suspense and Deferred).
+ */
+function renderOutcome(
+  outcome: Outcome | undefined,
+  children: ComponentChildren
+): ComponentChildren {
+  if (outcome === undefined) {
+    return <>{children}</>;
+  }
+  if (isRedirect(outcome)) {
+    if (isBrowser()) {
+      // The navigation is scheduled in an effect; render nothing meanwhile so
+      // the old tree doesn't briefly flash.
+      return null;
+    }
+    // Server: rethrow so renderPage's outer handler can translate to an HTTP redirect.
+    throw outcome;
+  }
+  if (isRender(outcome)) {
+    const Alt = outcome.Component;
+    // Equality-by-reference semantics: each `render(Component)` call returns a
+    // fresh outcome object, but the wrapped chain caches its result for the
+    // lifetime of a path. Within the same path render outcomes are stable.
+    // Across paths the chain is re-dispatched, so a fresh chain produces a
+    // fresh outcome and Preact remounts naturally when `Alt` differs. If a
+    // middleware returns the SAME component reference across paths, Preact
+    // treats it as the same element and preserves state. That's the documented
+    // semantic; callers needing a forced remount can wrap the component or vary
+    // props.
+    return <Alt />;
+  }
+  // Deny on the page-render path: rethrow so the outer error boundary or
+  // handler can translate to the right response.
+  throw outcome;
+}
+
+/**
+ * Suspense strategy: suspend on the middleware chain and render its outcome.
+ * Used for SSR (prerender awaits the suspension) and for post-navigation client
+ * renders (no hydration to mismatch, a fallback is fine while the chain runs).
+ */
 function HostConsumer({
   resultRef,
   children,
@@ -100,86 +142,106 @@ function HostConsumer({
   const { outcome } = wrapped ? wrapped.read() : { outcome: undefined };
   const { route } = useLocation();
 
-  // Client-side redirect: navigate in an effect rather than during render.
-  // Render-time side effects are forbidden by Suspense semantics; doing
-  // route() in render would also fire on every Preact re-entry during
-  // suspension resume. Keyed on the resolved target so a fresh outcome
-  // for the same path doesn't refire (the outcome is cached per chain,
-  // so this only changes when the path itself changes and a new chain
-  // produces a redirect to a different target).
+  // Client-side redirect: navigate in an effect rather than during render
+  // (render-time side effects are forbidden by Suspense semantics, and route()
+  // in render would also re-fire on every Preact re-entry during suspension
+  // resume). Keyed on the resolved target so a fresh outcome for the same path
+  // doesn't refire.
   const redirectTo = isRedirect(outcome) && isBrowser() ? outcome.to : null;
   useEffect(() => {
     if (redirectTo === null) return;
-    // Redirect before any client navigation = a redirect fired while the
-    // document is still showing its server-rendered, freshly hydrated route.
-    // An effect-driven SPA route() there leaves preact-iso's Router holding
-    // the server-committed DOM as its retained `prev` while the redirect
-    // target loads, double-mounting both routes in <main> (the previous tree
-    // is never dropped). A full document replacement guarantees no stale
-    // route DOM. Once any navigation has happened, route() is correct: there
-    // is no server-committed-then-retained tree to leak, and a hard nav would
-    // needlessly drop SPA state. The signal is global (per document load),
-    // not per host: cross-route navigation remounts this host, so a per-host
-    // "first render" flag would misfire on every navigation into a guarded
-    // route. See
-    // docs/superpowers/research/2026-05-30-client-redirect-double-mount.md.
-    if (hasClientNavigated()) {
-      route(redirectTo);
-    } else {
-      assignSafeRedirect(redirectTo);
-    }
-    // `route` is intentionally omitted from deps: it comes from
-    // useLocation() which is stable per LocationProvider mount, and
-    // referencing it here would re-fire the effect on every render the
-    // provider produces.
+    // A plain SPA route() is correct here. This consumer only runs on the
+    // server (where the redirect outcome is thrown above, not routed) and for
+    // post-navigation client renders; initial-load redirects are handled by
+    // DeferredHost, which renders the SSR content during hydration so there is
+    // no server-committed tree for the Router to orphan. (The
+    // orphan-on-hydration-mismatch is expected Preact behavior, see
+    // preactjs/preact#4442.)
+    route(redirectTo);
+    // `route` is intentionally omitted from deps: it comes from useLocation()
+    // which is stable per LocationProvider mount, and referencing it here would
+    // re-fire the effect on every render the provider produces.
   }, [redirectTo]);
 
-  if (outcome === undefined) {
-    return <>{children}</>;
-  }
-  if (isRedirect(outcome)) {
-    if (isBrowser()) {
-      // Effect above will schedule the navigation; render nothing in the
-      // meantime so the old tree doesn't briefly flash.
-      return null;
-    }
-    // Server: rethrow so renderPage's outer handler can translate to HTTP redirect.
-    throw outcome;
-  }
-  if (isRender(outcome)) {
-    const Alt = outcome.Component;
-    // Equality-by-reference semantics: each `render(Component)` call
-    // returns a fresh outcome object, but the wrapped chain caches its
-    // result for the lifetime of a path. Within the same path render
-    // outcomes are stable. Across paths, the `resultRef` is rewrapped
-    // (see PageMiddlewareHost below), so a fresh chain produces a fresh
-    // outcome and Preact remounts naturally when `Alt` differs. If a
-    // middleware returns the SAME component reference across paths,
-    // Preact treats it as the same element and preserves state. That's
-    // the documented semantic; if callers need a forced remount, they
-    // can wrap the returned component or vary props.
-    return <Alt />;
-  }
-  // Deny on the page-render path: rethrow so the outer error boundary or
-  // handler can translate to the right response.
-  throw outcome;
+  return renderOutcome(outcome, children);
 }
 
-export const PageMiddlewareHost: FunctionComponent<{
-  use?: ReadonlyArray<UseEntry>;
+/**
+ * Deferred strategy: used on the INITIAL document load (browser, before any
+ * client navigation). Renders the server-rendered children during hydration so
+ * the hydrated DOM matches SSR, then runs the client chain post-hydration and
+ * applies its outcome as a normal update. This avoids a Suspense boundary
+ * resolving to non-SSR content mid-hydration, which orphans the server route
+ * DOM (expected Preact behavior, preactjs/preact#4442) and stacks the redirect
+ * target on top (the "client redirect double-mount").
+ */
+function DeferredHost({
+  use,
+  location,
+  honoCtx,
+  children,
+}: {
+  use: ReadonlyArray<UseEntry>;
   location: RouteHook;
+  honoCtx: Context | undefined;
+  children: ComponentChildren;
+}) {
+  const { route } = useLocation();
+  // null = chain not yet settled, or settled to a redirect/pass: keep rendering
+  // the server children. A settled render()/deny outcome is stored so it can be
+  // swapped in via a normal post-hydration update.
+  const [applied, setApplied] = useState<HostResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    startChain(use, location, honoCtx).then((result) => {
+      if (cancelled) return;
+      if (isRedirect(result.outcome)) {
+        // SPA navigate from the fully hydrated tree. Because the server's
+        // content (not null) was rendered during hydration, there is no
+        // orphaned route DOM for the Router to stack the target on top of.
+        route(result.outcome.to);
+      } else if (result.outcome !== undefined) {
+        // render() / deny: surface after hydration via a normal update.
+        setApplied(result);
+      }
+      // undefined (chain passed): keep the already-rendered children.
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Re-dispatch if the path changes (mirrors SuspenseHost's per-path dispatch).
+  }, [location.path]);
+
+  if (applied === null) return <>{children}</>;
+  return renderOutcome(applied.outcome, children);
+}
+
+/**
+ * Suspense strategy wrapper. Lazily dispatches the chain once per path (see the
+ * lazy-ref note below) and renders the outcome through HostConsumer.
+ */
+function SuspenseHost({
+  use,
+  location,
+  honoCtx,
+  fallback,
+  children,
+}: {
+  use: ReadonlyArray<UseEntry>;
+  location: RouteHook;
+  honoCtx: Context | undefined;
   fallback?: JSX.Element;
   children: ComponentChildren;
-}> = ({ use = [], location, fallback, children }) => {
-  const honoCtx = useContext(HonoRequestContext).context;
+}) {
   // Lazy ref pattern. `useRef(null)` serves a dual purpose: it's the
-  // "not-yet-computed" sentinel AND the persistent slot for the wrapped
-  // chain result. We compute on first render and on subsequent renders
-  // ONLY when the path changed. `useRef(wrapPromise(startChain(...)))`
-  // would evaluate `startChain` every render before useRef decided whether
-  // to keep it, which synchronously fires `dispatchServer`/`dispatchClient`
-  // every render. That's O(renders) middleware invocations instead of
-  // O(navigations); auth checks, analytics, redirects would all repeat.
+  // "not-yet-computed" sentinel AND the persistent slot for the wrapped chain
+  // result. We compute on first render and on subsequent renders ONLY when the
+  // path changed. `useRef(wrapPromise(startChain(...)))` would evaluate
+  // `startChain` every render before useRef decided whether to keep it, which
+  // synchronously fires `dispatchServer`/`dispatchClient` every render. That's
+  // O(renders) middleware invocations instead of O(navigations); auth checks,
+  // analytics, redirects would all repeat.
   const resultRef = useRef<WrappedResult | null>(null);
   const prevPath = useRef(location.path);
   if (resultRef.current === null) {
@@ -192,5 +254,47 @@ export const PageMiddlewareHost: FunctionComponent<{
     <Suspense fallback={fallback}>
       <HostConsumer resultRef={resultRef}>{children}</HostConsumer>
     </Suspense>
+  );
+}
+
+export const PageMiddlewareHost: FunctionComponent<{
+  use?: ReadonlyArray<UseEntry>;
+  location: RouteHook;
+  fallback?: JSX.Element;
+  children: ComponentChildren;
+}> = ({ use = [], location, fallback, children }) => {
+  const honoCtx = useContext(HonoRequestContext).context;
+  // Choose the render strategy ONCE per mount so the hook order stays stable
+  // across renders (hasClientNavigated() flips to true after the first
+  // navigation, which would otherwise change which child - and its hooks - we
+  // render).
+  //
+  // Initial document load (browser, no navigation yet) -> DeferredHost: a
+  // Suspense boundary that suspends during hydration and resolves to non-SSR
+  // content (e.g. null for a redirect) orphans the server-rendered route DOM
+  // (expected Preact behavior, preactjs/preact#4442), which the Router then
+  // stacks the redirect target on top of. Rendering the server children during
+  // hydration and applying the client outcome afterwards removes that mismatch.
+  //
+  // Server render and post-navigation client renders have no hydration to
+  // mismatch, so the Suspense path (suspend on the chain, render the outcome)
+  // is correct there.
+  const deferRef = useRef(isBrowser() && !hasClientNavigated());
+  if (deferRef.current) {
+    return (
+      <DeferredHost use={use} location={location} honoCtx={honoCtx}>
+        {children}
+      </DeferredHost>
+    );
+  }
+  return (
+    <SuspenseHost
+      use={use}
+      location={location}
+      honoCtx={honoCtx}
+      fallback={fallback}
+    >
+      {children}
+    </SuspenseHost>
   );
 };

--- a/packages/iso/src/internal/page-middleware-host.tsx
+++ b/packages/iso/src/internal/page-middleware-host.tsx
@@ -18,6 +18,7 @@ import type { StreamObserver } from '../define-stream-observer.js';
 import { dispatchServer, dispatchClient } from './middleware-runner.js';
 import { partitionUse } from './use-partitioner.js';
 import wrapPromise from './wrap-promise.js';
+import { assignSafeRedirect } from './safe-redirect.js';
 import { HonoRequestContext } from './contexts.js';
 
 // Widest accepted observer shape: TResult defaults to `void` in
@@ -87,9 +88,11 @@ type RefValue = { current: WrappedResult | null };
 
 function HostConsumer({
   resultRef,
+  initialLoad,
   children,
 }: {
   resultRef: RefValue;
+  initialLoad: boolean;
   children: ComponentChildren;
 }) {
   // resultRef.current is populated by the parent before this consumer
@@ -107,12 +110,26 @@ function HostConsumer({
   // produces a redirect to a different target).
   const redirectTo = isRedirect(outcome) && isBrowser() ? outcome.to : null;
   useEffect(() => {
-    if (redirectTo !== null) route(redirectTo);
+    if (redirectTo === null) return;
+    // Initial-load redirect: hard navigation, not SPA route(). An
+    // effect-driven route() during hydration leaves preact-iso's Router
+    // holding the server-committed DOM as its retained `prev` while the
+    // redirect target loads, double-mounting both routes in <main> (the
+    // previous tree is never dropped). A full document replacement
+    // guarantees no stale route DOM. Post-navigation redirects keep route():
+    // there is no server-committed-then-retained tree to leak, and a hard
+    // nav would needlessly drop SPA state. See
+    // docs/superpowers/research/2026-05-30-client-redirect-double-mount.md.
+    if (initialLoad) {
+      assignSafeRedirect(redirectTo);
+    } else {
+      route(redirectTo);
+    }
     // `route` is intentionally omitted from deps: it comes from
     // useLocation() which is stable per LocationProvider mount, and
     // referencing it here would re-fire the effect on every render the
     // provider produces.
-  }, [redirectTo]);
+  }, [redirectTo, initialLoad]);
 
   if (outcome === undefined) {
     return <>{children}</>;
@@ -162,15 +179,24 @@ export const PageMiddlewareHost: FunctionComponent<{
   // O(navigations); auth checks, analytics, redirects would all repeat.
   const resultRef = useRef<WrappedResult | null>(null);
   const prevPath = useRef(location.path);
+  // Tracks whether any client-side navigation has changed the path since
+  // this host mounted. The first chain (the `resultRef.current === null`
+  // branch below) is the hydration/initial-load chain; once the path
+  // changes, every later chain is post-navigation. HostConsumer uses this
+  // to pick a hard navigation vs SPA route() for redirect outcomes.
+  const navigated = useRef(false);
   if (resultRef.current === null) {
     resultRef.current = wrapPromise(startChain(use, location, honoCtx));
   } else if (prevPath.current !== location.path) {
     prevPath.current = location.path;
+    navigated.current = true;
     resultRef.current = wrapPromise(startChain(use, location, honoCtx));
   }
   return (
     <Suspense fallback={fallback}>
-      <HostConsumer resultRef={resultRef}>{children}</HostConsumer>
+      <HostConsumer resultRef={resultRef} initialLoad={!navigated.current}>
+        {children}
+      </HostConsumer>
     </Suspense>
   );
 };

--- a/packages/iso/src/internal/page-middleware-host.tsx
+++ b/packages/iso/src/internal/page-middleware-host.tsx
@@ -174,6 +174,20 @@ function HostConsumer({
  * resolving to non-SSR content mid-hydration, which orphans the server route
  * DOM (expected Preact behavior, preactjs/preact#4442) and stacks the redirect
  * target on top (the "client redirect double-mount").
+ *
+ * Timing contract: on the initial load the client middleware runs AFTER
+ * hydration (in the effect), not before first paint. The server already
+ * authorized and rendered this content, so a client guard is advisory here and
+ * applies once hydrated; anything it would redirect away from is already on
+ * screen from SSR, so deferring exposes nothing new. Post-navigation renders
+ * take SuspenseHost, where the chain blocks the render as before.
+ *
+ * Known limitation: this matches the COMMON case where the server passed and
+ * rendered `children`. If a SERVER middleware instead rendered an alternative
+ * (so SSR markup != children) and the client produces no matching outcome, the
+ * client still renders `children` and the SSR/client mismatch is on the user -
+ * the framework does not transmit the server outcome to the client. This is
+ * pre-existing (it predates the deferred strategy) and out of scope here.
  */
 function DeferredHost({
   use,
@@ -194,6 +208,11 @@ function DeferredHost({
 
   useEffect(() => {
     let cancelled = false;
+    // Reset to the server children before re-dispatching, so a stale render()
+    // outcome from a previous path cannot linger if this host is ever reused
+    // across a path change (in practice it only handles the initial load, but
+    // a persisted layout host could in principle see location.path change).
+    setApplied(null);
     startChain(use, location, honoCtx).then((result) => {
       if (cancelled) return;
       if (isRedirect(result.outcome)) {

--- a/packages/iso/src/internal/page-middleware-host.tsx
+++ b/packages/iso/src/internal/page-middleware-host.tsx
@@ -19,6 +19,7 @@ import { dispatchServer, dispatchClient } from './middleware-runner.js';
 import { partitionUse } from './use-partitioner.js';
 import wrapPromise from './wrap-promise.js';
 import { assignSafeRedirect } from './safe-redirect.js';
+import { hasClientNavigated } from './history-shim.js';
 import { HonoRequestContext } from './contexts.js';
 
 // Widest accepted observer shape: TResult defaults to `void` in
@@ -88,11 +89,9 @@ type RefValue = { current: WrappedResult | null };
 
 function HostConsumer({
   resultRef,
-  initialLoad,
   children,
 }: {
   resultRef: RefValue;
-  initialLoad: boolean;
   children: ComponentChildren;
 }) {
   // resultRef.current is populated by the parent before this consumer
@@ -111,25 +110,29 @@ function HostConsumer({
   const redirectTo = isRedirect(outcome) && isBrowser() ? outcome.to : null;
   useEffect(() => {
     if (redirectTo === null) return;
-    // Initial-load redirect: hard navigation, not SPA route(). An
-    // effect-driven route() during hydration leaves preact-iso's Router
-    // holding the server-committed DOM as its retained `prev` while the
-    // redirect target loads, double-mounting both routes in <main> (the
-    // previous tree is never dropped). A full document replacement
-    // guarantees no stale route DOM. Post-navigation redirects keep route():
-    // there is no server-committed-then-retained tree to leak, and a hard
-    // nav would needlessly drop SPA state. See
+    // Redirect before any client navigation = a redirect fired while the
+    // document is still showing its server-rendered, freshly hydrated route.
+    // An effect-driven SPA route() there leaves preact-iso's Router holding
+    // the server-committed DOM as its retained `prev` while the redirect
+    // target loads, double-mounting both routes in <main> (the previous tree
+    // is never dropped). A full document replacement guarantees no stale
+    // route DOM. Once any navigation has happened, route() is correct: there
+    // is no server-committed-then-retained tree to leak, and a hard nav would
+    // needlessly drop SPA state. The signal is global (per document load),
+    // not per host: cross-route navigation remounts this host, so a per-host
+    // "first render" flag would misfire on every navigation into a guarded
+    // route. See
     // docs/superpowers/research/2026-05-30-client-redirect-double-mount.md.
-    if (initialLoad) {
-      assignSafeRedirect(redirectTo);
-    } else {
+    if (hasClientNavigated()) {
       route(redirectTo);
+    } else {
+      assignSafeRedirect(redirectTo);
     }
     // `route` is intentionally omitted from deps: it comes from
     // useLocation() which is stable per LocationProvider mount, and
     // referencing it here would re-fire the effect on every render the
     // provider produces.
-  }, [redirectTo, initialLoad]);
+  }, [redirectTo]);
 
   if (outcome === undefined) {
     return <>{children}</>;
@@ -179,24 +182,15 @@ export const PageMiddlewareHost: FunctionComponent<{
   // O(navigations); auth checks, analytics, redirects would all repeat.
   const resultRef = useRef<WrappedResult | null>(null);
   const prevPath = useRef(location.path);
-  // Tracks whether any client-side navigation has changed the path since
-  // this host mounted. The first chain (the `resultRef.current === null`
-  // branch below) is the hydration/initial-load chain; once the path
-  // changes, every later chain is post-navigation. HostConsumer uses this
-  // to pick a hard navigation vs SPA route() for redirect outcomes.
-  const navigated = useRef(false);
   if (resultRef.current === null) {
     resultRef.current = wrapPromise(startChain(use, location, honoCtx));
   } else if (prevPath.current !== location.path) {
     prevPath.current = location.path;
-    navigated.current = true;
     resultRef.current = wrapPromise(startChain(use, location, honoCtx));
   }
   return (
     <Suspense fallback={fallback}>
-      <HostConsumer resultRef={resultRef} initialLoad={!navigated.current}>
-        {children}
-      </HostConsumer>
+      <HostConsumer resultRef={resultRef}>{children}</HostConsumer>
     </Suspense>
   );
 };


### PR DESCRIPTION
## Problem

A client middleware that `throw redirect(...)` (or `render(Alt)`) during the **initial** page hydration double-mounted routes: the server-rendered route DOM stayed in the document and the redirect target stacked on top of it.

## Root cause (it's us, not Preact)

The host wraps the middleware chain in `<Suspense>`. On the initial load the boundary suspends during hydration and then resolves to content that does **not** match the server-rendered DOM (e.g. `null` for a redirect). Preact deliberately preserves the server DOM on such a hydration mismatch and surfaces a visible failure rather than throwing the DOM away. That orphaned DOM is what the Router then stacks the redirect target on top of.

This was confirmed with the Preact maintainers: it is **expected behavior**, and the scalable architecture for hydration markers lives in preactjs/preact#4442. So the fix belongs here on the consumer side, not upstream. (An earlier exploration of an upstream change, preactjs/preact#5107, was closed for this reason.)

## Fix: defer the initial-load client chain to post-hydration

`PageMiddlewareHost` now picks its render strategy once per mount (`isBrowser() && !hasClientNavigated()`), keeping hook order stable:

- **Initial document load → `DeferredHost`:** render the server `children` during hydration (so the hydrated DOM matches SSR and nothing is orphaned), then run the client chain in a `useEffect` and apply the outcome post-hydration:
  - `redirect` → SPA `route()` (clean navigation from a fully hydrated tree)
  - `render(Alt)` → state swap to `<Alt/>`
  - `deny` → throw (error boundary)
  - pass → keep the children
- **Server render and post-navigation client renders → `SuspenseHost`:** the existing suspend-on-the-chain behavior (no hydration to mismatch). `HostConsumer`'s redirect effect is simplified to a plain `route()`.

This supersedes the earlier hard-navigation approach, which was correct but narrow (it only handled `redirect`, not a client-only `render(Alt)` that orphans identically) and heavy (a full page reload). The deferred approach covers all client outcome types and keeps SPA semantics.

**Trade-off:** a brief flash of the SSR content before a client redirect/swap, but that content is already on screen from SSR (the hard-nav showed it too, then reloaded), so it is not a regression. The only unhandled case is a *server* `render(Alt)` plus a different client outcome, which is a genuine user-code mismatch and out of scope.

## Testing

Rewrote the happy-dom host tests to the new contract: initial-load redirect uses `route()` (not a hard nav) and renders the SSR children first; the deferred path renders children immediately while the chain runs; the post-navigation suspense path is unchanged. Validated end-to-end in a real browser (patched-vs-stock A/B: the orphaned marker count goes from 1 to 0). All CI checks green (build, format, typecheck, unit, integration, site build).
