### PR TITLE
feat(ui): useSafeArea pointer-grace primitive + Tooltip safe corridor

### DIFF
--- a/apps/site/src/pages/docs/components/tooltip.mdx
+++ b/apps/site/src/pages/docs/components/tooltip.mdx
@@ -40,6 +40,11 @@ export function SaveHint() {
 The trigger opens after a short delay on hover and immediately on focus. Set
 `delay` and `closeDelay` on `Tooltip.Root` to tune the timing.
 
+Once open, the tooltip stays open while you move from the trigger toward the
+popup, even across the gap between them, by tracking a safe corridor toward the
+popup; it closes when the pointer leaves that corridor or after `closeDelay`
+elapses. See [useSafeArea](/docs/components/use-safe-area).
+
 ## Styling
 
 Parts expose `data-state="open" | "closed"`; the Positioner and Arrow also
@@ -122,17 +127,17 @@ element it renders. The Trigger, Positioner, Popup, and Arrow also expose
 Provides open state, ids, refs, timing, and placement config to the parts.
 Renders only its children.
 
-| Prop           | Type                               | Default    | Description                                            |
-| -------------- | ---------------------------------- | ---------- | ------------------------------------------------------ |
-| `open`         | `boolean`                          | -          | Controlled open state. Pair with `onOpenChange`.       |
-| `defaultOpen`  | `boolean`                          | `false`    | Initial open state when uncontrolled.                  |
-| `onOpenChange` | `(open: boolean) => void`          | -          | Called when the tooltip requests an open or close.     |
-| `delay`        | `number`                           | `600`      | Open delay in ms after the pointer enters the trigger. |
-| `closeDelay`   | `number`                           | `300`      | Close delay in ms after the pointer leaves.            |
-| `side`         | `'top'\|'right'\|'bottom'\|'left'` | `'top'`    | Preferred side of the anchor to place the popup.       |
-| `align`        | `'start'\|'center'\|'end'`         | `'center'` | Alignment along that side.                             |
-| `offset`       | `number`                           | `8`        | Gap in pixels between the anchor and the popup.        |
-| `children`     | `ComponentChildren`                | -          | The trigger and positioner.                            |
+| Prop           | Type                               | Default    | Description                                                |
+| -------------- | ---------------------------------- | ---------- | ---------------------------------------------------------- |
+| `open`         | `boolean`                          | -          | Controlled open state. Pair with `onOpenChange`.           |
+| `defaultOpen`  | `boolean`                          | `false`    | Initial open state when uncontrolled.                      |
+| `onOpenChange` | `(open: boolean) => void`          | -          | Called when the tooltip requests an open or close.         |
+| `delay`        | `number`                           | `600`      | Open delay in ms after the pointer enters the trigger.     |
+| `closeDelay`   | `number`                           | `300`      | Grace window in ms for the safe corridor toward the popup. |
+| `side`         | `'top'\|'right'\|'bottom'\|'left'` | `'top'`    | Preferred side of the anchor to place the popup.           |
+| `align`        | `'start'\|'center'\|'end'`         | `'center'` | Alignment along that side.                                 |
+| `offset`       | `number`                           | `8`        | Gap in pixels between the anchor and the popup.            |
+| `children`     | `ComponentChildren`                | -          | The trigger and positioner.                                |
 
 ### Tooltip.Trigger
 
@@ -147,9 +152,9 @@ The element the tooltip describes. Binds hover and focus, wires
 | `...props` | `JSX.HTMLAttributes<HTMLButtonElement>` | -       | Forwarded; passed pointer / focus handlers run first. |
 
 Sets `data-state` and `aria-describedby` (the popup id, only while open). Opens
-after `delay` on a mouse `pointerenter`, immediately on `focus`; closes after
-`closeDelay` on `pointerleave`, immediately on `blur` or Escape. A touch pointer
-does not open it.
+after `delay` on a mouse `pointerenter`, immediately on `focus`; once open, it
+closes when the pointer leaves the safe corridor toward the popup, on `blur`, or
+on Escape. A touch pointer does not open it.
 
 ### Tooltip.Positioner
 
@@ -199,8 +204,9 @@ own components. Several have their own page with examples:
 [usePosition](/docs/components/use-position),
 [useDismiss](/docs/components/use-dismiss),
 [useRender](/docs/components/use-render),
-[useControllableState](/docs/components/use-controllable-state), and
-[mergeRefs](/docs/components/merge-refs).
+[useControllableState](/docs/components/use-controllable-state),
+[mergeRefs](/docs/components/merge-refs), and
+[useSafeArea](/docs/components/use-safe-area).
 
 ## Accessibility
 
@@ -213,7 +219,8 @@ has `role="tooltip"`.
 - It is **hoverable**: moving the pointer from the trigger onto the popup keeps
   it open (WCAG 1.4.13), so content that needs to be read or selected does not
   vanish.
-- It is **dismissible** with Escape and **persistent**: it stays until focus or
-  the pointer leaves, never on a timeout.
+- It is **dismissible** with Escape and **persistent**: while the pointer is over
+  the trigger or popup it never auto-hides on a timer; it closes when focus or the
+  pointer leaves.
 - Touch input cannot hover, so the tooltip is suppressed there. Do not place
   information that is only available through a tooltip; keep it supplementary.

--- a/apps/site/src/pages/docs/components/use-dismiss.mdx
+++ b/apps/site/src/pages/docs/components/use-dismiss.mdx
@@ -4,7 +4,7 @@
 Escape or pressing outside the overlay dismisses the topmost registered layer,
 so nested overlays close one at a time, innermost first.
 
-See also: [useFocusReturn](/docs/components/use-focus-return), [usePosition](/docs/components/use-position).
+See also: [useFocusReturn](/docs/components/use-focus-return), [usePosition](/docs/components/use-position), [useSafeArea](/docs/components/use-safe-area).
 
 ## Signature
 

--- a/apps/site/src/pages/docs/components/use-safe-area.mdx
+++ b/apps/site/src/pages/docs/components/use-safe-area.mdx
@@ -1,0 +1,66 @@
+# useSafeArea
+
+`useSafeArea` keeps a hover-opened floating element open while the pointer travels
+the empty gap toward it. When the pointer leaves the trigger it would normally
+fire `pointerleave` and close the element before the pointer arrives. This hook
+watches `pointermove` and treats motion through a safe corridor, a quad spanning
+the trigger's edge to the floating element's near edge, as intent to reach the
+element, so it stays open. Leaving the corridor, or dwelling in it past a short
+grace period, closes it.
+
+See also: [usePosition](/docs/components/use-position), [useDismiss](/docs/components/use-dismiss), [Tooltip](/docs/components/tooltip).
+
+## Signature
+
+```ts
+import { useSafeArea } from '@hono-preact/ui';
+
+function useSafeArea(opts: UseSafeAreaOptions): void;
+
+interface UseSafeAreaOptions {
+  enabled: boolean; // typically the open state of a hover-driven element
+  anchorRef: RefObject<HTMLElement>; // the trigger the corridor starts from
+  floatingRef: RefObject<HTMLElement>; // the floating element it points at
+  onClose: () => void; // pointer left the corridor, or the grace lapsed
+  graceMs?: number; // default 300
+}
+```
+
+## Options
+
+| Option        | Type                     | Default | Notes                                                                                          |
+| ------------- | ------------------------ | ------- | ---------------------------------------------------------------------------------------------- |
+| `enabled`     | `boolean`                | none    | Watch the pointer only while the element is open.                                              |
+| `anchorRef`   | `RefObject<HTMLElement>` | none    | The trigger the corridor starts from.                                                          |
+| `floatingRef` | `RefObject<HTMLElement>` | none    | The floating element the corridor points at.                                                   |
+| `onClose`     | `() => void`             | none    | Called when the pointer leaves the corridor or the grace lapses.                               |
+| `graceMs`     | `number`                 | `300`   | Max time the pointer may dwell in the corridor without reaching either element before closing. |
+
+It injects no DOM: it listens to `pointermove` while enabled and runs a
+point-in-polygon test against the live rects of the two elements, so nothing
+under the corridor is blocked from interaction. The corridor follows the elements
+through scroll, resize, and a flipped placement. A pointer session begins only
+once the pointer has been over the trigger or the floating element, so an element
+opened by keyboard focus is not closed by unrelated mouse movement (the consumer
+closes it on blur or Escape instead). Touch pointers are ignored.
+
+## Example
+
+```tsx
+import { useSafeArea } from '@hono-preact/ui';
+import { useRef } from 'preact/hooks';
+
+function HoverCard({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+
+  useSafeArea({ enabled: open, anchorRef, floatingRef, onClose });
+
+  return (
+    <>
+      <button ref={anchorRef}>Profile</button>
+      {open && <div ref={floatingRef}>card content</div>}
+    </>
+  );
+}
+```

--- a/apps/site/src/pages/docs/nav.ts
+++ b/apps/site/src/pages/docs/nav.ts
@@ -140,6 +140,10 @@ export const nav: NavArea[] = [
             title: 'useFocusReturn',
             route: '/docs/components/use-focus-return',
           },
+          {
+            title: 'useSafeArea',
+            route: '/docs/components/use-safe-area',
+          },
         ],
       },
     ],

