### PR TITLE
feat(iso): view transitions via options.debounceRendering + element morphs (stock preact-iso)

### DIFF
--- a/apps/example-node/package.json
+++ b/apps/example-node/package.json
@@ -11,7 +11,7 @@
     "hono-preact": "workspace:*",
     "hono": "^4.12.14",
     "preact": "^10.29.1",
-    "preact-iso": "github:sbesh91/preact-iso#feat/v3-wrap-update"
+    "preact-iso": "github:preactjs/preact-iso#v3"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.14",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -17,7 +17,7 @@
     "hoofd": "^1.7.3",
     "lucide-preact": "^1.14.0",
     "preact": "^10.29.1",
-    "preact-iso": "github:sbesh91/preact-iso#feat/v3-wrap-update",
+    "preact-iso": "github:preactjs/preact-iso#v3",
     "react": "npm:@preact/compat",
     "react-dom": "npm:@preact/compat",
     "react-is": "npm:@preact/compat"

--- a/docs/superpowers/plans/2026-05-31-cold-nav-transition-coordinator.md
+++ b/docs/superpowers/plans/2026-05-31-cold-nav-transition-coordinator.md
@@ -1,0 +1,471 @@
+# Defer-aware view-transition coordinator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make one coherent view transition fire per navigation, with lifecycle phases + types anchored to the transition that wraps the real DOM swap — for warm, cold-flat, and cold-nested navs.
+
+**Architecture:** A small state machine in `route-change.ts`. The top Router's `onRouteChange` fires `beforeTransition`; if a route is loading it stashes the `ViewTransitionEvent` as `pending` and starts nothing, otherwise it runs the transition immediately (warm). Routers' `wrapUpdate` calls the shared commit handler, which — if a `pending` exists — runs the single transition wrapping that commit with the deferred phases. `onLoadStart`/`onLoadEnd` from every Router maintain a `loadingDepth` counter that decides warm vs cold.
+
+**Tech Stack:** Preact, preact-iso (fork with the `wrapUpdate` prop), `flushSync` from `preact/compat`, Vitest (happy-dom), web-test-runner (preact-iso side, untouched here).
+
+**Branch:** `vt-cold-nav-coordinator` (already created off `demo-view-transitions`). Spec: `docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md`.
+
+---
+
+## Task 1: Phase 0 — confirm the event-sequence assumptions (browser)
+
+This validates the two load-bearing assumptions before coding. Strong prior evidence already exists from earlier instrumentation this session (a cold nav logged `SUSPEND` before `onRouteChange`, and the first `wrapUpdate` showed `old → content`), so the expected result below is the baseline; this task re-confirms it against the `loadingDepth` model and checks the two robustness risks.
+
+**Files:**
+- Temporary edits only (reverted in this task): `packages/iso/src/define-routes.tsx`, `packages/iso/src/internal/route-change.ts`.
+
+- [ ] **Step 1: Add temporary instrumentation**
+
+In `define-routes.tsx`, temporarily give every Router `onLoadStart`/`onLoadEnd`/`wrapUpdate` that log, and in `route-change.ts` log at `__dispatchRouteChange`. Concretely, add a module-level counter and log lines:
+
+```ts
+// TEMP in define-routes.tsx (module scope)
+let __depth = 0;
+const __onLoadStart = () => { __depth++; console.log('[p0] onLoadStart depth=', __depth); };
+const __onLoadEnd = () => { __depth = Math.max(0, __depth - 1); console.log('[p0] onLoadEnd depth=', __depth); };
+const __wrap = (commit: () => void) => {
+  const t = (document.getElementById('app')?.textContent ?? '').replace(/\s+/g, ' ').slice(0, 40);
+  console.log('[p0] wrapUpdate pre depth=', __depth, t);
+  commit();
+  console.log('[p0] wrapUpdate post', (document.getElementById('app')?.textContent ?? '').replace(/\s+/g, ' ').slice(0, 40));
+};
+```
+Pass `{ onLoadStart: __onLoadStart, onLoadEnd: __onLoadEnd, wrapUpdate: __wrap }` to both Router call sites (the top Router in `Routes` and the nested one in the layout wrapper). In `__dispatchRouteChange`, add `console.log('[p0] onRouteChange', to, 'from', from);` after the `beforeTransition` loop.
+
+- [ ] **Step 2: Run the three nav types and record the logs**
+
+Run `pnpm --filter site dev`, open Chrome devtools console, and for each: a **warm** nav (navigate to a route, back, then forward to it again), a **cold-flat** nav (hard refresh on `/demo`, click "Go to projects →"), and a **cold-nested** nav (hard refresh on `/demo/projects`, click an unvisited project). Record the order of `[p0]` lines and the `depth` at each `onRouteChange`.
+
+Expected (the design assumes):
+- warm: `onRouteChange` with `depth === 0`, then a synchronous swap (no `wrapUpdate`).
+- cold: one-or-more `onLoadStart` (`depth > 0`) BEFORE `onRouteChange`, `onRouteChange` sees `depth > 0`, then `wrapUpdate pre` shows the OLD content and `wrapUpdate post` shows the NEW content; `depth` returns to 0 by the end.
+- cold-nested: the FIRST `wrapUpdate` is the page-level (outer) commit.
+
+- [ ] **Step 3: Decide and record**
+
+Confirm assumptions (a) `depth > 0` at cold `onRouteChange`, (b) first `wrapUpdate` is page-level, (c) `depth` returns to 0 (no leak, incl. navigating away mid-load), (d) whether a warm nav can arrive while `depth > 0`. Append a short "Phase 0 findings" note to the spec file. **If (a) or (b) is false, STOP and re-plan.** If (c) leaks or (d) is reachable, note it — the coordinator below already degrades gracefully (a mis-stashed `pending` is discarded on the next dispatch; a warm nav mis-classified as cold simply doesn't animate), so proceed unless the leak is gross.
+
+- [ ] **Step 4: Revert the instrumentation**
+
+```bash
+git checkout -- packages/iso/src/define-routes.tsx packages/iso/src/internal/route-change.ts
+```
+
+- [ ] **Step 5: Commit the findings note**
+
+```bash
+git add docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
+git commit -m "docs(spec): record Phase 0 instrumentation findings"
+```
+
+---
+
+## Task 2: Build the coordinator in route-change.ts
+
+**Files:**
+- Modify: `packages/iso/src/internal/route-change.ts`
+- Test: `packages/iso/src/__tests__/route-change-coordinator.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/iso/src/__tests__/route-change-coordinator.test.ts`:
+
+```ts
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  __dispatchRouteChange,
+  __wrapRouteCommit,
+  __noteLoadStart,
+  __noteLoadEnd,
+  __subscribePhase,
+  resetDefaultTypesForTesting,
+  __resetTransitionStateForTesting,
+} from '../internal/route-change.js';
+import { resetHistoryShimForTesting } from '../internal/history-shim.js';
+
+function installFakeVt() {
+  const typeAdds: string[] = [];
+  let resolveFinished!: () => void;
+  const finished = new Promise<void>((r) => (resolveFinished = r));
+  const startViewTransition = vi.fn((cb: () => void) => {
+    cb();
+    return {
+      ready: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(),
+      finished,
+      types: { add: (t: string) => typeAdds.push(t) },
+    };
+  });
+  vi.stubGlobal('document', { startViewTransition });
+  return { startViewTransition, typeAdds, resolveFinished };
+}
+
+describe('defer-aware transition coordinator', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    resetHistoryShimForTesting();
+    resetDefaultTypesForTesting();
+    __resetTransitionStateForTesting();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('warm nav (depth 0): transition runs at dispatch', () => {
+    const { startViewTransition } = installFakeVt();
+    __dispatchRouteChange('/a', undefined);
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+  });
+
+  it('cold nav: dispatch starts nothing; first commit runs the single transition', () => {
+    const { startViewTransition } = installFakeVt();
+    const swapped: string[] = [];
+    __noteLoadStart(); // depth -> 1 (route loading)
+    __dispatchRouteChange('/b', '/a');
+    expect(startViewTransition).not.toHaveBeenCalled();
+    __wrapRouteCommit(() => swapped.push('content'));
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(swapped).toEqual(['content']);
+  });
+
+  it('cold nav: post-swap phases fire against the deferred transition with the nav types', () => {
+    const { typeAdds } = installFakeVt();
+    const phases: string[] = [];
+    const u1 = __subscribePhase('beforeTransition', () => phases.push('beforeTransition'));
+    const u2 = __subscribePhase('beforeSwap', () => phases.push('beforeSwap'));
+    const u3 = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
+    __noteLoadStart();
+    __dispatchRouteChange('/b', '/a');
+    expect(phases).toEqual(['beforeTransition']); // only beforeTransition at dispatch
+    __wrapRouteCommit(() => {});
+    expect(phases).toEqual(['beforeTransition', 'beforeSwap', 'afterSwap']);
+    expect(typeAdds).toContain('nav-same-origin'); // types applied to the real transition
+    u1(); u2(); u3();
+  });
+
+  it('nested cold nav: one transition, the second commit runs directly', () => {
+    const { startViewTransition } = installFakeVt();
+    const order: string[] = [];
+    __noteLoadStart(); __noteLoadStart(); // two routers loading
+    __dispatchRouteChange('/b', '/a');
+    __wrapRouteCommit(() => order.push('outer'));
+    __wrapRouteCommit(() => order.push('inner'));
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['outer', 'inner']);
+  });
+
+  it('initial load (no dispatch): commit runs directly with no transition', () => {
+    const { startViewTransition } = installFakeVt();
+    const swapped: string[] = [];
+    __wrapRouteCommit(() => swapped.push('home'));
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(swapped).toEqual(['home']);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run packages/iso/src/__tests__/route-change-coordinator.test.ts`
+Expected: FAIL — `__wrapRouteCommit`, `__noteLoadStart`, `__noteLoadEnd`, `__resetTransitionStateForTesting` are not exported.
+
+- [ ] **Step 3: Rewrite `route-change.ts` as the coordinator**
+
+Replace the body of `packages/iso/src/internal/route-change.ts` from the `__lastNavTypes` declaration through the end of `__dispatchRouteChange` with the following. Keep the imports, `PhaseName`/`PhaseSub`/`LegacySub` types, `phaseSubs`, `legacySubs`, `__subscribePhase`, `__subscribeRouteChange`, `fireLegacy`, `getStartViewTransition`, and the `ensureDefaultTypes`/`resetDefaultTypesForTesting` block at the bottom unchanged.
+
+Remove entirely: `__lastNavTypes`, `__getLastNavTypes`.
+
+Add this in their place (above `__dispatchRouteChange`):
+
+```ts
+// Coordinator state. `loadingDepth` is how many Routers are mid-suspense (via
+// their onLoadStart/onLoadEnd). `pending` is a cold navigation whose
+// beforeTransition has fired but whose transition is deferred until the route's
+// content commits (see __wrapRouteCommit).
+let loadingDepth = 0;
+let pending: ViewTransitionEvent | null = null;
+
+export function __noteLoadStart(): void {
+  loadingDepth++;
+}
+export function __noteLoadEnd(): void {
+  loadingDepth = Math.max(0, loadingDepth - 1);
+}
+
+/** @internal Test-only reset for coordinator state. */
+export function __resetTransitionStateForTesting(): void {
+  loadingDepth = 0;
+  pending = null;
+}
+
+function fireAfterSwap(event: ViewTransitionEvent): void {
+  for (const sub of phaseSubs.afterSwap) sub(event);
+  // Legacy subscribers fire at the afterSwap slot: after the DOM swap, before
+  // the browser begins animating the new frame.
+  fireLegacy(event.to, event.from);
+}
+
+function fireAfterTransition(
+  event: ViewTransitionEvent,
+  reason?: 'skipped' | 'unsupported' | 'aborted'
+): void {
+  if (reason !== undefined) event.reason = reason;
+  for (const sub of phaseSubs.afterTransition) sub(event);
+}
+
+// Runs `swap` wrapped in a view transition (when available), firing the
+// post-swap phases and applying the event's accumulated types. Used by both the
+// warm path (swap = no-op; flushSync flushes the already-pending route render)
+// and the cold path (swap = the deferred content commit).
+function runTransition(event: ViewTransitionEvent, swap: () => void): void {
+  if (event._skipped) {
+    flushSync(swap);
+    fireAfterSwap(event);
+    fireAfterTransition(event, 'skipped');
+    return;
+  }
+  const start = getStartViewTransition();
+  if (!start) {
+    flushSync(swap);
+    fireAfterSwap(event);
+    fireAfterTransition(event, 'unsupported');
+    return;
+  }
+  let transition: ViewTransition;
+  try {
+    transition = start(() => {
+      flushSync(swap);
+    });
+  } catch {
+    // Non-conformant / polyfilled startViewTransition that throws synchronously:
+    // still perform the swap so the navigation completes.
+    flushSync(swap);
+    fireAfterSwap(event);
+    fireAfterTransition(event, 'unsupported');
+    return;
+  }
+  event.transition = transition;
+  for (const sub of phaseSubs.beforeSwap) sub(event);
+  fireAfterSwap(event);
+  const vtTypes = (
+    transition as ViewTransition & { types?: { add(t: string): void } }
+  ).types;
+  if (vtTypes && typeof vtTypes.add === 'function') {
+    for (const t of event.types) vtTypes.add(t);
+  }
+  transition.finished.then(
+    () => fireAfterTransition(event),
+    () => fireAfterTransition(event, 'aborted')
+  );
+}
+
+export function __dispatchRouteChange(
+  to: string,
+  from: string | undefined
+): void {
+  ensureDefaultTypes();
+  const direction: NavDirection = getNavDirection();
+  const event = new ViewTransitionEvent({ to, from, direction });
+
+  for (const sub of phaseSubs.beforeTransition) sub(event);
+
+  if (loadingDepth > 0) {
+    // Cold navigation: the route is still loading, so its real content swap
+    // happens later via __wrapRouteCommit. Defer the transition to that commit.
+    // (A still-unconsumed pending from a prior nav is discarded here.)
+    pending = event;
+    return;
+  }
+
+  // Warm navigation: the route render is already pending; flushSync inside the
+  // transition commits it.
+  runTransition(event, () => {});
+}
+
+// Called from each Router's `wrapUpdate` (preact-iso fork). Runs the deferred
+// transition for the current cold navigation, or commits directly when there is
+// none (a later nested commit, the initial route load, or a post-load
+// re-suspense).
+export function __wrapRouteCommit(commit: () => void): void {
+  if (pending) {
+    const event = pending;
+    pending = null;
+    runTransition(event, commit);
+  } else {
+    commit();
+  }
+}
+```
+
+- [ ] **Step 4: Run the new test**
+
+Run: `pnpm exec vitest run packages/iso/src/__tests__/route-change-coordinator.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the existing route-change tests (no regression)**
+
+Run: `pnpm exec vitest run packages/iso/src/__tests__/route-change.test.ts packages/iso/src/__tests__/route-change-phases.test.ts`
+Expected: PASS. (Default `loadingDepth === 0` means those dispatches take the warm path, identical to before.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/iso/src/internal/route-change.ts packages/iso/src/__tests__/route-change-coordinator.test.ts
+git commit -m "feat(iso): defer-aware view-transition coordinator"
+```
+
+---
+
+## Task 3: Wire define-routes.tsx to the coordinator
+
+**Files:**
+- Modify: `packages/iso/src/define-routes.tsx`
+
+- [ ] **Step 1: Replace the imports + `wrapRouteUpdate` block**
+
+Replace the top block (the `flushSync` import line through the `ViewTransitionLike` type and the whole `wrapRouteUpdate` function — currently lines 8-51) with:
+
+```ts
+import { lazy, Route, Router, useLocation } from 'preact-iso';
+import type { RouteHook } from 'preact-iso';
+import { RouteLocationsProvider } from './internal/route-locations.js';
+import {
+  __noteLoadEnd,
+  __noteLoadStart,
+  __wrapRouteCommit,
+} from './internal/route-change.js';
+```
+
+(Removes the `preact/compat` `flushSync` import, the `__getLastNavTypes` import, the `ViewTransitionLike` type, and the `wrapRouteUpdate` function — all now in `route-change.ts`.)
+
+- [ ] **Step 2: Wire the nested layout Router**
+
+In the layout wrapper (currently around line 338), change the nested Router props to include the load hooks:
+
+```ts
+          h(
+            asRouteComponent(Router),
+            {
+              wrapUpdate: __wrapRouteCommit,
+              onLoadStart: __noteLoadStart,
+              onLoadEnd: __noteLoadEnd,
+            },
+            ...inner
+          )
+```
+
+- [ ] **Step 3: Wire the top Router in `Routes`**
+
+In the `Routes` component (currently around line 507), change the top Router props:
+
+```ts
+  return h(
+    asRouteComponent(Router),
+    {
+      wrapUpdate: __wrapRouteCommit,
+      onLoadStart: __noteLoadStart,
+      onLoadEnd: __noteLoadEnd,
+      ...(onRouteChange ? { onRouteChange } : {}),
+    },
+    ...routes.flat.map((r) =>
+      h(Route, {
+        key: r.key,
+        path: r.path,
+        component: asRouteComponent(r.component),
+      })
+    )
+  );
+```
+
+- [ ] **Step 4: Build the framework (typecheck)**
+
+Run: `pnpm --filter '@hono-preact/*' --filter hono-preact build`
+Expected: all packages build (`Done`), no type errors.
+
+- [ ] **Step 5: Run the view-transitions integration test**
+
+Run: `pnpm exec vitest run packages/iso/src/__tests__/view-transitions-integration.test.tsx`
+Expected: PASS (3 tests). The lazy routes suspend, so the click-driven nav now defers and the transition fires once at the deferred commit; the initial mount has no dispatch so no transition fires (matching the existing assertions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/iso/src/define-routes.tsx
+git commit -m "feat(iso): drive Router transitions through the coordinator (load hooks + wrapUpdate)"
+```
+
+---
+
+## Task 4: Fix the inaccurate client-entry comment (review nit #5)
+
+**Files:**
+- Modify: `packages/vite/src/client-entry.ts`
+
+- [ ] **Step 1: Tighten the comment**
+
+Replace the `lastPath` seed comment (the block above `let lastPath = ...`) with:
+
+```ts
+    // Seed lastPath with the initial pathname so the FIRST client navigation
+    // reports a defined `from` to user callbacks (useViewTransitionTypes /
+    // useViewTransitionLifecycle). preact-iso doesn't fire onRouteChange on the
+    // initial hydration mount, so without this the first nav's `from` would be
+    // undefined. (Built-in direction is computed from the history shim, not
+    // `from`, so only `from`-reading user callbacks are affected.)
+```
+
+- [ ] **Step 2: Verify the client-entry test still passes**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/client-entry.test.ts`
+Expected: PASS (the seed assertion is unchanged; only the comment changed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/vite/src/client-entry.ts
+git commit -m "docs(vite): clarify client-entry lastPath seed comment"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full local CI sequence**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test
+pnpm test:integration
+pnpm --filter site build
+```
+Expected: all pass. (If the unit run flakes on `exports.test.ts` timeouts under load, re-run it in isolation: `pnpm exec vitest run packages/hono-preact/__tests__/exports.test.ts`.)
+
+- [ ] **Step 2: Browser verification (Chrome)**
+
+Run `pnpm --filter site dev`. Log in, then verify:
+- **Warm** nav still slides (drill into a project, back to projects, drill in again → forward slide).
+- **Cold-flat**: hard refresh on `/demo`, click "Go to projects →" → the projects page slides in (forward).
+- **Cold-nested**: hard refresh on `/demo/projects`, click an unvisited project → the project page slides in (forward); "← all projects" slides reverse.
+- **Lifecycle correctness**: temporarily add `useViewTransitionLifecycle({ onAfterTransition: (e) => console.log('reason', e.reason) })` somewhere in the demo, do a cold nav, confirm `reason` is `undefined` (not `'aborted'`). Remove the temp log.
+- Console shows **no `AbortError`** during navigations.
+
+- [ ] **Step 3: Confirm no leftovers**
+
+Run: `grep -rn "wrapRouteUpdate\|__getLastNavTypes\|__lastNavTypes\|\[p0\]" packages apps 2>/dev/null | grep -v node_modules`
+Expected: no matches.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Phase 0 → Task 1. Coordinator architecture (state machine, warm/cold branch, `__wrapRouteCommit`, removal of `__lastNavTypes`) → Task 2. `define-routes` wiring (wrapUpdate + load hooks on top & nested Routers, removal of `wrapRouteUpdate`) → Task 3. Error handling (`try/catch`, dropped `AbortError` swallow, pending-discard) → folded into Task 2's `runTransition`/`__dispatchRouteChange`. Review nit #5 → Task 4. Testing (unit warm/cold/nested/initial, integration, browser) → Tasks 2 & 5.
+- **Naming consistency:** `__noteLoadStart`/`__noteLoadEnd`/`__wrapRouteCommit`/`__resetTransitionStateForTesting`/`runTransition`/`fireAfterSwap`/`fireAfterTransition`/`loadingDepth`/`pending` used identically across Tasks 2 and 3.
+- **No placeholders:** every code step shows full before/after.

--- a/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
+++ b/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
@@ -1,8 +1,23 @@
 # Defer-aware view-transition coordinator design
 
 **Date:** 2026-05-31
-**Status:** Implemented, with a cold-path revision (see update below)
+**Status:** Superseded by the `options.debounceRendering` implementation — see the FINAL note below. The design body and the first update are kept for history.
 **Branch:** `vt-cold-nav-coordinator` (off `demo-view-transitions`)
+
+> **FINAL (2026-05-31): driven by `options.debounceRendering`; no preact-iso
+> fork.** The two designs below both anchored the transition to a preact-iso
+> hook (the `wrapUpdate`/`wrapNavigation` fork, PR #150). Per maintainer feedback
+> (Jovi De Croock) the whole thing moved to the consumer side on **stock
+> `preactjs/preact-iso#v3`**: `installNavTransitionScheduler()` overrides
+> `options.debounceRendering` (the seam `flushSync` uses) and wraps a render
+> flush in `startViewTransition` when it is a navigation (the URL changed since
+> the last flush — covers clicks, `route()`, popstate), so the old route is
+> captured before the new one renders. Cold routes keep routing content flushes
+> into the transition until `loadingDepth` hits 0 (the shell), with a short
+> bounded grace for a morph partner that loads with the route's data (behind
+> inner Suspense that doesn't move `loadingDepth`). No `view-transition-name`
+> tricks; supersede + timeout guards remain. PR #150 was closed (unneeded). See
+> commit `feat(iso): drive view transitions via options.debounceRendering`.
 
 > **Update (2026-05-31): cold path revised for element morphs.** Browser
 > verification found that deferring the whole transition to the post-suspense

--- a/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
+++ b/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
@@ -1,0 +1,198 @@
+# Defer-aware view-transition coordinator design
+
+**Date:** 2026-05-31
+**Status:** Approved, pending implementation plan
+**Branch:** `vt-cold-nav-coordinator` (off `demo-view-transitions`)
+
+## Goal
+
+One coherent view transition per navigation, with the lifecycle phases
+(`beforeTransition` / `beforeSwap` / `afterSwap` / `afterTransition`) and the
+navigation types firing against the transition that wraps the **real** DOM
+swap, for warm, cold-flat, and cold-nested navigations alike.
+
+## Background / problem
+
+A route whose lazy view or loader suspends commits its content through
+preact-iso's internal post-suspense update, exposed via the `wrapUpdate` Router
+prop (preactjs/preact-iso#150, currently the `sbesh91/preact-iso` fork). The
+existing dispatch anchors the transition to `onRouteChange`, which for a cold
+route fires on the (no-op) fallback render; the real swap lands later via
+`wrapUpdate`. The current implementation works around this by starting a
+*second, bare* transition inside `wrapUpdate` that re-applies the types. Two
+problems remain:
+
+1. **Lifecycle phases fire against the wrong transition.** `beforeSwap` /
+   `afterSwap` / `afterTransition` (and `event.reason`) run against the no-op
+   `onRouteChange` transition, not the `wrapUpdate` one that actually animates.
+   `useViewTransitionLifecycle` consumers see `reason: 'aborted'` and phases
+   that don't correspond to the visible animation. (`useViewTransitionTypes`
+   and `Persist` are unaffected.)
+2. **Multiple transitions per nav.** Nested routers each call `wrapUpdate`, plus
+   the `onRouteChange` no-op transition, so several `startViewTransition` calls
+   supersede each other per navigation (functional, but noisy — `AbortError`s).
+
+This was approved as a full re-architecture (Approach A) rather than a
+patch, so the transition lifecycle is anchored to the real swap.
+
+## Cold-nav UX (decided)
+
+"Transition to shell, fill in": as soon as the new route's page-level shell is
+ready, transition to it (showing any loading skeletons), then nested/data
+content fills in afterward without animation. The single transition wraps the
+**page-level (first) commit**; later nested/data commits just apply. This keeps
+the current responsive behavior.
+
+## Phase 0 — instrumentation (de-risk first)
+
+Before writing the coordinator, instrument and map the exact event + DOM
+sequence for three navigation types:
+
+- **warm/sync** (revisiting a cached route),
+- **cold-flat** (e.g. `/demo` → `/demo/projects`),
+- **cold-nested** (e.g. `/demo/projects` → `/demo/projects/inf`).
+
+Capture, in order, each `onLoadStart` / `onRouteChange` / `wrapUpdate` /
+`onLoadEnd` with the `#app` content at that moment and the running
+`loadingDepth`. This confirms the two load-bearing assumptions:
+
+- (a) at `onRouteChange` for a cold nav, `loadingDepth > 0` (so the coordinator
+  can branch on it), and
+- (b) the first `wrapUpdate` is the page-level commit.
+
+It must also validate two robustness risks:
+
+- (c) **`loadingDepth` balance** — every `onLoadStart` is matched by an
+  `onLoadEnd`, including when a route's load is *abandoned* by navigating away
+  mid-load (preact-iso's `count` staleness guard drops the stale resolve; verify
+  it still fires `onLoadEnd` so the counter returns to 0). If it can leak,
+  switch from a global counter to a per-navigation load token (snapshot at
+  `onRouteChange`).
+- (d) **warm nav during a lingering load** — if `loadingDepth > 0` from an
+  earlier still-loading route when a *warm* nav arrives, the warm nav would be
+  misclassified as cold, stash a `pending`, and never transition (no
+  `wrapUpdate` fires for it). Confirm whether this is reachable; mitigation
+  below.
+
+If any assumption is false, revisit the coordinator branch logic before
+implementing. The instrumentation is throwaway logging, removed after.
+
+## Architecture
+
+A small state machine in `packages/iso/src/internal/route-change.ts` with three
+inputs and one piece of state.
+
+State:
+
+- `loadingDepth: number` — how many Routers are mid-suspense.
+- `pending: { event: ViewTransitionEvent; types: string[] } | null` — a cold
+  navigation awaiting its content commit.
+
+Inputs:
+
+1. **`__dispatchRouteChange(to, from)`** — called from the top Router's
+   `onRouteChange` (unchanged signature, still wired by the generated client
+   entry). Compute direction + types by firing `beforeTransition`. Then branch:
+   - **warm** (`loadingDepth === 0`): run the transition now — exactly today's
+     warm path (`startViewTransition(() => flushSync(() => {}))`, set
+     `event.transition`, fire `beforeSwap` / `afterSwap`, apply types,
+     `afterTransition` on `finished`). The `_skipped` and no-API fallbacks stay.
+   - **cold** (`loadingDepth > 0`): store `pending = { event, types }` and
+     return without starting a transition. `beforeTransition` has already fired;
+     the remaining phases are deferred to the commit.
+2. **`__noteLoadStart()` / `__noteLoadEnd()`** — wired to every Router's
+   `onLoadStart` / `onLoadEnd`. Increment / decrement `loadingDepth` (floored at
+   0).
+3. **`__wrapRouteCommit(commit)`** — wired to every Router's `wrapUpdate`.
+   - If `pending` is set: start the single transition that wraps the commit —
+     `start(() => flushSync(() => commit()))`; set `pending.event.transition`;
+     fire `beforeSwap` / `afterSwap`; apply `pending.types`; `afterTransition`
+     on `finished`. Then clear `pending`. If `startViewTransition` is
+     unavailable, run `commit()` and fire the post-swap phases synchronously
+     (mirrors today's no-API fallback).
+   - If `pending` is null (a later nested commit, the initial route load, or any
+     post-load re-suspense): just `commit()` — no transition.
+
+Net behavior: warm navs transition at `onRouteChange`; cold navs transition at
+the first `wrapUpdate`, with all phases against that transition; subsequent
+nested/data commits apply directly. Exactly one transition per navigation.
+
+## Components / files
+
+- **`route-change.ts`** — owns the coordinator. The transition-running logic
+  (currently duplicated between `__dispatchRouteChange` and
+  `define-routes.tsx`'s `wrapRouteUpdate`) is unified here as one internal
+  helper used by both the warm and cold paths. `__lastNavTypes` /
+  `__getLastNavTypes` are removed (replaced by the `pending` record). New
+  internal exports: `__noteLoadStart`, `__noteLoadEnd`, `__wrapRouteCommit`.
+- **`define-routes.tsx`** — drops `wrapRouteUpdate`, the `flushSync` import, and
+  the `__getLastNavTypes` import. Every Router it creates (the top Router in
+  `Routes` and the nested layout Router in the layout wrapper) is given
+  `wrapUpdate={__wrapRouteCommit}`, `onLoadStart={__noteLoadStart}`,
+  `onLoadEnd={__noteLoadEnd}`. `onRouteChange` stays top-Router-only.
+- **`client-entry.ts`** — unchanged except removing the now-inaccurate comment
+  about `from`-keyed direction logic (review nit #5). `onRouteChange` + the
+  `lastPath` seed stay.
+- **Demo / CSS** — unchanged; the `nav-initial` / `nav-up` rules already work.
+
+## Data flow (cold-nested example)
+
+```
+onLoadStart × N         loadingDepth: 0 -> N
+onRouteChange(to,from)  loadingDepth > 0  -> fire beforeTransition,
+                                             stash pending, start nothing
+wrapUpdate(outerCommit)  pending set      -> start ONE transition wrapping
+                                             outerCommit; beforeSwap/afterSwap;
+                                             apply types; clear pending
+wrapUpdate(innerCommit)  pending null     -> commit directly (fills in)
+onLoadEnd × N            loadingDepth -> 0
+transition.finished                       -> afterTransition
+```
+
+## Error handling
+
+- `try/catch` around `startViewTransition` so a throwing or polyfilled
+  implementation still runs `commit()` and the post-swap phases (review nit #3).
+- `pending` is replaced on each `onRouteChange`; a `wrapUpdate` consumes the
+  latest pending (rapid-nav edge case — last navigation wins; acceptable). A
+  pending from a prior navigation that was never consumed is simply discarded
+  when the next `onRouteChange` overwrites it.
+- **Warm-during-lingering-load mitigation** (risk (d)): if Phase 0 shows it is
+  reachable, guard the cold branch so an armed `pending` is reconciled — e.g.
+  if a `pending` is still set on the next `onRouteChange` (its commit never
+  came), discard it and let the new nav classify itself; and/or fall back to
+  running the transition at `onRouteChange` when no `wrapUpdate` consumes the
+  pending within a microtask. The exact mitigation is chosen from Phase-0 data.
+- The stale-types edge case (review nit #4) is gone: types live on `pending`,
+  cleared after the consuming commit, so a later non-navigation re-suspense
+  finds no pending and just commits with no transition.
+- With one transition per navigation there is no supersede, so the previous
+  `transition.finished.catch(() => {})` `AbortError` swallow is removed.
+
+## Testing
+
+- **Unit** (`packages/iso/src/__tests__/route-change*.test.ts`), driving load
+  state via `__noteLoadStart` / `__noteLoadEnd`:
+  - warm (`loadingDepth === 0`): `startViewTransition` called once at dispatch;
+    callback is a function. (Keep the existing assertion.)
+  - cold: dispatch starts no transition; the first `__wrapRouteCommit` starts it
+    once; `beforeSwap` / `afterSwap` / `afterTransition` subscribers all fire,
+    and the transition carries the navigation's types.
+  - nested cold: two `__wrapRouteCommit` calls under one pending → one
+    transition; the second commit runs without a transition.
+  - initial load (no dispatch, `pending` null): `__wrapRouteCommit` commits
+    with no transition. (Covers the "first paint must not animate" rule.)
+- **Integration**: the existing `view-transitions-integration.test.tsx` stays
+  green (warm path unchanged).
+- **Browser** (Chrome): warm forward/back slide, cold-flat slide, cold-nested
+  slide, and that `useViewTransitionLifecycle` phases fire against the real
+  transition on a cold nav (e.g. `onAfterTransition` no longer reports
+  `'aborted'`).
+
+## Out of scope
+
+- The upstream `wrapUpdate` API itself (already submitted as
+  preactjs/preact-iso#150). This spec is the consumer-side coordinator.
+- Changing the "transition to shell, fill in" UX (decided above).
+- The release-gate on the fork dependency (tracked separately; switch back to
+  `preactjs/preact-iso#v3` once the upstream PR lands).

--- a/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
+++ b/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
@@ -77,6 +77,34 @@ It must also validate two robustness risks:
 If any assumption is false, revisit the coordinator branch logic before
 implementing. The instrumentation is throwaway logging, removed after.
 
+## Phase 0 findings (2026-05-31)
+
+Confirmed from this session's earlier in-browser instrumentation (Chrome via the
+demo) plus the preact-iso fork source. A live re-confirmation against the
+`loadingDepth` model is deferred to the Task 5 browser verification (the Firefox
+MCP was unavailable when Phase 0 ran).
+
+- **(a) `loadingDepth > 0` at a cold `onRouteChange` — CONFIRMED.** A cold nav
+  logged `SUSPEND` (the Router's `this.__c`, which fires `onLoadStart`) *before*
+  the `onRouteChange` effect, then `UNSUSPEND -> RESOLVED.then(update)` (the
+  `wrapUpdate` trigger). So a load is in flight when `onRouteChange` runs.
+- **(b) the first `wrapUpdate` is the page-level commit — CONFIRMED.** The first
+  `wrapUpdate` logged `#app` going from the old route to the new route's
+  page-level content (`"← all projects api Loading projects…"` →
+  `"← all projects api"`); a cold-nested nav fired two `wrapUpdate`s, outer
+  (page-level) first.
+- **(c) `loadingDepth` balance — OK by construction.** preact-iso fires
+  `onLoadEnd` in the commit effect whenever `isLoading.current` is true on a
+  non-suspending commit (`router.js`), including the commit after a load is
+  abandoned by navigating away, so each `onLoadStart` is matched. Re-verify in
+  Task 5.
+- **(d) warm nav during a lingering load — graceful.** If it occurs, the warm
+  nav is mis-stashed as `pending` and simply doesn't animate (content still
+  updates via the normal render); the stale `pending` is discarded on the next
+  dispatch. Acceptable; no special handling.
+
+Assumptions (a) and (b) hold, so the coordinator design below proceeds.
+
 ## Architecture
 
 A small state machine in `packages/iso/src/internal/route-change.ts` with three

--- a/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
+++ b/docs/superpowers/specs/2026-05-31-cold-nav-transition-coordinator-design.md
@@ -1,8 +1,23 @@
 # Defer-aware view-transition coordinator design
 
 **Date:** 2026-05-31
-**Status:** Approved, pending implementation plan
+**Status:** Implemented, with a cold-path revision (see update below)
 **Branch:** `vt-cold-nav-coordinator` (off `demo-view-transitions`)
+
+> **Update (2026-05-31): cold path revised for element morphs.** Browser
+> verification found that deferring the whole transition to the post-suspense
+> commit (the design below) cannot animate a navigation into a route that shares
+> a `view-transition-name` with the originating page (a list -> detail-header
+> morph): by the commit, preact-iso has already painted the destination and
+> dropped the source, so the morph has no source and the two names transiently
+> collide. The cold path now instead starts the transition at **dispatch** (old
+> snapshot = the still-mounted source route) and bridges its async swap to the
+> content commit, with `useViewTransitionName` keeping the source name through
+> `prev`-keeping and deferring the destination name until the swap. A generation
+> guard, resume-on-next-navigation, and a timeout keep an abandoned or stalled
+> cold navigation from freezing the page. Warm and cold-flat behavior is as
+> described below. See commit `feat(iso): animate element morphs across cold
+> navigations`.
 
 ## Goal
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "@parcel/watcher"
     ],
     "overrides": {
-      "preact-iso": "github:sbesh91/preact-iso#feat/v3-wrap-update",
+      "preact-iso": "github:preactjs/preact-iso#v3",
       "typescript": "^6.0.3",
       "vite": "^8.0.8"
     }

--- a/packages/hono-preact/__tests__/exports.test.ts
+++ b/packages/hono-preact/__tests__/exports.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// Every test here does `await import('hono-preact'…)`, which the vitest alias
+// resolves to the package's *source* entry. The first import of each entry
+// triggers a cold Vite transform of a large graph (iso + server + the Vite
+// plugin), and under a saturated parallel pool that can exceed the default
+// 5000ms per-test timeout — surfacing as flaky timeouts on the heaviest graphs
+// (the root runtime and the Vite plugin). These are import-surface assertions,
+// not timing tests, so give them generous headroom.
+vi.setConfig({ testTimeout: 30000 });
 
 describe('hono-preact root export (iso runtime)', () => {
   it('surfaces the page + route + loader + action public API', async () => {

--- a/packages/iso/src/__tests__/define-routes.test.tsx
+++ b/packages/iso/src/__tests__/define-routes.test.tsx
@@ -436,18 +436,16 @@ describe('<Routes>', () => {
     expect(container.innerHTML).toBeDefined();
   });
 
-  it('wires the coordinator load hooks (wrapUpdate / onLoadStart / onLoadEnd) onto the Router', () => {
+  it('wires the coordinator load hooks (onLoadStart / onLoadEnd) onto the Router', () => {
     const m = defineRoutes([{ path: '/', view: noopView }]);
     const result = (
       Routes as unknown as (props: { routes: typeof m }) => VNode
     )({ routes: m });
     expect(result.type).toBe(Router);
     const props = result.props as {
-      wrapUpdate?: unknown;
       onLoadStart?: unknown;
       onLoadEnd?: unknown;
     };
-    expect(typeof props.wrapUpdate).toBe('function');
     expect(typeof props.onLoadStart).toBe('function');
     expect(typeof props.onLoadEnd).toBe('function');
   });

--- a/packages/iso/src/__tests__/define-routes.test.tsx
+++ b/packages/iso/src/__tests__/define-routes.test.tsx
@@ -436,31 +436,20 @@ describe('<Routes>', () => {
     expect(container.innerHTML).toBeDefined();
   });
 
-  it('forwards onRouteChange to the underlying Router', () => {
-    const cb = () => {};
-    const m = defineRoutes([{ path: '/', view: noopView }]);
-    // Call the function component directly to inspect what it returns.
-    const result = (
-      Routes as unknown as (props: {
-        routes: typeof m;
-        onRouteChange?: () => void;
-      }) => VNode
-    )({ routes: m, onRouteChange: cb });
-    expect(result.type).toBe(Router);
-    expect((result.props as { onRouteChange?: unknown }).onRouteChange).toBe(
-      cb
-    );
-  });
-
-  it('omits onRouteChange from Router when not provided', () => {
+  it('wires the coordinator load hooks (wrapUpdate / onLoadStart / onLoadEnd) onto the Router', () => {
     const m = defineRoutes([{ path: '/', view: noopView }]);
     const result = (
       Routes as unknown as (props: { routes: typeof m }) => VNode
     )({ routes: m });
     expect(result.type).toBe(Router);
-    expect(
-      (result.props as { onRouteChange?: unknown }).onRouteChange
-    ).toBeUndefined();
+    const props = result.props as {
+      wrapUpdate?: unknown;
+      onLoadStart?: unknown;
+      onLoadEnd?: unknown;
+    };
+    expect(typeof props.wrapUpdate).toBe('function');
+    expect(typeof props.onLoadStart).toBe('function');
+    expect(typeof props.onLoadEnd).toBe('function');
   });
 });
 

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -112,6 +112,42 @@ describe('defer-aware transition coordinator', () => {
     expect(startViewTransition).toHaveBeenCalledTimes(2);
   });
 
+  it('cold-flat nav (top Router suspends): commit precedes dispatch; the transition runs synchronously, not bridged', () => {
+    const { startViewTransition } = installFakeVt();
+    const swapped: string[] = [];
+    // The route's own (top) Router suspends, so its content commit (wrapUpdate)
+    // arrives BEFORE onRouteChange. The content must commit directly...
+    __noteLoadStart();
+    __wrapRouteCommit(() => swapped.push('content'));
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(swapped).toEqual(['content']);
+    // ...and the dispatch that follows must run a synchronous transition (the
+    // content is already on screen), NOT a bridged one that would await a commit
+    // that already happened and freeze the page.
+    __dispatchRouteChange('/b', '/a');
+    __noteLoadEnd();
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+  });
+
+  it('initial-load direct commit does not mislabel the next cold-nested nav', async () => {
+    const { startViewTransition } = installFakeVt();
+    // Initial hydration load: a commit during a load with no dispatch.
+    __noteLoadStart();
+    __wrapRouteCommit(() => {});
+    __noteLoadEnd();
+    startViewTransition.mockClear();
+    // A following cold-nested nav: dispatch precedes the commit, so it must take
+    // the bridged (async) path, not the synchronous cold-flat path.
+    const swapped: string[] = [];
+    __noteLoadStart();
+    __dispatchRouteChange('/b', '/a');
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(swapped).toEqual([]); // bridged: nothing swapped until the commit
+    __wrapRouteCommit(() => swapped.push('content'));
+    await tick();
+    expect(swapped).toEqual(['content']);
+  });
+
   it('initial load (no dispatch): commit runs directly with no transition', () => {
     const { startViewTransition } = installFakeVt();
     const swapped: string[] = [];

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  __dispatchRouteChange,
+  __wrapRouteCommit,
+  __noteLoadStart,
+  __noteLoadEnd,
+  __subscribePhase,
+  resetDefaultTypesForTesting,
+  __resetTransitionStateForTesting,
+} from '../internal/route-change.js';
+import { resetHistoryShimForTesting } from '../internal/history-shim.js';
+
+function installFakeVt() {
+  const typeAdds: string[] = [];
+  let resolveFinished!: () => void;
+  const finished = new Promise<void>((r) => (resolveFinished = r));
+  const startViewTransition = vi.fn((cb: () => void) => {
+    cb();
+    return {
+      ready: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(),
+      finished,
+      types: { add: (t: string) => typeAdds.push(t) },
+    };
+  });
+  vi.stubGlobal('document', { startViewTransition });
+  return { startViewTransition, typeAdds, resolveFinished };
+}
+
+describe('defer-aware transition coordinator', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    resetHistoryShimForTesting();
+    resetDefaultTypesForTesting();
+    __resetTransitionStateForTesting();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('warm nav (depth 0): transition runs at dispatch', () => {
+    const { startViewTransition } = installFakeVt();
+    __dispatchRouteChange('/a', undefined);
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+  });
+
+  it('cold nav: dispatch starts nothing; first commit runs the single transition', () => {
+    const { startViewTransition } = installFakeVt();
+    const swapped: string[] = [];
+    __noteLoadStart();
+    __dispatchRouteChange('/b', '/a');
+    expect(startViewTransition).not.toHaveBeenCalled();
+    __wrapRouteCommit(() => swapped.push('content'));
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(swapped).toEqual(['content']);
+  });
+
+  it('cold nav: post-swap phases fire against the deferred transition with the nav types', () => {
+    const { typeAdds } = installFakeVt();
+    const phases: string[] = [];
+    const u1 = __subscribePhase('beforeTransition', () => phases.push('beforeTransition'));
+    const u2 = __subscribePhase('beforeSwap', () => phases.push('beforeSwap'));
+    const u3 = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
+    __noteLoadStart();
+    __dispatchRouteChange('/b', '/a');
+    expect(phases).toEqual(['beforeTransition']);
+    __wrapRouteCommit(() => {});
+    expect(phases).toEqual(['beforeTransition', 'beforeSwap', 'afterSwap']);
+    expect(typeAdds).toContain('nav-same-origin');
+    u1(); u2(); u3();
+  });
+
+  it('nested cold nav: one transition, the second commit runs directly', () => {
+    const { startViewTransition } = installFakeVt();
+    const order: string[] = [];
+    __noteLoadStart(); __noteLoadStart();
+    __dispatchRouteChange('/b', '/a');
+    __wrapRouteCommit(() => order.push('outer'));
+    __wrapRouteCommit(() => order.push('inner'));
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['outer', 'inner']);
+  });
+
+  it('initial load (no dispatch): commit runs directly with no transition', () => {
+    const { startViewTransition } = installFakeVt();
+    const swapped: string[] = [];
+    __wrapRouteCommit(() => swapped.push('home'));
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(swapped).toEqual(['home']);
+  });
+});

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -1,38 +1,54 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
-  __dispatchRouteChange,
+  __wrapNavigation,
   __wrapRouteCommit,
   __noteLoadStart,
-  __noteLoadEnd,
   __subscribePhase,
   resetDefaultTypesForTesting,
   __resetTransitionStateForTesting,
 } from '../internal/route-change.js';
 import { resetHistoryShimForTesting } from '../internal/history-shim.js';
 
-// The cold path starts an async view-transition callback; `tick` lets its
-// post-await body run after the bridging commit resolves it.
+// __wrapNavigation runs an async view-transition callback; `tick` lets it run
+// after startViewTransition returns (the browser invokes the callback async, so
+// the fake below does too).
 const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 
 function installFakeVt() {
   const typeAdds: string[] = [];
   let resolveFinished!: () => void;
-  const finished = new Promise<void>((r) => (resolveFinished = r));
-  const startViewTransition = vi.fn((cb: () => void) => {
-    cb();
+  let rejectFinished!: (reason?: unknown) => void;
+  const finished = new Promise<void>((res, rej) => {
+    resolveFinished = res;
+    rejectFinished = rej;
+  });
+  let skipped = false;
+  const startViewTransition = vi.fn((cb: () => void | Promise<void>) => {
+    // Real browsers run the update callback asynchronously, after capturing the
+    // old snapshot; mirror that so the coordinator's `transition` ref is set.
+    void Promise.resolve().then(() => cb());
     return {
       ready: Promise.resolve(),
       updateCallbackDone: Promise.resolve(),
       finished,
       types: { add: (t: string) => typeAdds.push(t) },
+      skipTransition: () => {
+        skipped = true;
+      },
     };
   });
   vi.stubGlobal('document', { startViewTransition });
-  return { startViewTransition, typeAdds, resolveFinished };
+  return {
+    startViewTransition,
+    typeAdds,
+    resolveFinished,
+    rejectFinished,
+    isSkipped: () => skipped,
+  };
 }
 
-describe('defer-aware transition coordinator', () => {
+describe('navigation-wrapping view-transition coordinator', () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
     resetHistoryShimForTesting();
@@ -41,118 +57,114 @@ describe('defer-aware transition coordinator', () => {
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  it('warm nav (depth 0): transition runs at dispatch', () => {
-    const { startViewTransition } = installFakeVt();
-    __dispatchRouteChange('/a', undefined);
-    expect(startViewTransition).toHaveBeenCalledTimes(1);
-  });
-
-  it('cold nav: dispatch starts the transition; the content commit drives the swap', async () => {
+  it('warm navigation: starts a transition and runs the commit inside it', async () => {
     const { startViewTransition } = installFakeVt();
     const swapped: string[] = [];
-    __noteLoadStart();
-    __dispatchRouteChange('/b', '/a');
-    // The transition starts at dispatch so the browser captures the still-mounted
-    // source route as the old snapshot; the swap is bridged to the content commit.
-    expect(startViewTransition).toHaveBeenCalledTimes(1);
-    expect(swapped).toEqual([]);
-    __wrapRouteCommit(() => swapped.push('content'));
+    __wrapNavigation(() => swapped.push('commit'));
     await tick();
-    expect(swapped).toEqual(['content']);
     expect(startViewTransition).toHaveBeenCalledTimes(1);
+    // The navigation commit runs inside the transition callback (so the browser
+    // captures the old route first, then the commit swaps in the new one).
+    expect(swapped).toEqual(['commit']);
   });
 
-  it('cold nav: post-swap phases fire against the transition with the nav types', async () => {
-    const { typeAdds } = installFakeVt();
+  it('warm navigation: phases fire in order with the nav types', async () => {
+    const { typeAdds, resolveFinished } = installFakeVt();
     const phases: string[] = [];
-    const u1 = __subscribePhase('beforeTransition', () =>
-      phases.push('beforeTransition')
-    );
-    const u2 = __subscribePhase('beforeSwap', () => phases.push('beforeSwap'));
-    const u3 = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
-    __noteLoadStart();
-    __dispatchRouteChange('/b', '/a');
-    // beforeTransition and the nav types are applied at dispatch; the swap phases
-    // wait for the content commit.
-    expect(phases).toEqual(['beforeTransition']);
-    expect(typeAdds).toContain('nav-same-origin');
-    __wrapRouteCommit(() => {});
+    const subs = (
+      [
+        'beforeTransition',
+        'beforeSwap',
+        'afterSwap',
+        'afterTransition',
+      ] as const
+    ).map((p) => __subscribePhase(p, () => phases.push(p)));
+
+    __wrapNavigation(() => {});
     await tick();
     expect(phases).toEqual(['beforeTransition', 'beforeSwap', 'afterSwap']);
-    u1();
-    u2();
-    u3();
+    // afterTransition waits for transition.finished.
+    resolveFinished();
+    await tick();
+    expect(phases).toEqual([
+      'beforeTransition',
+      'beforeSwap',
+      'afterSwap',
+      'afterTransition',
+    ]);
+    expect(typeAdds).toContain('nav-same-origin');
+    subs.forEach((u) => u());
   });
 
-  it('nested cold nav: one transition, the second commit runs directly', async () => {
+  it('cold navigation: holds the transition until the content commits', async () => {
+    const { startViewTransition } = installFakeVt();
+    const order: string[] = [];
+    // Simulate the destination route suspending during the commit.
+    __noteLoadStart();
+    __wrapNavigation(() => order.push('nav-commit'));
+    await tick();
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    // The nav commit ran, but the transition is now awaiting the content.
+    expect(order).toEqual(['nav-commit']);
+    // The route's content commits via wrapUpdate, resuming the transition.
+    __wrapRouteCommit(() => order.push('content'));
+    await tick();
+    expect(order).toEqual(['nav-commit', 'content']);
+  });
+
+  it('cold navigation: a later (nested) commit applies directly, no extra transition', async () => {
     const { startViewTransition } = installFakeVt();
     const order: string[] = [];
     __noteLoadStart();
-    __noteLoadStart();
-    __dispatchRouteChange('/b', '/a');
-    expect(startViewTransition).toHaveBeenCalledTimes(1);
-    // First commit drives the single transition's swap; later (nested) commits
-    // apply directly.
-    __wrapRouteCommit(() => order.push('outer'));
+    __wrapNavigation(() => order.push('nav'));
     await tick();
-    __wrapRouteCommit(() => order.push('inner'));
-    expect(startViewTransition).toHaveBeenCalledTimes(1);
-    expect(order).toEqual(['outer', 'inner']);
-  });
-
-  it('cold nav abandoned by a new navigation: the stale transition resumes (no freeze)', async () => {
-    const { startViewTransition } = installFakeVt();
-    __noteLoadStart();
-    __dispatchRouteChange('/b', '/a');
-    expect(startViewTransition).toHaveBeenCalledTimes(1);
-    // A second navigation arrives before the first committed. It must resume the
-    // first (so its transition can't stay frozen) and start its own.
-    __dispatchRouteChange('/c', '/b');
+    __wrapRouteCommit(() => order.push('shell'));
     await tick();
-    expect(startViewTransition).toHaveBeenCalledTimes(2);
-  });
-
-  it('cold-flat nav (top Router suspends): commit precedes dispatch; the transition runs synchronously, not bridged', () => {
-    const { startViewTransition } = installFakeVt();
-    const swapped: string[] = [];
-    // The route's own (top) Router suspends, so its content commit (wrapUpdate)
-    // arrives BEFORE onRouteChange. The content must commit directly...
-    __noteLoadStart();
-    __wrapRouteCommit(() => swapped.push('content'));
-    expect(startViewTransition).not.toHaveBeenCalled();
-    expect(swapped).toEqual(['content']);
-    // ...and the dispatch that follows must run a synchronous transition (the
-    // content is already on screen), NOT a bridged one that would await a commit
-    // that already happened and freeze the page.
-    __dispatchRouteChange('/b', '/a');
-    __noteLoadEnd();
+    __wrapRouteCommit(() => order.push('fill-in'));
     expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['nav', 'shell', 'fill-in']);
   });
 
-  it('initial-load direct commit does not mislabel the next cold-nested nav', async () => {
-    const { startViewTransition } = installFakeVt();
-    // Initial hydration load: a commit during a load with no dispatch.
-    __noteLoadStart();
-    __wrapRouteCommit(() => {});
-    __noteLoadEnd();
-    startViewTransition.mockClear();
-    // A following cold-nested nav: dispatch precedes the commit, so it must take
-    // the bridged (async) path, not the synchronous cold-flat path.
-    const swapped: string[] = [];
-    __noteLoadStart();
-    __dispatchRouteChange('/b', '/a');
-    expect(startViewTransition).toHaveBeenCalledTimes(1);
-    expect(swapped).toEqual([]); // bridged: nothing swapped until the commit
-    __wrapRouteCommit(() => swapped.push('content'));
-    await tick();
-    expect(swapped).toEqual(['content']);
-  });
-
-  it('initial load (no dispatch): commit runs directly with no transition', () => {
+  it('initial route load (no navigation): commit applies directly with no transition', () => {
     const { startViewTransition } = installFakeVt();
     const swapped: string[] = [];
     __wrapRouteCommit(() => swapped.push('home'));
     expect(startViewTransition).not.toHaveBeenCalled();
     expect(swapped).toEqual(['home']);
+  });
+
+  it('skip(): no transition animation, no beforeSwap, afterTransition reason "skipped"', async () => {
+    const { isSkipped, resolveFinished } = installFakeVt();
+    const phases: string[] = [];
+    const u1 = __subscribePhase('beforeTransition', (e) => e.skip());
+    const u2 = __subscribePhase('beforeSwap', () => phases.push('beforeSwap'));
+    const u3 = __subscribePhase('afterTransition', (e) =>
+      phases.push(`afterTransition:${e.reason}`)
+    );
+
+    __wrapNavigation(() => {});
+    await tick();
+    expect(isSkipped()).toBe(true);
+    expect(phases).not.toContain('beforeSwap');
+    resolveFinished();
+    await tick();
+    expect(phases).toContain('afterTransition:skipped');
+    u1();
+    u2();
+    u3();
+  });
+
+  it('cold navigation abandoned by a new navigation: the stale transition resumes (no freeze)', async () => {
+    const { startViewTransition } = installFakeVt();
+    __noteLoadStart();
+    __wrapNavigation(() => {});
+    await tick();
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    // A second navigation arrives before the first committed its content. It
+    // must resume the first (so its transition can't stay frozen) and start its
+    // own.
+    __wrapNavigation(() => {});
+    await tick();
+    expect(startViewTransition).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -142,4 +142,25 @@ describe('debounceRendering view-transition scheduler', () => {
     await tick();
     expect(startViewTransition).toHaveBeenCalledTimes(2);
   });
+
+  it('a navigation resets a leaked loadingDepth so the next nav is not stuck cold', async () => {
+    installFakeVt();
+    installNavTransitionScheduler();
+    const phases: string[] = [];
+    const u = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
+
+    // Simulate a leaked load: a prior route suspended (onLoadStart) but
+    // unmounted before committing, so its onLoadEnd never fired.
+    __noteLoadStart();
+
+    // A new warm navigation must reset that leaked depth and complete its
+    // transition immediately — not hang on the cold loop waiting for content
+    // that will never come (which would only resolve at the 500ms timeout, well
+    // past this `tick`).
+    navigateTo('/b');
+    flushRender(() => {});
+    await tick();
+    expect(phases).toEqual(['afterSwap']);
+    u();
+  });
 });

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -34,6 +34,40 @@ function installFakeVt() {
   return { startViewTransition, typeAdds, resolveFinished };
 }
 
+type DocWithVt = Document & {
+  startViewTransition?: (cb: () => void | Promise<void>) => unknown;
+};
+
+// Like installFakeVt but augments the REAL happy-dom document instead of
+// replacing it, so the scheduler's `view-transition-name` DOM scans (collectVt
+// Names / hasMorphPartner) see actual elements. Required to exercise the
+// morph-partner grace path. Cleaned up in afterEach.
+function installFakeVtOnDoc() {
+  const typeAdds: string[] = [];
+  let resolveFinished!: () => void;
+  const finished = new Promise<void>((r) => (resolveFinished = r));
+  const startViewTransition = vi.fn((cb: () => void | Promise<void>) => {
+    void Promise.resolve().then(() => cb());
+    return {
+      ready: Promise.resolve(),
+      updateCallbackDone: Promise.resolve(),
+      finished,
+      types: { add: (t: string) => typeAdds.push(t) },
+      skipTransition: () => {},
+    };
+  });
+  (document as DocWithVt).startViewTransition = startViewTransition;
+  return { startViewTransition, typeAdds, resolveFinished };
+}
+
+// Paint an element carrying an inline `view-transition-name` (a morph endpoint).
+function appendNamed(name: string): HTMLElement {
+  const el = document.createElement('div');
+  el.style.setProperty('view-transition-name', name);
+  document.body.appendChild(el);
+  return el;
+}
+
 // Simulate Preact scheduling a render flush (Preact calls options.debounceRendering).
 function flushRender(process: () => void): void {
   options.debounceRendering!(process);
@@ -54,6 +88,11 @@ describe('debounceRendering view-transition scheduler', () => {
   afterEach(() => {
     __resetTransitionStateForTesting();
     vi.unstubAllGlobals();
+    // Undo installFakeVtOnDoc's direct augmentation of the real document and
+    // clear any morph endpoints it painted (vi.unstubAllGlobals doesn't, since
+    // these aren't stubs).
+    delete (document as DocWithVt).startViewTransition;
+    document.body.innerHTML = '';
   });
 
   it('navigation: wraps the render flush in a view transition; the render runs inside it', async () => {
@@ -162,5 +201,90 @@ describe('debounceRendering view-transition scheduler', () => {
     await tick();
     expect(phases).toEqual(['afterSwap']);
     u();
+  });
+
+  it('morph grace: holds the swap until a partner that loads with the route data appears', async () => {
+    // The outgoing route paints an element named `hero`.
+    const oldHero = appendNamed('hero');
+    const { startViewTransition } = installFakeVtOnDoc();
+    installNavTransitionScheduler();
+    const phases: string[] = [];
+    const u = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
+
+    // Navigate. The destination shell renders without the `hero` partner — its
+    // data is still loading behind inner Suspense, which doesn't move
+    // loadingDepth — so the morph has no partner in the new snapshot yet.
+    navigateTo('/b');
+    flushRender(() => oldHero.remove());
+    await tick();
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    // Held in the morph-partner grace window: no swap yet.
+    expect(phases).toEqual([]);
+
+    // The route data arrives and a new element claims the `hero` name. The
+    // partner is now present, so the grace is satisfied and the swap commits.
+    flushRender(() => appendNamed('hero'));
+    await tick();
+    expect(phases).toEqual(['afterSwap']);
+    u();
+  });
+
+  it('morph grace: commits the swap when the grace expires with no partner', async () => {
+    // Fake timers so the 150ms grace cap advances instantly — a real wall-clock
+    // wait here would hold a worker and starve the parallel pool (see the
+    // pool-starvation note in vitest.config.ts).
+    vi.useFakeTimers();
+    try {
+      const oldHero = appendNamed('hero');
+      installFakeVtOnDoc();
+      installNavTransitionScheduler();
+      const phases: string[] = [];
+      const u = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
+
+      navigateTo('/b');
+      flushRender(() => oldHero.remove());
+      // Flush the VT callback microtask so it parks on the grace timeout (the
+      // fake-VT schedules the callback as a microtask, not a timer).
+      await Promise.resolve();
+      await Promise.resolve();
+      // Held, waiting for a partner that never appears.
+      expect(phases).toEqual([]);
+
+      // Past the 150ms MORPH_PARTNER_GRACE_MS cap the transition stops waiting
+      // and commits as-is rather than freezing the page.
+      await vi.advanceTimersByTimeAsync(160);
+      expect(phases).toEqual(['afterSwap']);
+      u();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cold navigation: gives up after the cold-commit timeout if the content never loads', async () => {
+    // Fake timers so the 500ms cap advances instantly (see the grace-expiry test).
+    vi.useFakeTimers();
+    try {
+      installFakeVt();
+      installNavTransitionScheduler();
+      const phases: string[] = [];
+      const u = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
+
+      // The route suspends during the nav render — so loadingDepth is raised
+      // inside the transition, after the navigation's reset — and never resolves.
+      navigateTo('/b');
+      flushRender(() => __noteLoadStart());
+      await Promise.resolve();
+      await Promise.resolve();
+      // Held cold, waiting for content that never arrives.
+      expect(phases).toEqual([]);
+
+      // Past the 500ms COLD_COMMIT_TIMEOUT_MS cap the transition stops waiting
+      // and commits rather than freezing the page on a stalled load.
+      await vi.advanceTimersByTimeAsync(520);
+      expect(phases).toEqual(['afterSwap']);
+      u();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -11,6 +11,10 @@ import {
 } from '../internal/route-change.js';
 import { resetHistoryShimForTesting } from '../internal/history-shim.js';
 
+// The cold path starts an async view-transition callback; `tick` lets its
+// post-await body run after the bridging commit resolves it.
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
 function installFakeVt() {
   const typeAdds: string[] = [];
   let resolveFinished!: () => void;
@@ -43,18 +47,22 @@ describe('defer-aware transition coordinator', () => {
     expect(startViewTransition).toHaveBeenCalledTimes(1);
   });
 
-  it('cold nav: dispatch starts nothing; first commit runs the single transition', () => {
+  it('cold nav: dispatch starts the transition; the content commit drives the swap', async () => {
     const { startViewTransition } = installFakeVt();
     const swapped: string[] = [];
     __noteLoadStart();
     __dispatchRouteChange('/b', '/a');
-    expect(startViewTransition).not.toHaveBeenCalled();
-    __wrapRouteCommit(() => swapped.push('content'));
+    // The transition starts at dispatch so the browser captures the still-mounted
+    // source route as the old snapshot; the swap is bridged to the content commit.
     expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(swapped).toEqual([]);
+    __wrapRouteCommit(() => swapped.push('content'));
+    await tick();
     expect(swapped).toEqual(['content']);
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
   });
 
-  it('cold nav: post-swap phases fire against the deferred transition with the nav types', () => {
+  it('cold nav: post-swap phases fire against the transition with the nav types', async () => {
     const { typeAdds } = installFakeVt();
     const phases: string[] = [];
     const u1 = __subscribePhase('beforeTransition', () =>
@@ -64,25 +72,44 @@ describe('defer-aware transition coordinator', () => {
     const u3 = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
     __noteLoadStart();
     __dispatchRouteChange('/b', '/a');
+    // beforeTransition and the nav types are applied at dispatch; the swap phases
+    // wait for the content commit.
     expect(phases).toEqual(['beforeTransition']);
-    __wrapRouteCommit(() => {});
-    expect(phases).toEqual(['beforeTransition', 'beforeSwap', 'afterSwap']);
     expect(typeAdds).toContain('nav-same-origin');
+    __wrapRouteCommit(() => {});
+    await tick();
+    expect(phases).toEqual(['beforeTransition', 'beforeSwap', 'afterSwap']);
     u1();
     u2();
     u3();
   });
 
-  it('nested cold nav: one transition, the second commit runs directly', () => {
+  it('nested cold nav: one transition, the second commit runs directly', async () => {
     const { startViewTransition } = installFakeVt();
     const order: string[] = [];
     __noteLoadStart();
     __noteLoadStart();
     __dispatchRouteChange('/b', '/a');
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    // First commit drives the single transition's swap; later (nested) commits
+    // apply directly.
     __wrapRouteCommit(() => order.push('outer'));
+    await tick();
     __wrapRouteCommit(() => order.push('inner'));
     expect(startViewTransition).toHaveBeenCalledTimes(1);
     expect(order).toEqual(['outer', 'inner']);
+  });
+
+  it('cold nav abandoned by a new navigation: the stale transition resumes (no freeze)', async () => {
+    const { startViewTransition } = installFakeVt();
+    __noteLoadStart();
+    __dispatchRouteChange('/b', '/a');
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    // A second navigation arrives before the first committed. It must resume the
+    // first (so its transition can't stay frozen) and start its own.
+    __dispatchRouteChange('/c', '/b');
+    await tick();
+    expect(startViewTransition).toHaveBeenCalledTimes(2);
   });
 
   it('initial load (no dispatch): commit runs directly with no transition', () => {

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -57,7 +57,9 @@ describe('defer-aware transition coordinator', () => {
   it('cold nav: post-swap phases fire against the deferred transition with the nav types', () => {
     const { typeAdds } = installFakeVt();
     const phases: string[] = [];
-    const u1 = __subscribePhase('beforeTransition', () => phases.push('beforeTransition'));
+    const u1 = __subscribePhase('beforeTransition', () =>
+      phases.push('beforeTransition')
+    );
     const u2 = __subscribePhase('beforeSwap', () => phases.push('beforeSwap'));
     const u3 = __subscribePhase('afterSwap', () => phases.push('afterSwap'));
     __noteLoadStart();
@@ -66,13 +68,16 @@ describe('defer-aware transition coordinator', () => {
     __wrapRouteCommit(() => {});
     expect(phases).toEqual(['beforeTransition', 'beforeSwap', 'afterSwap']);
     expect(typeAdds).toContain('nav-same-origin');
-    u1(); u2(); u3();
+    u1();
+    u2();
+    u3();
   });
 
   it('nested cold nav: one transition, the second commit runs directly', () => {
     const { startViewTransition } = installFakeVt();
     const order: string[] = [];
-    __noteLoadStart(); __noteLoadStart();
+    __noteLoadStart();
+    __noteLoadStart();
     __dispatchRouteChange('/b', '/a');
     __wrapRouteCommit(() => order.push('outer'));
     __wrapRouteCommit(() => order.push('inner'));

--- a/packages/iso/src/__tests__/route-change-coordinator.test.ts
+++ b/packages/iso/src/__tests__/route-change-coordinator.test.ts
@@ -1,75 +1,87 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { options } from 'preact';
 import {
-  __wrapNavigation,
-  __wrapRouteCommit,
+  installNavTransitionScheduler,
   __noteLoadStart,
+  __noteLoadEnd,
   __subscribePhase,
   resetDefaultTypesForTesting,
   __resetTransitionStateForTesting,
 } from '../internal/route-change.js';
 import { resetHistoryShimForTesting } from '../internal/history-shim.js';
 
-// __wrapNavigation runs an async view-transition callback; `tick` lets it run
-// after startViewTransition returns (the browser invokes the callback async, so
-// the fake below does too).
+// The scheduler runs an async view-transition callback; `tick` lets it run after
+// startViewTransition returns (the browser invokes the callback async, so the
+// fake below does too).
 const tick = () => new Promise<void>((r) => setTimeout(r, 0));
 
 function installFakeVt() {
   const typeAdds: string[] = [];
   let resolveFinished!: () => void;
-  let rejectFinished!: (reason?: unknown) => void;
-  const finished = new Promise<void>((res, rej) => {
-    resolveFinished = res;
-    rejectFinished = rej;
-  });
-  let skipped = false;
+  const finished = new Promise<void>((r) => (resolveFinished = r));
   const startViewTransition = vi.fn((cb: () => void | Promise<void>) => {
-    // Real browsers run the update callback asynchronously, after capturing the
-    // old snapshot; mirror that so the coordinator's `transition` ref is set.
     void Promise.resolve().then(() => cb());
     return {
       ready: Promise.resolve(),
       updateCallbackDone: Promise.resolve(),
       finished,
       types: { add: (t: string) => typeAdds.push(t) },
-      skipTransition: () => {
-        skipped = true;
-      },
+      skipTransition: () => {},
     };
   });
   vi.stubGlobal('document', { startViewTransition });
-  return {
-    startViewTransition,
-    typeAdds,
-    resolveFinished,
-    rejectFinished,
-    isSkipped: () => skipped,
-  };
+  return { startViewTransition, typeAdds, resolveFinished };
 }
 
-describe('navigation-wrapping view-transition coordinator', () => {
+// Simulate Preact scheduling a render flush (Preact calls options.debounceRendering).
+function flushRender(process: () => void): void {
+  options.debounceRendering!(process);
+}
+// Simulate a navigation: the router pushes state before re-rendering.
+function navigateTo(url: string): void {
+  history.pushState(null, '', url);
+}
+
+describe('debounceRendering view-transition scheduler', () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
     resetHistoryShimForTesting();
     resetDefaultTypesForTesting();
     __resetTransitionStateForTesting();
+    history.replaceState(null, '', '/');
   });
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    __resetTransitionStateForTesting();
+    vi.unstubAllGlobals();
+  });
 
-  it('warm navigation: starts a transition and runs the commit inside it', async () => {
+  it('navigation: wraps the render flush in a view transition; the render runs inside it', async () => {
     const { startViewTransition } = installFakeVt();
-    const swapped: string[] = [];
-    __wrapNavigation(() => swapped.push('commit'));
+    installNavTransitionScheduler();
+    const ran: string[] = [];
+    navigateTo('/b');
+    flushRender(() => ran.push('render'));
     await tick();
     expect(startViewTransition).toHaveBeenCalledTimes(1);
-    // The navigation commit runs inside the transition callback (so the browser
-    // captures the old route first, then the commit swaps in the new one).
-    expect(swapped).toEqual(['commit']);
+    // The render runs inside the transition (so the browser captures the old
+    // route first, then this flush swaps in the new one).
+    expect(ran).toEqual(['render']);
   });
 
-  it('warm navigation: phases fire in order with the nav types', async () => {
+  it('non-navigation render schedules normally, with no transition', async () => {
+    const { startViewTransition } = installFakeVt();
+    installNavTransitionScheduler();
+    const ran: string[] = [];
+    flushRender(() => ran.push('render')); // no location change
+    await tick();
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(ran).toEqual(['render']);
+  });
+
+  it('navigation: phases fire in order with the nav types', async () => {
     const { typeAdds, resolveFinished } = installFakeVt();
+    installNavTransitionScheduler();
     const phases: string[] = [];
     const subs = (
       [
@@ -80,10 +92,10 @@ describe('navigation-wrapping view-transition coordinator', () => {
       ] as const
     ).map((p) => __subscribePhase(p, () => phases.push(p)));
 
-    __wrapNavigation(() => {});
+    navigateTo('/b');
+    flushRender(() => {});
     await tick();
     expect(phases).toEqual(['beforeTransition', 'beforeSwap', 'afterSwap']);
-    // afterTransition waits for transition.finished.
     resolveFinished();
     await tick();
     expect(phases).toEqual([
@@ -96,74 +108,37 @@ describe('navigation-wrapping view-transition coordinator', () => {
     subs.forEach((u) => u());
   });
 
-  it('cold navigation: holds the transition until the content commits', async () => {
+  it('cold navigation: holds the transition until the route modules finish loading', async () => {
     const { startViewTransition } = installFakeVt();
-    const order: string[] = [];
-    // Simulate the destination route suspending during the commit.
-    __noteLoadStart();
-    __wrapNavigation(() => order.push('nav-commit'));
+    installNavTransitionScheduler();
+    const ran: string[] = [];
+    navigateTo('/b');
+    __noteLoadStart(); // the route suspended on a module load
+    flushRender(() => ran.push('nav'));
     await tick();
     expect(startViewTransition).toHaveBeenCalledTimes(1);
-    // The nav commit ran, but the transition is now awaiting the content.
-    expect(order).toEqual(['nav-commit']);
-    // The route's content commits via wrapUpdate, resuming the transition.
-    __wrapRouteCommit(() => order.push('content'));
+    // The nav render ran, but the transition is awaiting the content.
+    expect(ran).toEqual(['nav']);
+    // The module loads: its content flushes (same URL) and is routed into the
+    // transition.
+    __noteLoadEnd();
+    flushRender(() => ran.push('content'));
     await tick();
-    expect(order).toEqual(['nav-commit', 'content']);
+    expect(ran).toEqual(['nav', 'content']);
   });
 
-  it('cold navigation: a later (nested) commit applies directly, no extra transition', async () => {
+  it('a second navigation supersedes an in-flight cold one', async () => {
     const { startViewTransition } = installFakeVt();
-    const order: string[] = [];
+    installNavTransitionScheduler();
+    navigateTo('/b');
     __noteLoadStart();
-    __wrapNavigation(() => order.push('nav'));
-    await tick();
-    __wrapRouteCommit(() => order.push('shell'));
-    await tick();
-    __wrapRouteCommit(() => order.push('fill-in'));
-    expect(startViewTransition).toHaveBeenCalledTimes(1);
-    expect(order).toEqual(['nav', 'shell', 'fill-in']);
-  });
-
-  it('initial route load (no navigation): commit applies directly with no transition', () => {
-    const { startViewTransition } = installFakeVt();
-    const swapped: string[] = [];
-    __wrapRouteCommit(() => swapped.push('home'));
-    expect(startViewTransition).not.toHaveBeenCalled();
-    expect(swapped).toEqual(['home']);
-  });
-
-  it('skip(): no transition animation, no beforeSwap, afterTransition reason "skipped"', async () => {
-    const { isSkipped, resolveFinished } = installFakeVt();
-    const phases: string[] = [];
-    const u1 = __subscribePhase('beforeTransition', (e) => e.skip());
-    const u2 = __subscribePhase('beforeSwap', () => phases.push('beforeSwap'));
-    const u3 = __subscribePhase('afterTransition', (e) =>
-      phases.push(`afterTransition:${e.reason}`)
-    );
-
-    __wrapNavigation(() => {});
-    await tick();
-    expect(isSkipped()).toBe(true);
-    expect(phases).not.toContain('beforeSwap');
-    resolveFinished();
-    await tick();
-    expect(phases).toContain('afterTransition:skipped');
-    u1();
-    u2();
-    u3();
-  });
-
-  it('cold navigation abandoned by a new navigation: the stale transition resumes (no freeze)', async () => {
-    const { startViewTransition } = installFakeVt();
-    __noteLoadStart();
-    __wrapNavigation(() => {});
+    flushRender(() => {});
     await tick();
     expect(startViewTransition).toHaveBeenCalledTimes(1);
-    // A second navigation arrives before the first committed its content. It
-    // must resume the first (so its transition can't stay frozen) and start its
-    // own.
-    __wrapNavigation(() => {});
+    // A new navigation arrives before /b's content loaded; it abandons /b and
+    // starts its own transition.
+    navigateTo('/c');
+    flushRender(() => {});
     await tick();
     expect(startViewTransition).toHaveBeenCalledTimes(2);
   });

--- a/packages/iso/src/__tests__/view-transitions-integration.test.tsx
+++ b/packages/iso/src/__tests__/view-transitions-integration.test.tsx
@@ -6,7 +6,7 @@ import { LocationProvider, useLocation } from 'preact-iso';
 import { defineRoutes, Routes } from '../define-routes.js';
 import {
   __dispatchRouteChange,
-  __wrapNavigation,
+  installNavTransitionScheduler,
   resetDefaultTypesForTesting,
   __resetTransitionStateForTesting,
 } from '../internal/route-change.js';
@@ -72,9 +72,10 @@ describe('view transitions: end-to-end wiring', () => {
       };
     });
 
-  it('routes a navigation through wrapNavigation into document.startViewTransition', async () => {
+  it('wraps a navigation in document.startViewTransition via the render scheduler', async () => {
     const startViewTransition = makeFakeVt();
     Object.assign(document, { startViewTransition });
+    installNavTransitionScheduler();
 
     const routes = defineRoutes([
       { path: '/', view: () => Promise.resolve({ default: Home }) },
@@ -82,11 +83,7 @@ describe('view transitions: end-to-end wiring', () => {
     ]);
 
     const { container } = render(
-      h(
-        LocationProvider,
-        { wrapNavigation: __wrapNavigation },
-        h(Routes, { routes })
-      )
+      h(LocationProvider, null, h(Routes, { routes }))
     );
 
     // Wait for the lazy Home view to mount.
@@ -96,8 +93,8 @@ describe('view transitions: end-to-end wiring', () => {
     // The initial mount is not a navigation.
     expect(startViewTransition).not.toHaveBeenCalled();
 
-    // A user navigation goes LocationProvider's wrapNavigation →
-    // __wrapNavigation → document.startViewTransition, and lands on /about.
+    // A user navigation's render flush is wrapped in a view transition by the
+    // scheduler, and lands on /about.
     fireEvent.click(container.querySelector('button')!);
     await waitFor(() => expect(startViewTransition).toHaveBeenCalledTimes(1));
     expect(typeof startViewTransition.mock.calls[0][0]).toBe('function');
@@ -111,6 +108,7 @@ describe('view transitions: end-to-end wiring', () => {
   it('navigates without throwing when the view-transition API is unavailable', async () => {
     // Browsers without view-transitions: the navigation still runs, no throw.
     Object.assign(document, { startViewTransition: undefined });
+    installNavTransitionScheduler();
 
     const routes = defineRoutes([
       { path: '/', view: () => Promise.resolve({ default: Home }) },
@@ -118,11 +116,7 @@ describe('view transitions: end-to-end wiring', () => {
     ]);
 
     const { container } = render(
-      h(
-        LocationProvider,
-        { wrapNavigation: __wrapNavigation },
-        h(Routes, { routes })
-      )
+      h(LocationProvider, null, h(Routes, { routes }))
     );
     await waitFor(() =>
       expect(container.querySelector('button')?.textContent).toBe('go to about')

--- a/packages/iso/src/__tests__/view-transitions-integration.test.tsx
+++ b/packages/iso/src/__tests__/view-transitions-integration.test.tsx
@@ -38,9 +38,10 @@ afterEach(() => {
 });
 
 // Real-DOM test that exercises the FULL wiring chain end-to-end:
-//   LocationProvider (wrapNavigation = __wrapNavigation) → a navigation runs
-//   the route change inside document.startViewTransition → the Router (mounted
-//   by `Routes`) swaps in the new route.
+//   a navigation triggers a Preact render flush → the render scheduler
+//   (installed by installNavTransitionScheduler, which overrides
+//   options.debounceRendering) wraps that flush in document.startViewTransition
+//   → the Router (mounted by `Routes`) swaps in the new route inside it.
 //
 // This is the guard that a real navigation reaches the coordinator: the
 // transition must start before the route re-renders so the browser can capture

--- a/packages/iso/src/__tests__/view-transitions-integration.test.tsx
+++ b/packages/iso/src/__tests__/view-transitions-integration.test.tsx
@@ -7,6 +7,7 @@ import { defineRoutes, Routes } from '../define-routes.js';
 import {
   __dispatchRouteChange,
   resetDefaultTypesForTesting,
+  __resetTransitionStateForTesting,
 } from '../internal/route-change.js';
 import {
   resetHistoryShimForTesting,
@@ -24,6 +25,9 @@ import {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  // Reset the coordinator's loadingDepth/pending so a navigation left mid-load
+  // by one test cannot misclassify the next test's navigation.
+  __resetTransitionStateForTesting();
   // The first test navigates to /about via history.pushState; subsequent
   // tests need to start fresh at '/' or their LocationProvider initialises
   // off the leftover URL and renders About instead of Home.
@@ -51,9 +55,12 @@ describe('view transitions: end-to-end wiring', () => {
     const { route } = useLocation();
     return h('button', { onClick: () => route('/about') }, 'go to about');
   };
-  const About = () => h('h1', null, 'About');
+  const About = () => {
+    const { route } = useLocation();
+    return h('button', { onClick: () => route('/') }, 'back to home');
+  };
 
-  it('fires document.startViewTransition once per navigation triggered through the Router', async () => {
+  it('fires document.startViewTransition once for a warm (already-loaded) navigation', async () => {
     const startViewTransition = vi.fn((cb: () => void) => {
       cb();
       return {
@@ -70,7 +77,7 @@ describe('view transitions: end-to-end wiring', () => {
     ]);
 
     // Wire onRouteChange the same way the framework's generated client
-    // entry does: forward every Router commit into __dispatchRouteChange.
+    // entry does: forward every top-Router commit into __dispatchRouteChange.
     let lastPath: string | undefined;
     function onRouteChange(path: string): void {
       const from = lastPath;
@@ -84,7 +91,7 @@ describe('view transitions: end-to-end wiring', () => {
 
     // Wait for the lazy Home view to mount.
     await waitFor(() =>
-      expect(container.querySelector('button')).not.toBeNull()
+      expect(container.querySelector('button')?.textContent).toBe('go to about')
     );
 
     // Initial mount does not fire onRouteChange (preact-iso's Router only
@@ -92,9 +99,23 @@ describe('view transitions: end-to-end wiring', () => {
     // should still be at zero calls before any user-driven nav.
     expect(startViewTransition).not.toHaveBeenCalled();
 
-    // Click triggers route('/about') → reducer updates url → Router renders
-    // About → useLayoutEffect fires onRouteChange → __dispatchRouteChange →
-    // startViewTransition.
+    // First nav to /about loads its view (a cold/suspending navigation). The
+    // coordinator defers a cold navigation's transition to its post-suspense
+    // commit; that path's exact event ordering is environment-specific (it is
+    // covered by route-change-coordinator.test.ts and the browser
+    // verification). Here we drive it only to land on a now-loaded route.
+    fireEvent.click(container.querySelector('button')!);
+    await waitFor(() =>
+      expect(container.querySelector('button')?.textContent).toBe(
+        'back to home'
+      )
+    );
+
+    // Now navigate back to '/'. Home is already loaded, so this is a warm
+    // (synchronous) navigation, which the coordinator transitions at dispatch
+    // time. This is the end-to-end guard that a real Router-driven navigation
+    // reaches document.startViewTransition.
+    startViewTransition.mockClear();
     fireEvent.click(container.querySelector('button')!);
 
     await waitFor(() => expect(startViewTransition).toHaveBeenCalledTimes(1));

--- a/packages/iso/src/__tests__/view-transitions-integration.test.tsx
+++ b/packages/iso/src/__tests__/view-transitions-integration.test.tsx
@@ -6,6 +6,7 @@ import { LocationProvider, useLocation } from 'preact-iso';
 import { defineRoutes, Routes } from '../define-routes.js';
 import {
   __dispatchRouteChange,
+  __wrapNavigation,
   resetDefaultTypesForTesting,
   __resetTransitionStateForTesting,
 } from '../internal/route-change.js';
@@ -37,16 +38,13 @@ afterEach(() => {
 });
 
 // Real-DOM test that exercises the FULL wiring chain end-to-end:
-//   LocationProvider → preact-iso <Router> (mounted by `Routes`) →
-//   onRouteChange callback fires in useLayoutEffect → __dispatchRouteChange
-//   → document.startViewTransition(cb).
+//   LocationProvider (wrapNavigation = __wrapNavigation) → a navigation runs
+//   the route change inside document.startViewTransition → the Router (mounted
+//   by `Routes`) swaps in the new route.
 //
-// The previous coverage in route-change.test.ts called __dispatchRouteChange
-// directly with a stubbed document. That tests "the dispatcher invokes the
-// API when enabled"; it does NOT test that a real Router-driven navigation
-// actually reaches the dispatcher. Given how recently the view-transitions
-// opt-in plumbing thrashed (74f952c → e837831), this is the regression we
-// most want a guard against.
+// This is the guard that a real navigation reaches the coordinator: the
+// transition must start before the route re-renders so the browser can capture
+// the outgoing route as the old snapshot.
 describe('view transitions: end-to-end wiring', () => {
   // A view component that uses useLocation so we can trigger a programmatic
   // navigation from inside the rendered tree (mirrors how real apps call
@@ -60,15 +58,22 @@ describe('view transitions: end-to-end wiring', () => {
     return h('button', { onClick: () => route('/') }, 'back to home');
   };
 
-  it('fires document.startViewTransition once for a warm (already-loaded) navigation', async () => {
-    const startViewTransition = vi.fn((cb: () => void) => {
-      cb();
+  const makeFakeVt = () =>
+    vi.fn((cb: () => void | Promise<void>) => {
+      // Real browsers run the update callback asynchronously, after capturing
+      // the old snapshot; mirror that here.
+      void Promise.resolve().then(() => cb());
       return {
         ready: Promise.resolve(),
         finished: Promise.resolve(),
         updateCallbackDone: Promise.resolve(),
+        types: { add: () => {} },
+        skipTransition: () => {},
       };
     });
+
+  it('routes a navigation through wrapNavigation into document.startViewTransition', async () => {
+    const startViewTransition = makeFakeVt();
     Object.assign(document, { startViewTransition });
 
     const routes = defineRoutes([
@@ -76,58 +81,35 @@ describe('view transitions: end-to-end wiring', () => {
       { path: '/about', view: () => Promise.resolve({ default: About }) },
     ]);
 
-    // Wire onRouteChange the same way the framework's generated client
-    // entry does: forward every top-Router commit into __dispatchRouteChange.
-    let lastPath: string | undefined;
-    function onRouteChange(path: string): void {
-      const from = lastPath;
-      lastPath = path;
-      __dispatchRouteChange(path, from);
-    }
-
     const { container } = render(
-      h(LocationProvider, null, h(Routes, { routes, onRouteChange }))
+      h(
+        LocationProvider,
+        { wrapNavigation: __wrapNavigation },
+        h(Routes, { routes })
+      )
     );
 
     // Wait for the lazy Home view to mount.
     await waitFor(() =>
       expect(container.querySelector('button')?.textContent).toBe('go to about')
     );
-
-    // Initial mount does not fire onRouteChange (preact-iso's Router only
-    // fires onRouteChange when prevRoute.current !== path). startViewTransition
-    // should still be at zero calls before any user-driven nav.
+    // The initial mount is not a navigation.
     expect(startViewTransition).not.toHaveBeenCalled();
 
-    // First nav to /about loads its view (a cold/suspending navigation). The
-    // coordinator defers a cold navigation's transition to its post-suspense
-    // commit; that path's exact event ordering is environment-specific (it is
-    // covered by route-change-coordinator.test.ts and the browser
-    // verification). Here we drive it only to land on a now-loaded route.
+    // A user navigation goes LocationProvider's wrapNavigation →
+    // __wrapNavigation → document.startViewTransition, and lands on /about.
     fireEvent.click(container.querySelector('button')!);
+    await waitFor(() => expect(startViewTransition).toHaveBeenCalledTimes(1));
+    expect(typeof startViewTransition.mock.calls[0][0]).toBe('function');
     await waitFor(() =>
       expect(container.querySelector('button')?.textContent).toBe(
         'back to home'
       )
     );
-
-    // Now navigate back to '/'. Home is already loaded, so this is a warm
-    // (synchronous) navigation, which the coordinator transitions at dispatch
-    // time. This is the end-to-end guard that a real Router-driven navigation
-    // reaches document.startViewTransition.
-    startViewTransition.mockClear();
-    fireEvent.click(container.querySelector('button')!);
-
-    await waitFor(() => expect(startViewTransition).toHaveBeenCalledTimes(1));
-    // The callback passed to startViewTransition must be a function. Real
-    // browsers call it inside the snapshot window; the framework hands them
-    // `() => flushSync(() => {})`.
-    expect(typeof startViewTransition.mock.calls[0][0]).toBe('function');
   });
 
-  it('does not call startViewTransition when the API is unavailable on document', async () => {
-    // Browsers without view-transitions: dispatching should still notify
-    // subscribers (other __dispatchRouteChange consumers) without throwing.
+  it('navigates without throwing when the view-transition API is unavailable', async () => {
+    // Browsers without view-transitions: the navigation still runs, no throw.
     Object.assign(document, { startViewTransition: undefined });
 
     const routes = defineRoutes([
@@ -135,24 +117,25 @@ describe('view transitions: end-to-end wiring', () => {
       { path: '/about', view: () => Promise.resolve({ default: About }) },
     ]);
 
-    let lastPath: string | undefined;
-    const onRouteChange = (path: string): void => {
-      const from = lastPath;
-      lastPath = path;
-      __dispatchRouteChange(path, from);
-    };
-
     const { container } = render(
-      h(LocationProvider, null, h(Routes, { routes, onRouteChange }))
+      h(
+        LocationProvider,
+        { wrapNavigation: __wrapNavigation },
+        h(Routes, { routes })
+      )
     );
     await waitFor(() =>
-      expect(container.querySelector('button')).not.toBeNull()
+      expect(container.querySelector('button')?.textContent).toBe('go to about')
     );
 
-    // Should NOT throw and should NOT call any view-transition API.
     expect(() =>
       fireEvent.click(container.querySelector('button')!)
     ).not.toThrow();
+    await waitFor(() =>
+      expect(container.querySelector('button')?.textContent).toBe(
+        'back to home'
+      )
+    );
   });
 });
 

--- a/packages/iso/src/define-routes.tsx
+++ b/packages/iso/src/define-routes.tsx
@@ -8,11 +8,7 @@ import type {
 import { lazy, Route, Router, useLocation } from 'preact-iso';
 import type { RouteHook } from 'preact-iso';
 import { RouteLocationsProvider } from './internal/route-locations.js';
-import {
-  __noteLoadEnd,
-  __noteLoadStart,
-  __wrapRouteCommit,
-} from './internal/route-change.js';
+import { __noteLoadEnd, __noteLoadStart } from './internal/route-change.js';
 
 function wrapWithRouteLocations(
   serverMod: unknown,
@@ -303,7 +299,6 @@ function makeLayoutGroupComponent(
           h(
             asRouteComponent(Router),
             {
-              wrapUpdate: __wrapRouteCommit,
               onLoadStart: __noteLoadStart,
               onLoadEnd: __noteLoadEnd,
             },
@@ -476,7 +471,6 @@ export const Routes: ComponentType<RoutesProps> = ({ routes }) => {
   return h(
     asRouteComponent(Router),
     {
-      wrapUpdate: __wrapRouteCommit,
       onLoadStart: __noteLoadStart,
       onLoadEnd: __noteLoadEnd,
     },

--- a/packages/iso/src/define-routes.tsx
+++ b/packages/iso/src/define-routes.tsx
@@ -5,49 +5,14 @@ import type {
   ComponentType,
   VNode,
 } from 'preact';
-import { flushSync } from 'preact/compat';
 import { lazy, Route, Router, useLocation } from 'preact-iso';
 import type { RouteHook } from 'preact-iso';
 import { RouteLocationsProvider } from './internal/route-locations.js';
-import { __getLastNavTypes } from './internal/route-change.js';
-
-type ViewTransitionLike = {
-  types?: { add(type: string): void };
-  finished?: Promise<unknown>;
-};
-
-// preact-iso commits a suspending route's content via an internal post-suspense
-// update that, unlike a synchronous route swap, isn't captured by the view
-// transition the onRouteChange path starts (it lands after that transition's
-// no-op callback). Its `wrapUpdate` prop hands us that commit so we can wrap it:
-// flush it synchronously inside a fresh transition (capturing old route ->
-// new content) and re-apply this navigation's types so a cold/suspending nav
-// animates with the same directional slide as a warm one. startViewTransition
-// called while one is active supersedes it, so this wins over the onRouteChange
-// no-op transition; that superseded transition rejects with AbortError, which
-// we swallow. Server-side (or without the API) it just commits.
-function wrapRouteUpdate(commit: () => void): void {
-  const types = __getLastNavTypes();
-  const start =
-    typeof document !== 'undefined'
-      ? (
-          document as Document & {
-            startViewTransition?: (cb: () => void) => ViewTransitionLike;
-          }
-        ).startViewTransition
-      : undefined;
-  // `types === null` means no navigation has been dispatched yet, i.e. this is
-  // the initial route load resolving its lazy view, which must not animate.
-  if (typeof start !== 'function' || types === null) {
-    commit();
-    return;
-  }
-  const transition = start.call(document, () => flushSync(() => commit()));
-  if (transition.types && typeof transition.types.add === 'function') {
-    for (const type of types) transition.types.add(type);
-  }
-  if (transition.finished) transition.finished.catch(() => {});
-}
+import {
+  __noteLoadEnd,
+  __noteLoadStart,
+  __wrapRouteCommit,
+} from './internal/route-change.js';
 
 function wrapWithRouteLocations(
   serverMod: unknown,
@@ -335,7 +300,15 @@ function makeLayoutGroupComponent(
         const layoutNode = h(
           Layout,
           null,
-          h(asRouteComponent(Router), { wrapUpdate: wrapRouteUpdate }, ...inner)
+          h(
+            asRouteComponent(Router),
+            {
+              wrapUpdate: __wrapRouteCommit,
+              onLoadStart: __noteLoadStart,
+              onLoadEnd: __noteLoadEnd,
+            },
+            ...inner
+          )
         );
         return wrapWithRouteLocations(serverMod, layoutLocation, layoutNode);
       };
@@ -507,7 +480,9 @@ export const Routes: ComponentType<RoutesProps> = ({
   return h(
     asRouteComponent(Router),
     {
-      wrapUpdate: wrapRouteUpdate,
+      wrapUpdate: __wrapRouteCommit,
+      onLoadStart: __noteLoadStart,
+      onLoadEnd: __noteLoadEnd,
       ...(onRouteChange ? { onRouteChange } : {}),
     },
     ...routes.flat.map((r) =>

--- a/packages/iso/src/define-routes.tsx
+++ b/packages/iso/src/define-routes.tsx
@@ -470,20 +470,15 @@ export function defineRoutes(tree: RouteDef[]): RoutesManifest {
 
 export type RoutesProps = {
   routes: RoutesManifest;
-  onRouteChange?: (url: string) => void;
 };
 
-export const Routes: ComponentType<RoutesProps> = ({
-  routes,
-  onRouteChange,
-}) => {
+export const Routes: ComponentType<RoutesProps> = ({ routes }) => {
   return h(
     asRouteComponent(Router),
     {
       wrapUpdate: __wrapRouteCommit,
       onLoadStart: __noteLoadStart,
       onLoadEnd: __noteLoadEnd,
-      ...(onRouteChange ? { onRouteChange } : {}),
     },
     ...routes.flat.map((r) =>
       h(Route, {

--- a/packages/iso/src/internal.ts
+++ b/packages/iso/src/internal.ts
@@ -59,7 +59,7 @@ export { HonoRequestContext } from './internal/contexts.js';
 export { PageMiddlewareHost } from './internal/page-middleware-host.js';
 
 export {
-  __dispatchRouteChange,
+  __wrapNavigation,
   __subscribeRouteChange,
 } from './internal/route-change.js';
 

--- a/packages/iso/src/internal.ts
+++ b/packages/iso/src/internal.ts
@@ -59,7 +59,7 @@ export { HonoRequestContext } from './internal/contexts.js';
 export { PageMiddlewareHost } from './internal/page-middleware-host.js';
 
 export {
-  __wrapNavigation,
+  installNavTransitionScheduler,
   __subscribeRouteChange,
 } from './internal/route-change.js';
 

--- a/packages/iso/src/internal/history-shim.ts
+++ b/packages/iso/src/internal/history-shim.ts
@@ -7,6 +7,19 @@ interface ShimState {
 let installed = false;
 let counter = 0;
 let lastDirection: NavDirection = 'initial';
+
+// Fires synchronously whenever a navigation occurs (pushState / replaceState /
+// popstate), BEFORE the resulting re-render. Lets the view-transition scheduler
+// observe a navigation at navigation time rather than only at render time (which
+// Preact's render batching can coalesce away). See route-change.ts.
+const navListeners = new Set<() => void>();
+export function onNavigation(listener: () => void): () => void {
+  navListeners.add(listener);
+  return () => navListeners.delete(listener);
+}
+function notifyNavigation(): void {
+  for (const listener of navListeners) listener();
+}
 let originalPush:
   | ((state: unknown, title: string, url?: string | URL | null) => void)
   | null = null;
@@ -44,6 +57,7 @@ export function installHistoryShim(): void {
     };
     originalPush!(merged, title, url);
     lastDirection = 'push';
+    notifyNavigation();
   };
 
   history.replaceState = function patchedReplace(
@@ -57,6 +71,7 @@ export function installHistoryShim(): void {
     };
     originalReplace!(merged, title, url);
     lastDirection = 'replace';
+    notifyNavigation();
   };
 
   popstateListener = (e: PopStateEvent) => {
@@ -64,6 +79,7 @@ export function installHistoryShim(): void {
     lastDirection =
       incoming < counter ? 'back' : incoming > counter ? 'forward' : 'replace';
     counter = incoming;
+    notifyNavigation();
   };
   window.addEventListener('popstate', popstateListener, { capture: true });
 
@@ -102,6 +118,7 @@ export function resetHistoryShimForTesting(): void {
   originalPush = null;
   originalReplace = null;
   popstateListener = null;
+  navListeners.clear();
 }
 
 /** Test-only direction setter. Do not call from production code. */

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -52,11 +52,63 @@ function getStartViewTransition():
 }
 
 // Coordinator state. `loadingDepth` is how many Routers are mid-suspense (via
-// their onLoadStart/onLoadEnd). `pending` is a cold navigation whose
-// beforeTransition has fired but whose transition is deferred until the route's
-// content commits (see __wrapRouteCommit).
+// their onLoadStart/onLoadEnd). `pending` holds a cold navigation only on the
+// no-view-transitions fallback path; the normal cold path starts the transition
+// at dispatch and bridges its swap to the route's content commit.
 let loadingDepth = 0;
 let pending: ViewTransitionEvent | null = null;
+
+// Cold-morph bridge state (Approach: capture the old snapshot at dispatch, while
+// the source route is still mounted, then swap when the content commits).
+//
+// `coldActive` is true between starting a cold transition and its swap; while it
+// is true, newly-mounted ViewTransitionName elements defer naming themselves so
+// the destination isn't named in the old snapshot. `deferredNames` collects
+// those name-applications; they run in the swap so they land in the new
+// snapshot. `coldBridgeResolve` resumes the (async) transition callback once the
+// route's content is ready; `coldCommit` is that content commit.
+let coldActive = false;
+let deferredNames: Array<() => void> = [];
+let coldBridgeResolve: (() => void) | null = null;
+let coldCommit: (() => void) | null = null;
+let coldTimeout: ReturnType<typeof setTimeout> | null = null;
+// Bumped per cold transition so a superseded one's (async) callback, once
+// resumed, can detect it is no longer current and bow out without clobbering
+// the live transition's state.
+let coldGen = 0;
+
+// Safety net: the longest a cold navigation will hold the page frozen waiting
+// for its content commit. A commit normally arrives within a frame or two (the
+// lazy route module resolving); this only fires if the load stalls or errors,
+// so the page can't stay frozen indefinitely.
+const COLD_COMMIT_TIMEOUT_MS = 2000;
+
+export function __isColdTransitionActive(): boolean {
+  return coldActive;
+}
+export function __deferTransitionName(apply: () => void): void {
+  deferredNames.push(apply);
+}
+function flushDeferredNames(): void {
+  const queued = deferredNames;
+  deferredNames = [];
+  for (const apply of queued) apply();
+}
+
+// Resume a cold transition that is awaiting its content commit (or its timeout).
+// Used by __wrapRouteCommit (the commit arrived), by a subsequent navigation
+// (the previous cold nav was abandoned mid-flight), and by the timeout. If no
+// commit is set the transition swaps nothing; the deferred names are flushed
+// either way so incoming elements end up named.
+function resumeColdTransition(): void {
+  if (coldTimeout !== null) {
+    clearTimeout(coldTimeout);
+    coldTimeout = null;
+  }
+  const resolve = coldBridgeResolve;
+  coldBridgeResolve = null;
+  if (resolve) resolve();
+}
 
 export function __noteLoadStart(): void {
   loadingDepth++;
@@ -69,6 +121,14 @@ export function __noteLoadEnd(): void {
 export function __resetTransitionStateForTesting(): void {
   loadingDepth = 0;
   pending = null;
+  coldActive = false;
+  deferredNames = [];
+  coldBridgeResolve = null;
+  coldCommit = null;
+  if (coldTimeout !== null) {
+    clearTimeout(coldTimeout);
+    coldTimeout = null;
+  }
 }
 
 function fireAfterSwap(event: ViewTransitionEvent): void {
@@ -140,13 +200,18 @@ export function __dispatchRouteChange(
   const direction: NavDirection = getNavDirection();
   const event = new ViewTransitionEvent({ to, from, direction });
 
+  // If a previous cold navigation is still awaiting its content commit, this new
+  // navigation abandoned it — resume it now (swapping nothing) so its transition
+  // can't stay frozen.
+  if (coldBridgeResolve) resumeColdTransition();
+
   for (const sub of phaseSubs.beforeTransition) sub(event);
 
   if (loadingDepth > 0) {
-    // Cold navigation: the route is still loading, so its real content swap
-    // happens later via __wrapRouteCommit. Defer the transition to that commit.
-    // (A still-unconsumed pending from a prior nav is discarded here.)
-    pending = event;
+    // Cold navigation: start the transition NOW so the browser captures the
+    // still-mounted source route as the old snapshot, and bridge the swap to
+    // the route's content commit (see __wrapRouteCommit).
+    runColdTransition(event);
     return;
   }
 
@@ -155,12 +220,70 @@ export function __dispatchRouteChange(
   runTransition(event, () => {});
 }
 
-// Called from each Router's `wrapUpdate` (preact-iso fork). Runs the deferred
-// transition for the current cold navigation, or commits directly when there is
-// none (a later nested commit, the initial route load, or a post-load
-// re-suspense).
+// Cold path: start the transition at dispatch (old snapshot = the source route,
+// still mounted), then resume and swap when the content commits.
+function runColdTransition(event: ViewTransitionEvent): void {
+  const start = getStartViewTransition();
+  if (!start || event._skipped) {
+    // No view transitions (or skipped): fall back to the deferred,
+    // non-morphing path — the swap still happens at the content commit.
+    pending = event;
+    return;
+  }
+  const myGen = ++coldGen;
+  coldActive = true;
+  let transition: ViewTransition;
+  try {
+    transition = start(async () => {
+      // The old snapshot has been captured. Wait for the route content to
+      // commit, then swap and reveal the deferred incoming names so they land
+      // in the new snapshot.
+      await new Promise<void>((resolve) => {
+        coldBridgeResolve = resolve;
+      });
+      // A newer navigation superseded this one while it was waiting: let this
+      // (now-stale) transition complete as a no-op rather than touch live state.
+      if (coldGen !== myGen) return;
+      for (const sub of phaseSubs.beforeSwap) sub(event);
+      const commit = coldCommit;
+      coldCommit = null;
+      if (commit) flushSync(commit);
+      flushDeferredNames();
+      coldActive = false;
+      fireAfterSwap(event);
+    });
+  } catch {
+    coldActive = false;
+    coldBridgeResolve = null;
+    coldCommit = null;
+    flushDeferredNames();
+    pending = event;
+    return;
+  }
+  // Safety net so a stalled or errored load can't freeze the page forever.
+  coldTimeout = setTimeout(resumeColdTransition, COLD_COMMIT_TIMEOUT_MS);
+  event.transition = transition;
+  const vtTypes = (
+    transition as ViewTransition & { types?: { add(t: string): void } }
+  ).types;
+  if (vtTypes && typeof vtTypes.add === 'function') {
+    for (const t of event.types) vtTypes.add(t);
+  }
+  transition.finished.then(
+    () => fireAfterTransition(event),
+    () => fireAfterTransition(event, 'aborted')
+  );
+}
+
+// Called from each Router's `wrapUpdate` (preact-iso fork). Resumes the active
+// cold transition with the page-level content commit, runs the no-VT fallback
+// transition, or commits directly (a later nested/fill-in commit, the initial
+// route load, or a post-load re-suspense).
 export function __wrapRouteCommit(commit: () => void): void {
-  if (pending) {
+  if (coldBridgeResolve) {
+    coldCommit = commit;
+    resumeColdTransition();
+  } else if (pending) {
     const event = pending;
     pending = null;
     runTransition(event, commit);

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -76,6 +76,14 @@ let coldTimeout: ReturnType<typeof setTimeout> | null = null;
 // resumed, can detect it is no longer current and bow out without clobbering
 // the live transition's state.
 let coldGen = 0;
+// True when a page-level content commit already ran via __wrapRouteCommit during
+// the current load WITHOUT a transition wrapping it. This is the "cold-flat"
+// ordering: the route's own (top) Router suspended, so its `wrapUpdate` fired
+// BEFORE `onRouteChange`. The dispatch reads this to run a synchronous
+// transition (the content is already on screen) instead of the bridged cold
+// path, which would otherwise wait for a commit that already happened and
+// freeze the page.
+let directCommitDuringLoad = false;
 
 // Safety net: the longest a cold navigation will hold the page frozen waiting
 // for its content commit. A commit normally arrives within a frame or two (the
@@ -115,6 +123,10 @@ export function __noteLoadStart(): void {
 }
 export function __noteLoadEnd(): void {
   loadingDepth = Math.max(0, loadingDepth - 1);
+  // Once the load settles, drop an unconsumed direct-commit flag (e.g. the
+  // initial hydration load, which commits but never dispatches) so it can't
+  // mislabel the next navigation.
+  if (loadingDepth === 0) directCommitDuringLoad = false;
 }
 
 /** @internal Test-only reset for coordinator state. */
@@ -125,6 +137,7 @@ export function __resetTransitionStateForTesting(): void {
   deferredNames = [];
   coldBridgeResolve = null;
   coldCommit = null;
+  directCommitDuringLoad = false;
   if (coldTimeout !== null) {
     clearTimeout(coldTimeout);
     coldTimeout = null;
@@ -201,16 +214,30 @@ export function __dispatchRouteChange(
   const event = new ViewTransitionEvent({ to, from, direction });
 
   // If a previous cold navigation is still awaiting its content commit, this new
-  // navigation abandoned it — resume it now (swapping nothing) so its transition
-  // can't stay frozen.
-  if (coldBridgeResolve) resumeColdTransition();
+  // navigation abandoned it — invalidate its (async) callback and resume it now
+  // (swapping nothing) so its transition can't stay frozen or re-fire phases.
+  if (coldBridgeResolve) {
+    coldGen++;
+    resumeColdTransition();
+  }
 
   for (const sub of phaseSubs.beforeTransition) sub(event);
 
   if (loadingDepth > 0) {
-    // Cold navigation: start the transition NOW so the browser captures the
-    // still-mounted source route as the old snapshot, and bridge the swap to
-    // the route's content commit (see __wrapRouteCommit).
+    if (directCommitDuringLoad) {
+      // Cold-flat ordering: the route's own Router suspended, so its content
+      // already committed (wrapUpdate fired before this dispatch). There is no
+      // earlier source snapshot left to capture, so run the transition
+      // synchronously — the directional root slide still plays — rather than
+      // bridging to a commit that already happened (which would freeze the page).
+      directCommitDuringLoad = false;
+      runTransition(event, () => {});
+      return;
+    }
+    // Cold-nested ordering: this dispatch precedes the content commit. Start the
+    // transition NOW so the browser captures the still-mounted source route as
+    // the old snapshot, and bridge the swap to the content commit (see
+    // __wrapRouteCommit).
     runColdTransition(event);
     return;
   }
@@ -260,8 +287,11 @@ function runColdTransition(event: ViewTransitionEvent): void {
     pending = event;
     return;
   }
-  // Safety net so a stalled or errored load can't freeze the page forever.
-  coldTimeout = setTimeout(resumeColdTransition, COLD_COMMIT_TIMEOUT_MS);
+  // Safety net so a stalled or errored load can't freeze the page forever. The
+  // generation check keeps a stale timer from resuming a newer transition.
+  coldTimeout = setTimeout(() => {
+    if (coldGen === myGen) resumeColdTransition();
+  }, COLD_COMMIT_TIMEOUT_MS);
   event.transition = transition;
   const vtTypes = (
     transition as ViewTransition & { types?: { add(t: string): void } }
@@ -288,6 +318,11 @@ export function __wrapRouteCommit(commit: () => void): void {
     pending = null;
     runTransition(event, commit);
   } else {
+    // No transition is wrapping this commit. If it lands during a load, it is a
+    // page-level commit that beat its dispatch (cold-flat ordering) — flag it so
+    // the imminent dispatch runs a synchronous transition rather than waiting
+    // for a commit that already happened.
+    if (loadingDepth > 0) directCommitDuringLoad = true;
     commit();
   }
 }

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -51,16 +51,85 @@ function getStartViewTransition():
   return typeof fn === 'function' ? fn.bind(document) : undefined;
 }
 
-// Types computed for the most recent navigation. A suspending route's content
-// commits after this dispatch's transition (see define-routes' wrapRouteUpdate),
-// so that deferred commit re-applies these types to its own transition to keep
-// the same direction-driven styling as a synchronous navigation. `null` until
-// the first navigation is dispatched, which lets the deferred-commit wrapper
-// distinguish a real navigation from the initial route load (whose lazy view
-// resolving must NOT trigger a transition).
-let __lastNavTypes: string[] | null = null;
-export function __getLastNavTypes(): string[] | null {
-  return __lastNavTypes;
+// Coordinator state. `loadingDepth` is how many Routers are mid-suspense (via
+// their onLoadStart/onLoadEnd). `pending` is a cold navigation whose
+// beforeTransition has fired but whose transition is deferred until the route's
+// content commits (see __wrapRouteCommit).
+let loadingDepth = 0;
+let pending: ViewTransitionEvent | null = null;
+
+export function __noteLoadStart(): void {
+  loadingDepth++;
+}
+export function __noteLoadEnd(): void {
+  loadingDepth = Math.max(0, loadingDepth - 1);
+}
+
+/** @internal Test-only reset for coordinator state. */
+export function __resetTransitionStateForTesting(): void {
+  loadingDepth = 0;
+  pending = null;
+}
+
+function fireAfterSwap(event: ViewTransitionEvent): void {
+  for (const sub of phaseSubs.afterSwap) sub(event);
+  // Legacy subscribers fire at the afterSwap slot: after the DOM swap, before
+  // the browser begins animating the new frame.
+  fireLegacy(event.to, event.from);
+}
+
+function fireAfterTransition(
+  event: ViewTransitionEvent,
+  reason?: 'skipped' | 'unsupported' | 'aborted'
+): void {
+  if (reason !== undefined) event.reason = reason;
+  for (const sub of phaseSubs.afterTransition) sub(event);
+}
+
+// Runs `swap` wrapped in a view transition (when available), firing the
+// post-swap phases and applying the event's accumulated types. Used by both the
+// warm path (swap = no-op; flushSync flushes the already-pending route render)
+// and the cold path (swap = the deferred content commit).
+function runTransition(event: ViewTransitionEvent, swap: () => void): void {
+  if (event._skipped) {
+    flushSync(swap);
+    fireAfterSwap(event);
+    fireAfterTransition(event, 'skipped');
+    return;
+  }
+  const start = getStartViewTransition();
+  if (!start) {
+    flushSync(swap);
+    fireAfterSwap(event);
+    fireAfterTransition(event, 'unsupported');
+    return;
+  }
+  let transition: ViewTransition;
+  try {
+    transition = start(() => {
+      flushSync(swap);
+    });
+  } catch {
+    // Non-conformant / polyfilled startViewTransition that throws synchronously:
+    // still perform the swap so the navigation completes.
+    flushSync(swap);
+    fireAfterSwap(event);
+    fireAfterTransition(event, 'unsupported');
+    return;
+  }
+  event.transition = transition;
+  for (const sub of phaseSubs.beforeSwap) sub(event);
+  fireAfterSwap(event);
+  const vtTypes = (
+    transition as ViewTransition & { types?: { add(t: string): void } }
+  ).types;
+  if (vtTypes && typeof vtTypes.add === 'function') {
+    for (const t of event.types) vtTypes.add(t);
+  }
+  transition.finished.then(
+    () => fireAfterTransition(event),
+    () => fireAfterTransition(event, 'aborted')
+  );
 }
 
 export function __dispatchRouteChange(
@@ -73,67 +142,31 @@ export function __dispatchRouteChange(
 
   for (const sub of phaseSubs.beforeTransition) sub(event);
 
-  // Remember the types for this navigation so a deferred suspending-route
-  // commit can re-apply them to its own transition.
-  __lastNavTypes = [...event.types];
-
-  const fireAfterSwap = () => {
-    for (const sub of phaseSubs.afterSwap) sub(event);
-    // Legacy subscribers fire at the afterSwap slot: after the DOM swap,
-    // before the browser begins animating the new frame.
-    fireLegacy(to, from);
-  };
-
-  const fireAfterTransition = (
-    reason?: 'skipped' | 'unsupported' | 'aborted'
-  ): void => {
-    if (reason !== undefined) event.reason = reason;
-    for (const sub of phaseSubs.afterTransition) sub(event);
-  };
-
-  if (event._skipped) {
-    flushSync(() => {});
-    fireAfterSwap();
-    fireAfterTransition('skipped');
+  if (loadingDepth > 0) {
+    // Cold navigation: the route is still loading, so its real content swap
+    // happens later via __wrapRouteCommit. Defer the transition to that commit.
+    // (A still-unconsumed pending from a prior nav is discarded here.)
+    pending = event;
     return;
   }
 
-  const start = getStartViewTransition();
-  if (!start) {
-    flushSync(() => {});
-    fireAfterSwap();
-    fireAfterTransition('unsupported');
-    return;
+  // Warm navigation: the route render is already pending; flushSync inside the
+  // transition commits it.
+  runTransition(event, () => {});
+}
+
+// Called from each Router's `wrapUpdate` (preact-iso fork). Runs the deferred
+// transition for the current cold navigation, or commits directly when there is
+// none (a later nested commit, the initial route load, or a post-load
+// re-suspense).
+export function __wrapRouteCommit(commit: () => void): void {
+  if (pending) {
+    const event = pending;
+    pending = null;
+    runTransition(event, commit);
+  } else {
+    commit();
   }
-
-  const transition = start(() => {
-    flushSync(() => {});
-  });
-  // Set event.transition before firing beforeSwap so all subsequent phase
-  // subscribers see a non-null transition. In real browsers startViewTransition
-  // invokes the callback asynchronously, meaning transition is set here before
-  // the browser calls the update function. In synchronous test mocks the
-  // callback returns before start() does, so we set transition here (after
-  // start() returns) and then fire the post-swap phases manually.
-  event.transition = transition;
-  for (const sub of phaseSubs.beforeSwap) sub(event);
-  fireAfterSwap();
-
-  // Apply types accumulated across all phases. beforeTransition and beforeSwap
-  // have both run by this point, so the full set of types is available here.
-  const vtTypes = (
-    transition as ViewTransition & {
-      types?: { add(t: string): void };
-    }
-  ).types;
-  if (vtTypes && typeof vtTypes.add === 'function') {
-    for (const t of event.types) vtTypes.add(t);
-  }
-
-  transition.finished.then(
-    () => fireAfterTransition(),
-    () => fireAfterTransition('aborted')
-  );
 }
 
 let defaultTypesInstalled = false;

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -1,4 +1,4 @@
-import { flushSync } from 'preact/compat';
+import { options } from 'preact';
 import {
   ViewTransitionEvent,
   type NavDirection,
@@ -77,10 +77,8 @@ let lastPath: string | undefined =
     ? location.pathname + location.search
     : undefined;
 
-// Cold-navigation bridge. A suspending route's content commits later via
-// __wrapRouteCommit; the in-flight transition awaits it so the new snapshot is
-// the loaded content (or shell), not the suspense fallback.
-let coldResolve: (() => void) | null = null;
+// Cold-navigation state: a navigation's transition holds until the suspending
+// route's content flushes have all run (see the scheduler below).
 let coldTimeout: ReturnType<typeof setTimeout> | null = null;
 // Bumped per navigation so a superseded transition's (async) callback bows out.
 let navGen = 0;
@@ -88,6 +86,10 @@ let navGen = 0;
 // route's content. Past it the navigation completes without finishing the
 // transition rather than freezing the page on a slow/stalled load.
 const COLD_COMMIT_TIMEOUT_MS = 500;
+// Extra grace, after the shell is ready, to let a morph partner that loads with
+// the route's DATA (behind inner Suspense, which doesn't move loadingDepth)
+// appear in the new snapshot before the transition captures it.
+const MORPH_PARTNER_GRACE_MS = 150;
 
 /** @internal Test-only reset for coordinator state. */
 export function __resetTransitionStateForTesting(): void {
@@ -97,11 +99,18 @@ export function __resetTransitionStateForTesting(): void {
     typeof location !== 'undefined'
       ? location.pathname + location.search
       : undefined;
+  coldRouteSignal = null;
   if (coldTimeout !== null) {
     clearTimeout(coldTimeout);
     coldTimeout = null;
   }
-  coldResolve = null;
+  // Uninstall the render scheduler (restoring Preact's debounceRendering) so
+  // each test can install it fresh.
+  if (schedulerInstalled) {
+    options.debounceRendering = prevDebounce;
+    schedulerInstalled = false;
+    prevDebounce = undefined;
+  }
 }
 
 function fireAfterSwap(event: ViewTransitionEvent): void {
@@ -149,52 +158,150 @@ function buildEvent(from: string | undefined): ViewTransitionEvent {
   return event;
 }
 
-// Resolve the pending cold bridge — the content commit arrived, the timeout
-// fired, or a newer navigation superseded it.
-function resolveCold(): void {
-  if (coldTimeout !== null) {
-    clearTimeout(coldTimeout);
-    coldTimeout = null;
-  }
-  const resolve = coldResolve;
-  coldResolve = null;
-  if (resolve) resolve();
+// ---------------------------------------------------------------------------
+// debounceRendering-based scheduler (no preact-iso navigation hooks required).
+//
+// Preact calls `options.debounceRendering(process)` to schedule a render flush
+// (this is the seam `flushSync` uses). We override it: when a flush is the
+// result of a navigation (the URL changed since the last flush, because the
+// router pushes state before re-rendering), wrap that flush in a view
+// transition so the browser captures the current route as the old snapshot
+// before `process()` swaps in the new one. Everything else schedules normally.
+//
+// Cold (suspending) routes commit their content in a later, same-URL flush; the
+// in-flight transition routes that flush into itself so the new snapshot is the
+// loaded route. Uses only stock preact-iso props (onLoadStart/onLoadEnd via
+// `loadingDepth`).
+// ---------------------------------------------------------------------------
+
+type ProcessFn = () => void;
+
+let schedulerInstalled = false;
+let lastHref = '';
+let prevDebounce: ((process: ProcessFn) => void) | undefined;
+// Set while a cold navigation's transition awaits a content flush; the next
+// same-URL flush hands its `process` here (or `null` on supersede/timeout) so
+// the transition can run it inside itself.
+let coldRouteSignal: ((process: ProcessFn | null) => void) | null = null;
+
+function defaultSchedule(process: ProcessFn): void {
+  if (prevDebounce) prevDebounce(process);
+  else Promise.resolve().then(process);
 }
 
-// Called from `LocationProvider`'s `wrapNavigation` (preact-iso fork). Starts
-// the view transition, THEN performs the navigation inside it (flushSync) so the
-// browser captures the current route as the old snapshot before the new route
-// swaps in. For a navigation to a suspending route, the transition waits for the
-// content to commit (via __wrapRouteCommit) before finishing.
-export function __wrapNavigation(commit: () => void): void {
-  const from = lastPath;
+/** @internal Install the view-transition render scheduler (client only). */
+export function installNavTransitionScheduler(): void {
+  if (schedulerInstalled) return;
+  if (typeof document === 'undefined' || typeof location === 'undefined')
+    return;
+  schedulerInstalled = true;
+  lastHref = location.href;
+  prevDebounce = options.debounceRendering;
+  options.debounceRendering = scheduleRender;
+}
 
-  // A previous cold navigation never finished committing; abandon it so its
-  // transition can't stay frozen and its callback won't touch live state.
-  if (coldResolve) {
-    navGen++;
-    resolveCold();
-  }
+function scheduleRender(process: ProcessFn): void {
+  const href = location.href;
+  const navigated = href !== lastHref;
 
-  const start = getStartViewTransition();
-  if (!start) {
-    // No view transitions: navigate, then fire the post-swap phases (no
-    // transition runs, so `beforeSwap` is skipped).
-    flushSync(commit);
-    const event = buildEvent(from);
-    fireAfterSwap(event);
-    fireAfterTransition(event, event._skipped ? 'skipped' : 'unsupported');
+  // The content flush for an in-flight cold navigation (same URL): hand it back
+  // to that transition so it lands in the new snapshot.
+  if (coldRouteSignal && !navigated) {
+    const resolve = coldRouteSignal;
+    coldRouteSignal = null;
+    if (coldTimeout !== null) {
+      clearTimeout(coldTimeout);
+      coldTimeout = null;
+    }
+    resolve(process); // the transition's callback runs `process()` itself
     return;
   }
 
+  // A new navigation arrived while a cold one was still loading: abandon it.
+  if (coldRouteSignal && navigated) {
+    navGen++;
+    const resolve = coldRouteSignal;
+    coldRouteSignal = null;
+    if (coldTimeout !== null) {
+      clearTimeout(coldTimeout);
+      coldTimeout = null;
+    }
+    resolve(null);
+  }
+
+  lastHref = href;
+  const start = navigated ? getStartViewTransition() : undefined;
+  if (!start) {
+    defaultSchedule(process);
+    return;
+  }
+  runNavTransition(process, start);
+}
+
+// Wait for the next content flush of an in-flight cold navigation (routed here
+// by scheduleRender), or null on timeout/supersede.
+function waitForColdFlush(
+  myGen: number,
+  timeoutMs: number
+): Promise<ProcessFn | null> {
+  return new Promise((resolve) => {
+    coldRouteSignal = resolve;
+    coldTimeout = setTimeout(() => {
+      if (navGen === myGen && coldRouteSignal) {
+        coldRouteSignal = null;
+        coldTimeout = null;
+        resolve(null);
+      }
+    }, timeoutMs);
+  });
+}
+
+// The view-transition-names currently applied in the document (inline styles).
+function collectVtNames(): Set<string> {
+  const names = new Set<string>();
+  if (typeof document === 'undefined' || !document.querySelectorAll)
+    return names;
+  document.querySelectorAll<HTMLElement>('*').forEach((el) => {
+    const n = el.style?.getPropertyValue?.('view-transition-name');
+    if (n) names.add(n);
+  });
+  return names;
+}
+
+// Whether any currently-applied view-transition-name was also in `oldNames` —
+// i.e. a morph pair (same name old + new) is present.
+function hasMorphPartner(oldNames: Set<string>): boolean {
+  if (
+    oldNames.size === 0 ||
+    typeof document === 'undefined' ||
+    !document.querySelectorAll
+  ) {
+    return false;
+  }
+  const els = document.querySelectorAll<HTMLElement>('*');
+  for (const el of els) {
+    const n = el.style?.getPropertyValue?.('view-transition-name');
+    if (n && oldNames.has(n)) return true;
+  }
+  return false;
+}
+
+function runNavTransition(
+  process: ProcessFn,
+  start: (cb: () => void | Promise<void>) => ViewTransition
+): void {
+  const from = lastPath;
+  // The names present in the outgoing route — used to know when a morph partner
+  // has appeared in the new route (see the grace wait below).
+  const oldNames = collectVtNames();
   const myGen = ++navGen;
   let transition: ViewTransition;
   let event: ViewTransitionEvent | undefined;
   try {
     transition = start(async () => {
-      // The old snapshot has been captured. Perform the navigation.
-      flushSync(commit);
-      if (navGen !== myGen) return; // superseded while capturing
+      // The old snapshot has been captured. Flush the navigation render.
+      process();
+      if (navGen !== myGen) return;
       event = buildEvent(from);
       event.transition = transition;
       applyTypes(transition, event.types);
@@ -203,16 +310,32 @@ export function __wrapNavigation(commit: () => void): void {
         skipTransition(transition);
       } else {
         for (const sub of phaseSubs.beforeSwap) sub(event);
-        if (loadingDepth > 0) {
-          // Cold navigation: the new route suspended. Wait for its content (the
-          // shell) to commit via __wrapRouteCommit, so the new snapshot is the
-          // loaded route rather than the suspense fallback.
-          await new Promise<void>((resolve) => {
-            coldResolve = resolve;
-            coldTimeout = setTimeout(() => {
-              if (navGen === myGen) resolveCold();
-            }, COLD_COMMIT_TIMEOUT_MS);
-          });
+        // Cold: the route suspended. Keep routing its content flushes into the
+        // transition until every route module has loaded (loadingDepth back to
+        // 0) — the page-level shell.
+        while (loadingDepth > 0) {
+          const contentProcess = await waitForColdFlush(
+            myGen,
+            COLD_COMMIT_TIMEOUT_MS
+          );
+          if (navGen !== myGen) return;
+          if (!contentProcess) break; // timed out waiting
+          contentProcess();
+        }
+        // If the outgoing route had named elements but none has a partner in the
+        // new shell yet, the partner may load with the route's DATA (behind
+        // inner Suspense, which doesn't move loadingDepth — e.g. a list whose
+        // items come from a loader). Wait briefly for it so the morph can pair.
+        if (oldNames.size > 0 && !hasMorphPartner(oldNames)) {
+          while (!hasMorphPartner(oldNames)) {
+            const contentProcess = await waitForColdFlush(
+              myGen,
+              MORPH_PARTNER_GRACE_MS
+            );
+            if (navGen !== myGen) return;
+            if (!contentProcess) break; // grace expired — capture as-is
+            contentProcess();
+          }
         }
       }
 
@@ -220,15 +343,13 @@ export function __wrapNavigation(commit: () => void): void {
       fireAfterSwap(event);
     });
   } catch {
-    // Non-conformant / polyfilled startViewTransition that throws synchronously:
-    // still perform the navigation and fire the post-swap phases.
-    flushSync(commit);
+    // Non-conformant startViewTransition: just flush and fire the post phases.
+    process();
     const ev = buildEvent(from);
     fireAfterSwap(ev);
     fireAfterTransition(ev, 'unsupported');
     return;
   }
-
   transition.finished.then(
     () => {
       if (event)
@@ -243,9 +364,10 @@ export function __wrapNavigation(commit: () => void): void {
 // Synchronous route-change dispatch for an explicit `to`/`from`: fires
 // `beforeTransition` and runs a transition that wraps a no-op swap (the route is
 // assumed already on screen), firing the post-swap phases and applying types.
-// Production navigations go through `__wrapNavigation`; this drives the same
-// phase/type/lifecycle machinery directly for callers that change the route
-// outside the normal navigation flow (and in unit tests).
+// Production navigations are driven by the scheduler (installNavTransition
+// scheduler); this drives the same phase/type/lifecycle machinery directly for
+// callers that change the route outside the normal navigation flow (and in unit
+// tests).
 export function __dispatchRouteChange(
   to: string,
   from: string | undefined
@@ -282,19 +404,6 @@ export function __dispatchRouteChange(
     () => fireAfterTransition(event),
     () => fireAfterTransition(event, 'aborted')
   );
-}
-
-// Called from each Router's `wrapUpdate` (preact-iso fork). When a cold
-// navigation is awaiting its content, apply the commit and resume the
-// transition; otherwise commit directly (the initial route load, a nested
-// fill-in commit after the shell, or a post-load re-suspense).
-export function __wrapRouteCommit(commit: () => void): void {
-  if (coldResolve) {
-    flushSync(commit);
-    resolveCold();
-  } else {
-    commit();
-  }
 }
 
 let defaultTypesInstalled = false;

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -3,7 +3,7 @@ import {
   ViewTransitionEvent,
   type NavDirection,
 } from './view-transition-event.js';
-import { getNavDirection } from './history-shim.js';
+import { getNavDirection, onNavigation } from './history-shim.js';
 
 export type PhaseName =
   | 'beforeTransition'
@@ -104,12 +104,17 @@ export function __resetTransitionStateForTesting(): void {
     clearTimeout(coldTimeout);
     coldTimeout = null;
   }
+  transitionActive = false;
   // Uninstall the render scheduler (restoring Preact's debounceRendering) so
   // each test can install it fresh.
   if (schedulerInstalled) {
     options.debounceRendering = prevDebounce;
     schedulerInstalled = false;
     prevDebounce = undefined;
+    if (unsubscribeNav) {
+      unsubscribeNav();
+      unsubscribeNav = null;
+    }
   }
 }
 
@@ -179,6 +184,10 @@ type ProcessFn = () => void;
 let schedulerInstalled = false;
 let lastHref = '';
 let prevDebounce: ((process: ProcessFn) => void) | undefined;
+let unsubscribeNav: (() => void) | null = null;
+// True while a navigation's transition is in flight (its callback is pending or
+// awaiting cold content). Lets the navigation observer abandon it.
+let transitionActive = false;
 // Set while a cold navigation's transition awaits a content flush; the next
 // same-URL flush hands its `process` here (or `null` on supersede/timeout) so
 // the transition can run it inside itself.
@@ -187,6 +196,25 @@ let coldRouteSignal: ((process: ProcessFn | null) => void) | null = null;
 function defaultSchedule(process: ProcessFn): void {
   if (prevDebounce) prevDebounce(process);
   else Promise.resolve().then(process);
+}
+
+// Fired (via the history shim) at navigation time, before the re-render. If a
+// transition from a previous navigation is still in flight, abandon it here:
+// Preact may coalesce the new navigation's render into the in-flight one, so
+// scheduleRender never sees it and its own supersede branch can't fire.
+function onNavObserved(): void {
+  if (!transitionActive && !coldRouteSignal) return;
+  navGen++; // the in-flight callback bows out at its next navGen check
+  transitionActive = false;
+  if (coldRouteSignal) {
+    const resolve = coldRouteSignal;
+    coldRouteSignal = null;
+    if (coldTimeout !== null) {
+      clearTimeout(coldTimeout);
+      coldTimeout = null;
+    }
+    resolve(null);
+  }
 }
 
 /** @internal Install the view-transition render scheduler (client only). */
@@ -198,6 +226,7 @@ export function installNavTransitionScheduler(): void {
   lastHref = location.href;
   prevDebounce = options.debounceRendering;
   options.debounceRendering = scheduleRender;
+  unsubscribeNav = onNavigation(onNavObserved);
 }
 
 function scheduleRender(process: ProcessFn): void {
@@ -306,6 +335,7 @@ function runNavTransition(
   // has appeared in the new route (see the grace wait below).
   const oldNames = collectVtNames();
   const myGen = ++navGen;
+  transitionActive = true;
   let transition: ViewTransition;
   let event: ViewTransitionEvent | undefined;
   try {
@@ -352,9 +382,11 @@ function runNavTransition(
 
       if (navGen !== myGen) return;
       fireAfterSwap(event);
+      transitionActive = false; // reached only when still current
     });
   } catch {
     // Non-conformant startViewTransition: just flush and fire the post phases.
+    transitionActive = false;
     process();
     const ev = buildEvent(from);
     fireAfterSwap(ev);

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -217,7 +217,18 @@ function onNavObserved(): void {
   }
 }
 
-/** @internal Install the view-transition render scheduler (client only). */
+/**
+ * @internal Install the view-transition render scheduler (client only).
+ *
+ * Takes ownership of `options.debounceRendering`: it captures the previous value
+ * as `prevDebounce` (delegated to for every non-navigation flush) and installs
+ * `scheduleRender` in its place. This assumes nothing else permanently overrides
+ * `options.debounceRendering` afterward. `preact/compat`'s `flushSync` swaps it
+ * temporarily and restores it, so that composes fine; a second permanent
+ * override would shadow this scheduler (the install is idempotent, so calling it
+ * twice is a no-op, not a double-install). Reversed by
+ * `__resetTransitionStateForTesting`.
+ */
 export function installNavTransitionScheduler(): void {
   if (schedulerInstalled) return;
   if (typeof document === 'undefined' || typeof location === 'undefined')
@@ -296,30 +307,34 @@ function waitForColdFlush(
   });
 }
 
+// Elements carrying an inline `view-transition-name`. The attribute selector
+// lets the browser filter natively instead of walking every node in JS — this
+// runs on the frozen hot path (inside the transition callback, possibly once per
+// grace tick), so the candidate set should be as small as possible. The selector
+// is a substring match on the serialized `style` attribute, so we still confirm
+// each match by reading the resolved property below.
+function queryVtNamedElements(): HTMLElement[] {
+  if (typeof document === 'undefined' || !document.querySelectorAll) return [];
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[style*="view-transition-name"]')
+  );
+}
+
 // The view-transition-names currently applied in the document (inline styles).
 function collectVtNames(): Set<string> {
   const names = new Set<string>();
-  if (typeof document === 'undefined' || !document.querySelectorAll)
-    return names;
-  document.querySelectorAll<HTMLElement>('*').forEach((el) => {
+  for (const el of queryVtNamedElements()) {
     const n = el.style?.getPropertyValue?.('view-transition-name');
     if (n) names.add(n);
-  });
+  }
   return names;
 }
 
 // Whether any currently-applied view-transition-name was also in `oldNames` —
 // i.e. a morph pair (same name old + new) is present.
 function hasMorphPartner(oldNames: Set<string>): boolean {
-  if (
-    oldNames.size === 0 ||
-    typeof document === 'undefined' ||
-    !document.querySelectorAll
-  ) {
-    return false;
-  }
-  const els = document.querySelectorAll<HTMLElement>('*');
-  for (const el of els) {
+  if (oldNames.size === 0) return false;
+  for (const el of queryVtNamedElements()) {
     const n = el.style?.getPropertyValue?.('view-transition-name');
     if (n && oldNames.has(n)) return true;
   }

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -229,6 +229,17 @@ function scheduleRender(process: ProcessFn): void {
     resolve(null);
   }
 
+  if (navigated) {
+    // Reset the load counter at the start of a navigation. A previous route's
+    // loads are abandoned by a new navigation, and preact-iso fires onLoadStart
+    // without a matching onLoadEnd when a still-suspended Router unmounts (it
+    // emits onLoadEnd only on a committed render, not on unmount). Left alone,
+    // that leaked depth would make this nav (and later ones) look perpetually
+    // cold and burn the cold-load timeout. This nav re-increments it as its own
+    // route suspends.
+    loadingDepth = 0;
+  }
+
   lastHref = href;
   const start = navigated ? getStartViewTransition() : undefined;
   if (!start) {

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -85,11 +85,12 @@ let coldGen = 0;
 // freeze the page.
 let directCommitDuringLoad = false;
 
-// Safety net: the longest a cold navigation will hold the page frozen waiting
-// for its content commit. A commit normally arrives within a frame or two (the
-// lazy route module resolving); this only fires if the load stalls or errors,
-// so the page can't stay frozen indefinitely.
-const COLD_COMMIT_TIMEOUT_MS = 2000;
+// Safety net: the longest a cold navigation will hold the page frozen on the old
+// snapshot waiting for its content commit. A commit normally arrives within a
+// frame or two (the lazy route module resolving). On a slow connection or a
+// stalled/errored load this caps the freeze — past it the navigation just
+// completes without the transition rather than holding the page.
+const COLD_COMMIT_TIMEOUT_MS = 500;
 
 export function __isColdTransitionActive(): boolean {
   return coldActive;

--- a/packages/iso/src/internal/route-change.ts
+++ b/packages/iso/src/internal/route-change.ts
@@ -42,107 +42,66 @@ function fireLegacy(to: string, from: string | undefined): void {
 }
 
 function getStartViewTransition():
-  | ((cb: () => void) => ViewTransition)
+  | ((cb: () => void | Promise<void>) => ViewTransition)
   | undefined {
   if (typeof document === 'undefined') return undefined;
   const fn = (
-    document as { startViewTransition?: (cb: () => void) => ViewTransition }
+    document as {
+      startViewTransition?: (cb: () => void | Promise<void>) => ViewTransition;
+    }
   ).startViewTransition;
   return typeof fn === 'function' ? fn.bind(document) : undefined;
 }
 
-// Coordinator state. `loadingDepth` is how many Routers are mid-suspense (via
-// their onLoadStart/onLoadEnd). `pending` holds a cold navigation only on the
-// no-view-transitions fallback path; the normal cold path starts the transition
-// at dispatch and bridges its swap to the route's content commit.
+function currentPath(): string {
+  return typeof location !== 'undefined'
+    ? location.pathname + location.search
+    : '';
+}
+
+// `loadingDepth`: how many Routers are mid-suspense (via onLoadStart/onLoadEnd).
+// Read right after a navigation commits to tell whether the route suspended (a
+// cold navigation), so the transition can wait for the suspended content.
 let loadingDepth = 0;
-let pending: ViewTransitionEvent | null = null;
-
-// Cold-morph bridge state (Approach: capture the old snapshot at dispatch, while
-// the source route is still mounted, then swap when the content commits).
-//
-// `coldActive` is true between starting a cold transition and its swap; while it
-// is true, newly-mounted ViewTransitionName elements defer naming themselves so
-// the destination isn't named in the old snapshot. `deferredNames` collects
-// those name-applications; they run in the swap so they land in the new
-// snapshot. `coldBridgeResolve` resumes the (async) transition callback once the
-// route's content is ready; `coldCommit` is that content commit.
-let coldActive = false;
-let deferredNames: Array<() => void> = [];
-let coldBridgeResolve: (() => void) | null = null;
-let coldCommit: (() => void) | null = null;
-let coldTimeout: ReturnType<typeof setTimeout> | null = null;
-// Bumped per cold transition so a superseded one's (async) callback, once
-// resumed, can detect it is no longer current and bow out without clobbering
-// the live transition's state.
-let coldGen = 0;
-// True when a page-level content commit already ran via __wrapRouteCommit during
-// the current load WITHOUT a transition wrapping it. This is the "cold-flat"
-// ordering: the route's own (top) Router suspended, so its `wrapUpdate` fired
-// BEFORE `onRouteChange`. The dispatch reads this to run a synchronous
-// transition (the content is already on screen) instead of the bridged cold
-// path, which would otherwise wait for a commit that already happened and
-// freeze the page.
-let directCommitDuringLoad = false;
-
-// Safety net: the longest a cold navigation will hold the page frozen on the old
-// snapshot waiting for its content commit. A commit normally arrives within a
-// frame or two (the lazy route module resolving). On a slow connection or a
-// stalled/errored load this caps the freeze — past it the navigation just
-// completes without the transition rather than holding the page.
-const COLD_COMMIT_TIMEOUT_MS = 500;
-
-export function __isColdTransitionActive(): boolean {
-  return coldActive;
-}
-export function __deferTransitionName(apply: () => void): void {
-  deferredNames.push(apply);
-}
-function flushDeferredNames(): void {
-  const queued = deferredNames;
-  deferredNames = [];
-  for (const apply of queued) apply();
-}
-
-// Resume a cold transition that is awaiting its content commit (or its timeout).
-// Used by __wrapRouteCommit (the commit arrived), by a subsequent navigation
-// (the previous cold nav was abandoned mid-flight), and by the timeout. If no
-// commit is set the transition swaps nothing; the deferred names are flushed
-// either way so incoming elements end up named.
-function resumeColdTransition(): void {
-  if (coldTimeout !== null) {
-    clearTimeout(coldTimeout);
-    coldTimeout = null;
-  }
-  const resolve = coldBridgeResolve;
-  coldBridgeResolve = null;
-  if (resolve) resolve();
-}
-
 export function __noteLoadStart(): void {
   loadingDepth++;
 }
 export function __noteLoadEnd(): void {
   loadingDepth = Math.max(0, loadingDepth - 1);
-  // Once the load settles, drop an unconsumed direct-commit flag (e.g. the
-  // initial hydration load, which commits but never dispatches) so it can't
-  // mislabel the next navigation.
-  if (loadingDepth === 0) directCommitDuringLoad = false;
 }
+
+// The path the app is currently on (the previous navigation's `to`); seeds
+// `from` for the first navigation. A server render leaves it undefined.
+let lastPath: string | undefined =
+  typeof location !== 'undefined'
+    ? location.pathname + location.search
+    : undefined;
+
+// Cold-navigation bridge. A suspending route's content commits later via
+// __wrapRouteCommit; the in-flight transition awaits it so the new snapshot is
+// the loaded content (or shell), not the suspense fallback.
+let coldResolve: (() => void) | null = null;
+let coldTimeout: ReturnType<typeof setTimeout> | null = null;
+// Bumped per navigation so a superseded transition's (async) callback bows out.
+let navGen = 0;
+// Cap on how long a navigation holds the old snapshot waiting for a suspending
+// route's content. Past it the navigation completes without finishing the
+// transition rather than freezing the page on a slow/stalled load.
+const COLD_COMMIT_TIMEOUT_MS = 500;
 
 /** @internal Test-only reset for coordinator state. */
 export function __resetTransitionStateForTesting(): void {
   loadingDepth = 0;
-  pending = null;
-  coldActive = false;
-  deferredNames = [];
-  coldBridgeResolve = null;
-  coldCommit = null;
-  directCommitDuringLoad = false;
+  navGen = 0;
+  lastPath =
+    typeof location !== 'undefined'
+      ? location.pathname + location.search
+      : undefined;
   if (coldTimeout !== null) {
     clearTimeout(coldTimeout);
     coldTimeout = null;
   }
+  coldResolve = null;
 }
 
 function fireAfterSwap(event: ViewTransitionEvent): void {
@@ -160,185 +119,195 @@ function fireAfterTransition(
   for (const sub of phaseSubs.afterTransition) sub(event);
 }
 
-// Runs `swap` wrapped in a view transition (when available), firing the
-// post-swap phases and applying the event's accumulated types. Used by both the
-// warm path (swap = no-op; flushSync flushes the already-pending route render)
-// and the cold path (swap = the deferred content commit).
-function runTransition(event: ViewTransitionEvent, swap: () => void): void {
-  if (event._skipped) {
-    flushSync(swap);
-    fireAfterSwap(event);
-    fireAfterTransition(event, 'skipped');
-    return;
-  }
-  const start = getStartViewTransition();
-  if (!start) {
-    flushSync(swap);
-    fireAfterSwap(event);
-    fireAfterTransition(event, 'unsupported');
-    return;
-  }
-  let transition: ViewTransition;
-  try {
-    transition = start(() => {
-      flushSync(swap);
-    });
-  } catch {
-    // Non-conformant / polyfilled startViewTransition that throws synchronously:
-    // still perform the swap so the navigation completes.
-    flushSync(swap);
-    fireAfterSwap(event);
-    fireAfterTransition(event, 'unsupported');
-    return;
-  }
-  event.transition = transition;
-  for (const sub of phaseSubs.beforeSwap) sub(event);
-  fireAfterSwap(event);
+function applyTypes(
+  transition: ViewTransition,
+  types: readonly string[]
+): void {
   const vtTypes = (
     transition as ViewTransition & { types?: { add(t: string): void } }
   ).types;
   if (vtTypes && typeof vtTypes.add === 'function') {
-    for (const t of event.types) vtTypes.add(t);
+    for (const t of types) vtTypes.add(t);
   }
+}
+
+function skipTransition(transition: ViewTransition): void {
+  const t = transition as ViewTransition & { skipTransition?: () => void };
+  if (typeof t.skipTransition === 'function') t.skipTransition();
+}
+
+// Build the event for a navigation that has just committed: `to`/`direction`
+// are only correct after the commit (pushState updates the history shim), so
+// this is always called post-commit. Advances `lastPath`.
+function buildEvent(from: string | undefined): ViewTransitionEvent {
+  ensureDefaultTypes();
+  const to = currentPath();
+  lastPath = to;
+  const direction: NavDirection = getNavDirection();
+  const event = new ViewTransitionEvent({ to, from, direction });
+  for (const sub of phaseSubs.beforeTransition) sub(event);
+  return event;
+}
+
+// Resolve the pending cold bridge — the content commit arrived, the timeout
+// fired, or a newer navigation superseded it.
+function resolveCold(): void {
+  if (coldTimeout !== null) {
+    clearTimeout(coldTimeout);
+    coldTimeout = null;
+  }
+  const resolve = coldResolve;
+  coldResolve = null;
+  if (resolve) resolve();
+}
+
+// Called from `LocationProvider`'s `wrapNavigation` (preact-iso fork). Starts
+// the view transition, THEN performs the navigation inside it (flushSync) so the
+// browser captures the current route as the old snapshot before the new route
+// swaps in. For a navigation to a suspending route, the transition waits for the
+// content to commit (via __wrapRouteCommit) before finishing.
+export function __wrapNavigation(commit: () => void): void {
+  const from = lastPath;
+
+  // A previous cold navigation never finished committing; abandon it so its
+  // transition can't stay frozen and its callback won't touch live state.
+  if (coldResolve) {
+    navGen++;
+    resolveCold();
+  }
+
+  const start = getStartViewTransition();
+  if (!start) {
+    // No view transitions: navigate, then fire the post-swap phases (no
+    // transition runs, so `beforeSwap` is skipped).
+    flushSync(commit);
+    const event = buildEvent(from);
+    fireAfterSwap(event);
+    fireAfterTransition(event, event._skipped ? 'skipped' : 'unsupported');
+    return;
+  }
+
+  const myGen = ++navGen;
+  let transition: ViewTransition;
+  let event: ViewTransitionEvent | undefined;
+  try {
+    transition = start(async () => {
+      // The old snapshot has been captured. Perform the navigation.
+      flushSync(commit);
+      if (navGen !== myGen) return; // superseded while capturing
+      event = buildEvent(from);
+      event.transition = transition;
+      applyTypes(transition, event.types);
+
+      if (event._skipped) {
+        skipTransition(transition);
+      } else {
+        for (const sub of phaseSubs.beforeSwap) sub(event);
+        if (loadingDepth > 0) {
+          // Cold navigation: the new route suspended. Wait for its content (the
+          // shell) to commit via __wrapRouteCommit, so the new snapshot is the
+          // loaded route rather than the suspense fallback.
+          await new Promise<void>((resolve) => {
+            coldResolve = resolve;
+            coldTimeout = setTimeout(() => {
+              if (navGen === myGen) resolveCold();
+            }, COLD_COMMIT_TIMEOUT_MS);
+          });
+        }
+      }
+
+      if (navGen !== myGen) return;
+      fireAfterSwap(event);
+    });
+  } catch {
+    // Non-conformant / polyfilled startViewTransition that throws synchronously:
+    // still perform the navigation and fire the post-swap phases.
+    flushSync(commit);
+    const ev = buildEvent(from);
+    fireAfterSwap(ev);
+    fireAfterTransition(ev, 'unsupported');
+    return;
+  }
+
   transition.finished.then(
-    () => fireAfterTransition(event),
-    () => fireAfterTransition(event, 'aborted')
+    () => {
+      if (event)
+        fireAfterTransition(event, event._skipped ? 'skipped' : undefined);
+    },
+    () => {
+      if (event) fireAfterTransition(event, 'aborted');
+    }
   );
 }
 
+// Synchronous route-change dispatch for an explicit `to`/`from`: fires
+// `beforeTransition` and runs a transition that wraps a no-op swap (the route is
+// assumed already on screen), firing the post-swap phases and applying types.
+// Production navigations go through `__wrapNavigation`; this drives the same
+// phase/type/lifecycle machinery directly for callers that change the route
+// outside the normal navigation flow (and in unit tests).
 export function __dispatchRouteChange(
   to: string,
   from: string | undefined
 ): void {
   ensureDefaultTypes();
-  const direction: NavDirection = getNavDirection();
-  const event = new ViewTransitionEvent({ to, from, direction });
-
-  // If a previous cold navigation is still awaiting its content commit, this new
-  // navigation abandoned it — invalidate its (async) callback and resume it now
-  // (swapping nothing) so its transition can't stay frozen or re-fire phases.
-  if (coldBridgeResolve) {
-    coldGen++;
-    resumeColdTransition();
-  }
-
+  const event = new ViewTransitionEvent({
+    to,
+    from,
+    direction: getNavDirection(),
+  });
   for (const sub of phaseSubs.beforeTransition) sub(event);
 
-  if (loadingDepth > 0) {
-    if (directCommitDuringLoad) {
-      // Cold-flat ordering: the route's own Router suspended, so its content
-      // already committed (wrapUpdate fired before this dispatch). There is no
-      // earlier source snapshot left to capture, so run the transition
-      // synchronously — the directional root slide still plays — rather than
-      // bridging to a commit that already happened (which would freeze the page).
-      directCommitDuringLoad = false;
-      runTransition(event, () => {});
-      return;
-    }
-    // Cold-nested ordering: this dispatch precedes the content commit. Start the
-    // transition NOW so the browser captures the still-mounted source route as
-    // the old snapshot, and bridge the swap to the content commit (see
-    // __wrapRouteCommit).
-    runColdTransition(event);
-    return;
-  }
-
-  // Warm navigation: the route render is already pending; flushSync inside the
-  // transition commits it.
-  runTransition(event, () => {});
-}
-
-// Cold path: start the transition at dispatch (old snapshot = the source route,
-// still mounted), then resume and swap when the content commits.
-function runColdTransition(event: ViewTransitionEvent): void {
   const start = getStartViewTransition();
   if (!start || event._skipped) {
-    // No view transitions (or skipped): fall back to the deferred,
-    // non-morphing path — the swap still happens at the content commit.
-    pending = event;
+    // No transition runs, so `beforeSwap` (which precedes a real swap) is
+    // skipped; the post-swap phases still fire.
+    fireAfterSwap(event);
+    fireAfterTransition(event, event._skipped ? 'skipped' : 'unsupported');
     return;
   }
-  const myGen = ++coldGen;
-  coldActive = true;
   let transition: ViewTransition;
   try {
-    transition = start(async () => {
-      // The old snapshot has been captured. Wait for the route content to
-      // commit, then swap and reveal the deferred incoming names so they land
-      // in the new snapshot.
-      await new Promise<void>((resolve) => {
-        coldBridgeResolve = resolve;
-      });
-      // A newer navigation superseded this one while it was waiting: let this
-      // (now-stale) transition complete as a no-op rather than touch live state.
-      if (coldGen !== myGen) return;
-      for (const sub of phaseSubs.beforeSwap) sub(event);
-      const commit = coldCommit;
-      coldCommit = null;
-      if (commit) flushSync(commit);
-      flushDeferredNames();
-      coldActive = false;
-      fireAfterSwap(event);
-    });
+    transition = start(() => {});
   } catch {
-    coldActive = false;
-    coldBridgeResolve = null;
-    coldCommit = null;
-    flushDeferredNames();
-    pending = event;
+    fireAfterSwap(event);
+    fireAfterTransition(event, 'unsupported');
     return;
   }
-  // Safety net so a stalled or errored load can't freeze the page forever. The
-  // generation check keeps a stale timer from resuming a newer transition.
-  coldTimeout = setTimeout(() => {
-    if (coldGen === myGen) resumeColdTransition();
-  }, COLD_COMMIT_TIMEOUT_MS);
   event.transition = transition;
-  const vtTypes = (
-    transition as ViewTransition & { types?: { add(t: string): void } }
-  ).types;
-  if (vtTypes && typeof vtTypes.add === 'function') {
-    for (const t of event.types) vtTypes.add(t);
-  }
+  applyTypes(transition, event.types);
+  for (const sub of phaseSubs.beforeSwap) sub(event);
+  fireAfterSwap(event);
   transition.finished.then(
     () => fireAfterTransition(event),
     () => fireAfterTransition(event, 'aborted')
   );
 }
 
-// Called from each Router's `wrapUpdate` (preact-iso fork). Resumes the active
-// cold transition with the page-level content commit, runs the no-VT fallback
-// transition, or commits directly (a later nested/fill-in commit, the initial
-// route load, or a post-load re-suspense).
+// Called from each Router's `wrapUpdate` (preact-iso fork). When a cold
+// navigation is awaiting its content, apply the commit and resume the
+// transition; otherwise commit directly (the initial route load, a nested
+// fill-in commit after the shell, or a post-load re-suspense).
 export function __wrapRouteCommit(commit: () => void): void {
-  if (coldBridgeResolve) {
-    coldCommit = commit;
-    resumeColdTransition();
-  } else if (pending) {
-    const event = pending;
-    pending = null;
-    runTransition(event, commit);
+  if (coldResolve) {
+    flushSync(commit);
+    resolveCold();
   } else {
-    // No transition is wrapping this commit. If it lands during a load, it is a
-    // page-level commit that beat its dispatch (cold-flat ordering) — flag it so
-    // the imminent dispatch runs a synchronous transition rather than waiting
-    // for a commit that already happened.
-    if (loadingDepth > 0) directCommitDuringLoad = true;
     commit();
   }
 }
 
 let defaultTypesInstalled = false;
-let firstDispatchSeen = false;
+let firstNavSeen = false;
 let defaultTypeUnsubscriber: (() => void) | null = null;
 
 function ensureDefaultTypes(): void {
   if (defaultTypesInstalled) return;
   defaultTypesInstalled = true;
   defaultTypeUnsubscriber = __subscribePhase('beforeTransition', (event) => {
-    if (!firstDispatchSeen) {
+    if (!firstNavSeen) {
       event.types.push('nav-initial');
-      firstDispatchSeen = true;
+      firstNavSeen = true;
     } else {
       event.types.push(`nav-${event.direction}`);
     }
@@ -352,6 +321,6 @@ export function resetDefaultTypesForTesting(): void {
     defaultTypeUnsubscriber();
   }
   defaultTypesInstalled = false;
-  firstDispatchSeen = false;
+  firstNavSeen = false;
   defaultTypeUnsubscriber = null;
 }

--- a/packages/iso/src/view-transition-name.ts
+++ b/packages/iso/src/view-transition-name.ts
@@ -42,17 +42,16 @@ export function useViewTransitionName(
 
   // Stable ref callback: applies on attach, clears the previous node on swap.
   return useCallback((node: Element | null) => {
-    if (nodeRef.current && nodeRef.current !== node) {
-      // On a real element swap (node !== null) always clear the name from the
-      // node we no longer hold. On a detach (node === null) keep the name ONLY
-      // while a cold transition is in flight, so the outgoing element can serve
-      // as a morph source while preact-iso retains it as `prev` (preact removes
-      // the node, and its inline name, when it drops prev). Outside a cold
-      // transition, clear on detach as usual so a name can't linger on a
-      // retained node.
-      if (node !== null || !__isColdTransitionActive()) {
-        nodeRef.current.style.removeProperty('view-transition-name');
-      }
+    if (nodeRef.current && nodeRef.current !== node && node !== null) {
+      // Real element swap: clear the name from the node we no longer hold. On a
+      // detach (node === null) KEEP the name: the link click removes the source
+      // element before any navigation hook fires, but preact-iso retains its DOM
+      // as `prev`, so keeping the name lets it serve as the morph source in the
+      // old snapshot. preact removes the node (and its inline name) when it drops
+      // prev. (Trade-off: a name can briefly linger on a retained `prev` node;
+      // the destination defers naming during the cold transition so the two
+      // don't collide.)
+      nodeRef.current.style.removeProperty('view-transition-name');
     }
     if (isStyledElement(node)) {
       nodeRef.current = node;

--- a/packages/iso/src/view-transition-name.ts
+++ b/packages/iso/src/view-transition-name.ts
@@ -2,10 +2,6 @@ import type { ComponentChildren, VNode } from 'preact';
 import { useCallback, useLayoutEffect, useRef } from 'preact/hooks';
 import { mergeRefs } from './internal/merge-refs.js';
 import { useRender, type UseRenderRender } from './internal/use-render.js';
-import {
-  __isColdTransitionActive,
-  __deferTransitionName,
-} from './internal/route-change.js';
 
 type NodeRef = HTMLElement | SVGElement;
 
@@ -42,31 +38,12 @@ export function useViewTransitionName(
 
   // Stable ref callback: applies on attach, clears the previous node on swap.
   return useCallback((node: Element | null) => {
-    if (nodeRef.current && nodeRef.current !== node && node !== null) {
-      // Real element swap: clear the name from the node we no longer hold. On a
-      // detach (node === null) KEEP the name: the link click removes the source
-      // element before any navigation hook fires, but preact-iso retains its DOM
-      // as `prev`, so keeping the name lets it serve as the morph source in the
-      // old snapshot. preact removes the node (and its inline name) when it drops
-      // prev. (Trade-off: a name can briefly linger on a retained `prev` node;
-      // the destination defers naming during the cold transition so the two
-      // don't collide.)
+    if (nodeRef.current && nodeRef.current !== node) {
       nodeRef.current.style.removeProperty('view-transition-name');
     }
     if (isStyledElement(node)) {
       nodeRef.current = node;
-      const name = nameRef.current;
-      if (name != null && name !== '' && __isColdTransitionActive()) {
-        // A cold navigation's view transition has already captured the old
-        // snapshot. Defer naming this incoming element until the transition
-        // swaps, so it appears only in the new snapshot (and can't collide with
-        // a retained source name in the old snapshot).
-        __deferTransitionName(() =>
-          applyCssProp(node, 'view-transition-name', name)
-        );
-      } else {
-        applyCssProp(node, 'view-transition-name', name);
-      }
+      applyCssProp(node, 'view-transition-name', nameRef.current);
     } else {
       nodeRef.current = null;
     }

--- a/packages/iso/src/view-transition-name.ts
+++ b/packages/iso/src/view-transition-name.ts
@@ -2,6 +2,10 @@ import type { ComponentChildren, VNode } from 'preact';
 import { useCallback, useLayoutEffect, useRef } from 'preact/hooks';
 import { mergeRefs } from './internal/merge-refs.js';
 import { useRender, type UseRenderRender } from './internal/use-render.js';
+import {
+  __isColdTransitionActive,
+  __deferTransitionName,
+} from './internal/route-change.js';
 
 type NodeRef = HTMLElement | SVGElement;
 
@@ -38,12 +42,27 @@ export function useViewTransitionName(
 
   // Stable ref callback: applies on attach, clears the previous node on swap.
   return useCallback((node: Element | null) => {
-    if (nodeRef.current && nodeRef.current !== node) {
+    if (nodeRef.current && nodeRef.current !== node && node !== null) {
+      // Real element swap: clear the name from the node we no longer hold. On a
+      // detach (node === null) we intentionally KEEP the name, so the outgoing
+      // element can serve as a morph source while preact-iso retains it as
+      // `prev`; preact removes the node (and its inline name) when it drops prev.
       nodeRef.current.style.removeProperty('view-transition-name');
     }
     if (isStyledElement(node)) {
       nodeRef.current = node;
-      applyCssProp(node, 'view-transition-name', nameRef.current);
+      const name = nameRef.current;
+      if (name != null && name !== '' && __isColdTransitionActive()) {
+        // A cold navigation's view transition has already captured the old
+        // snapshot. Defer naming this incoming element until the transition
+        // swaps, so it appears only in the new snapshot (and can't collide with
+        // a retained source name in the old snapshot).
+        __deferTransitionName(() =>
+          applyCssProp(node, 'view-transition-name', name)
+        );
+      } else {
+        applyCssProp(node, 'view-transition-name', name);
+      }
     } else {
       nodeRef.current = null;
     }

--- a/packages/iso/src/view-transition-name.ts
+++ b/packages/iso/src/view-transition-name.ts
@@ -42,12 +42,17 @@ export function useViewTransitionName(
 
   // Stable ref callback: applies on attach, clears the previous node on swap.
   return useCallback((node: Element | null) => {
-    if (nodeRef.current && nodeRef.current !== node && node !== null) {
-      // Real element swap: clear the name from the node we no longer hold. On a
-      // detach (node === null) we intentionally KEEP the name, so the outgoing
-      // element can serve as a morph source while preact-iso retains it as
-      // `prev`; preact removes the node (and its inline name) when it drops prev.
-      nodeRef.current.style.removeProperty('view-transition-name');
+    if (nodeRef.current && nodeRef.current !== node) {
+      // On a real element swap (node !== null) always clear the name from the
+      // node we no longer hold. On a detach (node === null) keep the name ONLY
+      // while a cold transition is in flight, so the outgoing element can serve
+      // as a morph source while preact-iso retains it as `prev` (preact removes
+      // the node, and its inline name, when it drops prev). Outside a cold
+      // transition, clear on detach as usual so a name can't linger on a
+      // retained node.
+      if (node !== null || !__isColdTransitionActive()) {
+        nodeRef.current.style.removeProperty('view-transition-name');
+      }
     }
     if (isStyledElement(node)) {
       nodeRef.current = node;

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -79,7 +79,7 @@
     "@types/ws": "^8.5.0",
     "hono": "^4.12.14",
     "preact": "^10.29.1",
-    "preact-iso": "github:sbesh91/preact-iso#feat/v3-wrap-update",
+    "preact-iso": "github:preactjs/preact-iso#v3",
     "typescript": "*",
     "vite": "*",
     "ws": "^8.18.0"

--- a/packages/vite/src/__tests__/client-entry.test.ts
+++ b/packages/vite/src/__tests__/client-entry.test.ts
@@ -24,29 +24,21 @@ describe('generateClientEntrySource', () => {
     expect(src).toContain(`import { LocationProvider } from 'preact-iso';`);
     expect(src).toContain(`import { Routes, PersistHost } from 'hono-preact';`);
     expect(src).toContain(
-      `import { __dispatchRouteChange, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';`
+      `import { __wrapNavigation, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';`
     );
     expect(src).toContain(`installHistoryShim();`);
     expect(src).toContain(`installStreamRegistry();`);
     expect(src).toContain(`import routes from '/proj/src/routes.ts';`);
   });
 
-  it('hydrates into #app and wires onRouteChange to the dispatcher', () => {
+  it('hydrates into #app and wraps navigations in the view-transition coordinator', () => {
     const src = generateClientEntrySource({
       routesAbsPath: '/proj/src/routes.ts',
     });
     expect(src).toContain(`document.getElementById('app')`);
-    expect(src).toContain(`onRouteChange`);
-    expect(src).toContain(`__dispatchRouteChange`);
-  });
-
-  it('seeds lastPath from the initial pathname so the first nav has a defined `from`', () => {
-    const src = generateClientEntrySource({
-      routesAbsPath: '/proj/src/routes.ts',
-    });
-    expect(src).toContain(
-      `let lastPath = typeof location !== 'undefined' ? location.pathname : undefined;`
-    );
+    // wrapNavigation is wired onto LocationProvider so navigations start a
+    // transition before the route re-renders.
+    expect(src).toContain(`wrapNavigation: __wrapNavigation`);
   });
 
   it('imports installHistoryShim and calls it before installStreamRegistry', () => {

--- a/packages/vite/src/__tests__/client-entry.test.ts
+++ b/packages/vite/src/__tests__/client-entry.test.ts
@@ -24,7 +24,7 @@ describe('generateClientEntrySource', () => {
     expect(src).toContain(`import { LocationProvider } from 'preact-iso';`);
     expect(src).toContain(`import { Routes, PersistHost } from 'hono-preact';`);
     expect(src).toContain(
-      `import { __wrapNavigation, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';`
+      `import { installNavTransitionScheduler, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';`
     );
     expect(src).toContain(`installHistoryShim();`);
     expect(src).toContain(`installStreamRegistry();`);
@@ -36,9 +36,9 @@ describe('generateClientEntrySource', () => {
       routesAbsPath: '/proj/src/routes.ts',
     });
     expect(src).toContain(`document.getElementById('app')`);
-    // wrapNavigation is wired onto LocationProvider so navigations start a
-    // transition before the route re-renders.
-    expect(src).toContain(`wrapNavigation: __wrapNavigation`);
+    // The render scheduler is installed so navigations start a transition
+    // before the route re-renders.
+    expect(src).toContain(`installNavTransitionScheduler();`);
   });
 
   it('imports installHistoryShim and calls it before installStreamRegistry', () => {

--- a/packages/vite/src/client-entry.ts
+++ b/packages/vite/src/client-entry.ts
@@ -30,10 +30,11 @@ export function generateClientEntrySource(
     `renderPreact(h(PersistHost, null), persistHost);\n` +
     `\n` +
     // Seed lastPath with the initial pathname so the FIRST client navigation
-    // reports a defined `from`. preact-iso doesn't fire onRouteChange on the
+    // reports a defined `from` to user callbacks (useViewTransitionTypes /
+    // useViewTransitionLifecycle). preact-iso doesn't fire onRouteChange on the
     // initial hydration mount, so without this the first nav's `from` would be
-    // undefined and any direction logic keyed on it (e.g. up-navigation slides)
-    // would be skipped for that one navigation.
+    // undefined. (Built-in direction is computed from the history shim, not
+    // `from`, so only `from`-reading user callbacks are affected.)
     `let lastPath = typeof location !== 'undefined' ? location.pathname : undefined;\n` +
     `function onRouteChange(path) {\n` +
     `  const from = lastPath;\n` +

--- a/packages/vite/src/client-entry.ts
+++ b/packages/vite/src/client-entry.ts
@@ -15,7 +15,7 @@ export function generateClientEntrySource(
     `import { h, hydrate, render as renderPreact } from 'preact';\n` +
     `import { LocationProvider } from 'preact-iso';\n` +
     `import { Routes, PersistHost } from 'hono-preact';\n` +
-    `import { __dispatchRouteChange, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';\n` +
+    `import { __wrapNavigation, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';\n` +
     `import routes from '${opts.routesAbsPath}';\n` +
     `\n` +
     `installHistoryShim();\n` +
@@ -29,22 +29,15 @@ export function generateClientEntrySource(
     `}\n` +
     `renderPreact(h(PersistHost, null), persistHost);\n` +
     `\n` +
-    // Seed lastPath with the initial pathname so the FIRST client navigation
-    // reports a defined `from` to user callbacks (useViewTransitionTypes /
-    // useViewTransitionLifecycle). preact-iso doesn't fire onRouteChange on the
-    // initial hydration mount, so without this the first nav's `from` would be
-    // undefined. (Built-in direction is computed from the history shim, not
-    // `from`, so only `from`-reading user callbacks are affected.)
-    `let lastPath = typeof location !== 'undefined' ? location.pathname : undefined;\n` +
-    `function onRouteChange(path) {\n` +
-    `  const from = lastPath;\n` +
-    `  lastPath = path;\n` +
-    `  __dispatchRouteChange(path, from);\n` +
-    `}\n` +
-    `\n` +
+    // Wrap every navigation in a view transition that starts BEFORE the route
+    // re-renders, so the browser captures the outgoing route as the old snapshot
+    // before the new one swaps in (this is what lets shared-element morphs and
+    // directional slides animate old->new). The coordinator runs the commit
+    // inside the transition and, for navigations to suspending routes, waits for
+    // the content via the Router's wrapUpdate.
     `hydrate(\n` +
-    `  h(LocationProvider, null,\n` +
-    `    h(Routes, { routes, onRouteChange })\n` +
+    `  h(LocationProvider, { wrapNavigation: __wrapNavigation },\n` +
+    `    h(Routes, { routes })\n` +
     `  ),\n` +
     `  document.getElementById('app')\n` +
     `);\n`

--- a/packages/vite/src/client-entry.ts
+++ b/packages/vite/src/client-entry.ts
@@ -15,10 +15,11 @@ export function generateClientEntrySource(
     `import { h, hydrate, render as renderPreact } from 'preact';\n` +
     `import { LocationProvider } from 'preact-iso';\n` +
     `import { Routes, PersistHost } from 'hono-preact';\n` +
-    `import { __wrapNavigation, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';\n` +
+    `import { installNavTransitionScheduler, installStreamRegistry, installHistoryShim } from 'hono-preact/internal';\n` +
     `import routes from '${opts.routesAbsPath}';\n` +
     `\n` +
     `installHistoryShim();\n` +
+    `installNavTransitionScheduler();\n` +
     `installStreamRegistry();\n` +
     `\n` +
     `let persistHost = document.getElementById('__hp_persist_root');\n` +
@@ -29,14 +30,12 @@ export function generateClientEntrySource(
     `}\n` +
     `renderPreact(h(PersistHost, null), persistHost);\n` +
     `\n` +
-    // Wrap every navigation in a view transition that starts BEFORE the route
-    // re-renders, so the browser captures the outgoing route as the old snapshot
-    // before the new one swaps in (this is what lets shared-element morphs and
-    // directional slides animate old->new). The coordinator runs the commit
-    // inside the transition and, for navigations to suspending routes, waits for
-    // the content via the Router's wrapUpdate.
+    // View transitions are driven by installNavTransitionScheduler() above: it
+    // overrides Preact's render scheduler so a navigation's re-render runs inside
+    // document.startViewTransition (capturing the outgoing route as the old
+    // snapshot before the new one swaps in). No per-navigation wiring needed.
     `hydrate(\n` +
-    `  h(LocationProvider, { wrapNavigation: __wrapNavigation },\n` +
+    `  h(LocationProvider, null,\n` +
     `    h(Routes, { routes })\n` +
     `  ),\n` +
     `  document.getElementById('app')\n` +

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  preact-iso: github:sbesh91/preact-iso#feat/v3-wrap-update
+  preact-iso: github:preactjs/preact-iso#v3
   typescript: ^6.0.3
   vite: ^8.0.8
 
@@ -44,8 +44,8 @@ importers:
         specifier: ^10.29.1
         version: 10.29.1
       preact-iso:
-        specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        specifier: github:preactjs/preact-iso#v3
+        version: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
     devDependencies:
       '@hono/node-server':
         specifier: ^1.19.14
@@ -87,8 +87,8 @@ importers:
         specifier: ^10.29.1
         version: 10.29.1
       preact-iso:
-        specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        specifier: github:preactjs/preact-iso#v3
+        version: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       react:
         specifier: npm:@preact/compat
         version: '@preact/compat@18.3.2(preact@10.29.1)'
@@ -209,8 +209,8 @@ importers:
         specifier: '>=10.0.0'
         version: 10.29.1
       preact-iso:
-        specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        specifier: github:preactjs/preact-iso#v3
+        version: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       preact-render-to-string:
         specifier: '>=6.0.0'
         version: 6.6.7(preact@10.29.1)
@@ -243,8 +243,8 @@ importers:
         specifier: '>=10.0.0'
         version: 10.29.1
       preact-iso:
-        specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        specifier: github:preactjs/preact-iso#v3
+        version: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -268,8 +268,8 @@ importers:
         specifier: '>=10.0.0'
         version: 10.29.1
       preact-iso:
-        specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        specifier: github:preactjs/preact-iso#v3
+        version: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       preact-render-to-string:
         specifier: '>=6.0.0'
         version: 6.6.7(preact@10.29.1)
@@ -315,8 +315,8 @@ importers:
         specifier: ^10.29.1
         version: 10.29.1
       preact-iso:
-        specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        specifier: github:preactjs/preact-iso#v3
+        version: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2537,8 +2537,8 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
-  preact-iso@https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9:
-    resolution: {tarball: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9}
+  preact-iso@https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777:
+    resolution: {tarball: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777}
     version: 2.11.1
     peerDependencies:
       preact: '>=10 || >= 11.0.0-0'
@@ -5498,7 +5498,7 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  preact-iso@https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1):
+  preact-iso@https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1):
     dependencies:
       preact: 10.29.1
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 10.29.1
       preact-iso:
         specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
     devDependencies:
       '@hono/node-server':
         specifier: ^1.19.14
@@ -88,7 +88,7 @@ importers:
         version: 10.29.1
       preact-iso:
         specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       react:
         specifier: npm:@preact/compat
         version: '@preact/compat@18.3.2(preact@10.29.1)'
@@ -210,7 +210,7 @@ importers:
         version: 10.29.1
       preact-iso:
         specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       preact-render-to-string:
         specifier: '>=6.0.0'
         version: 6.6.7(preact@10.29.1)
@@ -244,7 +244,7 @@ importers:
         version: 10.29.1
       preact-iso:
         specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -269,7 +269,7 @@ importers:
         version: 10.29.1
       preact-iso:
         specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       preact-render-to-string:
         specifier: '>=6.0.0'
         version: 6.6.7(preact@10.29.1)
@@ -316,7 +316,7 @@ importers:
         version: 10.29.1
       preact-iso:
         specifier: github:sbesh91/preact-iso#feat/v3-wrap-update
-        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
+        version: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2537,8 +2537,8 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
-  preact-iso@https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251:
-    resolution: {tarball: https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251}
+  preact-iso@https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9:
+    resolution: {tarball: https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9}
     version: 2.11.1
     peerDependencies:
       preact: '>=10 || >= 11.0.0-0'
@@ -5498,7 +5498,7 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
-  preact-iso@https://codeload.github.com/sbesh91/preact-iso/tar.gz/ed777d7457d492c01300c92c4f5ebb9b4912e251(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1):
+  preact-iso@https://codeload.github.com/sbesh91/preact-iso/tar.gz/bfc9dd6862c38347ec17a8fb250ab9befe17cfa9(preact-render-to-string@6.6.7(preact@10.29.1))(preact@10.29.1):
     dependencies:
       preact: 10.29.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Makes view-transition **morphs and directional slides animate old→new on every navigation** (warm, cold, and back/forward), driven entirely framework-side via `options.debounceRendering` — on **stock `preactjs/preact-iso#v3`, no fork**.

Stacked on `demo-view-transitions`; the diff is just this coordinator work.

### The core fix

The framework used to start the transition from `onRouteChange`, which preact-iso fires in a layout effect **after** the route has already swapped into the DOM — so `startViewTransition` only ever captured the new page as both snapshots, and morphs could never animate.

Now `installNavTransitionScheduler()` (run once from the client entry) overrides `options.debounceRendering` — the seam Preact uses to schedule a render flush (the same one `flushSync` swaps out). When a flush is the result of a navigation (the URL changed since the last flush, because the router pushes state before re-rendering), it wraps that flush in a view transition:

```js
options.debounceRendering = (process) => {
  if (urlChangedSinceLastFlush())
    document.startViewTransition(() => process()); // capture old → flush (new)
  else
    scheduleNormally(process);
};
```

So the browser captures the current route as the old snapshot before the new route renders. This covers clicks, `route()`, and popstate uniformly, with no event interception and no per-navigation wiring.

**Cold (suspending) routes:** the transition keeps routing the route's content flushes into itself until every route module has loaded (`loadingDepth` back to 0, via the stock `onLoadStart`/`onLoadEnd` props) — the page-level shell. If the outgoing route had a named element whose morph partner loads with the route's **data** (behind inner Suspense, which doesn't move `loadingDepth` — e.g. a list whose items come from a loader), it waits a short bounded grace for the partner to appear so the morph can pair. Superseded or stalled navigations are abandoned and capped by a timeout.

### What this replaces

Earlier commits on this branch anchored the transition to a preact-iso fork hook (`wrapUpdate`/`wrapNavigation`, preactjs/preact-iso#150). Per maintainer feedback that this is doable with `options.debounceRendering`, the whole thing moved consumer-side — so there's **no fork dependency**, and `view-transition-name.ts` stays plain apply/clear with no coordinator coupling. (`__dispatchRouteChange` remains only as a synchronous phase/type/lifecycle dispatch primitive used by unit tests.)

## Test plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`, `format:check`, `typecheck`
- [x] `pnpm test` (872) + `pnpm test:integration` (4), rewritten for the scheduler
- [x] `pnpm --filter site build`
- [x] In-browser, all with no console errors: **into-a-project morph**, the **reverse "← all projects" morph** (data-loaded partner), **warm** revisits, **directional slides**, and **back/forward**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
