### PR TITLE
ci(size): rerun-visible client-size comment + collapse superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# Collapse superseded runs per ref. Cancel-in-progress only for PRs: a fast
+# series of pushes to a PR branch should drop stale runs (and the stale size
+# comment they'd post). On main, build-and-tag commits the size baseline and
+# force-pushes the `next` tag, so never interrupt it mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -90,6 +98,11 @@ jobs:
         run: node scripts/measure-client-size.mjs --out /tmp/fresh-size.json
 
       - name: Render comment
+        env:
+          # Pins the comment to the commit it measured, so a re-measured sticky
+          # comment is distinguishable from the original at-open one.
+          SIZE_COMMENT_SHA: ${{ github.event.pull_request.head.sha }}
+          SIZE_COMMENT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: node scripts/render-size-comment.mjs /tmp/fresh-size.json client-size-report.json > /tmp/size-comment.md
 
       - name: Post sticky comment

--- a/scripts/__tests__/render-size-comment.test.mjs
+++ b/scripts/__tests__/render-size-comment.test.mjs
@@ -60,4 +60,26 @@ describe('renderComment', () => {
     expect(md).toContain('(new)');
     expect(md).toContain('(removed)');
   });
+
+  it('omits the freshness footer when no meta is given', () => {
+    const md = renderComment(report(), report(), cfg);
+    expect(md).not.toContain('Measured');
+  });
+
+  it('renders a freshness footer with short sha, timestamp, and run link', () => {
+    const md = renderComment(report(), report(), cfg, {
+      sha: '2af64e6d9abc123',
+      generatedAt: '2026-06-02T01:36:33Z',
+      runUrl: 'https://github.com/o/r/actions/runs/123',
+    });
+    expect(md).toContain('Measured `2af64e6d9`');
+    expect(md).toContain('2026-06-02T01:36:33Z');
+    expect(md).toContain('[run](https://github.com/o/r/actions/runs/123)');
+  });
+
+  it('drops missing footer fields without emitting empty separators', () => {
+    const md = renderComment(report(), report(), cfg, { sha: 'deadbeefcafe' });
+    expect(md).toContain('Measured `deadbeefc`');
+    expect(md).not.toContain('· ');
+  });
 });

--- a/scripts/render-size-comment.mjs
+++ b/scripts/render-size-comment.mjs
@@ -38,7 +38,21 @@ function sectionAGzip(report, bucket) {
   return e ? tableGzip(bucket, e) : undefined;
 }
 
-export function renderComment(fresh, baseline, config = defaultConfig) {
+// Footer that pins the comment to the commit it measured. The sticky comment
+// updates in place on every push, so without this a re-measured comment is
+// indistinguishable from the original at-open one (GitHub freezes the
+// created-at timestamp and only quietly marks it "edited").
+function freshnessFooter(meta) {
+  if (!meta) return undefined;
+  const parts = [];
+  if (meta.sha) parts.push(`\`${meta.sha.slice(0, 9)}\``);
+  if (meta.generatedAt) parts.push(meta.generatedAt);
+  if (meta.runUrl) parts.push(`[run](${meta.runUrl})`);
+  if (parts.length === 0) return undefined;
+  return `<sub>Measured ${parts.join(' · ')}</sub>`;
+}
+
+export function renderComment(fresh, baseline, config = defaultConfig, meta) {
   const budgets = config.BUDGETS ?? {};
   const lines = [COMMENT_HEADER, '## Client JS size', ''];
 
@@ -78,6 +92,8 @@ export function renderComment(fresh, baseline, config = defaultConfig) {
   );
   lines.push('');
   lines.push('<sub>Budgets are advisory; overages flag ⚠️ but never fail CI.</sub>');
+  const footer = freshnessFooter(meta);
+  if (footer) lines.push(footer);
   return lines.join('\n');
 }
 
@@ -92,5 +108,11 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   }
   const fresh = JSON.parse(readFileSync(freshPath, 'utf8'));
   const baseline = JSON.parse(readFileSync(basePath, 'utf8'));
-  process.stdout.write(renderComment(fresh, baseline) + '\n');
+  const meta = {
+    sha: process.env.SIZE_COMMENT_SHA,
+    runUrl: process.env.SIZE_COMMENT_RUN_URL,
+    // Second precision; milliseconds add noise without telling the reader anything.
+    generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+  };
+  process.stdout.write(renderComment(fresh, baseline, undefined, meta) + '\n');
 }


### PR DESCRIPTION
## What

Two small CI changes around the client-size report.

### Background

The `client-size` job **already re-runs on every push to a PR** (the `pull_request` trigger fires on `synchronize`, not just `opened`; verified against PR #68, where the job ran on all three pushed commits). The problem was purely that the re-runs were invisible.

### Changes

1. **Freshness footer on the sticky comment.** `marocchino/sticky-pull-request-comment` updates the comment in place, so GitHub freezes its `created_at` and only quietly marks it "edited", making a re-measured comment indistinguishable from the at-open one. The comment now ends with the commit it measured:

   ```
   Measured `2af64e6d9` · 2026-06-02T01:36:33Z · [run](.../actions/runs/123)
   ```

   `renderComment` gains an optional `meta` arg and stays pure; the CLI populates it from `SIZE_COMMENT_SHA` / `SIZE_COMMENT_RUN_URL` env vars set in the workflow.

2. **Concurrency group.** Rapid pushes left stale runs racing to post the comment last. Added `concurrency` keyed on ref. `cancel-in-progress` is scoped to PRs only on purpose: on `main`, `build-and-tag` commits the size baseline and force-pushes the `next` tag, so it must never be interrupted mid-flight.

## Verification

All six local pre-push CI steps pass:

- ✅ framework build
- ✅ `format:check`
- ✅ `typecheck`
- ✅ `test` (902 tests; +3 covering the footer present/absent/partial)
- ✅ `test:integration` (4 tests)
- ✅ site build

`ci.yml` parses cleanly via Prettier; CLI footer rendering confirmed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)