--- a/packages/ui/src/__tests__/exports.test.ts
+++ b/packages/ui/src/__tests__/exports.test.ts
@@ -7,6 +7,7 @@ describe('@hono-preact/ui exports', () => {
     expect(typeof ui.usePosition).toBe('function');
     expect(typeof ui.useDismiss).toBe('function');
     expect(typeof ui.useFocusReturn).toBe('function');
+    expect(typeof ui.useSafeArea).toBe('function');
     expect(typeof ui.placementFor).toBe('function');
   });
 });

--- a/packages/ui/src/__tests__/safe-area.test.ts
+++ b/packages/ui/src/__tests__/safe-area.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import {
+  pointInRect,
+  pointInPolygon,
+  sideFromRects,
+  buildSafePolygon,
+} from '../safe-area.js';
+
+function rect(
+  left: number,
+  top: number,
+  width: number,
+  height: number
+): DOMRect {
+  return {
+    x: left,
+    y: top,
+    width,
+    height,
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  };
+}
+
+describe('pointInRect', () => {
+  const r = rect(0, 0, 100, 50);
+  it('is true inside, false outside', () => {
+    expect(pointInRect({ x: 50, y: 25 }, r)).toBe(true);
+    expect(pointInRect({ x: 150, y: 25 }, r)).toBe(false);
+    expect(pointInRect({ x: 50, y: 80 }, r)).toBe(false);
+  });
+  it('is inclusive on the edges and corners', () => {
+    expect(pointInRect({ x: 0, y: 0 }, r)).toBe(true);
+    expect(pointInRect({ x: 100, y: 50 }, r)).toBe(true);
+    expect(pointInRect({ x: 100, y: 25 }, r)).toBe(true);
+  });
+});
+
+describe('pointInPolygon', () => {
+  // The right-opening corridor between anchor(0,0,100,50) and
+  // floating(200,0,100,150).
+  const corridor = [
+    { x: 100, y: 0 },
+    { x: 200, y: 0 },
+    { x: 200, y: 150 },
+    { x: 100, y: 50 },
+  ];
+  it('is true for a point inside the corridor', () => {
+    expect(pointInPolygon({ x: 150, y: 25 }, corridor)).toBe(true);
+  });
+  it('is false for a point below the corridor', () => {
+    expect(pointInPolygon({ x: 150, y: 130 }, corridor)).toBe(false);
+  });
+  it('is false for a point left of the corridor', () => {
+    expect(pointInPolygon({ x: 50, y: 25 }, corridor)).toBe(false);
+  });
+});
+
+describe('sideFromRects', () => {
+  const anchor = rect(0, 0, 100, 50);
+  it('detects right', () => {
+    expect(sideFromRects(anchor, rect(200, 0, 100, 150))).toBe('right');
+  });
+  it('detects left', () => {
+    expect(sideFromRects(anchor, rect(-200, 0, 100, 50))).toBe('left');
+  });
+  it('detects bottom', () => {
+    expect(sideFromRects(anchor, rect(0, 100, 100, 80))).toBe('bottom');
+  });
+  it('detects top', () => {
+    expect(sideFromRects(anchor, rect(0, -120, 100, 50))).toBe('top');
+  });
+  it('breaks an exact diagonal tie toward the horizontal axis', () => {
+    expect(sideFromRects(anchor, rect(100, 75, 100, 100))).toBe('right');
+  });
+});
+
+describe('buildSafePolygon', () => {
+  const anchor = rect(0, 0, 100, 50);
+  it('joins the near edges for a right-opening floating element', () => {
+    expect(buildSafePolygon(anchor, rect(200, 0, 100, 150), 'right')).toEqual([
+      { x: 100, y: 0 },
+      { x: 200, y: 0 },
+      { x: 200, y: 150 },
+      { x: 100, y: 50 },
+    ]);
+  });
+  it('joins the near edges for a bottom-opening floating element', () => {
+    expect(buildSafePolygon(anchor, rect(0, 100, 100, 80), 'bottom')).toEqual([
+      { x: 0, y: 50 },
+      { x: 100, y: 50 },
+      { x: 100, y: 100 },
+      { x: 0, y: 100 },
+    ]);
+  });
+  it('joins the near edges for a left-opening floating element', () => {
+    expect(buildSafePolygon(anchor, rect(-200, 0, 100, 50), 'left')).toEqual([
+      { x: 0, y: 0 },
+      { x: -100, y: 0 },
+      { x: -100, y: 50 },
+      { x: 0, y: 50 },
+    ]);
+  });
+  it('joins the near edges for a top-opening floating element', () => {
+    expect(buildSafePolygon(anchor, rect(0, -120, 100, 50), 'top')).toEqual([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: -70 },
+      { x: 0, y: -70 },
+    ]);
+  });
+});

