### PR TITLE
Standardize docs pages + validator hook

### DIFF
--- a/.claude/hooks/docs-template-check.sh
+++ b/.claude/hooks/docs-template-check.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# PostToolUse hook on Edit|Write. Soft-warns when a docs .mdx page is written
+# that is missing the required sections for its template. Never blocks: it
+# writes notes to stderr for the agent to see and always exits 0.
+#
+# Templates are inferred from the file path:
+#   apps/site/src/pages/docs/components/*.mdx  -> Reference template
+#   apps/site/src/pages/docs/*.mdx (elsewhere) -> Guide template
+# index.mdx pages (area overviews) are exempt.
+#
+# Required pillars (warned on if missing):
+#   Prose    : an `# h1` followed by a lead paragraph.
+#   Examples : >=1 fenced code block, or an <Example> live demo.
+#   API ref  : (Reference template only) a `## API reference`, `## Signature`,
+#              or `## Options`/`## Parameters` heading plus a markdown table.
+# Recommended (component pages only -- those with a live demo or styling):
+#   ## Demo, ## Styling, ## Accessibility. Reported as optional, never blocks.
+# Hook/primitive pages (no live demo) are never nagged about those.
+#
+# See .claude/skills/add-docs-page.md (Page templates) for the canonical
+# skeletons the author should target.
+
+# Read the written file path from the tool input JSON on stdin. Try the nested
+# tool_input.file_path first, fall back to a top-level file_path.
+file_path=$(python3 -c "import sys,json; d=json.load(sys.stdin); ti=d.get('tool_input',{}); print(ti.get('file_path') or d.get('file_path') or '')" 2>/dev/null <<< "$(cat)")
+
+# Only act on docs .mdx files.
+case "$file_path" in
+  *apps/site/src/pages/docs/*.mdx) ;;
+  *) exit 0 ;;
+esac
+
+# Exempt area-overview pages.
+[ "$(basename "$file_path")" = "index.mdx" ] && exit 0
+
+# Must exist on disk (post-write).
+[ -f "$file_path" ] || exit 0
+
+# Infer template from path.
+case "$file_path" in
+  *apps/site/src/pages/docs/components/*) template="reference" ;;
+  *) template="guide" ;;
+esac
+
+# --- Parse the file ------------------------------------------------------
+
+has_h1=0
+grep -qE '^# ' "$file_path" && has_h1=1
+
+# Lead paragraph: a prose line between the h1 and the first '## '. Lines before
+# the h1 (imports, etc.) are ignored; blank/heading/import/fence/JSX lines after
+# the h1 do not count as prose.
+has_lead=$(awk '
+  BEGIN { seen=0; done=0; found=0 }
+  !seen && /^# / { seen=1; next }
+  seen && /^## / { done=1 }
+  done { next }
+  seen {
+    if ($0 ~ /^[[:space:]]*$/) next
+    if ($0 ~ /^import /) next
+    if ($0 ~ /^#/) next
+    if ($0 ~ /^```/) next
+    if ($0 ~ /^</) next
+    found=1
+  }
+  END { print found }
+' "$file_path")
+
+# Examples: at least one fenced code block OR an <Example> live demo.
+fence_lines=$(grep -cE '^```' "$file_path")
+has_example_tag=0
+grep -q '<Example' "$file_path" && has_example_tag=1
+
+# Headings (##/###), lowercased, for alias matching.
+headings=$(grep -E '^#{2,3} ' "$file_path" | tr '[:upper:]' '[:lower:]')
+
+# A GFM table separator row, e.g. | --- | --- | or |:--|--:|.
+has_table=0
+grep -qE '^[[:space:]]*\|?([[:space:]]*:?-+:?[[:space:]]*\|)+' "$file_path" && has_table=1
+
+# --- Validate ------------------------------------------------------------
+
+missing=()
+recommend=()
+
+# Prose pillar (both templates).
+if [ "$has_h1" = "0" ] || [ "$has_lead" = "0" ]; then
+  missing+=("Prose: an \`# Title\` heading followed by a lead paragraph (what it does and why).")
+fi
+
+# Examples pillar (both templates).
+if [ "$fence_lines" -lt 1 ] && [ "$has_example_tag" = "0" ]; then
+  missing+=("Examples: at least one fenced code block or an <Example> live demo.")
+fi
+
+if [ "$template" = "reference" ]; then
+  # API reference pillar (required). Accept the component heading (API reference)
+  # and the hook/primitive headings (Signature, Options, Parameters).
+  api_heading=0
+  printf '%s\n' "$headings" | grep -qE '^#{2,3} (api reference|signature|options|parameters)' && api_heading=1
+  if [ "$api_heading" = "0" ] || [ "$has_table" = "0" ]; then
+    missing+=("API reference: a \`## API reference\`, \`## Signature\`, or \`## Options\`/\`## Parameters\` section with a prop/options markdown table.")
+  fi
+
+  # Recommended sections apply to component pages (those with a live demo or a
+  # styling section). Hook/primitive pages have neither and are not nagged.
+  is_component=0
+  [ "$has_example_tag" = "1" ] && is_component=1
+  printf '%s\n' "$headings" | grep -qE '^#{2,3} (styling|demo)' && is_component=1
+  if [ "$is_component" = "1" ]; then
+    printf '%s\n' "$headings" | grep -qE '^#{2,3} demo' || recommend+=("## Demo with an <Example> live demo")
+    printf '%s\n' "$headings" | grep -qE '^#{2,3} styling' || recommend+=("## Styling")
+    printf '%s\n' "$headings" | grep -qE '^#{2,3} accessibility' || recommend+=("## Accessibility")
+  fi
+fi
+# Guide template: prose + examples are the only checks (many guides are pure
+# tutorial), keeping the hook's signal clean.
+
+# --- Report --------------------------------------------------------------
+
+[ ${#missing[@]} -eq 0 ] && [ ${#recommend[@]} -eq 0 ] && exit 0
+
+rel="${file_path#*hono-preact/}"
+echo "docs-template-check: ${rel} (${template} template)" >&2
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "  Missing required sections:" >&2
+  for m in "${missing[@]}"; do
+    echo "    - ${m}" >&2
+  done
+fi
+
+if [ ${#recommend[@]} -gt 0 ]; then
+  echo "  Recommended (optional):" >&2
+  for r in "${recommend[@]}"; do
+    echo "    - ${r}" >&2
+  done
+fi
+
+echo "  See .claude/skills/add-docs-page.md (Page templates) for the full skeleton." >&2
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/keep-docs-fresh.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/docs-template-check.sh"
           }
         ]
       }

--- a/.claude/skills/add-docs-page.md
+++ b/.claude/skills/add-docs-page.md
@@ -42,8 +42,79 @@ Add an entry `{ title: 'Page Title', route: '/docs/<slug>' }` to the right secti
 
 **Components area sections** (under `basePath` `/docs/components`): `Getting started`, `Overlays` (Dialog; Popover and Tooltip as they ship), `Foundations` (the shared primitives: useRender, useControllableState, mergeRefs; LayerHost and FocusScope as they ship), then add `Collections` (Menu, Select, Combobox) as those pages are created. When adding the first page of a not-yet-present section, create the section with an appropriate `lucide-preact` icon.
 
+## Page templates
+
+Every docs page rests on three pillars: **prose**, **examples**, **API reference**. The `docs-template-check` hook (PostToolUse on Edit|Write) infers the page's template from its path and soft-warns on stderr if a required pillar is missing. It never blocks. Match one of the two templates below.
+
+| Pillar | What it is | How the hook recognizes it |
+|---|---|---|
+| Prose | What the page documents and why it exists | An `# Title` h1 followed by a lead paragraph before the first `##` |
+| Examples | Realistic code, common case first | At least one fenced code block, or an `<Example>` live demo |
+| API reference | The configurable surface | A `## API reference`, `## Signature`, or `## Options`/`## Parameters` heading plus a GFM table |
+
+`index.mdx` pages (area overviews) are exempt from the hook.
+
+### Guide template (`docs/*.mdx`)
+
+```
+# Title
+<lead paragraph: what this does and why it exists>
+
+## How it works            (or the first concept section)
+  …prose interleaved with code examples…
+
+## Options / <reference>   (a GFM table of the API the page documents)
+
+<cross-links to related docs pages>
+```
+
+- **Required:** Prose, Examples.
+- **Recommended:** a reference/options table where the page documents configurable API; cross-links to related pages.
+
+Reference implementations: `loaders.mdx`, `actions.mdx`.
+
+### Component / Reference template (`docs/components/*.mdx`)
+
+This area holds two shapes; the hook's required set is their common core (Prose + Examples + API reference). Component pages additionally get optional nudges for `## Demo`, `## Styling`, `## Accessibility`; hook/primitive pages (no live demo) do not.
+
+**Component variant** (reference implementations: `dialog.mdx`, `popover.mdx`, `tooltip.mdx`):
+
+```
+# Name
+<lead: what it is, why it exists, "ships unstyled" if applicable>
+
+## Demo          (<Example> wrapping a live demo)
+## Usage         (common-case code)
+## Styling       (CSS + Tailwind via <CodeTabs>)
+## API reference (markdown prop tables, one per part)
+## Accessibility
+```
+
+**Hook / primitive variant** (reference implementations: `use-render.mdx`, `merge-refs.mdx`, `use-dismiss.mdx`):
+
+```
+# name
+<lead paragraph>
+
+## Signature                   (optional; some pages go straight to Options)
+### Options / ### Parameters   (a markdown table), or a top-level ## Options
+## Example
+```
+
+- **Required (both variants):** Prose, Examples, API reference (any of `## API reference`, `## Signature`, `## Options`, `## Parameters`, plus a table).
+- **Recommended (component variant):** `## Demo` with `<Example>`, `## Styling`, `## Accessibility`.
+
+### Shared UI
+
+Use the existing docs components rather than rolling new markup:
+
+- `<Example>` (from `components/docs/Example.js`) frames a live demo.
+- `<CodeTabs labels={[...]}>` (from `components/docs/CodeTabs.js`) for multi-flavor code (e.g. CSS + Tailwind).
+- API reference tables are plain GFM markdown tables (styled by `.mdx-content`).
+
 ## Checklist
 
 - [ ] MDX file created in the correct directory (`docs/` for guide, `docs/components/` for components)
 - [ ] Entry added to the correct area/section in `apps/site/src/pages/docs/nav.ts`
+- [ ] Page matches its template's required sections (the `docs-template-check` hook warns on stderr if not)
 - [ ] `pnpm test docs/__tests__` passes (route ↔ nav parity)

--- a/.claude/skills/keep-docs-fresh.md
+++ b/.claude/skills/keep-docs-fresh.md
@@ -46,6 +46,8 @@ apps/site/src/pages/docs/nav.ts
 
 Each MDX file maps to a route: `loaders.mdx` → `/docs/loaders`, etc.
 
+When adding or restructuring a page, also follow the **Page templates** section of the `add-docs-page` skill; the `docs-template-check` hook soft-warns when a page is missing its template's required sections.
+
 ## Red Flags — You Are About to Leave Docs Stale
 
 These thoughts mean **stop, grep the docs first:**

--- a/apps/site/src/pages/docs/deployment.mdx
+++ b/apps/site/src/pages/docs/deployment.mdx
@@ -1,5 +1,9 @@
 # Build & Deploy
 
+How you build and deploy a hono-preact app depends on the adapter it targets.
+This page covers development, production builds, and deployment for each shipped
+adapter.
+
 ## Adapters
 
 The framework targets whichever adapter you choose. Two adapters ship today:


### PR DESCRIPTION
## Summary

Codifies a standard structure for docs pages and adds a soft-warn Claude hook that nudges authors toward it. Implements the design in `docs/superpowers/specs/2026-06-04-standardized-docs-pages-design.md`.

- **Two templates, inferred from path:** Guide/Concept (`docs/*.mdx`) and Component/Reference (`docs/components/*.mdx`), each resting on three pillars: prose, examples, API reference.
- **`docs-template-check.sh`** (new PostToolUse `Edit|Write` hook): infers the template from the file path, parses the `.mdx`, and writes a non-blocking stderr note listing any missing required pillars. Always exits 0. Mirrors the existing `keep-docs-fresh` hooks' conventions.
- **`add-docs-page` skill** gains a "Page templates" section (the source of truth: the three pillars, both skeletons with their accepted heading aliases, and the shared docs UI), plus a checklist line. `keep-docs-fresh` cross-references it.
- **No app code, no new components, no MDX-pipeline change.**

## Design deviation worth noting

During implementation, PR #74's new component-area pages revealed a third, leaner hook-page shape (`use-dismiss`, `use-focus-return`, `use-position`) whose API surface lives under a bare `## Options` (no `## Signature`/`## API reference`). The shipped hook is therefore broader than the original plan draft:

- API-reference pillar accepts `## API reference`, `## Signature`, `## Options`, or `## Parameters` (+ a table), not just the first two.
- The recommended Demo/Styling/Accessibility nudges are gated on an "is-component" signal (a live `<Example>` or a `## Styling`/`## Demo` heading), so hook/primitive pages are never nagged.

These two changes are what make the standard ratify every existing page rather than false-warn.

## Ratification

The standard is designed to ratify reality, not impose an aspiration. The hook produces **zero output** across all 31 validated docs pages (the 2 `index.mdx` overviews are exempt). The one page that didn't already conform, `deployment.mdx`, jumped from its `#` title straight into `## Adapters`; this PR adds a one-line lead paragraph so it meets the Prose pillar (it was the lone outlier among 31 pages).

## Test Plan

- [x] Ratification scan: hook emits no required-section warning for any of the 31 validated pages (verified by me and two review subagents independently).
- [x] Fixture test: a Reference page missing its API-reference section correctly warns.
- [x] `prettier --check apps/site/src/pages/docs/deployment.mdx` passes (the only branch file `format:check` covers; `.claude/**` is outside the format glob).
- [x] Settings JSON valid; the pre-existing `keep-docs-fresh.sh` hook is retained, `docs-template-check.sh` appended under the same matcher.
- [x] Skill documentation matches the hook's actual behavior (aliases, is-component gating, exemptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)