### PR TITLE
feat(iso): active-route detection (useRouteMatch, useRouteActive, NavLink)

### DIFF
--- a/apps/site/src/components/DocsLayout.tsx
+++ b/apps/site/src/components/DocsLayout.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { useLocation } from 'preact-iso';
+import { NavLink, useRouteActive } from 'hono-preact';
 import { ThemeToggle } from './ThemeToggle.js';
 import { nav, type NavArea } from '../pages/docs/nav.js';
 
@@ -34,7 +35,7 @@ export function DocsLayout({ children }: Props) {
     setMobileOpen(false);
   }, [path]);
 
-  const activeAreaId = path.startsWith('/docs/components')
+  const activeAreaId = useRouteActive('/docs/components', { exact: false })
     ? 'components'
     : 'guide';
   const activeArea = nav.find((a) => a.id === activeAreaId) ?? nav[0];
@@ -55,22 +56,18 @@ export function DocsLayout({ children }: Props) {
               <Icon size={14} class="shrink-0 opacity-80" />
               <span class="whitespace-nowrap">{section.heading}</span>
             </div>
-            {section.entries.map((entry) => {
-              const active = entry.route === path;
-              return (
-                <a
-                  key={entry.route}
-                  href={entry.route}
-                  class={`flex items-center h-9 rounded text-sm no-underline whitespace-nowrap pl-9 pr-3 ${
-                    active
-                      ? 'bg-accent/10 text-accent font-semibold'
-                      : 'text-muted hover:text-foreground hover:bg-foreground/10'
-                  }`}
-                >
-                  <span>{entry.title}</span>
-                </a>
-              );
-            })}
+            {section.entries.map((entry) => (
+              <NavLink
+                key={entry.route}
+                href={entry.route}
+                exact
+                class="flex items-center h-9 rounded text-sm no-underline whitespace-nowrap pl-9 pr-3"
+                activeClass="bg-accent/10 text-accent font-semibold"
+                inactiveClass="text-muted hover:text-foreground hover:bg-foreground/10"
+              >
+                <span>{entry.title}</span>
+              </NavLink>
+            ))}
           </div>
         );
       })}