--- a/packages/ui/src/__tests__/tooltip-popup.test.tsx
+++ b/packages/ui/src/__tests__/tooltip-popup.test.tsx
@@ -39,7 +39,7 @@ describe('Tooltip Positioner + Popup', () => {
     const { getByText, getByRole, queryByRole } = render(<Example />);
     fireEvent.focus(getByText('Help')); // open
     fireEvent.pointerLeave(getByText('Help'), { pointerType: 'mouse' });
-    // Before the close timer fires, hovering the popup cancels the close.
+    // Moving onto the popup keeps it open (hoverable); no leave-close timer runs.
     fireEvent.pointerEnter(getByRole('tooltip'), { pointerType: 'mouse' });
     vi.advanceTimersByTime(100);
     expect(queryByRole('tooltip')).not.toBeNull();

--- a/packages/ui/src/__tests__/tooltip-safe-area.test.tsx
+++ b/packages/ui/src/__tests__/tooltip-safe-area.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import {
+  TooltipRoot,
+  TooltipTrigger,
+  TooltipPositioner,
+  TooltipPopup,
+} from '../tooltip/tooltip.js';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+function rect(
+  left: number,
+  top: number,
+  width: number,
+  height: number
+): DOMRect {
+  return {
+    x: left,
+    y: top,
+    width,
+    height,
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  };
+}
+
+function Example() {
+  return (
+    <TooltipRoot delay={100} closeDelay={300}>
+      <TooltipTrigger>Help</TooltipTrigger>
+      <TooltipPositioner>
+        <TooltipPopup>More info</TooltipPopup>
+      </TooltipPositioner>
+    </TooltipRoot>
+  );
+}
+
+// Open via hover, stub the trigger + positioner rects, and engage the session.
+function openAndStub() {
+  const utils = render(<Example />);
+  fireEvent.pointerEnter(utils.getByText('Help'), { pointerType: 'mouse' });
+  act(() => vi.advanceTimersByTime(100)); // open after delay
+  const popup = utils.getByRole('tooltip');
+  const positioner = popup.parentElement;
+  if (!positioner) throw new Error('positioner not found');
+  utils.getByText('Help').getBoundingClientRect = () => rect(0, 0, 100, 50);
+  positioner.getBoundingClientRect = () => rect(200, 0, 100, 150);
+  // Pointer seen over the trigger -> session engaged.
+  fireEvent.pointerMove(document, {
+    clientX: 50,
+    clientY: 25,
+    pointerType: 'mouse',
+  });
+  return utils;
+}
+
+const move = (clientX: number, clientY: number) =>
+  fireEvent.pointerMove(document, { clientX, clientY, pointerType: 'mouse' });
+
+describe('Tooltip safe area', () => {
+  it('stays open while the pointer travels the corridor toward the popup', () => {
+    const { queryByRole } = openAndStub();
+    move(150, 25); // inside the corridor
+    expect(queryByRole('tooltip')).not.toBeNull();
+  });
+
+  it('closes when the pointer leaves the corridor (away from the popup)', () => {
+    const { queryByRole } = openAndStub();
+    move(150, 130); // gap, below the corridor
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+
+  it('keeps it open after the pointer reaches the popup', () => {
+    const { queryByRole } = openAndStub();
+    move(150, 25); // arm grace in the corridor
+    move(250, 75); // reach the popup -> clears grace
+    act(() => vi.advanceTimersByTime(300));
+    expect(queryByRole('tooltip')).not.toBeNull();
+  });
+
+  it('closes when the grace period expires mid-corridor', () => {
+    const { queryByRole } = openAndStub();
+    move(150, 25); // dawdle in the corridor
+    expect(queryByRole('tooltip')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(300));
+    expect(queryByRole('tooltip')).toBeNull();
+  });
+});

--- a/packages/ui/src/__tests__/tooltip-trigger.test.tsx
+++ b/packages/ui/src/__tests__/tooltip-trigger.test.tsx
@@ -42,13 +42,21 @@ describe('Tooltip Trigger', () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it('closes after closeDelay on pointer leave', () => {
+  it('cancels a pending open when the pointer leaves before the delay', () => {
     const onOpenChange = vi.fn();
     const { getByText } = render(<Harness onOpenChange={onOpenChange} />);
-    fireEvent.focus(getByText('Hover me')); // open immediately
-    onOpenChange.mockClear();
+    fireEvent.pointerEnter(getByText('Hover me'), { pointerType: 'mouse' });
     fireEvent.pointerLeave(getByText('Hover me'), { pointerType: 'mouse' });
-    vi.advanceTimersByTime(100);
+    vi.advanceTimersByTime(1000);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('closes on blur', () => {
+    const onOpenChange = vi.fn();
+    const { getByText } = render(<Harness onOpenChange={onOpenChange} />);
+    fireEvent.focus(getByText('Hover me'));
+    onOpenChange.mockClear();
+    fireEvent.blur(getByText('Hover me'));
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/ui/src/__tests__/use-safe-area.test.tsx
+++ b/packages/ui/src/__tests__/use-safe-area.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { useSafeArea } from '../use-safe-area.js';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+function rect(
+  left: number,
+  top: number,
+  width: number,
+  height: number
+): DOMRect {
+  return {
+    x: left,
+    y: top,
+    width,
+    height,
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  };
+}
+
+function Harness({
+  enabled,
+  onClose,
+  graceMs,
+}: {
+  enabled: boolean;
+  onClose: () => void;
+  graceMs?: number;
+}) {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+  useSafeArea({ enabled, anchorRef, floatingRef, onClose, graceMs });
+  return (
+    <div>
+      <div ref={anchorRef}>anchor</div>
+      <div ref={floatingRef}>floating</div>
+    </div>
+  );
+}
+
+function stub(getByText: (t: string) => HTMLElement) {
+  getByText('anchor').getBoundingClientRect = () => rect(0, 0, 100, 50);
+  getByText('floating').getBoundingClientRect = () => rect(200, 0, 100, 150);
+}
+
+const move = (clientX: number, clientY: number) =>
+  fireEvent.pointerMove(document, { clientX, clientY, pointerType: 'mouse' });
+
+describe('useSafeArea', () => {
+  it('does not close before the pointer has touched a reference (engaged gate)', () => {
+    const onClose = vi.fn();
+    const { getByText } = render(
+      <Harness enabled onClose={onClose} graceMs={300} />
+    );
+    stub(getByText);
+    move(150, 130); // gap, outside corridor, but no reference hit yet
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes immediately when the pointer leaves the corridor', () => {
+    const onClose = vi.fn();
+    const { getByText } = render(
+      <Harness enabled onClose={onClose} graceMs={300} />
+    );
+    stub(getByText);
+    move(50, 25); // over the anchor -> engaged
+    move(150, 130); // gap, outside corridor
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays open inside the corridor, then closes on grace expiry', () => {
+    const onClose = vi.fn();
+    const { getByText } = render(
+      <Harness enabled onClose={onClose} graceMs={300} />
+    );
+    stub(getByText);
+    move(50, 25); // engaged
+    move(150, 25); // inside corridor -> arms grace
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(300));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-arm the grace timer on continued movement in the corridor', () => {
+    const onClose = vi.fn();
+    const { getByText } = render(
+      <Harness enabled onClose={onClose} graceMs={300} />
+    );
+    stub(getByText);
+    move(50, 25); // engaged
+    move(150, 25); // inside corridor -> arms grace at t=0
+    act(() => vi.advanceTimersByTime(200)); // t=200, still pending
+    move(150, 30); // still inside; must NOT reset the deadline
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(100)); // t=300 from arm -> fires
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the grace timer when the pointer reaches the floating element', () => {
+    const onClose = vi.fn();
+    const { getByText } = render(
+      <Harness enabled onClose={onClose} graceMs={300} />
+    );
+    stub(getByText);
+    move(50, 25); // engaged
+    move(150, 25); // inside corridor -> arms grace
+    move(250, 75); // over the floating element -> clears grace
+    act(() => vi.advanceTimersByTime(300));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores touch pointers', () => {
+    const onClose = vi.fn();
+    const { getByText } = render(
+      <Harness enabled onClose={onClose} graceMs={300} />
+    );
+    stub(getByText);
+    fireEvent.pointerMove(document, {
+      clientX: 50,
+      clientY: 25,
+      pointerType: 'touch',
+    });
+    fireEvent.pointerMove(document, {
+      clientX: 150,
+      clientY: 130,
+      pointerType: 'touch',
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('stops listening once disabled', () => {
+    const onClose = vi.fn();
+    const { getByText, rerender } = render(
+      <Harness enabled onClose={onClose} graceMs={300} />
+    );
+    stub(getByText);
+    move(50, 25); // engaged
+    rerender(<Harness enabled={false} onClose={onClose} graceMs={300} />);
+    move(150, 130); // would close if still listening
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,6 +18,7 @@ export {
   useFocusReturn,
   type UseFocusReturnOptions,
 } from './use-focus-return.js';
+export { useSafeArea, type UseSafeAreaOptions } from './use-safe-area.js';
 export {
   Dialog,
   DialogRoot,

--- a/packages/ui/src/safe-area.ts
+++ b/packages/ui/src/safe-area.ts
@@ -1,0 +1,90 @@
+// packages/ui/src/safe-area.ts
+//
+// Pure geometry for the pointer "safe area" (a quad spanning the gap from a
+// trigger's near edge to a floating element's near edge). No DOM, no Preact.
+import type { Side } from './use-position.js';
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+// Inclusive rectangle containment.
+export function pointInRect(point: Point, rect: DOMRect): boolean {
+  return (
+    point.x >= rect.left &&
+    point.x <= rect.right &&
+    point.y >= rect.top &&
+    point.y <= rect.bottom
+  );
+}
+
+// Even-odd ray cast. Winding order does not matter; the polygon must be simple.
+export function pointInPolygon(point: Point, polygon: Point[]): boolean {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const yi = polygon[i].y;
+    const xj = polygon[j].x;
+    const yj = polygon[j].y;
+    const intersects =
+      yi > point.y !== yj > point.y &&
+      point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+// Which side of the anchor the floating element sits on, from the dominant axis
+// of center separation. Derived live so a usePosition flip is honored. An exact
+// diagonal tie (|dx| === |dy|) resolves to the horizontal axis.
+export function sideFromRects(anchor: DOMRect, floating: DOMRect): Side {
+  const dx =
+    (floating.left + floating.right) / 2 - (anchor.left + anchor.right) / 2;
+  const dy =
+    (floating.top + floating.bottom) / 2 - (anchor.top + anchor.bottom) / 2;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0 ? 'right' : 'left';
+  }
+  return dy >= 0 ? 'bottom' : 'top';
+}
+
+// The safe quad: the anchor's near edge joined to the floating element's near
+// edge. `side` selects which edges are "near". Points are returned in boundary
+// order so the quad is simple (non-self-intersecting).
+export function buildSafePolygon(
+  anchor: DOMRect,
+  floating: DOMRect,
+  side: Side
+): Point[] {
+  switch (side) {
+    case 'right':
+      return [
+        { x: anchor.right, y: anchor.top },
+        { x: floating.left, y: floating.top },
+        { x: floating.left, y: floating.bottom },
+        { x: anchor.right, y: anchor.bottom },
+      ];
+    case 'left':
+      return [
+        { x: anchor.left, y: anchor.top },
+        { x: floating.right, y: floating.top },
+        { x: floating.right, y: floating.bottom },
+        { x: anchor.left, y: anchor.bottom },
+      ];
+    case 'bottom':
+      return [
+        { x: anchor.left, y: anchor.bottom },
+        { x: anchor.right, y: anchor.bottom },
+        { x: floating.right, y: floating.top },
+        { x: floating.left, y: floating.top },
+      ];
+    case 'top':
+      return [
+        { x: anchor.left, y: anchor.top },
+        { x: anchor.right, y: anchor.top },
+        { x: floating.right, y: floating.bottom },
+        { x: floating.left, y: floating.bottom },
+      ];
+  }
+}

--- a/packages/ui/src/tooltip/context.ts
+++ b/packages/ui/src/tooltip/context.ts
@@ -8,7 +8,6 @@ export interface TooltipContextValue {
   // open/close go through delayed schedulers; `immediate` skips the timers
   // (used by focus/blur and Escape).
   scheduleOpen: () => void;
-  scheduleClose: () => void;
   setOpenImmediate: (open: boolean) => void;
   cancelPending: () => void;
   anchorRef: RefObject<HTMLElement>;
@@ -18,6 +17,7 @@ export interface TooltipContextValue {
   side: Side;
   align: Align;
   offset: number;
+  closeDelay: number; // grace window for the safe corridor
   position: PositionState;
   setPosition: (p: PositionState) => void;
 }

--- a/packages/ui/src/tooltip/tooltip.tsx
+++ b/packages/ui/src/tooltip/tooltip.tsx
@@ -18,6 +18,7 @@ import {
   type PositionState,
 } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
+import { useSafeArea } from '../use-safe-area.js';
 import { TooltipContext, useTooltipContext } from './context.js';
 
 export interface TooltipRootProps {
@@ -25,7 +26,7 @@ export interface TooltipRootProps {
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   delay?: number; // open delay (ms), default 600
-  closeDelay?: number; // close delay (ms), default 300
+  closeDelay?: number; // safe-corridor grace window (ms), default 300
   side?: Side; // default 'top'
   align?: Align; // default 'center'
   offset?: number; // default 8
@@ -74,10 +75,6 @@ export function TooltipRoot(props: TooltipRootProps) {
     cancelPending();
     timer.current = setTimeout(() => setOpen(true), delay);
   }, [cancelPending, setOpen, delay]);
-  const scheduleClose = useCallback(() => {
-    cancelPending();
-    timer.current = setTimeout(() => setOpen(false), closeDelay);
-  }, [cancelPending, setOpen, closeDelay]);
 
   // Clear any pending open/close timer if the Root unmounts mid-delay, so the
   // timer cannot fire setOpen after unmount.
@@ -94,7 +91,6 @@ export function TooltipRoot(props: TooltipRootProps) {
     () => ({
       open,
       scheduleOpen,
-      scheduleClose,
       setOpenImmediate,
       cancelPending,
       anchorRef,
@@ -104,19 +100,20 @@ export function TooltipRoot(props: TooltipRootProps) {
       side,
       align,
       offset,
+      closeDelay,
       position,
       setPosition,
     }),
     [
       open,
       scheduleOpen,
-      scheduleClose,
       setOpenImmediate,
       cancelPending,
       popupId,
       side,
       align,
       offset,
+      closeDelay,
       position,
     ]
   );
@@ -154,7 +151,9 @@ export function TooltipTrigger(props: TooltipTriggerProps): VNode {
   ) => {
     onPointerLeave?.(event);
     if (event.pointerType === 'touch') return;
-    ctx.scheduleClose();
+    // Cancel a pending open if the pointer leaves before the open delay fires.
+    // While open, the safe corridor (useSafeArea in Popup) governs the close.
+    ctx.cancelPending();
   };
   const handleFocus = (event: JSX.TargetedFocusEvent<HTMLButtonElement>) => {
     onFocus?.(event);
@@ -272,8 +271,19 @@ export function TooltipPopup(props: TooltipPopupProps): VNode {
     onDismiss: () => ctx.setOpenImmediate(false),
   });
 
-  // Hoverable (WCAG 1.4.13): moving onto the popup keeps it open; leaving it
-  // re-schedules the close.
+  // While open, keep the tooltip open as the pointer travels the safe corridor
+  // from the trigger toward the popup; close once it leaves the corridor or the
+  // grace period elapses.
+  useSafeArea({
+    enabled: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    onClose: () => ctx.setOpenImmediate(false),
+    graceMs: ctx.closeDelay,
+  });
+
+  // Hoverable (WCAG 1.4.13): moving onto the popup keeps it open. The close is
+  // governed by the safe corridor (useSafeArea), not a leave timer.
   const handlePointerEnter = (
     event: JSX.TargetedPointerEvent<HTMLDivElement>
   ) => {
@@ -284,7 +294,6 @@ export function TooltipPopup(props: TooltipPopupProps): VNode {
     event: JSX.TargetedPointerEvent<HTMLDivElement>
   ) => {
     onPointerLeave?.(event);
-    ctx.scheduleClose();
   };
 
   // No ref here: the Positioner holds floatingRef, and the dismiss layer's

--- a/packages/ui/src/use-safe-area.ts
+++ b/packages/ui/src/use-safe-area.ts
@@ -1,0 +1,83 @@
+// packages/ui/src/use-safe-area.ts
+import type { RefObject } from 'preact';
+import { useLayoutEffect, useRef } from 'preact/hooks';
+import {
+  buildSafePolygon,
+  pointInPolygon,
+  pointInRect,
+  sideFromRects,
+} from './safe-area.js';
+
+export interface UseSafeAreaOptions {
+  enabled: boolean; // typically the open state of a hover-driven element
+  anchorRef: RefObject<HTMLElement>;
+  floatingRef: RefObject<HTMLElement>;
+  onClose: () => void; // intent abandoned, or grace expired
+  graceMs?: number; // default 300
+}
+
+export function useSafeArea(opts: UseSafeAreaOptions): void {
+  const { enabled, anchorRef, floatingRef, onClose, graceMs = 300 } = opts;
+
+  // Forward to the latest onClose without re-subscribing the listener.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // anchorRef/floatingRef are stable RefObjects; depend only on the values that
+  // change the listener's behavior. Matches useDismiss's effect shape.
+  useLayoutEffect(() => {
+    if (!enabled) return;
+    const anchor = anchorRef.current;
+    const floating = floatingRef.current;
+    if (!anchor || !floating) return;
+
+    // Per-session state lives in the effect closure (reset on each open).
+    let engaged = false;
+    let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearGrace = () => {
+      if (graceTimer != null) {
+        clearTimeout(graceTimer);
+        graceTimer = null;
+      }
+    };
+
+    const close = () => {
+      clearGrace();
+      onCloseRef.current();
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (event.pointerType === 'touch') return;
+      const point = { x: event.clientX, y: event.clientY };
+      const anchorRect = anchor.getBoundingClientRect();
+      const floatingRect = floating.getBoundingClientRect();
+
+      // 1. Over a reference element: safely parked, stay open.
+      if (pointInRect(point, anchorRect) || pointInRect(point, floatingRect)) {
+        engaged = true;
+        clearGrace();
+        return;
+      }
+
+      // 2. No hover session yet (e.g. opened by keyboard focus): ignore, so a
+      //    stray mouse move never closes a focus-opened element.
+      if (!engaged) return;
+
+      // 3. In the gap: honor the corridor toward the floating element.
+      const side = sideFromRects(anchorRect, floatingRect);
+      const polygon = buildSafePolygon(anchorRect, floatingRect, side);
+      if (pointInPolygon(point, polygon)) {
+        if (graceTimer == null) graceTimer = setTimeout(close, graceMs);
+        return;
+      }
+      close();
+    };
+
+    document.addEventListener('pointermove', onPointerMove);
+    return () => {
+      clearGrace();
+      document.removeEventListener('pointermove', onPointerMove);
+    };
+  }, [enabled, graceMs]);
+}


### PR DESCRIPTION
## Summary

Adds a generic **`useSafeArea`** pointer-grace primitive to `@hono-preact/ui` and rewires `Tooltip` to use it as the sole hover-close authority.

- **`safe-area.ts`** (internal, pure geometry, no DOM/Preact): `pointInRect`, `pointInPolygon` (even-odd ray cast), `sideFromRects`, `buildSafePolygon` (a quad joining the trigger's near edge to the floating element's near edge).
- **`useSafeArea`** hook (public): owns one `document` `pointermove` listener + a grace timer inside an `enabled`-guarded `useLayoutEffect`, mirroring `useDismiss`. While the pointer travels the safe corridor toward the floating element it stays open; leaving the corridor closes immediately, dwelling past `graceMs` (default 300) closes on expiry. No injected DOM, so nothing under the corridor is blocked. An `engaged` gate means a focus-opened element is never closed by stray mouse movement; touch pointers are ignored.
- **Tooltip rewire**: `closeDelay` now feeds `graceMs`; the old `scheduleClose` timer is removed entirely; the trigger's leave handler cancels a pending open; `TooltipPopup` mounts `useSafeArea`. All prior behaviors preserved (open-on-hover-delay, focus/blur, Escape via `useDismiss`, touch suppression, hoverable popup) — verified for replacement parity.
- **Docs**: new Foundations page `use-safe-area.mdx` (normalized template) + reciprocal cross-link in `use-dismiss.mdx`; `tooltip.mdx` reworded to describe the corridor/grace (no stale timer-close prose).

Design decisions are recorded in `docs/superpowers/specs/2026-06-04-safe-area-design.md`; the implementation plan in `docs/superpowers/plans/2026-06-04-safe-area.md`.

## Test Plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test:coverage` (1048 tests pass; +26 new: geometry, hook, Tooltip corridor)
- [x] `pnpm test:integration`
- [x] `pnpm --filter site build`
- [ ] Manual: hover a tooltip, move diagonally toward the popup across the gap — it stays open; move away — it closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)