@@ -95,6 +92,10 @@ export function DocsLayout({ children }: Props) {
         >
           hono-preact
         </a>
+        {/* Area tabs key off `activeAreaId` (mutually exclusive: components
+            wins over guide), not per-href route matching, so they stay plain
+            <a>. A NavLink on the Guide tab (`/docs`) would also light up on
+            every `/docs/components/*` page since that is a descendant path. */}
         <nav class="flex items-center gap-1" aria-label="Docs areas">
           {nav.map((area) => {
             const TabIcon = area.icon;

--- a/apps/site/src/pages/docs/active-links.mdx
+++ b/apps/site/src/pages/docs/active-links.mdx
@@ -1,0 +1,72 @@
+# Active Links
+
+Highlighting the current page in navigation needs one question answered: does the current URL match a given route? `useRouteActive`, `useRouteMatch`, and `<NavLink>` answer it against the same route grammar your route table uses, so `/posts/:id` matches any post and hands you the `id`.
+
+## `useRouteActive`
+
+Returns `true` when the current path matches the route.
+
+```tsx
+import { useRouteActive } from 'hono-preact';
+
+function Tab() {
+  const active = useRouteActive('/docs');
+  return (
+    <a href="/docs" aria-current={active ? 'page' : undefined}>
+      Docs
+    </a>
+  );
+}
+```
+
+By default the match is **exact**. Pass `{ exact: false }` to also match descendant paths, e.g. highlight a section for every page beneath it:
+
+```tsx
+// active on /docs/components AND /docs/components/dialog
+const inSection = useRouteActive('/docs/components', { exact: false });
+```
+
+One caveat: because every path is a descendant of `/`, a non-exact match on the root (`useRouteActive('/', { exact: false })`) is active everywhere. Keep a "Home" link `exact` (the default).
+
+## `useRouteMatch`
+
+Same matching, but returns the captured params (or `null`). Use it when you want to both test _and_ read the dynamic segments.
+
+```tsx
+import { useRouteMatch } from 'hono-preact';
+
+function Crumb() {
+  const params = useRouteMatch('/posts/:id');
+  // on /posts/42 -> { id: '42' }, elsewhere -> null
+  return params ? <span>Post {params.id}</span> : null;
+}
+```
+
+The route accepts the full pattern grammar: `:param`, `*`, `+`, `:param?`.
+
+## `<NavLink>`
+
+A `<a>` that applies an active or inactive class for you (and sets `aria-current="page"` when active).
+
+```tsx
+import { NavLink } from 'hono-preact';
+
+<NavLink
+  href="/docs"
+  activeClass="text-accent font-semibold"
+  inactiveClass="text-muted"
+>
+  Docs
+</NavLink>;
+```
+
+Any `class` you pass is always applied; `activeClass` / `inactiveClass` are merged on top per state. Other anchor props (`target`, `rel`, `data-*`) pass straight through.
+
+Use `exact={false}` for section links, and `match` when the link target differs from the pattern you want to highlight on:
+
+```tsx
+// links to /posts, but stays active on /posts/123
+<NavLink href="/posts" match="/posts/:id" activeClass="text-accent">
+  Posts
+</NavLink>
+```

--- a/apps/site/src/pages/docs/nav.ts
+++ b/apps/site/src/pages/docs/nav.ts
@@ -49,6 +49,7 @@ export const nav: NavArea[] = [
           { title: 'The Route Table', route: '/docs/routes' },
           { title: 'Layouts & Nesting', route: '/docs/layouts' },
           { title: 'Adding Pages', route: '/docs/pages' },
+          { title: 'Active Links', route: '/docs/active-links' },
         ],
       },
       {

--- a/packages/iso/src/__tests__/nav-link.test.tsx
+++ b/packages/iso/src/__tests__/nav-link.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, it, expect } from 'vitest';
+import { cleanup, render } from '@testing-library/preact';
+import { LocationProvider } from 'preact-iso';
+import { NavLink } from '../nav-link.js';
+
+afterEach(() => {
+  cleanup();
+  history.replaceState(null, '', '/');
+});
+
+describe('NavLink', () => {
+  it('applies activeClass and aria-current="page" when active', () => {
+    history.replaceState(null, '', '/docs');
+    const { getByText } = render(
+      <LocationProvider>
+        <NavLink href="/docs" class="base" activeClass="on" inactiveClass="off">
+          Docs
+        </NavLink>
+      </LocationProvider>
+    );
+    const a = getByText('Docs') as HTMLAnchorElement;
+    expect(a.getAttribute('class')).toBe('base on');
+    expect(a.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('applies inactiveClass and no aria-current when inactive', () => {
+    history.replaceState(null, '', '/other');
+    const { getByText } = render(
+      <LocationProvider>
+        <NavLink href="/docs" class="base" activeClass="on" inactiveClass="off">
+          Docs
+        </NavLink>
+      </LocationProvider>
+    );
+    const a = getByText('Docs') as HTMLAnchorElement;
+    expect(a.getAttribute('class')).toBe('base off');
+    expect(a.getAttribute('aria-current')).toBeNull();
+  });
+
+  it('uses `match` for the active test instead of href', () => {
+    history.replaceState(null, '', '/posts/7');
+    const { getByText } = render(
+      <LocationProvider>
+        <NavLink href="/posts" match="/posts/:id" activeClass="on">
+          Posts
+        </NavLink>
+      </LocationProvider>
+    );
+    const a = getByText('Posts') as HTMLAnchorElement;
+    expect(a.getAttribute('href')).toBe('/posts');
+    expect(a.getAttribute('class')).toBe('on');
+  });
+
+  it('matches a descendant when exact is false', () => {
+    history.replaceState(null, '', '/docs/components/dialog');
+    const { getByText } = render(
+      <LocationProvider>
+        <NavLink
+          href="/docs/components"
+          exact={false}
+          activeClass="on"
+          inactiveClass="off"
+        >
+          Components
+        </NavLink>
+      </LocationProvider>
+    );
+    expect((getByText('Components') as HTMLElement).getAttribute('class')).toBe(
+      'on'
+    );
+  });
+
+  it('forwards arbitrary anchor props', () => {
+    history.replaceState(null, '', '/x');
+    const { getByText } = render(
+      <LocationProvider>
+        <NavLink href="/y" target="_blank" rel="noreferrer" data-kind="nav">
+          Y
+        </NavLink>
+      </LocationProvider>
+    );
+    const a = getByText('Y') as HTMLAnchorElement;
+    expect(a.getAttribute('target')).toBe('_blank');
+    expect(a.getAttribute('rel')).toBe('noreferrer');
+    expect(a.getAttribute('data-kind')).toBe('nav');
+  });
+
+  it('omits the class attribute when no class props are given', () => {
+    history.replaceState(null, '', '/docs');
+    const { getByText } = render(
+      <LocationProvider>
+        <NavLink href="/docs">Docs</NavLink>
+      </LocationProvider>
+    );
+    expect(getByText('Docs').getAttribute('class')).toBeNull();
+  });
+
+  it('lets a caller-supplied aria-current win over the default', () => {
+    history.replaceState(null, '', '/docs');
+    const { getByText } = render(
+      <LocationProvider>
+        {/* active, but the caller forces aria-current off */}
+        <NavLink href="/docs" aria-current={false} activeClass="on">
+          Docs
+        </NavLink>
+      </LocationProvider>
+    );
+    expect(getByText('Docs').getAttribute('aria-current')).toBe('false');
+  });
+});

--- a/packages/iso/src/__tests__/public-exports.test.ts
+++ b/packages/iso/src/__tests__/public-exports.test.ts
@@ -38,3 +38,17 @@ describe('view transitions toolkit exports', () => {
     expect(typeof iso.PersistHost).toBe('function');
   });
 });
+
+describe('active-route detection exports', () => {
+  it('exports useRouteMatch', () => {
+    expect(typeof iso.useRouteMatch).toBe('function');
+  });
+
+  it('exports useRouteActive', () => {
+    expect(typeof iso.useRouteActive).toBe('function');
+  });
+
+  it('exports NavLink', () => {
+    expect(typeof iso.NavLink).toBe('function');
+  });
+});

--- a/packages/iso/src/__tests__/route-active.test.tsx
+++ b/packages/iso/src/__tests__/route-active.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { matchPath } from '../route-active.js';
+
+describe('matchPath', () => {
+  it('exact-matches an identical literal path', () => {
+    expect(matchPath('/docs', '/docs', true)).toEqual({});
+  });
+
+  it('returns null when the path differs', () => {
+    expect(matchPath('/docs', '/about', true)).toBeNull();
+  });
+
+  it('captures params from a dynamic pattern', () => {
+    expect(matchPath('/posts/123', '/posts/:id', true)).toEqual({ id: '123' });
+  });
+
+  it('does NOT match a descendant in exact mode', () => {
+    expect(matchPath('/posts/123/edit', '/posts/:id', true)).toBeNull();
+  });
+
+  it('matches a descendant in non-exact mode', () => {
+    expect(
+      matchPath('/docs/components/dialog', '/docs/components', false)
+    ).toEqual({});
+  });
+
+  it('matches the section root itself in non-exact mode', () => {
+    expect(matchPath('/docs/components', '/docs/components', false)).toEqual(
+      {}
+    );
+  });
+
+  it('ignores a trailing slash on the route argument', () => {
+    expect(matchPath('/docs', '/docs/', true)).toEqual({});
+  });
+
+  it('matches the root path only against itself', () => {
+    expect(matchPath('/', '/', true)).toEqual({});
+    expect(matchPath('/x', '/', true)).toBeNull();
+  });
+
+  it('matches any path in non-exact mode for the root route', () => {
+    // `/` in non-exact mode is a universal ancestor: every path is a
+    // descendant of root, so this is intentionally always-active.
+    expect(matchPath('/anything', '/', false)).toEqual({});
+  });
+
+  it('supports a wildcard pattern', () => {
+    expect(matchPath('/files/a/b', '/files/*', true)).toEqual({});
+  });
+});

--- a/packages/iso/src/__tests__/route-active.test.tsx
+++ b/packages/iso/src/__tests__/route-active.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
-import { describe, it, expect } from 'vitest';
-import { matchPath } from '../route-active.js';
+import { afterEach, describe, it, expect } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact';
+import { LocationProvider } from 'preact-iso';
+import { matchPath, useRouteMatch, useRouteActive } from '../route-active.js';
 
 describe('matchPath', () => {
   it('exact-matches an identical literal path', () => {
@@ -48,5 +50,72 @@ describe('matchPath', () => {
 
   it('supports a wildcard pattern', () => {
     expect(matchPath('/files/a/b', '/files/*', true)).toEqual({});
+  });
+});
+
+function Probe({ route, exact }: { route: string; exact?: boolean }) {
+  const params = useRouteMatch(route, { exact });
+  const active = useRouteActive(route, { exact });
+  return (
+    <div>
+      <span data-testid="active">{active ? 'yes' : 'no'}</span>
+      <span data-testid="params">{JSON.stringify(params)}</span>
+      <a href="/posts/2" data-testid="nav">
+        go
+      </a>
+    </div>
+  );
+}
+
+// Unmount between renders, and restore the URL so a leaked path (e.g. the
+// `/posts/2` that test 3 navigates to) can't bleed into later tests.
+afterEach(() => {
+  cleanup();
+  history.replaceState(null, '', '/');
+});
+
+describe('useRouteMatch / useRouteActive', () => {
+  it('reflects the initial location and captured params', () => {
+    history.replaceState(null, '', '/posts/1');
+    const { getByTestId } = render(
+      <LocationProvider>
+        <Probe route="/posts/:id" />
+      </LocationProvider>
+    );
+    expect(getByTestId('active').textContent).toBe('yes');
+    expect(getByTestId('params').textContent).toBe('{"id":"1"}');
+  });
+
+  it('returns null params and inactive when the route does not match', () => {
+    history.replaceState(null, '', '/posts/1');
+    const { getByTestId } = render(
+      <LocationProvider>
+        <Probe route="/about" />
+      </LocationProvider>
+    );
+    expect(getByTestId('active').textContent).toBe('no');
+    expect(getByTestId('params').textContent).toBe('null');
+  });
+
+  it('re-evaluates after navigation', async () => {
+    history.replaceState(null, '', '/posts/1');
+    const { getByTestId } = render(
+      <LocationProvider>
+        <Probe route="/posts/2" exact />
+      </LocationProvider>
+    );
+    expect(getByTestId('active').textContent).toBe('no');
+    fireEvent.click(getByTestId('nav'));
+    await waitFor(() => expect(getByTestId('active').textContent).toBe('yes'));
+  });
+
+  it('matches a descendant when exact is false', () => {
+    history.replaceState(null, '', '/docs/components/dialog');
+    const { getByTestId } = render(
+      <LocationProvider>
+        <Probe route="/docs/components" exact={false} />
+      </LocationProvider>
+    );
+    expect(getByTestId('active').textContent).toBe('yes');
   });
 });

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -45,6 +45,14 @@ export type {
   UseOptimisticActionResult,
 } from './optimistic-action.js';
 
+// Active-route detection.
+export {
+  useRouteMatch,
+  useRouteActive,
+  type RouteMatchOptions,
+} from './route-active.js';
+export { NavLink, type NavLinkProps } from './nav-link.js';
+
 // Forms.
 export { Form } from './form.js';
 export { useActionResult, type ActionResult } from './use-action-result.js';

--- a/packages/iso/src/nav-link.tsx
+++ b/packages/iso/src/nav-link.tsx
@@ -1,0 +1,48 @@
+import type { JSX, VNode } from 'preact';
+import { useRouteActive } from './route-active.js';
+
+export type NavLinkProps = Omit<
+  JSX.HTMLAttributes<HTMLAnchorElement>,
+  'class' | 'className'
+> & {
+  href: string;
+  /** Pattern to test for active state. Defaults to `href`. */
+  match?: string;
+  /** Default true. */
+  exact?: boolean;
+  /** Always applied. */
+  class?: string;
+  /** Merged in when active. */
+  activeClass?: string;
+  /** Merged in when not active. */
+  inactiveClass?: string;
+};
+
+export function NavLink(props: NavLinkProps): VNode {
+  const {
+    href,
+    match,
+    exact = true,
+    class: baseClass,
+    activeClass,
+    inactiveClass,
+    'aria-current': ariaCurrentProp,
+    children,
+    ...rest
+  } = props;
+
+  const active = useRouteActive(match ?? href, { exact });
+
+  const className =
+    [baseClass, active ? activeClass : inactiveClass]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  const ariaCurrent = ariaCurrentProp ?? (active ? 'page' : undefined);
+
+  return (
+    <a {...rest} href={href} class={className} aria-current={ariaCurrent}>
+      {children}
+    </a>
+  );
+}

--- a/packages/iso/src/route-active.ts
+++ b/packages/iso/src/route-active.ts
@@ -1,0 +1,55 @@
+import { useLocation, exec } from 'preact-iso';
+
+export interface RouteMatchOptions {
+  /** When false, also match descendant paths (segment-prefix). Default true. */
+  exact?: boolean;
+}
+
+/**
+ * preact-iso types `exec` as always returning a `MatchProps` whose captured
+ * params are `any`, but at runtime it returns `undefined` on no match. This
+ * helper pins the half we use to a precise type so callers stay cast-free.
+ */
+function execParams(
+  path: string,
+  route: string
+): Record<string, string> | undefined {
+  return exec(path, route)?.pathParams;
+}
+
+/**
+ * Test `path` against a route pattern (same grammar as `<Route path>`).
+ * Returns the captured params on a match, else null. In non-exact mode a
+ * descendant path also matches (`/a` matches `/a/b`).
+ */
+export function matchPath(
+  path: string,
+  route: string,
+  exact: boolean
+): Record<string, string> | null {
+  const direct = execParams(path, route);
+  if (direct) return direct;
+  if (!exact) {
+    // Strip a trailing slash before appending `/*`. A route already ending in
+    // `*` becomes e.g. `/files/*/*`, which never yields a false match because
+    // `exec` requires at least one matched segment per `*`.
+    const nested = execParams(path, route.replace(/\/+$/, '') + '/*');
+    if (nested) return nested;
+  }
+  return null;
+}
+
+export function useRouteMatch(
+  route: string,
+  options?: RouteMatchOptions
+): Record<string, string> | null {
+  const { path } = useLocation();
+  return matchPath(path, route, options?.exact ?? true);
+}
+
+export function useRouteActive(
+  route: string,
+  options?: RouteMatchOptions
+): boolean {
+  return useRouteMatch(route, options) !== null;
+}


### PR DESCRIPTION
## Summary

Adds a first-class way to ask "is this route currently active?", a gap the framework had (the docs site hand-rolled `path === x` / `path.startsWith(x)`).

- **`useRouteMatch(route, { exact? })`** returns the captured params (`Record<string,string>`) or `null`. Matches against the same route grammar as `<Route path>` (`:param`, `*`, `+`, `:param?`), so `/posts/:id` matches any post and hands back the `id`.
- **`useRouteActive(route, { exact? })`** boolean wrapper for the common case.
- **`<NavLink>`** wraps `<a>`, applying `class` (always) + `activeClass`/`inactiveClass` (per state) + `aria-current="page"` when active. `match` defaults to `href`; `exact` defaults to `true`; `exact={false}` also matches descendant paths. Renders a plain anchor and relies on preact-iso's existing global click interception (no own nav handler).

Built on preact-iso's `useLocation().path` + `exec`, so matching is identical to the router and the hooks are reactive and SSR-safe with no extra wiring. An internal `execParams` helper pins `exec`'s loosely-typed result so the public surface stays cast-free (no inline `as`, per repo rule). `matchPath` stays internal.

**Dogfood:** `DocsLayout` sidebar links now use `<NavLink exact>`, and `activeAreaId` derives from `useRouteActive('/docs/components', { exact: false })` (strictly more correct than the old `startsWith`, segment-boundary matching). The Guide/Components area tabs are deliberately left as plain `<a>` driven by area precedence (a `NavLink` on `/docs` would also light up on every `/docs/components/*` page); an inline comment documents why.

**Docs:** new Guide page at `/docs/active-links`.

## Test Plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (980 passing, incl. 14 matchPath/hook + 7 NavLink + route↔nav parity)
- [x] `pnpm test:integration` (4 passing)
- [x] `pnpm --filter site build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)