### PR TITLE
feat(ui): Select (listbox, Phase 4)

### DIFF
--- a/apps/site/src/components/docs/SelectDemo.tsx
+++ b/apps/site/src/components/docs/SelectDemo.tsx
@@ -1,0 +1,46 @@
+import { Select } from '@hono-preact/ui';
+import { useState } from 'preact/hooks';
+
+// A single-select listbox showing the common parts: a trigger with a
+// placeholder Value, plain options, one disabled option, and a labelled
+// option group. Styling is in root.css (.docs-select* / .docs-select-trigger).
+export function SelectDemo() {
+  const [value, setValue] = useState('');
+  return (
+    <Select.Root
+      value={value}
+      onValueChange={(v) => setValue(Array.isArray(v) ? (v[0] ?? '') : v)}
+    >
+      <Select.Trigger class="docs-select-trigger">
+        <Select.Value class="docs-select__value" placeholder="Pick a fruit" />
+        <span class="docs-select__chevron" aria-hidden="true">
+          ▾
+        </span>
+      </Select.Trigger>
+      <Select.Positioner class="docs-select-positioner">
+        <Select.Popup class="docs-select" aria-label="Fruit">
+          <Select.Option class="docs-select__option" value="apple">
+            Apple
+          </Select.Option>
+          <Select.Option class="docs-select__option" value="banana">
+            Banana
+          </Select.Option>
+          <Select.Option class="docs-select__option" value="cherry" disabled>
+            Cherry (out of season)
+          </Select.Option>
+          <Select.OptionGroup class="docs-select__group">
+            <Select.OptionGroupLabel class="docs-select__label">
+              Citrus
+            </Select.OptionGroupLabel>
+            <Select.Option class="docs-select__option" value="orange">
+              Orange
+            </Select.Option>
+            <Select.Option class="docs-select__option" value="lemon">
+              Lemon
+            </Select.Option>
+          </Select.OptionGroup>
+        </Select.Popup>
+      </Select.Positioner>
+    </Select.Root>
+  );
+}

--- a/apps/site/src/components/docs/SelectMultiDemo.tsx
+++ b/apps/site/src/components/docs/SelectMultiDemo.tsx
@@ -1,0 +1,38 @@
+import { Select } from '@hono-preact/ui';
+import { useState } from 'preact/hooks';
+
+// A multiple-select listbox. Picking an option toggles it and keeps the popup
+// open; the Value joins the selected labels. Styling is in root.css.
+export function SelectMultiDemo() {
+  const [value, setValue] = useState<string[]>([]);
+  return (
+    <Select.Root
+      multiple
+      value={value}
+      onValueChange={(v) => setValue(Array.isArray(v) ? v : [v])}
+    >
+      <Select.Trigger class="docs-select-trigger">
+        <Select.Value class="docs-select__value" placeholder="Pick toppings" />
+        <span class="docs-select__chevron" aria-hidden="true">
+          ▾
+        </span>
+      </Select.Trigger>
+      <Select.Positioner class="docs-select-positioner">
+        <Select.Popup class="docs-select" aria-label="Toppings">
+          <Select.Option class="docs-select__option" value="cheese">
+            Cheese
+          </Select.Option>
+          <Select.Option class="docs-select__option" value="mushroom">
+            Mushroom
+          </Select.Option>
+          <Select.Option class="docs-select__option" value="pepperoni">
+            Pepperoni
+          </Select.Option>
+          <Select.Option class="docs-select__option" value="olive">
+            Olive
+          </Select.Option>
+        </Select.Popup>
+      </Select.Positioner>
+    </Select.Root>
+  );
+}

--- a/apps/site/src/pages/docs/__tests__/nav.test.ts
+++ b/apps/site/src/pages/docs/__tests__/nav.test.ts
@@ -52,7 +52,7 @@ describe('docs nav', () => {
     expect(new Set(routes).size).toBe(routes.length);
   });
 
-  it('lists Popover, Tooltip, Menu, and Context Menu under Overlays', () => {
+  it('lists Popover, Tooltip, Menu, Context Menu, and Select under Overlays', () => {
     const components = nav.find((a) => a.id === 'components')!;
     const overlays = components.sections.find((s) => s.heading === 'Overlays')!;
     const routes = overlays.entries.map((e) => e.route);
@@ -60,9 +60,10 @@ describe('docs nav', () => {
     expect(routes).toContain('/docs/components/tooltip');
     expect(routes).toContain('/docs/components/menu');
     expect(routes).toContain('/docs/components/context-menu');
+    expect(routes).toContain('/docs/components/select');
   });
 
-  it('lists usePosition, useDismiss, and useFocusReturn under Foundations', () => {
+  it('lists usePosition, useDismiss, useFocusReturn, and useListNavigation under Foundations', () => {
     const components = nav.find((a) => a.id === 'components')!;
     const foundations = components.sections.find(
       (s) => s.heading === 'Foundations'
@@ -71,5 +72,6 @@ describe('docs nav', () => {
     expect(routes).toContain('/docs/components/use-position');
     expect(routes).toContain('/docs/components/use-dismiss');
     expect(routes).toContain('/docs/components/use-focus-return');
+    expect(routes).toContain('/docs/components/use-list-navigation');
   });
 });

--- a/apps/site/src/pages/docs/components/select.mdx
+++ b/apps/site/src/pages/docs/components/select.mdx
@@ -1,0 +1,442 @@
+import { Example } from '../../../components/docs/Example.js';
+import { CodeTabs } from '../../../components/docs/CodeTabs.js';
+import { SelectDemo } from '../../../components/docs/SelectDemo.js';
+import { SelectMultiDemo } from '../../../components/docs/SelectMultiDemo.js';
+
+# Select
+
+A custom listbox select: a button that opens a popup of options and writes the
+chosen value back. It supports single and multiple selection, carries a generic
+value type so an option's `value` is your own data rather than a string, and
+submits in a real form through a `name`. Positioning runs on Floating UI; the
+popup renders in place and promotes to the browser top layer where the Popover
+API is available. It ships unstyled: style it through the `data-state`,
+`data-highlighted`, `data-selected`, `data-disabled`, `data-placeholder`,
+`data-side`, and `data-align` contract.
+
+`Select.Value` shows the selected option's label by reading the registered
+options client-side, so on the server (before hydration) it falls back to the
+placeholder. For a label that is correct in server-rendered HTML, pass
+`Select.Value` a render prop (or a children function) and resolve the label from
+your own data, which runs on the server too.
+
+## Demo
+
+A single select closes when you pick an option; the trigger shows the chosen
+label.
+
+<Example>
+  <SelectDemo />
+</Example>
+
+A multiple select toggles each option and stays open; the trigger joins the
+selected labels.
+
+<Example>
+  <SelectMultiDemo />
+</Example>
+
+## Usage
+
+```tsx
+import { Select } from '@hono-preact/ui';
+
+export function FruitPicker() {
+  return (
+    <Select.Root name="fruit">
+      <Select.Trigger>
+        <Select.Value placeholder="Pick a fruit" />
+      </Select.Trigger>
+      <Select.Positioner>
+        <Select.Popup aria-label="Fruit">
+          <Select.Option value="apple">Apple</Select.Option>
+          <Select.Option value="banana">Banana</Select.Option>
+          <Select.Option value="cherry" disabled>
+            Cherry
+          </Select.Option>
+          <Select.OptionGroup>
+            <Select.OptionGroupLabel>Citrus</Select.OptionGroupLabel>
+            <Select.Option value="orange">Orange</Select.Option>
+            <Select.Option value="lemon">Lemon</Select.Option>
+          </Select.OptionGroup>
+        </Select.Popup>
+      </Select.Positioner>
+    </Select.Root>
+  );
+}
+```
+
+Set `multiple` on `Select.Root` for multi-selection: picking an option toggles
+it and keeps the popup open, and the value becomes an array. Pass a `value` /
+`onValueChange` pair to control the selection, or `defaultValue` to leave it
+uncontrolled. When `name` is set, the value submits as a hidden field (one
+field per selected value in multiple mode), present before hydration.
+
+The value type is generic. By default an option's `value` is a string, but you
+can pass objects: give `Select.Root` an `isValueEqual` comparator so the
+component can match selected values by identity, and a `serializeValue` so the
+hidden form field has a string to submit.
+
+```tsx
+<Select.Root<User>
+  isValueEqual={(a, b) => a.id === b.id}
+  serializeValue={(u) => u.id}
+  name="assignee"
+>
+  <Select.Trigger>
+    <Select.Value placeholder="Assign to">
+      {({ selectedLabels }) => selectedLabels.join(', ') || 'Assign to'}
+    </Select.Value>
+  </Select.Trigger>
+  {/* ... */}
+</Select.Root>
+```
+
+## Styling
+
+Parts expose `data-state` (`open` / `closed` on the trigger, positioner, and
+popup). Options expose `data-highlighted` while active, `data-selected` when
+selected, and `data-disabled` when disabled; `Select.Value` exposes
+`data-placeholder` while empty; the Positioner and Arrow expose `data-side` and
+`data-align`. The Positioner is the fixed-positioned wrapper, so size, z-index,
+and the entry animation go on the Popup inside it. The demo above uses the
+styles below; copy a starting point in either flavor:
+
+<CodeTabs labels={['CSS', 'Tailwind']}>
+
+```css
+.docs-select-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 14rem;
+  font-size: 0.875rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e4e4e7;
+  border-radius: 0.5rem;
+  background: #fff;
+  color: #18181b;
+  cursor: pointer;
+}
+.docs-select-trigger:hover,
+.docs-select-trigger[data-state='open'] {
+  border-color: #18181b;
+}
+.docs-select__value[data-placeholder] {
+  color: #71717a;
+}
+.docs-select-positioner {
+  z-index: 50;
+}
+.docs-select {
+  box-sizing: border-box;
+  min-width: 14rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.25rem;
+  border: 1px solid #e4e4e7;
+  border-radius: 0.625rem;
+  background: #fff;
+  color: #18181b;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.25),
+    0 4px 6px -4px rgb(0 0 0 / 0.25);
+  outline: none;
+}
+.docs-select[data-state='open'] {
+  animation: docs-select-in 120ms ease-out;
+}
+@keyframes docs-select-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+/* Options: the active descendant is data-highlighted (set by hover and arrow
+   keys); the selected option is data-selected. Both can be true at once. */
+.docs-select__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  outline: none;
+}
+.docs-select__option[data-selected]::after {
+  content: '✓';
+  margin-left: auto;
+}
+.docs-select__option[data-highlighted] {
+  background: #18181b;
+  color: #fafafa;
+}
+.docs-select__option[data-disabled] {
+  color: #a1a1aa;
+  pointer-events: none;
+}
+.docs-select__label {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #71717a;
+}
+@media (prefers-color-scheme: dark) {
+  .docs-select-trigger,
+  .docs-select {
+    border-color: #27272a;
+    background: #18181b;
+    color: #fafafa;
+  }
+  .docs-select-trigger:hover,
+  .docs-select-trigger[data-state='open'] {
+    border-color: #fafafa;
+  }
+  .docs-select__option[data-highlighted] {
+    background: #fafafa;
+    color: #18181b;
+  }
+}
+```
+
+```tsx
+<Select.Trigger className="flex min-w-56 items-center justify-between gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 cursor-pointer hover:border-zinc-900 data-[state=open]:border-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:border-zinc-50 dark:data-[state=open]:border-zinc-50">
+  <Select.Value
+    className="data-[placeholder]:text-zinc-500"
+    placeholder="Pick a fruit"
+  />
+</Select.Trigger>
+<Select.Positioner className="z-50">
+  <Select.Popup className="min-w-56 max-h-64 overflow-y-auto rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
+    <Select.Option className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none cursor-pointer data-[selected]:after:content-['✓'] data-[selected]:after:ml-auto data-[highlighted]:bg-zinc-900 data-[highlighted]:text-zinc-50 data-[disabled]:pointer-events-none data-[disabled]:text-zinc-400 dark:data-[highlighted]:bg-zinc-50 dark:data-[highlighted]:text-zinc-900">
+      Apple
+    </Select.Option>
+    <Select.OptionGroupLabel className="px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+      Citrus
+    </Select.OptionGroupLabel>
+  </Select.Popup>
+</Select.Positioner>
+```
+
+</CodeTabs>
+
+## Keyboard
+
+| Keys                   | When                    | Action                                                                      |
+| ---------------------- | ----------------------- | --------------------------------------------------------------------------- |
+| `Enter` / `Space`      | Trigger, closed         | Open the listbox.                                                           |
+| `↓` / `↑`              | Trigger, closed         | Open the listbox.                                                           |
+| `Alt` + `↓`            | Trigger, closed         | Open the listbox.                                                           |
+| `↓` / `↑`              | Listbox open            | Move the active option to the next / previous, wrapping at the ends.        |
+| `Home` / `End`         | Listbox open            | Move the active option to the first / last.                                 |
+| _printable characters_ | Listbox open            | Typeahead: activate the next option whose label starts with the typed text. |
+| `Enter` / `Space`      | Listbox open (single)   | Select the active option and close.                                         |
+| `Enter` / `Space`      | Listbox open (multiple) | Toggle the active option and stay open.                                     |
+| `Escape`               | Listbox open            | Close without changing the selection; focus stays on the trigger.           |
+| `Tab`                  | Listbox open            | Close, then move focus to the next element.                                 |
+
+Focus stays on the trigger the whole time; navigation moves the active option
+via `aria-activedescendant` rather than moving DOM focus. Disabled options are
+skipped by arrow keys and typeahead. Set `loop={false}` on `Select.Root` to stop
+arrow navigation from wrapping, and `typeahead={false}` to disable
+type-to-activate.
+
+## Data attributes
+
+| Attribute          | On                         | Values                                            |
+| ------------------ | -------------------------- | ------------------------------------------------- |
+| `data-state`       | Trigger, Positioner, Popup | `open` \| `closed`                                |
+| `data-highlighted` | Option                     | present while the option is the active descendant |
+| `data-selected`    | Option                     | present when the option is selected               |
+| `data-disabled`    | Option                     | present when the option is disabled               |
+| `data-placeholder` | Value                      | present while no option is selected               |
+| `data-side`        | Positioner, Arrow          | `top` \| `right` \| `bottom` \| `left` (resolved) |
+| `data-align`       | Positioner                 | `start` \| `center` \| `end` (resolved)           |
+
+The selected option also carries `aria-selected="true"`, so you can style the
+selection with either the data attribute or the ARIA state.
+
+## API reference
+
+Every part accepts a `render` prop for composition (see
+[useRender](/docs/components/use-render)) and forwards unknown props to the
+element it renders. `Select.Option` passes its
+`{ selected, disabled, highlighted }` state to a render function; `Select.Value`
+passes `{ selectedLabels }`.
+
+### Select.Root
+
+Provides selection and open state, ids, refs, navigation config, and placement
+to the parts. Generic over the value type (`Select.Root<Value>`); defaults to
+`string`. Renders its children plus the hidden form field(s) when `name` is set.
+
+| Prop             | Type                                | Default     | Description                                                                 |
+| ---------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------- |
+| `value`          | `Value \| Value[]`                  | -           | Controlled selection. Pair with `onValueChange`. An array in multiple mode. |
+| `defaultValue`   | `Value \| Value[]`                  | -           | Initial selection when uncontrolled.                                        |
+| `onValueChange`  | `(value: Value \| Value[]) => void` | -           | Called when the selection changes.                                          |
+| `multiple`       | `boolean`                           | `false`     | Allow more than one selection; the value becomes an array.                  |
+| `open`           | `boolean`                           | -           | Controlled open state. Pair with `onOpenChange`.                            |
+| `defaultOpen`    | `boolean`                           | `false`     | Initial open state when uncontrolled.                                       |
+| `onOpenChange`   | `(open: boolean) => void`           | -           | Called when the listbox requests an open or close.                          |
+| `name`           | `string`                            | -           | Submit the value as a hidden field (one per value in multiple mode).        |
+| `disabled`       | `boolean`                           | `false`     | Disable the trigger and skip the hidden field.                              |
+| `required`       | `boolean`                           | `false`     | Mark the trigger `aria-required`.                                           |
+| `isValueEqual`   | `(a: Value, b: Value) => boolean`   | `Object.is` | Compare values for selection matching (use for object values).              |
+| `serializeValue` | `(value: Value) => string`          | `String`    | Stringify a value for the hidden form field.                                |
+| `side`           | `'top'\|'right'\|'bottom'\|'left'`  | `'bottom'`  | Preferred side of the trigger to place the popup.                           |
+| `align`          | `'start'\|'center'\|'end'`          | `'start'`   | Alignment along that side.                                                  |
+| `offset`         | `number`                            | `8`         | Gap in pixels between the trigger and the popup.                            |
+| `loop`           | `boolean`                           | `true`      | Wrap arrow navigation at the first / last option.                           |
+| `typeahead`      | `boolean`                           | `true`      | Activate options by typing their leading characters.                        |
+| `children`       | `ComponentChildren`                 | -           | The trigger and positioner.                                                 |
+
+### Select.Trigger
+
+Toggles the listbox on click and anchors it. Owns the keyboard navigation and
+typeahead while open (focus stays on it). Default element
+`<button type="button">` with `role="combobox"`.
+
+| Prop       | Type                                    | Default | Description                                                                   |
+| ---------- | --------------------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `render`   | `RenderProp<{ open: boolean }>`         | -       | Compose or replace the element.                                               |
+| `children` | `ComponentChildren`                     | -       | Usually a `Select.Value` and an indicator.                                    |
+| `...props` | `JSX.HTMLAttributes<HTMLButtonElement>` | -       | Forwarded to the element; a passed `onClick` runs before the listbox toggles. |
+
+Sets `role="combobox"`, `aria-haspopup="listbox"`, `aria-expanded`,
+`aria-controls`, `aria-activedescendant` (while open), `aria-required` (when
+required), `id`, and `data-state`.
+
+### Select.Value
+
+Shows the selected option's label, or the placeholder while empty. Reads the
+registered option labels client-side, so server-rendered HTML shows the
+placeholder unless you supply a children / render function. Default element
+`<span>`.
+
+| Prop          | Type                                                         | Default | Description                                                    |
+| ------------- | ------------------------------------------------------------ | ------- | -------------------------------------------------------------- |
+| `placeholder` | `string`                                                     | `''`    | Text shown while nothing is selected.                          |
+| `render`      | `RenderProp<{ selectedLabels: string[] }>`                   | -       | Compose or replace the element.                                |
+| `children`    | `(state: { selectedLabels: string[] }) => ComponentChildren` | -       | Render the display from the selected labels (server-accurate). |
+| `...props`    | `JSX.HTMLAttributes<HTMLSpanElement>`                        | -       | Forwarded to the element.                                      |
+
+Sets `data-placeholder` while no option is selected.
+
+### Select.Positioner
+
+The fixed-positioned wrapper that Floating UI drives. Always mounted (so options
+register their labels) and `hidden` while closed. Default element `<div>`.
+
+| Prop       | Type                                       | Default | Description                                              |
+| ---------- | ------------------------------------------ | ------- | -------------------------------------------------------- |
+| `render`   | `RenderProp<{ side: Side; align: Align }>` | -       | Compose or replace the element.                          |
+| `children` | `ComponentChildren`                        | -       | The popup (and optional arrow).                          |
+| `...props` | `JSX.HTMLAttributes<HTMLDivElement>`       | -       | Forwarded to the element. Style positioning via `class`. |
+
+Sets `position: fixed`, the resolved `data-side` / `data-align`, and `hidden`
+while closed. Where the browser supports the Popover API, the element is promoted
+to the top layer so it escapes ancestor clipping.
+
+### Select.Popup
+
+The listbox surface. Default element `<div>` with `role="listbox"`.
+
+| Prop         | Type                                 | Default | Description                                       |
+| ------------ | ------------------------------------ | ------- | ------------------------------------------------- |
+| `render`     | `RenderProp<{ open: boolean }>`      | -       | Compose or replace the element.                   |
+| `aria-label` | `string`                             | -       | Accessible name. Defaults to the trigger's label. |
+| `children`   | `ComponentChildren`                  | -       | Options and option groups.                        |
+| `...props`   | `JSX.HTMLAttributes<HTMLDivElement>` | -       | Forwarded to the element.                         |
+
+Sets `role="listbox"`, `id`, `aria-multiselectable` (in multiple mode),
+`data-state`, and `aria-labelledby` (the trigger) or `aria-label`. Owns
+Escape / outside-press dismissal.
+
+### Select.Option
+
+A selectable row. Default element `<div>` with `role="option"`.
+
+| Prop       | Type                                                                         | Default  | Description                                         |
+| ---------- | ---------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| `value`    | `Value`                                                                      | required | The value this option selects.                      |
+| `render`   | `RenderProp<{ selected: boolean; disabled: boolean; highlighted: boolean }>` | -        | Compose or replace the element.                     |
+| `disabled` | `boolean`                                                                    | `false`  | Skip the option in navigation and ignore selection. |
+| `children` | `ComponentChildren`                                                          | -        | Option content; a string child is its label.        |
+| `...props` | `JSX.HTMLAttributes<HTMLDivElement>`                                         | -        | Forwarded to the element.                           |
+
+Sets `role="option"`, `aria-selected`, `aria-disabled` (when disabled), and
+`data-selected` / `data-highlighted` / `data-disabled`.
+
+### Select.OptionGroup
+
+Wraps related options and labels them with a `Select.OptionGroupLabel`. Default
+element `<div>` with `role="group"`.
+
+| Prop       | Type                                 | Default | Description                              |
+| ---------- | ------------------------------------ | ------- | ---------------------------------------- |
+| `render`   | `RenderProp`                         | -       | Compose or replace it.                   |
+| `children` | `ComponentChildren`                  | -       | A `Select.OptionGroupLabel` and options. |
+| `...props` | `JSX.HTMLAttributes<HTMLDivElement>` | -       | Forwarded to the element.                |
+
+Wires its label to `aria-labelledby`.
+
+### Select.OptionGroupLabel
+
+The accessible name for a `Select.OptionGroup`. Presentational, not selectable.
+Default element `<div>`.
+
+| Prop       | Type                                 | Default | Description               |
+| ---------- | ------------------------------------ | ------- | ------------------------- |
+| `render`   | `RenderProp`                         | -       | Compose or replace it.    |
+| `children` | `ComponentChildren`                  | -       | Label text.               |
+| `...props` | `JSX.HTMLAttributes<HTMLDivElement>` | -       | Forwarded to the element. |
+
+### Select.Arrow
+
+Optional pointer positioned from the Floating UI arrow data. Default element
+`<div>`. Place it on the correct edge with CSS keyed on `data-side`.
+
+| Prop       | Type                                 | Default | Description                     |
+| ---------- | ------------------------------------ | ------- | ------------------------------- |
+| `render`   | `RenderProp<{ side: Side }>`         | -       | Compose or replace the element. |
+| `children` | `ComponentChildren`                  | -       | Optional arrow content.         |
+| `...props` | `JSX.HTMLAttributes<HTMLDivElement>` | -       | Forwarded to the element.       |
+
+Sets `data-side` and `position: absolute` with the computed offset.
+
+### Primitives
+
+`@hono-preact/ui` exports the building blocks the parts use, for composing your
+own components. Several have their own page with examples:
+[useListNavigation](/docs/components/use-list-navigation),
+[usePosition](/docs/components/use-position),
+[useDismiss](/docs/components/use-dismiss),
+[useRender](/docs/components/use-render),
+[useControllableState](/docs/components/use-controllable-state), and
+[mergeRefs](/docs/components/merge-refs).
+
+## Accessibility
+
+The select follows the ARIA combobox-with-listbox pattern. The trigger is a
+`role="combobox"` carrying `aria-haspopup="listbox"`, `aria-expanded`,
+`aria-controls`, and `aria-activedescendant`; the popup is a `role="listbox"`
+(`aria-multiselectable` in multiple mode), named by the trigger or an explicit
+`aria-label`. Options are `role="option"` with `aria-selected`.
+
+- Both Enter / Space and the arrow keys open the listbox from the trigger, so it
+  is reachable without a pointer.
+- Focus stays on the trigger while the listbox is open; the active option is
+  tracked with `aria-activedescendant` rather than moving DOM focus, and the
+  active option is scrolled into view.
+- On open, the active descendant starts on the selected option (or the first
+  option when nothing is selected).
+- Escape closes without changing the selection, an outside pointer press closes
+  it, and Tab closes then moves on. Disabled options are skipped by navigation,
+  typeahead, and selection.
+- Set a `name` so the value submits in a real form; the hidden field is a real
+  input present before hydration.

--- a/apps/site/src/pages/docs/components/use-list-navigation.mdx
+++ b/apps/site/src/pages/docs/components/use-list-navigation.mdx
@@ -1,0 +1,113 @@
+# useListNavigation
+
+`useListNavigation` is the keyboard navigation binding the [Menu](/docs/components/menu)
+and [Select](/docs/components/select) components use. Given a container of items,
+it handles ArrowUp / ArrowDown, Home / End, and typeahead, tracking which item is
+active and moving the active state through the list (wrapping at the ends, skipping
+disabled items).
+
+It supports two modes. In `roving` mode it moves DOM focus to the active item (a
+roving tabindex list, as in a menu). In `activedescendant` mode focus stays on a
+container element and you render `aria-activedescendant` pointing at the active
+item, scrolling it into view rather than focusing it (as in a listbox where the
+trigger keeps focus).
+
+## Signature
+
+```ts
+import { useListNavigation } from '@hono-preact/ui';
+
+function useListNavigation(opts: UseListNavigationOptions): ListNavigation;
+
+interface UseListNavigationOptions {
+  enabled: boolean;
+  containerRef: RefObject<HTMLElement>;
+  itemSelector: string;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  mode: 'roving' | 'activedescendant';
+  loop?: boolean; // default true
+  typeahead?: boolean; // default true
+  scopeSelector?: string;
+}
+
+interface ListNavigation {
+  onKeyDown: (event: KeyboardEvent) => void;
+  getItems: () => HTMLElement[];
+  setActiveItem: (index: number) => void;
+}
+```
+
+## Options
+
+| Option          | Type                             | Default | Notes                                                                           |
+| --------------- | -------------------------------- | ------- | ------------------------------------------------------------------------------- |
+| `enabled`       | `boolean`                        | none    | Handle keys only while active (typically the open state).                       |
+| `containerRef`  | `RefObject<HTMLElement>`         | none    | The element holding the items.                                                  |
+| `itemSelector`  | `string`                         | none    | CSS selector matching the navigable items (exclude disabled items here).        |
+| `activeId`      | `string \| null`                 | none    | The id of the active item; drives `aria-activedescendant`.                      |
+| `setActiveId`   | `(id: string \| null) => void`   | none    | Called to change the active item.                                               |
+| `mode`          | `'roving' \| 'activedescendant'` | none    | `roving` moves DOM focus; `activedescendant` keeps focus and scrolls into view. |
+| `loop`          | `boolean`                        | `true`  | Wrap arrow navigation at the first / last item.                                 |
+| `typeahead`     | `boolean`                        | `true`  | Activate items by typing their leading characters.                              |
+| `scopeSelector` | `string`                         | none    | Exclude items nested in a closer same-role container (a submenu).               |
+
+## Returns
+
+| Field           | Type                             | Description                                                                          |
+| --------------- | -------------------------------- | ------------------------------------------------------------------------------------ |
+| `onKeyDown`     | `(event: KeyboardEvent) => void` | Handle navigation keys; calls `preventDefault` on keys it consumes.                  |
+| `getItems`      | `() => HTMLElement[]`            | The current enabled items, queried live from the DOM in order.                       |
+| `setActiveItem` | `(index: number) => void`        | Activate the item at `index`: sets the active id and focuses or scrolls it per mode. |
+
+`onKeyDown` calls `event.preventDefault()` on the keys it handles, so a caller
+that adds its own keys (Enter to select, Escape to close) can early-return on
+`event.defaultPrevented` after delegating.
+
+## Example
+
+A listbox where the trigger keeps focus and the active option is tracked with
+`aria-activedescendant`:
+
+```tsx
+import { useListNavigation } from '@hono-preact/ui';
+import { useRef, useState } from 'preact/hooks';
+
+function Listbox({ open }: { open: boolean }) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const nav = useListNavigation({
+    enabled: open,
+    containerRef: listRef,
+    itemSelector: '[role="option"]:not([aria-disabled="true"])',
+    activeId,
+    setActiveId,
+    mode: 'activedescendant',
+  });
+  return (
+    <button
+      role="combobox"
+      aria-expanded={open}
+      aria-activedescendant={open ? (activeId ?? undefined) : undefined}
+      onKeyDown={nav.onKeyDown}
+    >
+      <div ref={listRef} role="listbox">
+        {/* role="option" rows */}
+      </div>
+    </button>
+  );
+}
+```
+
+## Companion exports
+
+`@hono-preact/ui` also exports the pieces `useListNavigation` is built from, for
+composing your own navigation:
+
+| Export           | Type                                                                                  | Description                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `useTypeahead`   | `(opts?: UseTypeaheadOptions) => (char: string) => string`                            | A hook returning a callback that accumulates printable chars into a query, resetting after an idle gap. |
+| `wrapNext`       | `(current: number, length: number, loop: boolean) => number`                          | Next index, wrapping or clamping at the end.                                                            |
+| `wrapPrev`       | `(current: number, length: number, loop: boolean) => number`                          | Previous index, wrapping or clamping at the start.                                                      |
+| `matchTypeahead` | `(labels: string[], query: string, fromIndex: number) => number`                      | The next index (circularly) whose label starts with the query, or `-1`.                                 |
+| `getItems`       | `(container: HTMLElement, selector: string, scopeSelector?: string) => HTMLElement[]` | The enabled items in a container in DOM order.                                                          |

--- a/apps/site/src/pages/docs/nav.ts
+++ b/apps/site/src/pages/docs/nav.ts
@@ -124,6 +124,7 @@ export const nav: NavArea[] = [
           { title: 'Tooltip', route: '/docs/components/tooltip' },
           { title: 'Menu', route: '/docs/components/menu' },
           { title: 'Context Menu', route: '/docs/components/context-menu' },
+          { title: 'Select', route: '/docs/components/select' },
         ],
       },
       {
@@ -136,6 +137,10 @@ export const nav: NavArea[] = [
             route: '/docs/components/use-controllable-state',
           },
           { title: 'mergeRefs', route: '/docs/components/merge-refs' },
+          {
+            title: 'useListNavigation',
+            route: '/docs/components/use-list-navigation',
+          },
           { title: 'usePosition', route: '/docs/components/use-position' },
           { title: 'useDismiss', route: '/docs/components/use-dismiss' },
           {

--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -1309,3 +1309,116 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     animation: none;
   }
 }
+
+/* Select docs demos (single + multiple). Mirrors the copyable CSS on
+   /docs/components/select, but uses the site theme tokens so it tracks
+   light/dark. The trigger is a button showing the Value; the popup is a
+   role="listbox" of options with highlighted / selected / disabled states. */
+.docs-select-trigger {
+  appearance: none;
+  font: inherit;
+  font-size: 0.875rem;
+  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 14rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  color: var(--foreground);
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+.docs-select-trigger:hover {
+  border-color: var(--accent);
+}
+.docs-select-trigger:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+.docs-select-trigger[data-state='open'] {
+  border-color: var(--accent);
+}
+.docs-select__value[data-placeholder] {
+  color: var(--muted);
+}
+.docs-select__chevron {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+.docs-select-positioner {
+  z-index: 50;
+}
+.docs-select {
+  box-sizing: border-box;
+  min-width: 14rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.625rem;
+  background: var(--surface);
+  color: var(--foreground);
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.25),
+    0 4px 6px -4px rgb(0 0 0 / 0.25);
+  outline: none;
+}
+.docs-select[data-state='open'] {
+  animation: docs-select-in 120ms ease-out;
+}
+@keyframes docs-select-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+/* Options: the active descendant is data-highlighted (set by hover and arrow
+   keys); the selected option is data-selected. Both can be true at once. */
+.docs-select__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.2;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+}
+.docs-select__option[data-selected]::after {
+  content: '✓';
+  margin-left: auto;
+  font-size: 0.8125rem;
+}
+.docs-select__option[data-highlighted] {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.docs-select__option[data-disabled] {
+  color: var(--muted);
+  cursor: default;
+  pointer-events: none;
+}
+.docs-select__group {
+  padding: 0.15rem 0;
+}
+.docs-select__label {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-select {
+    animation: none;
+  }
+}

--- a/docs/superpowers/plans/2026-06-06-select.md
+++ b/docs/superpowers/plans/2026-06-06-select.md
@@ -1,0 +1,1792 @@
+# Select (listbox, Phase 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the headless `Select` (custom listbox) for `@hono-preact/ui` with single + multiple selection, a generic value type, and HTML form submission; and promote the list-navigation machinery to a public `useListNavigation` primitive (refactoring Menu onto it).
+
+**Architecture:** A new public `useListNavigation` hook unifies movement across roving (Menu) and `aria-activedescendant` (Select) modes; Menu is refactored onto it. Select is a compound component over a generic-value context: a `role="combobox"` trigger that keeps focus and drives `aria-activedescendant`, an always-mounted `role="listbox"` (hidden when closed so the trigger can auto-show the selected label), `role="option"` children that register their label, and hidden native inputs for form submission.
+
+**Tech Stack:** Preact (hooks, no compat), `@floating-ui/dom`, TypeScript, vitest + `@testing-library/preact` (happy-dom). MDX docs in `apps/site`.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-select-design.md`.
+
+**Conventions (read before starting):**
+- Mirror the shipped compound components: `packages/ui/src/menu/menu.tsx`, `popover/popover.tsx`. Every part via `useRender`; `useControllableState` for open/value; `useId` ids in `Root`; `data-state`; Positioner does positioning + Popover-API promotion.
+- No inline `as` casts (project CLAUDE.md). The one unavoidable seam is generic erasure through the module-level context (see Task 4); localize and comment it, and prefer the adapter-wrapper shape shown.
+- No em-dashes in prose/comments/commit messages.
+- Tests run via `pnpm exec vitest run <pattern>` (NOT `pnpm --filter @hono-preact/ui test` — the package has no `test` script). Full UI suite: `pnpm exec vitest run packages/ui`.
+- After each task: run the new test green, then `pnpm exec vitest run packages/ui` (regression), then `pnpm typecheck`, then commit. Verify the branch before every commit. Run `pnpm format` on touched files before committing (the recurring `format:check` miss). Only spec/plan docs go to `main`; implementation runs on a feature branch.
+
+---
+
+## File Structure
+
+**New (package):**
+- `packages/ui/src/list-navigation.ts` — pure helpers (`wrapNext`/`wrapPrev`/`matchTypeahead`/`getItems`) + the `useListNavigation` hook.
+- `packages/ui/src/select/context.ts` — `SelectContext` + `useSelectContext` + `SelectOptionGroupContext`.
+- `packages/ui/src/select/select.tsx` — all `Select.*` parts.
+- `packages/ui/src/select/index.ts` — `Select` namespace + named exports.
+- Test files under `packages/ui/src/__tests__/`.
+
+**Modified (package):**
+- `packages/ui/src/menu/navigation.ts` — re-export the relocated pure helpers (keep `ITEM_SELECTOR` + a menu `getMenuItems` wrapper).
+- `packages/ui/src/menu/menu.tsx` — `MenuPopup` refactored onto `useListNavigation`.
+- `packages/ui/src/index.ts` — export `Select`, `useListNavigation`, `useTypeahead`, the pure helpers.
+
+**Modified (repo):**
+- `scripts/client-size-config.mjs` — add `select`.
+- `apps/site/src/pages/docs/components/select.mdx` + `use-list-navigation.mdx` (Foundations) — new docs.
+- `apps/site/src/pages/docs/nav.ts` (+ nav test) — register the pages.
+
+---
+
+## Task 0: Feature branch
+
+- [ ] **Step 1: Branch off main**
+
+Run:
+```bash
+git checkout -b feat/ui-select
+git log --oneline -1
+```
+Expected: a branch at the spec commit `6eaa828`.
+
+- [ ] **Step 2: Clean baseline**
+
+Run:
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm exec vitest run packages/ui
+```
+Expected: build succeeds; UI suite passes (134 tests).
+
+---
+
+## Task 1: `useListNavigation` primitive + relocate pure helpers
+
+Create the public primitive and move the pure helpers into it. The menu keeps working via a re-export until Task 2.
+
+**Files:**
+- Create: `packages/ui/src/list-navigation.ts`
+- Modify: `packages/ui/src/menu/navigation.ts`
+- Test: `packages/ui/src/__tests__/list-navigation.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { useRef, useState } from 'preact/hooks';
+import {
+  useListNavigation,
+  getItems,
+  wrapNext,
+} from '../list-navigation.js';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe('getItems', () => {
+  it('returns enabled items matching the selector, in DOM order', () => {
+    document.body.innerHTML = `
+      <div id="c">
+        <div role="option" data-x>A</div>
+        <div role="option" data-x aria-disabled="true">B</div>
+        <div role="option" data-x>C</div>
+      </div>`;
+    const c = document.getElementById('c')!;
+    const items = getItems(c, '[data-x]:not([aria-disabled="true"])');
+    expect(items.map((e) => e.textContent)).toEqual(['A', 'C']);
+  });
+});
+
+// A harness exercising both modes against a static option list.
+function Harness({ mode }: { mode: 'roving' | 'activedescendant' }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const nav = useListNavigation({
+    enabled: true,
+    containerRef,
+    itemSelector: '[role="option"]:not([aria-disabled="true"])',
+    activeId,
+    setActiveId,
+    mode,
+  });
+  return (
+    <div>
+      <div
+        data-testid="focusable"
+        tabIndex={0}
+        aria-activedescendant={mode === 'activedescendant' ? (activeId ?? undefined) : undefined}
+        onKeyDown={(e) => nav.onKeyDown(e)}
+      >
+        focusable
+      </div>
+      <div ref={containerRef}>
+        <div role="option" id="o1">Apple</div>
+        <div role="option" id="o2">Banana</div>
+        <div role="option" id="o3">Cherry</div>
+      </div>
+    </div>
+  );
+}
+
+describe('useListNavigation', () => {
+  it('activedescendant: ArrowDown advances the active id without moving focus', () => {
+    const { getByTestId, getByText } = render(<Harness mode="activedescendant" />);
+    const host = getByTestId('focusable');
+    host.focus();
+    fireEvent.keyDown(host, { key: 'ArrowDown' });
+    expect(host.getAttribute('aria-activedescendant')).toBe('o1');
+    expect(document.activeElement).toBe(host); // focus stayed
+    fireEvent.keyDown(host, { key: 'ArrowDown' });
+    expect(host.getAttribute('aria-activedescendant')).toBe('o2');
+  });
+
+  it('roving: ArrowDown moves DOM focus to the active item', () => {
+    const { getByTestId, getByText } = render(<Harness mode="roving" />);
+    const host = getByTestId('focusable');
+    host.focus();
+    fireEvent.keyDown(host, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(getByText('Apple'));
+  });
+
+  it('typeahead jumps to the matching item (space is not typeahead)', () => {
+    const { getByTestId } = render(<Harness mode="activedescendant" />);
+    const host = getByTestId('focusable');
+    host.focus();
+    fireEvent.keyDown(host, { key: 'c' });
+    expect(host.getAttribute('aria-activedescendant')).toBe('o3'); // Cherry
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pnpm exec vitest run list-navigation`
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement `list-navigation.ts`**
+
+```tsx
+// packages/ui/src/list-navigation.ts
+import type { RefObject } from 'preact';
+import { useTypeahead } from './use-typeahead.js';
+
+// --- pure helpers (relocated from menu/navigation.ts) ---
+
+export function wrapNext(
+  current: number,
+  length: number,
+  loop: boolean
+): number {
+  if (length === 0) return -1;
+  const next = current + 1;
+  if (next < length) return next;
+  return loop ? 0 : length - 1;
+}
+
+export function wrapPrev(
+  current: number,
+  length: number,
+  loop: boolean
+): number {
+  if (length === 0) return -1;
+  const prev = current - 1;
+  if (prev >= 0) return prev;
+  return loop ? length - 1 : 0;
+}
+
+// The next item (circularly, starting after fromIndex) whose text begins with
+// query. Returns -1 when nothing matches.
+export function matchTypeahead(
+  labels: string[],
+  query: string,
+  fromIndex: number
+): number {
+  const q = query.toLowerCase();
+  const n = labels.length;
+  for (let step = 1; step <= n; step++) {
+    const i = (fromIndex + step) % n;
+    if (labels[i].trim().toLowerCase().startsWith(q)) return i;
+  }
+  return -1;
+}
+
+// Enabled items inside `container` matching `selector`, in DOM order. When
+// `scopeSelector` is given, an item nested inside a closer same-role container
+// (a submenu) is excluded, so a parent's navigation skips a child's items.
+export function getItems(
+  container: HTMLElement,
+  selector: string,
+  scopeSelector?: string
+): HTMLElement[] {
+  const all = Array.from(container.querySelectorAll<HTMLElement>(selector));
+  if (!scopeSelector) return all;
+  return all.filter((el) => el.closest(scopeSelector) === container);
+}
+
+// --- the hook ---
+
+export type ListNavigationMode = 'roving' | 'activedescendant';
+
+export interface UseListNavigationOptions {
+  enabled: boolean;
+  containerRef: RefObject<HTMLElement>; // element holding the items
+  itemSelector: string;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  mode: ListNavigationMode;
+  loop?: boolean; // default true
+  typeahead?: boolean; // default true
+  scopeSelector?: string; // exclude nested same-role containers (menus)
+}
+
+export interface ListNavigation {
+  // Handle ArrowUp/Down, Home/End, and typeahead. Calls preventDefault on keys
+  // it consumes (so the caller can early-return on event.defaultPrevented).
+  onKeyDown: (event: KeyboardEvent) => void;
+  // Current enabled items (live DOM query).
+  getItems: () => HTMLElement[];
+  // Activate the item at `index`: set the active id and, in roving mode, move
+  // DOM focus; in activedescendant mode scroll it into view (focus stays put).
+  setActiveItem: (index: number) => void;
+}
+
+export function useListNavigation(
+  opts: UseListNavigationOptions
+): ListNavigation {
+  const {
+    enabled,
+    containerRef,
+    itemSelector,
+    activeId,
+    setActiveId,
+    mode,
+    loop = true,
+    typeahead = true,
+    scopeSelector,
+  } = opts;
+  const runTypeahead = useTypeahead();
+
+  const items = (): HTMLElement[] => {
+    const container = containerRef.current;
+    if (!container) return [];
+    return getItems(container, itemSelector, scopeSelector);
+  };
+
+  const activate = (list: HTMLElement[], index: number) => {
+    if (index < 0 || index >= list.length) return;
+    const el = list[index];
+    setActiveId(el.id);
+    if (mode === 'roving') {
+      el.focus();
+    } else {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (!enabled) return;
+    const list = items();
+    const current = list.findIndex((el) => el.id === activeId);
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        activate(list, wrapNext(current, list.length, loop));
+        return;
+      case 'ArrowUp':
+        event.preventDefault();
+        activate(list, wrapPrev(current, list.length, loop));
+        return;
+      case 'Home':
+        event.preventDefault();
+        activate(list, 0);
+        return;
+      case 'End':
+        event.preventDefault();
+        activate(list, list.length - 1);
+        return;
+    }
+
+    // Typeahead: single printable chars, never Space (Space selects/activates
+    // in both menu and listbox patterns) and never modifier combos.
+    if (
+      typeahead &&
+      event.key.length === 1 &&
+      event.key !== ' ' &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey
+    ) {
+      const query = runTypeahead(event.key);
+      const labels = list.map((el) => el.textContent ?? '');
+      // Start the search after the current item on the first keystroke (repeats
+      // cycle); on a refining query start at current-1 so the current item is
+      // re-tested first and keeps the active state while it still matches.
+      const from = current < 0 ? -1 : current - (query.length > 1 ? 1 : 0);
+      const match = matchTypeahead(labels, query, from);
+      if (match >= 0) {
+        event.preventDefault();
+        activate(list, match);
+      }
+    }
+  };
+
+  return { onKeyDown, getItems: items, setActiveItem: (i) => activate(items(), i) };
+}
+```
+
+- [ ] **Step 4: Update `menu/navigation.ts` to re-export the relocated helpers**
+
+Replace the pure-helper bodies in `packages/ui/src/menu/navigation.ts` with re-exports, keeping the menu's `ITEM_SELECTOR` and a `getMenuItems` wrapper:
+
+```ts
+// packages/ui/src/menu/navigation.ts
+import { getItems } from '../list-navigation.js';
+export { wrapNext, wrapPrev, matchTypeahead } from '../list-navigation.js';
+
+// Navigable menu item roles carry data-menu-item; disabled items set
+// aria-disabled="true" and are excluded.
+export const ITEM_SELECTOR = '[data-menu-item]:not([aria-disabled="true"])';
+
+// Enabled menu items belonging to exactly this surface (a submenu's items are
+// scoped out via their closer [role="menu"]).
+export function getMenuItems(surface: HTMLElement): HTMLElement[] {
+  return getItems(surface, ITEM_SELECTOR, '[role="menu"]');
+}
+```
+
+- [ ] **Step 5: Run tests + full suite + typecheck**
+
+Run:
+```bash
+pnpm exec vitest run list-navigation
+pnpm exec vitest run packages/ui
+pnpm typecheck
+```
+Expected: list-navigation passes; the menu suite still passes (getMenuItems behavior unchanged via the re-export); typecheck clean.
+
+- [ ] **Step 6: Commit** (verify branch first)
+
+```bash
+git add packages/ui/src/list-navigation.ts packages/ui/src/menu/navigation.ts packages/ui/src/__tests__/list-navigation.test.tsx
+git commit -m "feat(ui): useListNavigation primitive + relocate nav helpers"
+```
+
+---
+
+## Task 2: Refactor Menu onto `useListNavigation`
+
+Behavior-preserving; the existing menu suite is the guard.
+
+**Files:**
+- Modify: `packages/ui/src/menu/menu.tsx` (MenuPopup)
+
+- [ ] **Step 1: Replace MenuPopup's bespoke handler**
+
+In `packages/ui/src/menu/menu.tsx`:
+- Add the import: `import { useListNavigation } from '../list-navigation.js';`
+- In `MenuPopup`, replace the `runTypeahead`, `focusIndex`, and the movement/typeahead portions of `handleKeyDown` with the primitive. Keep the open-focus effect (rewritten to use the nav helpers) and the Menu-specific keys (Tab, Enter/Space). The result:
+
+```tsx
+export function MenuPopup(props: MenuPopupProps): VNode {
+  const {
+    render,
+    children,
+    'aria-label': ariaLabel,
+    onKeyDown,
+    ...rest
+  } = props;
+  const ctx = useMenuContext('Popup');
+
+  const nav = useListNavigation({
+    enabled: ctx.open,
+    containerRef: ctx.popupRef,
+    itemSelector: '[data-menu-item]:not([aria-disabled="true"])',
+    scopeSelector: '[role="menu"]',
+    activeId: ctx.activeId,
+    setActiveId: ctx.setActiveId,
+    mode: 'roving',
+    loop: ctx.loop,
+    typeahead: ctx.typeahead,
+  });
+
+  useDismiss({
+    enabled: ctx.open,
+    refs: [ctx.floatingRef, ctx.anchorRef],
+    escape: true,
+    outsidePress: true,
+    onDismiss: () => ctx.setOpen(false),
+    id: ctx.dismissId,
+    parentId: ctx.parentDismissId,
+  });
+
+  useFocusReturn({ open: ctx.open, popupRef: ctx.popupRef });
+
+  // On open, focus the first (or last, on ArrowUp open) enabled item.
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    const list = nav.getItems();
+    if (list.length === 0) return;
+    nav.setActiveItem(
+      ctx.pendingEdgeRef.current === 'last' ? list.length - 1 : 0
+    );
+  }, [ctx.open]);
+
+  const handleKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLDivElement>) => {
+    onKeyDown?.(event);
+    if (event.defaultPrevented) return;
+    nav.onKeyDown(event);
+    if (event.defaultPrevented) return;
+    const list = nav.getItems();
+    const current = list.findIndex((el) => el.id === ctx.activeId);
+    if (event.key === 'Tab') {
+      ctx.setOpen(false);
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (current >= 0) list[current].click();
+    }
+  };
+
+  return useRender<{ open: boolean }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.popupRef,
+      role: 'menu',
+      id: ctx.popupId,
+      tabIndex: -1,
+      'aria-orientation': 'vertical',
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabel ? undefined : ctx.triggerId,
+      'data-state': ctx.open ? 'open' : 'closed',
+      onKeyDown: handleKeyDown,
+    },
+    state: { open: ctx.open },
+    children,
+  });
+}
+```
+Remove now-unused imports from `menu.tsx` if `wrapNext`/`wrapPrev`/`matchTypeahead`/`getMenuItems`/`useTypeahead` are no longer referenced elsewhere in the file (check first; `getMenuItems` may still be used by other parts; if not used, drop the import).
+
+- [ ] **Step 2: Run the full menu suite + full UI suite + typecheck**
+
+Run:
+```bash
+pnpm exec vitest run menu
+pnpm exec vitest run packages/ui
+pnpm typecheck
+```
+Expected: ALL menu tests (trigger, item, navigation-dom, checkable, structure, submenu, submenu-safe-area, ssr) pass unchanged; full suite green. If any menu test fails, the refactor changed behavior; debug until green before committing (do NOT alter the menu tests to fit).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/menu/menu.tsx
+git commit -m "refactor(ui): Menu navigation onto useListNavigation"
+```
+
+---
+
+## Task 3: Export the primitive + helpers from the barrel
+
+**Files:**
+- Modify: `packages/ui/src/index.ts`
+- Test: `packages/ui/src/__tests__/exports.test.ts` (extend)
+
+- [ ] **Step 1: Add the exports**
+
+In `packages/ui/src/index.ts` (after the existing primitive exports):
+```ts
+export {
+  useListNavigation,
+  getItems,
+  wrapNext,
+  wrapPrev,
+  matchTypeahead,
+  type UseListNavigationOptions,
+  type ListNavigation,
+  type ListNavigationMode,
+} from './list-navigation.js';
+export { useTypeahead, type UseTypeaheadOptions } from './use-typeahead.js';
+```
+
+- [ ] **Step 2: Extend the exports test**
+
+In `packages/ui/src/__tests__/exports.test.ts` add:
+```ts
+  it('exposes the list-navigation primitive + helpers', () => {
+    expect(typeof ui.useListNavigation).toBe('function');
+    expect(typeof ui.useTypeahead).toBe('function');
+    expect(typeof ui.wrapNext).toBe('function');
+    expect(typeof ui.matchTypeahead).toBe('function');
+    expect(typeof ui.getItems).toBe('function');
+  });
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+pnpm exec vitest run exports
+pnpm typecheck
+git add packages/ui/src/index.ts packages/ui/src/__tests__/exports.test.ts
+git commit -m "feat(ui): export useListNavigation + nav helpers"
+```
+
+---
+
+## Task 4: Select context + Root + Trigger + Value
+
+The generic-value core: value state, selection helpers, the option label registry, and the form-field state. The Trigger drives `aria-activedescendant`; `Value` shows the selected label.
+
+**Files:**
+- Create: `packages/ui/src/select/context.ts`
+- Create: `packages/ui/src/select/select.tsx`
+- Test: `packages/ui/src/__tests__/select-trigger.test.tsx`
+
+- [ ] **Step 1: Write the context module**
+
+```ts
+// packages/ui/src/select/context.ts
+import { createContext, type RefObject } from 'preact';
+import { useContext } from 'preact/hooks';
+import type { Side, Align, PositionState } from '../use-position.js';
+
+// The value generic is erased to `unknown` at this module-level context (a
+// React-context cannot carry a per-instance generic). The public Root/Option
+// props re-apply the generic; Root owns the comparator so all value handling
+// stays in one typed place.
+export interface SelectContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  multiple: boolean;
+  // Selection, value-erased. Implemented by Root with its typed comparator.
+  isSelected: (optionValue: unknown) => boolean;
+  toggle: (optionValue: unknown) => void; // select (single) or toggle (multi)
+  // Active-descendant id (the highlighted option), null until navigated.
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  // Option label registry: each Option registers/unregisters its label.
+  registerOption: (id: string, value: unknown, label: string) => () => void;
+  // Labels for the currently selected value(s), in registry order.
+  selectedLabels: () => string[];
+  anchorRef: RefObject<HTMLElement>; // the Trigger
+  floatingRef: RefObject<HTMLElement>; // the Positioner
+  listboxRef: RefObject<HTMLElement>; // the Popup (items container)
+  arrowRef: RefObject<HTMLElement>;
+  triggerId: string;
+  listboxId: string;
+  disabled: boolean;
+  required: boolean;
+  side: Side;
+  align: Align;
+  offset: number;
+  loop: boolean;
+  typeahead: boolean;
+  position: PositionState;
+  setPosition: (p: PositionState) => void;
+}
+
+export const SelectContext = createContext<SelectContextValue | null>(null);
+
+export function useSelectContext(part: string): SelectContextValue {
+  const ctx = useContext(SelectContext);
+  if (!ctx) {
+    throw new Error(`<Select.${part}> must be used within <Select.Root>`);
+  }
+  return ctx;
+}
+
+export interface SelectOptionGroupContextValue {
+  labelId: string;
+}
+export const SelectOptionGroupContext =
+  createContext<SelectOptionGroupContextValue | null>(null);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { SelectRoot, SelectTrigger, SelectValue } from '../select/select.js';
+
+afterEach(cleanup);
+
+describe('Select Trigger + Value', () => {
+  it('is a combobox button that toggles open and wires aria', () => {
+    const onOpenChange = vi.fn();
+    const { getByRole } = render(
+      <SelectRoot onOpenChange={onOpenChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+      </SelectRoot>
+    );
+    const trigger = getByRole('combobox');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger.textContent).toContain('Pick one'); // placeholder, nothing selected
+    fireEvent.click(trigger);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('opens on ArrowDown', () => {
+    const onOpenChange = vi.fn();
+    const { getByRole } = render(
+      <SelectRoot onOpenChange={onOpenChange}>
+        <SelectTrigger><SelectValue placeholder="x" /></SelectTrigger>
+      </SelectRoot>
+    );
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' });
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `pnpm exec vitest run select-trigger`
+Expected: FAIL (module missing).
+
+- [ ] **Step 4: Implement Root + Trigger + Value**
+
+```tsx
+// packages/ui/src/select/select.tsx
+import { h, type ComponentChildren, type JSX, type VNode } from 'preact';
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
+import { useRender, type RenderProp } from '../use-render.js';
+import { useControllableState } from '../use-controllable-state.js';
+import type { Side, Align, PositionState } from '../use-position.js';
+import { SelectContext, useSelectContext } from './context.js';
+
+interface OptionEntry {
+  id: string;
+  value: unknown;
+  label: string;
+}
+
+export interface SelectRootProps<Value = string> {
+  value?: Value | Value[];
+  defaultValue?: Value | Value[];
+  onValueChange?: (value: Value | Value[]) => void;
+  multiple?: boolean;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  name?: string;
+  disabled?: boolean;
+  required?: boolean;
+  isValueEqual?: (a: Value, b: Value) => boolean;
+  serializeValue?: (value: Value) => string;
+  side?: Side; // default 'bottom'
+  align?: Align; // default 'start'
+  offset?: number; // default 8
+  loop?: boolean; // default true
+  typeahead?: boolean; // default true
+  children?: ComponentChildren;
+}
+
+export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
+  const {
+    value: valueProp,
+    defaultValue,
+    onValueChange,
+    multiple = false,
+    open: openProp,
+    defaultOpen,
+    onOpenChange,
+    name,
+    disabled = false,
+    required = false,
+    isValueEqual,
+    serializeValue,
+    side = 'bottom',
+    align = 'start',
+    offset = 8,
+    loop = true,
+    typeahead = true,
+    children,
+  } = props;
+
+  const emptyDefault = (multiple ? [] : undefined) as Value | Value[] | undefined;
+  const [value, setValue] = useControllableState<Value | Value[] | undefined>({
+    value: valueProp,
+    defaultValue: defaultValue ?? emptyDefault,
+    onChange: (v) => v !== undefined && onValueChange?.(v),
+  });
+
+  const [open, setOpen] = useControllableState<boolean>({
+    value: openProp,
+    defaultValue: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  const anchorRef = useRef<HTMLElement>(null);
+  const floatingRef = useRef<HTMLElement>(null);
+  const listboxRef = useRef<HTMLElement>(null);
+  const arrowRef = useRef<HTMLElement>(null);
+  const baseId = useId();
+  const triggerId = `${baseId}-trigger`;
+  const listboxId = `${baseId}-listbox`;
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [position, setPosition] = useState<PositionState>({
+    side,
+    align,
+    arrowX: null,
+    arrowY: null,
+  });
+
+  // Comparator is the one place the generic is re-applied. Object.is accepts
+  // unknowns directly; a user comparator is adapted at this seam (the sole
+  // generic-erasure boundary of the component).
+  const equal = useCallback(
+    (a: unknown, b: unknown): boolean => {
+      if (!isValueEqual) return Object.is(a, b);
+      return isValueEqual(a as Value, b as Value);
+    },
+    [isValueEqual]
+  );
+
+  const valuesArray = useCallback((): unknown[] => {
+    if (value === undefined) return [];
+    return Array.isArray(value) ? value : [value];
+  }, [value]);
+
+  const isSelected = useCallback(
+    (optionValue: unknown) => valuesArray().some((v) => equal(v, optionValue)),
+    [valuesArray, equal]
+  );
+
+  const toggle = useCallback(
+    (optionValue: unknown) => {
+      if (multiple) {
+        const current = valuesArray();
+        const next = current.some((v) => equal(v, optionValue))
+          ? current.filter((v) => !equal(v, optionValue))
+          : [...current, optionValue];
+        setValue(next as Value[]);
+      } else {
+        setValue(optionValue as Value);
+        setOpen(false);
+      }
+    },
+    [multiple, valuesArray, equal, setValue, setOpen]
+  );
+
+  // Option label registry.
+  const registry = useRef<OptionEntry[]>([]);
+  const [, force] = useState(0);
+  const registerOption = useCallback(
+    (id: string, optionValue: unknown, label: string) => {
+      registry.current = [
+        ...registry.current,
+        { id, value: optionValue, label },
+      ];
+      force((n) => n + 1);
+      return () => {
+        registry.current = registry.current.filter((e) => e.id !== id);
+        force((n) => n + 1);
+      };
+    },
+    []
+  );
+  const selectedLabels = useCallback(
+    () =>
+      registry.current.filter((e) => isSelected(e.value)).map((e) => e.label),
+    [isSelected]
+  );
+
+  const ctx = useMemo(
+    () => ({
+      open,
+      setOpen,
+      multiple,
+      isSelected,
+      toggle,
+      activeId,
+      setActiveId,
+      registerOption,
+      selectedLabels,
+      anchorRef,
+      floatingRef,
+      listboxRef,
+      arrowRef,
+      triggerId,
+      listboxId,
+      disabled,
+      required,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+      setPosition,
+    }),
+    [
+      open,
+      setOpen,
+      multiple,
+      isSelected,
+      toggle,
+      activeId,
+      registerOption,
+      selectedLabels,
+      baseId,
+      disabled,
+      required,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+    ]
+  );
+
+  // The hidden form field is rendered in Task 7; for now Root provides context.
+  return h(SelectContext.Provider, { value: ctx }, children);
+}
+
+export type SelectTriggerProps = {
+  render?: RenderProp<{ open: boolean }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'children'>;
+
+export function SelectTrigger(props: SelectTriggerProps): VNode {
+  const { render, children, onClick, onKeyDown, ...rest } = props;
+  const ctx = useSelectContext('Trigger');
+
+  const handleClick = (event: JSX.TargetedMouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (ctx.disabled) return;
+    ctx.setOpen(!ctx.open);
+  };
+  const handleKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLButtonElement>) => {
+    onKeyDown?.(event);
+    if (ctx.disabled || event.defaultPrevented) return;
+    if (!ctx.open) {
+      if (
+        event.key === 'ArrowDown' ||
+        event.key === 'ArrowUp' ||
+        event.key === 'Enter' ||
+        event.key === ' '
+      ) {
+        event.preventDefault();
+        ctx.setOpen(true);
+      }
+    }
+    // While open, the listbox-navigation handler (Task 5) is composed in via a
+    // shared keydown; see SelectTrigger wiring there. This base handler only
+    // owns the closed-state open keys.
+  };
+
+  return useRender<{ open: boolean }>({
+    render,
+    defaultTag: 'button',
+    props: {
+      ...rest,
+      ref: ctx.anchorRef,
+      type: 'button',
+      role: 'combobox',
+      'aria-haspopup': 'listbox',
+      'aria-expanded': ctx.open,
+      'aria-controls': ctx.listboxId,
+      'aria-activedescendant': ctx.open ? (ctx.activeId ?? undefined) : undefined,
+      'aria-required': ctx.required ? true : undefined,
+      id: ctx.triggerId,
+      disabled: ctx.disabled,
+      'data-state': ctx.open ? 'open' : 'closed',
+      onClick: handleClick,
+      onKeyDown: handleKeyDown,
+    },
+    state: { open: ctx.open },
+    children,
+  });
+}
+
+export type SelectValueProps = {
+  placeholder?: string;
+  render?: RenderProp<{ selectedLabels: string[] }>;
+  children?: (value: { selectedLabels: string[] }) => ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLSpanElement>, 'children'>;
+
+export function SelectValue(props: SelectValueProps): VNode {
+  const { placeholder, render, children, ...rest } = props;
+  const ctx = useSelectContext('Value');
+  const labels = ctx.selectedLabels();
+  const display =
+    labels.length > 0 ? labels.join(', ') : (placeholder ?? '');
+  const content = children ? children({ selectedLabels: labels }) : display;
+  return useRender<{ selectedLabels: string[] }>({
+    render,
+    defaultTag: 'span',
+    props: { ...rest, 'data-placeholder': labels.length === 0 ? '' : undefined },
+    state: { selectedLabels: labels },
+    children: content,
+  });
+}
+```
+
+Notes on the casts: the three `as Value`/`as Value[]` casts are the generic-erasure seam called out in the spec (§Type casts). They are localized to `equal` and `toggle` where the erased `unknown` is re-applied to the Root's own generic. Do not spread these casts elsewhere; Options pass their typed `value` into `unknown`-typed context methods (assignable, no cast).
+
+- [ ] **Step 5: Run + full suite + typecheck**
+
+Run:
+```bash
+pnpm exec vitest run select-trigger
+pnpm exec vitest run packages/ui
+pnpm typecheck
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/select/context.ts packages/ui/src/select/select.tsx packages/ui/src/__tests__/select-trigger.test.tsx
+git commit -m "feat(ui): Select context + Root + Trigger + Value"
+```
+
+---
+
+## Task 5: Select Positioner + Popup (always-mounted listbox) + nav wiring
+
+The listbox is always in the DOM (so options register) and `hidden` when closed. Positioning + Popover-API promotion run only when open. The trigger's keydown composes `useListNavigation` (activedescendant) while open.
+
+**Files:**
+- Modify: `packages/ui/src/select/select.tsx`
+- Test: `packages/ui/src/__tests__/select-nav.test.tsx`
+
+- [ ] **Step 1: Write the failing test** (renders Options from Task 6; implement Task 6's `SelectOption` before running, or run Tasks 5+6 as a pair)
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import {
+  SelectRoot, SelectTrigger, SelectValue,
+  SelectPositioner, SelectPopup, SelectOption,
+} from '../select/select.js';
+
+afterEach(cleanup);
+
+function Harness(props: { multiple?: boolean }) {
+  return (
+    <SelectRoot multiple={props.multiple}>
+      <SelectTrigger><SelectValue placeholder="Pick" /></SelectTrigger>
+      <SelectPositioner>
+        <SelectPopup aria-label="Fruits">
+          <SelectOption value="apple">Apple</SelectOption>
+          <SelectOption value="banana">Banana</SelectOption>
+          <SelectOption value="cherry">Cherry</SelectOption>
+        </SelectPopup>
+      </SelectPositioner>
+    </SelectRoot>
+  );
+}
+
+describe('Select navigation', () => {
+  it('listbox is present but hidden until open', () => {
+    const { getByRole } = render(<Harness />);
+    const listbox = getByRole('listbox', { hidden: true });
+    expect(listbox.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('ArrowDown opens and moves the active descendant on the trigger', async () => {
+    const { getByRole } = render(<Harness />);
+    const trigger = getByRole('combobox');
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await act(async () => {});
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    // focus stayed on the trigger; activedescendant points at an option
+    expect(document.activeElement).toBe(trigger);
+    const active = trigger.getAttribute('aria-activedescendant');
+    expect(active).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm exec vitest run select-nav`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement Positioner + Popup + the open-state trigger nav**
+
+Append to `select.tsx` (add imports `useLayoutEffect` from `preact/hooks`, `usePosition` from `../use-position.js`, `useDismiss` from `../use-dismiss.js`, `useListNavigation` from `../list-navigation.js`):
+
+```tsx
+function supportsPopover(el: HTMLElement): boolean {
+  return typeof el.showPopover === 'function';
+}
+
+export const OPTION_SELECTOR = '[role="option"]:not([aria-disabled="true"])';
+
+export type SelectPositionerProps = {
+  render?: RenderProp<{ side: Side; align: Align }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectPositioner(props: SelectPositionerProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useSelectContext('Positioner');
+
+  const position = usePosition({
+    open: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+  });
+
+  useLayoutEffect(() => {
+    ctx.setPosition(position);
+  }, [position.side, position.align, position.arrowX, position.arrowY]);
+
+  useLayoutEffect(() => {
+    const el = ctx.floatingRef.current;
+    if (!ctx.open || !el || !supportsPopover(el)) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      el.hidePopover();
+      el.removeAttribute('popover');
+    };
+  }, [ctx.open]);
+
+  // Always rendered so options register; `hidden` while closed makes it inert
+  // and invisible without requiring consumer CSS, and composes with the
+  // Popover-API promotion (which only runs while open).
+  return useRender<{ side: Side; align: Align }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.floatingRef,
+      hidden: ctx.open ? undefined : true,
+      'data-side': position.side,
+      'data-align': position.align,
+      style: {
+        position: 'fixed',
+        inset: 'auto',
+        margin: 0,
+        overflow: 'visible',
+        border: 0,
+        padding: 0,
+        background: 'transparent',
+      },
+    },
+    state: { side: position.side, align: position.align },
+    children,
+  });
+}
+
+export type SelectPopupProps = {
+  render?: RenderProp<{ open: boolean }>;
+  'aria-label'?: string;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectPopup(props: SelectPopupProps): VNode {
+  const { render, children, 'aria-label': ariaLabel, ...rest } = props;
+  const ctx = useSelectContext('Popup');
+
+  useDismiss({
+    enabled: ctx.open,
+    refs: [ctx.floatingRef, ctx.anchorRef],
+    escape: true,
+    outsidePress: true,
+    onDismiss: () => ctx.setOpen(false),
+  });
+
+  return useRender<{ open: boolean }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.listboxRef,
+      role: 'listbox',
+      id: ctx.listboxId,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabel ? undefined : ctx.triggerId,
+      'aria-multiselectable': ctx.multiple ? true : undefined,
+      'data-state': ctx.open ? 'open' : 'closed',
+    },
+    state: { open: ctx.open },
+    children,
+  });
+}
+```
+
+Then wire the open-state navigation into `SelectTrigger`. Replace `SelectTrigger`'s `handleKeyDown` so it composes `useListNavigation` (activedescendant, items in the listbox) and handles select/close while open. Add inside `SelectTrigger`:
+
+```tsx
+  const nav = useListNavigation({
+    enabled: ctx.open,
+    containerRef: ctx.listboxRef,
+    itemSelector: OPTION_SELECTOR,
+    activeId: ctx.activeId,
+    setActiveId: ctx.setActiveId,
+    mode: 'activedescendant',
+    loop: ctx.loop,
+    typeahead: ctx.typeahead,
+  });
+
+  // On open, set the active descendant to the selected option (or first).
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    const list = nav.getItems();
+    if (list.length === 0) return;
+    const selectedIdx = list.findIndex(
+      (el) => el.getAttribute('aria-selected') === 'true'
+    );
+    nav.setActiveItem(selectedIdx >= 0 ? selectedIdx : 0);
+  }, [ctx.open]);
+```
+
+and rewrite `handleKeyDown`:
+
+```tsx
+  const handleKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLButtonElement>) => {
+    onKeyDown?.(event);
+    if (ctx.disabled || event.defaultPrevented) return;
+    if (!ctx.open) {
+      if (
+        event.key === 'ArrowDown' ||
+        event.key === 'ArrowUp' ||
+        event.key === 'Enter' ||
+        event.key === ' '
+      ) {
+        event.preventDefault();
+        ctx.setOpen(true);
+      }
+      return;
+    }
+    nav.onKeyDown(event);
+    if (event.defaultPrevented) return;
+    const list = nav.getItems();
+    const current = list.findIndex((el) => el.id === ctx.activeId);
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (current >= 0) list[current].click();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      ctx.setOpen(false);
+    } else if (event.key === 'Tab') {
+      ctx.setOpen(false);
+    }
+  };
+```
+
+(Add `useLayoutEffect` to `SelectTrigger`'s hook imports; it is already imported at the file level.)
+
+- [ ] **Step 4: Run select-nav (after Task 6's SelectOption exists) + full suite + typecheck**
+
+Run:
+```bash
+pnpm exec vitest run select-nav select-trigger
+pnpm exec vitest run packages/ui
+pnpm typecheck
+```
+Expected: PASS once Task 6 lands `SelectOption`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/select/select.tsx packages/ui/src/__tests__/select-nav.test.tsx
+git commit -m "feat(ui): Select Positioner + Popup + activedescendant navigation"
+```
+
+---
+
+## Task 6: Select Option + OptionGroup + OptionGroupLabel + Arrow
+
+**Files:**
+- Modify: `packages/ui/src/select/select.tsx`
+- Test: `packages/ui/src/__tests__/select-option.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import {
+  SelectRoot, SelectTrigger, SelectValue,
+  SelectPositioner, SelectPopup, SelectOption,
+} from '../select/select.js';
+
+afterEach(cleanup);
+
+function open(utils: ReturnType<typeof render>) {
+  fireEvent.click(utils.getByRole('combobox'));
+}
+
+describe('Select Option', () => {
+  it('single: selecting sets value, marks aria-selected, closes, and shows the label', async () => {
+    const onValueChange = vi.fn();
+    const utils = render(
+      <SelectRoot onValueChange={onValueChange}>
+        <SelectTrigger><SelectValue placeholder="Pick" /></SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple">Apple</SelectOption>
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    await act(async () => {}); // let options register
+    open(utils);
+    fireEvent.click(utils.getByText('Banana'));
+    expect(onValueChange).toHaveBeenCalledWith('banana');
+    expect(utils.getByRole('combobox').getAttribute('aria-expanded')).toBe('false');
+    expect(utils.getByRole('combobox').textContent).toContain('Banana'); // auto-label
+  });
+
+  it('multi: toggling keeps it open and accumulates values', async () => {
+    const onValueChange = vi.fn();
+    const utils = render(
+      <SelectRoot multiple onValueChange={onValueChange}>
+        <SelectTrigger><SelectValue placeholder="Pick" /></SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple">Apple</SelectOption>
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    await act(async () => {});
+    open(utils);
+    fireEvent.click(utils.getByText('Apple'));
+    fireEvent.click(utils.getByText('Banana'));
+    expect(onValueChange).toHaveBeenLastCalledWith(['apple', 'banana']);
+    expect(utils.getByRole('combobox').getAttribute('aria-expanded')).toBe('true'); // stayed open
+    expect(utils.getByText('Apple').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('disabled option is not selectable and is aria-disabled', async () => {
+    const onValueChange = vi.fn();
+    const utils = render(
+      <SelectRoot onValueChange={onValueChange}>
+        <SelectTrigger><SelectValue placeholder="Pick" /></SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple" disabled>Apple</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    await act(async () => {});
+    open(utils);
+    expect(utils.getByText('Apple').getAttribute('aria-disabled')).toBe('true');
+    fireEvent.click(utils.getByText('Apple'));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm exec vitest run select-option`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement Option + groups + arrow**
+
+Append to `select.tsx` (extend imports with `useLayoutEffect`, `createContext`, `useContext`; import `SelectOptionGroupContext` from `./context.js`):
+
+```tsx
+export type SelectOptionProps<Value = string> = {
+  value: Value;
+  render?: RenderProp<{ selected: boolean; disabled: boolean; highlighted: boolean }>;
+  disabled?: boolean;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectOption<Value = string>(
+  props: SelectOptionProps<Value>
+): VNode {
+  const { value, render, children, disabled = false, onClick, onPointerEnter, ...rest } = props;
+  const ctx = useSelectContext('Option');
+  const id = useId();
+  const selected = ctx.isSelected(value);
+  const highlighted = ctx.activeId === id;
+
+  // Register this option's label (its text content) for auto-display.
+  useLayoutEffect(() => {
+    const label =
+      typeof children === 'string'
+        ? children
+        : (document.getElementById(id)?.textContent ?? '');
+    return ctx.registerOption(id, value, label);
+    // value identity may change; re-register if it does.
+  }, [id, value, ctx.registerOption]);
+
+  const handleClick = (event: JSX.TargetedMouseEvent<HTMLDivElement>) => {
+    onClick?.(event);
+    if (disabled) return;
+    ctx.toggle(value);
+  };
+  const handlePointerEnter = (event: JSX.TargetedPointerEvent<HTMLDivElement>) => {
+    onPointerEnter?.(event);
+    if (disabled) return;
+    ctx.setActiveId(id);
+  };
+
+  return useRender<{ selected: boolean; disabled: boolean; highlighted: boolean }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      id,
+      role: 'option',
+      'aria-selected': selected,
+      'aria-disabled': disabled ? 'true' : undefined,
+      'data-selected': selected ? '' : undefined,
+      'data-highlighted': highlighted ? '' : undefined,
+      'data-disabled': disabled ? '' : undefined,
+      onClick: handleClick,
+      onPointerEnter: handlePointerEnter,
+    },
+    state: { selected, disabled, highlighted },
+    children,
+  });
+}
+
+const SelectGroupCtx = SelectOptionGroupContext;
+
+export type SelectOptionGroupProps = {
+  render?: RenderProp;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectOptionGroup(props: SelectOptionGroupProps): VNode {
+  const { render, children, ...rest } = props;
+  const labelId = useId();
+  const node = useRender({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, role: 'group', 'aria-labelledby': labelId },
+    children,
+  });
+  return h(SelectGroupCtx.Provider, { value: { labelId } }, node);
+}
+
+export type SelectOptionGroupLabelProps = {
+  render?: RenderProp;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectOptionGroupLabel(
+  props: SelectOptionGroupLabelProps
+): VNode {
+  const { render, children, ...rest } = props;
+  const group = useContext(SelectGroupCtx);
+  return useRender({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, id: group?.labelId },
+    children,
+  });
+}
+
+export type SelectArrowProps = {
+  render?: RenderProp<{ side: Side }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectArrow(props: SelectArrowProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useSelectContext('Arrow');
+  const { side, arrowX, arrowY } = ctx.position;
+  return useRender<{ side: Side }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.arrowRef,
+      'data-side': side,
+      style: {
+        position: 'absolute',
+        left: arrowX != null ? `${arrowX}px` : undefined,
+        top: arrowY != null ? `${arrowY}px` : undefined,
+      },
+    },
+    state: { side },
+    children,
+  });
+}
+```
+
+Notes: the Option registers its label from its text content. For the common string-children case it uses the string directly; otherwise it reads `textContent` after mount. Since the listbox is always mounted (Task 5), registration runs once and persists. `createContext`/`useContext` may already be imported; do not duplicate.
+
+- [ ] **Step 4: Run select-option + select-nav + full suite + typecheck**
+
+Run:
+```bash
+pnpm exec vitest run select-option select-nav
+pnpm exec vitest run packages/ui
+pnpm typecheck
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/select/select.tsx packages/ui/src/__tests__/select-option.test.tsx
+git commit -m "feat(ui): Select Option + OptionGroup + Arrow with selection + registry"
+```
+
+---
+
+## Task 7: Hidden native form field
+
+**Files:**
+- Modify: `packages/ui/src/select/select.tsx` (SelectRoot)
+- Test: `packages/ui/src/__tests__/select-form.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import {
+  SelectRoot, SelectTrigger, SelectValue,
+  SelectPositioner, SelectPopup, SelectOption,
+} from '../select/select.js';
+
+afterEach(cleanup);
+
+describe('Select form field', () => {
+  it('single: renders one hidden input with the serialized value', () => {
+    const { container } = render(
+      <SelectRoot name="fruit" defaultValue="banana">
+        <SelectTrigger><SelectValue placeholder="x" /></SelectTrigger>
+        <SelectPositioner><SelectPopup aria-label="f">
+          <SelectOption value="banana">Banana</SelectOption>
+        </SelectPopup></SelectPositioner>
+      </SelectRoot>
+    );
+    const inputs = container.querySelectorAll('input[type="hidden"][name="fruit"]');
+    expect(inputs.length).toBe(1);
+    expect((inputs[0] as HTMLInputElement).value).toBe('banana');
+  });
+
+  it('multi: renders one hidden input per selected value, repeated name', () => {
+    const { container } = render(
+      <SelectRoot name="fruit" multiple defaultValue={['apple', 'cherry']}>
+        <SelectTrigger><SelectValue placeholder="x" /></SelectTrigger>
+        <SelectPositioner><SelectPopup aria-label="f">
+          <SelectOption value="apple">Apple</SelectOption>
+          <SelectOption value="cherry">Cherry</SelectOption>
+        </SelectPopup></SelectPositioner>
+      </SelectRoot>
+    );
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="hidden"][name="fruit"]')
+    );
+    expect(inputs.map((i) => i.value).sort()).toEqual(['apple', 'cherry']);
+  });
+
+  it('renders no hidden field when name is absent', () => {
+    const { container } = render(
+      <SelectRoot defaultValue="banana">
+        <SelectTrigger><SelectValue placeholder="x" /></SelectTrigger>
+        <SelectPositioner><SelectPopup aria-label="f">
+          <SelectOption value="banana">Banana</SelectOption>
+        </SelectPopup></SelectPositioner>
+      </SelectRoot>
+    );
+    expect(container.querySelectorAll('input[type="hidden"]').length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `pnpm exec vitest run select-form`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the hidden field in SelectRoot**
+
+In `SelectRoot`, add a serializer and render hidden inputs alongside `children`. Add near the comparator:
+
+```tsx
+  const serialize = useCallback(
+    (v: unknown): string => (serializeValue ? serializeValue(v as Value) : String(v)),
+    [serializeValue]
+  );
+```
+
+Replace the final return with:
+
+```tsx
+  const hiddenFields =
+    name == null
+      ? null
+      : valuesArray().map((v, i) =>
+          h('input', {
+            // A stable key per index is fine; values can repeat.
+            key: `${name}-${i}`,
+            type: 'hidden',
+            name,
+            value: serialize(v),
+            disabled: disabled || undefined,
+          })
+        );
+
+  return h(
+    SelectContext.Provider,
+    { value: ctx },
+    h(h.Fragment ?? 'div', null, children, hiddenFields)
+  );
+```
+
+If `h.Fragment` is not available, import `Fragment` from `preact` and use it: `import { Fragment } from 'preact'` then `h(Fragment, null, children, hiddenFields)`. Prefer `Fragment` so no wrapper element is introduced around the consumer's tree.
+
+- [ ] **Step 4: Run select-form + full suite + typecheck**
+
+Run:
+```bash
+pnpm exec vitest run select-form
+pnpm exec vitest run packages/ui
+pnpm typecheck
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/select/select.tsx packages/ui/src/__tests__/select-form.test.tsx
+git commit -m "feat(ui): Select hidden native form field"
+```
+
+---
+
+## Task 8: Select namespace + barrel + SSR/exports tests
+
+**Files:**
+- Create: `packages/ui/src/select/index.ts`
+- Modify: `packages/ui/src/index.ts`
+- Test: `packages/ui/src/__tests__/select-ssr.test.tsx`, extend `exports.test.ts`
+
+- [ ] **Step 1: Namespace module**
+
+```ts
+// packages/ui/src/select/index.ts
+export {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+  SelectOptionGroup,
+  SelectOptionGroupLabel,
+  SelectArrow,
+  OPTION_SELECTOR,
+  type SelectRootProps,
+  type SelectTriggerProps,
+  type SelectValueProps,
+  type SelectPositionerProps,
+  type SelectPopupProps,
+  type SelectOptionProps,
+  type SelectOptionGroupProps,
+  type SelectOptionGroupLabelProps,
+  type SelectArrowProps,
+} from './select.js';
+
+import {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+  SelectOptionGroup,
+  SelectOptionGroupLabel,
+  SelectArrow,
+} from './select.js';
+
+export const Select = {
+  Root: SelectRoot,
+  Trigger: SelectTrigger,
+  Value: SelectValue,
+  Positioner: SelectPositioner,
+  Popup: SelectPopup,
+  Option: SelectOption,
+  OptionGroup: SelectOptionGroup,
+  OptionGroupLabel: SelectOptionGroupLabel,
+  Arrow: SelectArrow,
+};
+```
+
+- [ ] **Step 2: Barrel**
+
+In `packages/ui/src/index.ts` add a Select export block mirroring the others (the `Select` namespace + named parts + prop types from `./select/index.js`).
+
+- [ ] **Step 3: SSR test**
+
+```tsx
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { renderToString } from 'preact-render-to-string';
+import {
+  SelectRoot, SelectTrigger, SelectValue,
+  SelectPositioner, SelectPopup, SelectOption,
+} from '../select/select.js';
+
+describe('Select SSR', () => {
+  it('renders the combobox + hidden field and a hidden listbox on the server', () => {
+    const html = renderToString(
+      <SelectRoot name="fruit" defaultValue="banana">
+        <SelectTrigger><SelectValue placeholder="Pick" /></SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple">Apple</SelectOption>
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    expect(html).toContain('role="combobox"');
+    expect(html).toContain('role="listbox"');
+    expect(html).toContain('hidden'); // listbox hidden when closed
+    expect(html).toContain('name="fruit"');
+    expect(html).toContain('value="banana"');
+  });
+});
+```
+
+- [ ] **Step 4: Extend exports test** — add `expect(typeof ui.Select.Root).toBe('function')` and `ui.Select.Option`.
+
+- [ ] **Step 5: Run + full suite + typecheck + commit**
+
+```bash
+pnpm exec vitest run select-ssr exports
+pnpm exec vitest run packages/ui
+pnpm typecheck
+git add packages/ui/src/select/index.ts packages/ui/src/index.ts packages/ui/src/__tests__/select-ssr.test.tsx packages/ui/src/__tests__/exports.test.ts
+git commit -m "feat(ui): export Select namespace + SSR test"
+```
+
+---
+
+## Task 9: Typecheck + build
+
+- [ ] **Step 1:** `pnpm typecheck` (fix any errors at the source; no `as` beyond the documented seam).
+- [ ] **Step 2:** `pnpm --filter '@hono-preact/*' --filter hono-preact build` (confirm `packages/ui/dist/select/` + `list-navigation.js` emit).
+- [ ] **Step 3:** commit any fixes: `git add -A && git commit -m "fix(ui): typecheck fixes for select" || echo "nothing to commit"`.
+
+---
+
+## Task 10: Size tracking
+
+**Files:** Modify `scripts/client-size-config.mjs`.
+
+- [ ] **Step 1:** add `select: ['select/index.js']` to `COMPONENT_MODULES` and `['select', 'components']` to `CHUNK_PREFIXES` (next to the other component pages).
+- [ ] **Step 2:** validate the config imports: `node --input-type=module -e "import('./scripts/client-size-config.mjs').then(m=>console.log(Object.keys(m.COMPONENT_MODULES)))"`.
+- [ ] **Step 3:** commit: `git add scripts/client-size-config.mjs && git commit -m "chore(size): track select client size"`. Do NOT regenerate the committed baseline (the Menu refactor will shift Menu's number; that is reported by the size comment, not committed here).
+
+---
+
+## Task 11: Docs
+
+**Files:**
+- Create: `apps/site/src/pages/docs/components/select.mdx`
+- Create: `apps/site/src/pages/docs/components/use-list-navigation.mdx` (Foundations)
+- Create: `apps/site/src/components/docs/SelectDemo.tsx` (single) + `SelectMultiDemo.tsx` (multi)
+- Modify: `apps/site/src/pages/docs/nav.ts` (+ nav test), `apps/site/src/styles/root.css` (demo styles)
+
+- [ ] **Step 1: Read the docs skill + siblings**
+
+REQUIRED: read `.claude/skills/add-docs-page.md` and follow it. Use `apps/site/src/pages/docs/components/menu.mdx` and `use-position.mdx` as the structural templates (frontmatter, `CodeTabs`, API tables, Foundations page shape). Document the Select page's parts in full (per the docs memory; do not cross-link parts away). CSS and Tailwind tabs must be feature-equivalent (base Tailwind v4, `starting:` for entry; per the parity memory).
+
+- [ ] **Step 2: `select.mdx`** — Component/Reference page. Sections: intro (custom listbox select, single + multi, generic value, form via `name`); a single-select styled demo and a multi-select demo in `<CodeTabs>` (CSS + Tailwind, copy button); the keyboard map (spec §7.1); the data-attribute table; per-part API reference (Root with the generic `<Value>`, `multiple`, `name`, `isValueEqual`, `serializeValue`; Trigger; Value with `placeholder` + render-prop; Positioner; Popup; Option; OptionGroup; OptionGroupLabel; Arrow), built from the source types. Note the SSR auto-label caveat (use the `Value` render-prop for SSR-accurate labels).
+
+- [ ] **Step 3: `use-list-navigation.mdx`** — Foundations page documenting `useListNavigation` (options table: `enabled`, `containerRef`, `itemSelector`, `activeId`/`setActiveId`, `mode`, `loop`, `typeahead`, `scopeSelector`; returns `onKeyDown`/`getItems`/`setActiveItem`), the roving vs activedescendant modes, and a short usage snippet. Mention `useTypeahead` and the pure helpers as companions.
+
+- [ ] **Step 4: Demos + styles** — `SelectDemo`/`SelectMultiDemo` compose the parts (mirror `MenuDemo.tsx`); add `.docs-select*` styles to `root.css` (theme tokens, light/dark, reduced-motion), reproducing the entry animation in both flavors.
+
+- [ ] **Step 5: Nav** — add `Select` (`/docs/components/select`) under the components nav and `useListNavigation` (`/docs/components/use-list-navigation`) under Foundations; update `nav.test.ts` if it asserts the list.
+
+- [ ] **Step 6: Verify**
+
+```bash
+pnpm --filter @hono-preact/ui build
+pnpm exec vitest run apps/site/src/pages/docs/__tests__/nav.test.ts
+pnpm --filter site build
+pnpm format
+pnpm format:check
+```
+Expected: nav test passes; site builds and emits both pages.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/site/src/pages/docs/components/select.mdx apps/site/src/pages/docs/components/use-list-navigation.mdx apps/site/src/components/docs/SelectDemo.tsx apps/site/src/components/docs/SelectMultiDemo.tsx apps/site/src/pages/docs/nav.ts apps/site/src/pages/docs/__tests__/nav.test.ts apps/site/src/styles/root.css
+git commit -m "docs(components): add Select + useListNavigation pages"
+```
+
+---
+
+## Task 12: Full CI mirror + PR
+
+Run the six pre-push checks in CI order; fix; open PR; deep review; deferred-work memory.
+
+- [ ] **Step 1:** `pnpm --filter '@hono-preact/*' --filter hono-preact build`
+- [ ] **Step 2:** `pnpm format:check` (run `pnpm format` + commit if it fails)
+- [ ] **Step 3:** `pnpm typecheck`
+- [ ] **Step 4:** `pnpm test` (or `pnpm test:coverage`) — all packages green, including the Menu suite (refactor guard) and the new Select/list-navigation suites
+- [ ] **Step 5:** `pnpm test:integration` and `pnpm --filter site build`
+- [ ] **Step 6:** push + PR
+
+```bash
+git push -u origin feat/ui-select
+gh pr create --base main --title "feat(ui): Select (listbox, Phase 4)" --body "$(cat <<'EOF'
+Implements Phase 4: a headless Select (custom listbox) for @hono-preact/ui with
+single + multiple selection, a generic value type, and HTML form submission via
+a hidden native field. Promotes useListNavigation (roving + activedescendant) as
+a public primitive and refactors Menu onto it.
+
+Spec: docs/superpowers/specs/2026-06-06-select-design.md
+Plan: docs/superpowers/plans/2026-06-06-select.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Deep PR review** (CLAUDE.md PR workflow). Emphasis: **replacement parity for the Menu refactor** (enumerate the pre-refactor MenuPopup behaviors: arrow wrap, Home/End, typeahead with the Space exclusion, Tab-close, Enter/Space-activate, open-focus first/last, submenu ArrowLeft interception) and verify each survives; the generic-erasure cast seam is the only cast; the always-mounted/hidden listbox does not leak interactivity when closed; the hidden form field matches native multi-select submission.
+
+- [ ] **Step 8: Deferred-work memory** — after the PR number exists, add/update `project_select_slice_followups.md` (typeahead-while-closed, virtualization, async options, constraint validation, native variant explicitly-not-built; `usePresence`/styling-variant standing) and a `MEMORY.md` pointer; note Phase 5 Combobox reuses `useListNavigation` + this trigger shape.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** primitive promotion + Menu refactor (T1–T3), generic value + selection + Root/Trigger/Value (T4), always-mounted listbox + activedescendant nav (T5), Option/groups/arrow + single/multi selection + disabled + registry/auto-label (T6), hidden form field single/multi/serializeValue (T7), namespace + SSR (T8), size (T10), docs incl. the `useListNavigation` Foundations page (T11), deferred memory (T12). Keyboard map across T4 (closed) + T5 (open).
+- **Sequencing dependency:** T5's `select-nav` test and T6's `select-option` test both need `SelectOption`; treat T5+T6 as a pair (run their tests after T6). T2's only guard is the menu suite; do not edit menu tests to fit.
+- **Cast policy:** the sole `as Value`/`as Value[]` casts live in `SelectRoot`'s `equal`/`toggle`/`serialize` (the generic-erasure-through-context seam), documented and localized; flagged for the reviewer. Everything else reshapes.
+- **Type consistency:** `isSelected`/`toggle`/`registerOption`/`selectedLabels`/`activeId`/`listboxRef`/`OPTION_SELECTOR` names are identical across context.ts, select.tsx, and the tests; `useListNavigation` option/return names match between list-navigation.ts and both consumers.

--- a/docs/superpowers/specs/2026-06-06-select-design.md
+++ b/docs/superpowers/specs/2026-06-06-select-design.md
@@ -1,0 +1,158 @@
+# Select (listbox) (Phase 4): design spec
+
+Status: approved design, ready for an implementation plan.
+Date: 2026-06-06.
+Predecessor context: `docs/superpowers/specs/2026-05-31-headless-components-investigation.md` (§3.4 collections/navigation, §8 roadmap Phase 4), the shipped Menu + Context Menu slice (`docs/superpowers/specs/2026-06-05-menu-context-menu-design.md`, PR #78), and the deferred-work backlog (`project_menu_slice_followups`: promote the collection + `useTypeahead` to a public primitive when Select is a second consumer).
+
+## 1. Goal and scope
+
+Build **Phase 4** of the headless component roadmap: the **Select** (custom listbox) component for `@hono-preact/ui`, supporting single and multiple selection, a generic value type, and HTML form submission. This slice also **promotes the internal navigation machinery to a public primitive** (`useListNavigation`), validated by two consumers (Menu via roving tabindex, Select via `aria-activedescendant`), and refactors Menu onto it.
+
+Select differs from Menu in its navigation model: focus stays on the trigger and an `aria-activedescendant` pointer names the active option (the APG select-only combobox pattern), rather than Menu's roving DOM focus. It reuses the positioning, dismissal, controllable-state, render-prop, and `data-state` machinery already shipped.
+
+The custom listbox is the only Select built. No native-`<select>`-backed escape-hatch variant is shipped (decided during brainstorming).
+
+## 2. Locked decisions (from brainstorming)
+
+1. **Single and multiple selection**, forked by a `multiple` prop: `value` is `Value | undefined` (single) or `Value[]` (multi). Single selecting closes the listbox; multi toggles and stays open (`aria-multiselectable`).
+2. **Generic value type `<Value>`, defaulting to `string`.** Equality is `Object.is` by default, overridable via an optional `isValueEqual(a, b)` on `Root` (also sidesteps the inline-new-reference footgun for object values). Strings and numbers are zero-config; objects and enums are supported.
+3. **Form integration via a hidden native field.** A `name` prop makes `Root` render hidden native inputs mirroring the value (single: one; multi: one per selected value, repeated `name`, matching native multi-select submission). The string is produced by an optional `serializeValue(value) => string` on `Root` (default `String(value)`), consulted only when `name` is set. The hidden field is a real input, so the value is present in the form even before hydration.
+4. **Select-only combobox ARIA / focus model.** `Select.Trigger` is a button with `role="combobox"`, `aria-expanded`, `aria-controls`, and `aria-activedescendant` (while open); **focus stays on the trigger**. The surface is `role="listbox"`; options are `role="option"`. This is the exact shape Phase 5 (Combobox) reuses with a text input in place of the button.
+5. **Auto-label, always-mounted listbox.** Each `Select.Option` registers its `value -> label` into `Root`; the listbox is always in the DOM (visually hidden when closed) so `Select.Value` auto-shows the selected label even while closed (like native `<select>`, which also keeps all options in the DOM). `Select.Value` takes a `placeholder` and an optional render-prop escape hatch for custom or SSR-accurate labels (registration is client-only).
+6. **Promote `useListNavigation` to a public primitive** (supporting both `roving` and `activedescendant` modes), promote `useTypeahead` and the pure nav helpers to public exports, refactor Menu onto it, and add a Foundations docs page. Fulfils the backlog item and sets up Combobox.
+
+## 3. Architecture
+
+Same compound-component shape as the prior slices: each part renders via `useRender` over a context provided by `Root`.
+
+```
+@hono-preact/ui
+  (reused, already shipped)
+    useRender / RenderProp      render-prop composition + state arg
+    mergeRefs                   ref merging
+    useControllableState        open state + value / value-set
+    usePosition                 @floating-ui/dom binding (positioning + autoUpdate)
+    useDismiss + dismiss-stack  shared capture-phase Escape / outside-press (single-node; no tree)
+    inline useId wiring         aria-* id plumbing
+    data-state contract         data-state / data-side / data-align
+    matchTypeahead, wrapNext,   pure nav helpers (promoted to public this slice)
+      wrapPrev
+    useTypeahead                keystroke buffer (promoted to public this slice)
+
+  (new shared machinery, built + promoted this slice)
+    useListNavigation           public primitive: active-item state + movement keydown +
+                                roving | activedescendant DOM effect; getItems(container, selector)
+
+  (refactored)
+    Menu.Popup                  rewired onto useListNavigation (mode: 'roving'); behavior preserved,
+                                guarded by the existing 134 menu tests
+
+  (new component)
+    Select.*                    Root, Trigger, Value, Positioner, Popup (listbox), Option,
+                                OptionGroup, OptionGroupLabel, Arrow?; Root renders the hidden field
+```
+
+## 4. The navigation primitive: `useListNavigation`
+
+### 4.1 Promoted to public
+
+A new public hook at `packages/ui/src/use-list-navigation.ts` that unifies list movement across both navigation models:
+
+- Owns the **active item** (`activeId`) and a setter; derives the ordered, enabled item list from a container via a configurable selector (`getItems(container, selector)`, generalizing the Menu's `getMenuItems`).
+- Returns an **`onKeyDown(event)`** that handles ArrowDown/ArrowUp (Home/End, and typeahead via `useTypeahead` + `matchTypeahead`), updating the active item with `loop` wrapping.
+- Applies the navigation effect by **`mode`**:
+  - `'roving'`: focuses the active element on change (Menu). The component renders the item's `tabIndex` from `activeId`.
+  - `'activedescendant'`: does not move focus; the component renders `aria-activedescendant` on the focused container (Select trigger) from `activeId`.
+- Accepts an initial-active resolver (first / last / a specific id, e.g. the selected option) for on-open positioning.
+
+The pure helpers (`wrapNext`, `wrapPrev`, `matchTypeahead`) and `useTypeahead` are promoted to public barrel exports alongside it. The exact hook signature, the `getItems` scope-exclusion for nested same-role containers (menus need it; Select does not), and how `activeId` ownership is split between the hook and the component are finalized in the implementation plan (§9).
+
+### 4.2 Menu refactor
+
+`Menu.Popup` replaces its bespoke ArrowUp/Down/Home/End/typeahead switch with `useListNavigation({ mode: 'roving', ... })`. The Menu-specific keys stay in `Menu.Popup`, composed with the primitive's `onKeyDown`: Enter/Space activate the active item, Tab closes, and the dismiss-stack still owns Escape and outside-press. The submenu keyboard (ArrowRight/Left) is unchanged. This refactor is behavior-preserving; the 134 existing menu tests are the safety net, and any divergence is a blocking finding.
+
+## 5. Component API: Select
+
+| Part | Role | Key wiring |
+| --- | --- | --- |
+| `Select.Root<Value>` | Context provider | props: `value` / `defaultValue` / `onValueChange`, `multiple?` (default `false`), `open` / `defaultOpen` / `onOpenChange`, `name?`, `disabled?`, `required?`, `isValueEqual?`, `serializeValue?`, `side` (default `bottom`), `align` (default `start`), `offset`, `loop` (default `true`), `typeahead` (default `true`). Owns value state, open state, the `useListNavigation` (activedescendant) instance, the option `value -> label` registry, ids, and refs. Renders the hidden form field when `name` is set. |
+| `Select.Trigger` | `role="combobox"` button | `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls={listboxId}`, `aria-activedescendant={activeId}` (while open), `aria-required` (when `required`), `id`, `data-state`, `disabled`. Owns the keydown handler (movement via the primitive plus open / select / close). Focus stays here. Default anchor for `usePosition`. |
+| `Select.Value` | Selected-value display | Shows the selected option's registered label (single) or a comma-joined summary (multi); `placeholder` shown when empty. Optional render-prop `(value) => VNode` for custom or SSR-accurate display. |
+| `Select.Positioner` | Fixed wrapper | `usePosition` + Popover-API promotion while open; carries `data-side` / `data-align`. Always rendered; `hidden` (and not promoted) while closed. |
+| `Select.Popup` | Listbox surface | `role="listbox"`, `id={listboxId}`, `aria-multiselectable` (multi), `aria-labelledby` / `aria-label`, `data-state`. Always in the DOM (so options register); hidden while closed. Not focused (focus stays on the trigger). |
+| `Select.Option` | A choice | `role="option"`, `id`, `value: Value`, `aria-selected`, `data-highlighted` (active), `data-selected`, `data-disabled`. Registers `value -> label` on mount. Pointer hover sets active; click selects. |
+| `Select.OptionGroup` + `Select.OptionGroupLabel` | Grouped options | `role="group"` + `aria-labelledby`; label is presentational. |
+| `Select.Arrow` | Optional arrow | floating-ui arrow data; `data-side`. |
+
+- **Selection (single):** `value: Value | undefined`. Activating an option sets the value and closes. On open, the active descendant initializes to the selected option (or the first enabled option).
+- **Selection (multi):** `value: Value[]`. Activating an option toggles it in the set and keeps the listbox open; the listbox sets `aria-multiselectable="true"`. On open, the active descendant initializes to the first selected option (or the first enabled option).
+- **Equality:** an Option is selected when its `value` matches the Root value under `isValueEqual` (default `Object.is`). The label registry and selection both use `isValueEqual`, so object values with stable references or a custom comparator work.
+
+## 6. The form field and value display
+
+### 6.1 Hidden native field (`name`)
+
+When `name` is set, `Root` renders, outside the listbox, hidden native inputs carrying the serialized value(s):
+- single: one `<input type="hidden" name={name} value={serializeValue(value)} />` (empty when nothing selected).
+- multi: one hidden input per selected value, all sharing `name` (repeated field, the native multi-select convention).
+
+`serializeValue` defaults to `String(value)`, which covers string and number values with no config; object values that need form submission supply a `serializeValue`. `required` / `disabled` propagate to the trigger (`aria-required`, `disabled`); full constraint validation is out of scope (§8).
+
+### 6.2 Auto-label and `Select.Value`
+
+Each `Select.Option` registers `{ value, label }` (label from its text content) into a `Root` registry on mount and unregisters on unmount. Because the listbox is always mounted (§5), the registry is populated whenever the component is alive, so `Select.Value` can render the selected option's label even while the listbox is closed. `Select.Value` finds the entry whose `value` matches the selected value under `isValueEqual`. Multi renders a comma-joined list of labels by default. The `placeholder` shows when nothing is selected. The optional render-prop form `(value) => VNode` gives full control (chips, counts) and is the path to an SSR-accurate label, since registration is a client-only effect (on SSR the auto-label is empty and fills on hydration).
+
+## 7. Cross-cutting concerns
+
+### 7.1 Keyboard map (APG select-only combobox)
+
+- **Closed trigger:** Enter / Space / ArrowDown / ArrowUp / Alt+ArrowDown open the listbox; the active descendant starts on the selected option.
+- **Open:** ArrowDown / ArrowUp move the active descendant (wrap when `loop`), Home / End jump, printable characters drive typeahead, **Enter / Space** select the active option (single: select and close; multi: toggle and stay open), **Escape** closes without changing the selection, **Tab** closes and proceeds. Disabled options are skipped by navigation and typeahead.
+
+### 7.2 Data-attribute contract
+
+`data-state="open|closed"` on trigger, positioner, popup; `data-highlighted` on the active option; `data-selected` and `aria-selected` on selected options; `data-disabled` on disabled options and a disabled trigger; `data-side` / `data-align` on the positioner (mirrored where useful). `@starting-style` entry animation; no exit animation (the standing `usePresence` deferral). No CSS ships from the package.
+
+### 7.3 SSR and hydration
+
+The listbox is rendered (with all options) on the server but `hidden`, so the markup is present and the hidden form field carries the initial value (submittable pre-hydration). The Popover-API promotion is applied imperatively while open (no hydration attribute mismatch), as in Menu/Popover. Ids come from `useId`. `Select.Value` auto-label is client-only (registration runs in an effect); for an SSR-accurate label use its render-prop form. Positioning runs only while open.
+
+### 7.4 Documentation (apps/site)
+
+- `/docs/components/select` under the Components nav (Overlays or a Forms grouping, matching the existing nav shape): full per-part API reference plus styled live demos for **single and multiple** selection, with a copy button in **CSS + Tailwind** flavors (parity rules per `feedback_css_tailwind_parity`; base Tailwind v4, `starting:` for entry). Describe what is; no migration breadcrumbs. The page documents its own parts in full (per `feedback_docs_self_contained_parts`).
+- A **Foundations page for `useListNavigation`** (and the now-public `useTypeahead`), matching how `usePosition` / `useDismiss` were documented.
+
+### 7.5 Size tracking
+
+Add `select` to `COMPONENT_MODULES` and a `select` prefix to `CHUNK_PREFIXES` in `scripts/client-size-config.mjs`. Do not regenerate the committed `client-size-report.json` baseline in the PR. The Menu refactor onto the shared primitive may shift Menu's measured bundle slightly; that is expected and reported by the size comment.
+
+### 7.6 Testing
+
+Package unit tests in the established style:
+- **`useListNavigation`**: movement + wrap + Home/End; typeahead; both modes (roving focuses the element, activedescendant updates the active id without moving focus); `getItems` ordering and disabled exclusion.
+- **Menu regression**: the full menu suite must stay green after the refactor (the primary guard that the refactor is behavior-preserving).
+- **Select**: activedescendant movement; single select-and-close; multi toggle-and-stay; `aria-selected` / `data-selected`; disabled options skipped; typeahead; Escape-closes-without-change; the hidden form field (single value, multi repeated names, `serializeValue`); generic value with a custom `isValueEqual` (object values); `Select.Value` auto-label and render-prop; SSR-rendered-but-hidden listbox; full ARIA wiring (`role="combobox"` / `listbox` / `option`, `aria-expanded` / `aria-controls` / `aria-activedescendant` / `aria-multiselectable`).
+
+### 7.7 Accessibility bar
+
+APG select-only-combobox / listbox conformance with a documented keyboard map. The NVDA / JAWS / VoiceOver matrix stays documented-not-automated, per the investigation. Avoid passing an automated scan while failing a real screen reader.
+
+## 8. Deferred / future work
+
+Restated for a durable backlog when the PR merges.
+
+- **Native-`<select>`-backed variant**: explicitly not built (brainstorming decision).
+- **Option virtualization**: add only when a real large-list use case demands it.
+- **Typeahead while closed** (changing the value by typing on the closed trigger, as native selects do): a nicety; typeahead is open-only this slice.
+- **Async / loading options**, and **constraint validation** (`required` beyond `aria-required`).
+- **Exit animations (`usePresence`)** and the **styling-variant runtime helper**: standing cross-slice deferrals.
+- **Roadmap continuation:** Phase 5 **Combobox** (the hardest), which reuses this slice's `useListNavigation`, `aria-activedescendant` wiring, and the select-only-combobox trigger shape, swapping the button for a text input with `aria-autocomplete`.
+
+## 9. Open items for the implementation plan
+
+- Finalize the `useListNavigation` signature: how `activeId` ownership splits between the hook and the consuming component, the initial-active resolver shape, and whether `getItems` takes an optional scope selector for nested same-role containers (menus need it, Select does not).
+- Confirm the option `value -> label` registry shape (an array of `{ value, label }` matched by `isValueEqual`, given object values cannot be Map-keyed by reference reliably).
+- Confirm how the listbox is hidden while closed across browsers (the `hidden` attribute vs a `data-state`-keyed style), so options register but the surface is inert and invisible without requiring consumer CSS, and so it composes with the Popover-API promotion.
+- Decide whether `Select.Arrow` and `Select.OptionGroup` ship in v1 (both cheap; default is to ship them).
+- Sequence the Menu refactor so it lands behind the green menu suite before Select is built on the shared primitive.
+- TDD task breakdown, subagent-buildable, on a feature branch + PR (only spec / plan docs go to main).

--- a/packages/ui/src/__tests__/exports.test.ts
+++ b/packages/ui/src/__tests__/exports.test.ts
@@ -23,4 +23,12 @@ describe('@hono-preact/ui exports', () => {
     expect(typeof ui.ContextMenu.Trigger).toBe('function');
     expect(typeof ui.ContextMenu.Item).toBe('function');
   });
+
+  it('exposes the list-navigation primitive + helpers', () => {
+    expect(typeof ui.useListNavigation).toBe('function');
+    expect(typeof ui.useTypeahead).toBe('function');
+    expect(typeof ui.wrapNext).toBe('function');
+    expect(typeof ui.matchTypeahead).toBe('function');
+    expect(typeof ui.getItems).toBe('function');
+  });
 });

--- a/packages/ui/src/__tests__/exports.test.ts
+++ b/packages/ui/src/__tests__/exports.test.ts
@@ -31,4 +31,11 @@ describe('@hono-preact/ui exports', () => {
     expect(typeof ui.matchTypeahead).toBe('function');
     expect(typeof ui.getItems).toBe('function');
   });
+
+  it('exposes the Select namespace', () => {
+    expect(typeof ui.Select.Root).toBe('function');
+    expect(typeof ui.Select.Trigger).toBe('function');
+    expect(typeof ui.Select.Option).toBe('function');
+    expect(typeof ui.Select.Value).toBe('function');
+  });
 });

--- a/packages/ui/src/__tests__/list-navigation.test.tsx
+++ b/packages/ui/src/__tests__/list-navigation.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { useRef, useState } from 'preact/hooks';
+import { useListNavigation, getItems, wrapNext } from '../list-navigation.js';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe('getItems', () => {
+  it('returns enabled items matching the selector, in DOM order', () => {
+    document.body.innerHTML = `
+      <div id="c">
+        <div role="option" data-x>A</div>
+        <div role="option" data-x aria-disabled="true">B</div>
+        <div role="option" data-x>C</div>
+      </div>`;
+    const c = document.getElementById('c')!;
+    const items = getItems(c, '[data-x]:not([aria-disabled="true"])');
+    expect(items.map((e) => e.textContent)).toEqual(['A', 'C']);
+  });
+});
+
+function Harness({ mode }: { mode: 'roving' | 'activedescendant' }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const nav = useListNavigation({
+    enabled: true,
+    containerRef,
+    itemSelector: '[role="option"]:not([aria-disabled="true"])',
+    activeId,
+    setActiveId,
+    mode,
+  });
+  return (
+    <div>
+      <div
+        data-testid="focusable"
+        tabIndex={0}
+        aria-activedescendant={
+          mode === 'activedescendant' ? (activeId ?? undefined) : undefined
+        }
+        onKeyDown={(e) => nav.onKeyDown(e)}
+      >
+        focusable
+      </div>
+      <div ref={containerRef}>
+        <div role="option" id="o1">
+          Apple
+        </div>
+        <div role="option" id="o2">
+          Banana
+        </div>
+        <div role="option" id="o3">
+          Cherry
+        </div>
+      </div>
+    </div>
+  );
+}
+
+describe('useListNavigation', () => {
+  it('activedescendant: ArrowDown advances the active id without moving focus', () => {
+    const { getByTestId } = render(<Harness mode="activedescendant" />);
+    const host = getByTestId('focusable');
+    host.focus();
+    fireEvent.keyDown(host, { key: 'ArrowDown' });
+    expect(host.getAttribute('aria-activedescendant')).toBe('o1');
+    expect(document.activeElement).toBe(host);
+    fireEvent.keyDown(host, { key: 'ArrowDown' });
+    expect(host.getAttribute('aria-activedescendant')).toBe('o2');
+  });
+
+  it('roving: ArrowDown moves DOM focus to the active item', () => {
+    const { getByTestId, getByText } = render(<Harness mode="roving" />);
+    const host = getByTestId('focusable');
+    host.focus();
+    fireEvent.keyDown(host, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(getByText('Apple'));
+  });
+
+  it('typeahead jumps to the matching item (space is not typeahead)', () => {
+    const { getByTestId } = render(<Harness mode="activedescendant" />);
+    const host = getByTestId('focusable');
+    host.focus();
+    fireEvent.keyDown(host, { key: 'c' });
+    expect(host.getAttribute('aria-activedescendant')).toBe('o3');
+  });
+});

--- a/packages/ui/src/__tests__/select-form.test.tsx
+++ b/packages/ui/src/__tests__/select-form.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+} from '../select/select.js';
+
+afterEach(cleanup);
+
+describe('Select form field', () => {
+  it('single: renders one hidden input with the serialized value', () => {
+    const { container } = render(
+      <SelectRoot name="fruit" defaultValue="banana">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="f">
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    const inputs = container.querySelectorAll(
+      'input[type="hidden"][name="fruit"]'
+    );
+    expect(inputs.length).toBe(1);
+    expect((inputs[0] as HTMLInputElement).value).toBe('banana');
+  });
+
+  it('multi: renders one hidden input per selected value, repeated name', () => {
+    const { container } = render(
+      <SelectRoot name="fruit" multiple defaultValue={['apple', 'cherry']}>
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="f">
+            <SelectOption value="apple">Apple</SelectOption>
+            <SelectOption value="cherry">Cherry</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>(
+        'input[type="hidden"][name="fruit"]'
+      )
+    );
+    expect(inputs.map((i) => i.value).sort()).toEqual(['apple', 'cherry']);
+  });
+
+  it('renders no hidden field when name is absent', () => {
+    const { container } = render(
+      <SelectRoot defaultValue="banana">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="f">
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    expect(container.querySelectorAll('input[type="hidden"]').length).toBe(0);
+  });
+});

--- a/packages/ui/src/__tests__/select-nav.test.tsx
+++ b/packages/ui/src/__tests__/select-nav.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+} from '../select/select.js';
+
+afterEach(cleanup);
+
+function Harness(props: { multiple?: boolean }) {
+  return (
+    <SelectRoot multiple={props.multiple}>
+      <SelectTrigger>
+        <SelectValue placeholder="Pick" />
+      </SelectTrigger>
+      <SelectPositioner>
+        <SelectPopup aria-label="Fruits">
+          <SelectOption value="apple">Apple</SelectOption>
+          <SelectOption value="banana">Banana</SelectOption>
+          <SelectOption value="cherry">Cherry</SelectOption>
+        </SelectPopup>
+      </SelectPositioner>
+    </SelectRoot>
+  );
+}
+
+describe('Select navigation', () => {
+  it('listbox is present in the DOM but not accessible until open', () => {
+    const { queryByRole } = render(<Harness />);
+    // Closed: rendered inside a hidden Positioner, so not in the a11y tree.
+    expect(queryByRole('listbox')).toBeNull();
+    // But present in the DOM (so options can register their labels).
+    const listbox = queryByRole('listbox', { hidden: true });
+    expect(listbox).not.toBeNull();
+    expect(listbox!.closest('[hidden]')).not.toBeNull();
+  });
+
+  it('ArrowDown opens and moves the active descendant on the trigger', async () => {
+    const { getByRole } = render(<Harness />);
+    const trigger = getByRole('combobox');
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await act(async () => {});
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(trigger);
+    const active = trigger.getAttribute('aria-activedescendant');
+    expect(active).toBeTruthy();
+  });
+});

--- a/packages/ui/src/__tests__/select-option.test.tsx
+++ b/packages/ui/src/__tests__/select-option.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/preact';
+import {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+} from '../select/select.js';
+
+afterEach(cleanup);
+
+function open(utils: ReturnType<typeof render>) {
+  fireEvent.click(utils.getByRole('combobox'));
+}
+
+describe('Select Option', () => {
+  it('single: selecting sets value, marks aria-selected, closes, shows label', async () => {
+    const onValueChange = vi.fn();
+    const utils = render(
+      <SelectRoot onValueChange={onValueChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple">Apple</SelectOption>
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    await act(async () => {});
+    open(utils);
+    fireEvent.click(utils.getByText('Banana'));
+    expect(onValueChange).toHaveBeenCalledWith('banana');
+    expect(utils.getByRole('combobox').getAttribute('aria-expanded')).toBe(
+      'false'
+    );
+    expect(utils.getByRole('combobox').textContent).toContain('Banana');
+  });
+
+  it('multi: toggling keeps it open and accumulates values', async () => {
+    const onValueChange = vi.fn();
+    const utils = render(
+      <SelectRoot multiple onValueChange={onValueChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple">Apple</SelectOption>
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    await act(async () => {});
+    open(utils);
+    fireEvent.click(utils.getByText('Apple'));
+    fireEvent.click(utils.getByText('Banana'));
+    expect(onValueChange).toHaveBeenLastCalledWith(['apple', 'banana']);
+    expect(utils.getByRole('combobox').getAttribute('aria-expanded')).toBe(
+      'true'
+    );
+    expect(utils.getByText('Apple').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('disabled option is not selectable and is aria-disabled', async () => {
+    const onValueChange = vi.fn();
+    const utils = render(
+      <SelectRoot onValueChange={onValueChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple" disabled>
+              Apple
+            </SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    await act(async () => {});
+    open(utils);
+    expect(utils.getByText('Apple').getAttribute('aria-disabled')).toBe('true');
+    fireEvent.click(utils.getByText('Apple'));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/__tests__/select-ssr.test.tsx
+++ b/packages/ui/src/__tests__/select-ssr.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { renderToString } from 'preact-render-to-string';
+import {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+} from '../select/select.js';
+
+describe('Select SSR', () => {
+  it('renders the combobox + hidden field and a hidden listbox on the server', () => {
+    const html = renderToString(
+      <SelectRoot name="fruit" defaultValue="banana">
+        <SelectTrigger>
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectPositioner>
+          <SelectPopup aria-label="Fruits">
+            <SelectOption value="apple">Apple</SelectOption>
+            <SelectOption value="banana">Banana</SelectOption>
+          </SelectPopup>
+        </SelectPositioner>
+      </SelectRoot>
+    );
+    expect(html).toContain('role="combobox"');
+    expect(html).toContain('role="listbox"');
+    expect(html).toContain('hidden'); // listbox hidden while closed
+    expect(html).toContain('name="fruit"');
+    expect(html).toContain('value="banana"');
+  });
+});

--- a/packages/ui/src/__tests__/select-trigger.test.tsx
+++ b/packages/ui/src/__tests__/select-trigger.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { SelectRoot, SelectTrigger, SelectValue } from '../select/select.js';
+
+afterEach(cleanup);
+
+describe('Select Trigger + Value', () => {
+  it('is a combobox button that toggles open and wires aria', () => {
+    const onOpenChange = vi.fn();
+    const { getByRole } = render(
+      <SelectRoot onOpenChange={onOpenChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+      </SelectRoot>
+    );
+    const trigger = getByRole('combobox');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger.textContent).toContain('Pick one');
+    fireEvent.click(trigger);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('opens on ArrowDown', () => {
+    const onOpenChange = vi.fn();
+    const { getByRole } = render(
+      <SelectRoot onOpenChange={onOpenChange}>
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+      </SelectRoot>
+    );
+    fireEvent.keyDown(getByRole('combobox'), { key: 'ArrowDown' });
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -110,3 +110,14 @@ export {
   type ContextMenuRootProps,
   type ContextMenuTriggerProps,
 } from './context-menu/index.js';
+export {
+  useListNavigation,
+  getItems,
+  wrapNext,
+  wrapPrev,
+  matchTypeahead,
+  type UseListNavigationOptions,
+  type ListNavigation,
+  type ListNavigationMode,
+} from './list-navigation.js';
+export { useTypeahead, type UseTypeaheadOptions } from './use-typeahead.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -121,3 +121,25 @@ export {
   type ListNavigationMode,
 } from './list-navigation.js';
 export { useTypeahead, type UseTypeaheadOptions } from './use-typeahead.js';
+export {
+  Select,
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+  SelectOptionGroup,
+  SelectOptionGroupLabel,
+  SelectArrow,
+  OPTION_SELECTOR,
+  type SelectRootProps,
+  type SelectTriggerProps,
+  type SelectValueProps,
+  type SelectPositionerProps,
+  type SelectPopupProps,
+  type SelectOptionProps,
+  type SelectOptionGroupProps,
+  type SelectOptionGroupLabelProps,
+  type SelectArrowProps,
+} from './select/index.js';

--- a/packages/ui/src/list-navigation.ts
+++ b/packages/ui/src/list-navigation.ts
@@ -1,0 +1,171 @@
+// packages/ui/src/list-navigation.ts
+import type { RefObject } from 'preact';
+import { useTypeahead } from './use-typeahead.js';
+
+// --- pure helpers (relocated from menu/navigation.ts) ---
+
+export function wrapNext(
+  current: number,
+  length: number,
+  loop: boolean
+): number {
+  if (length === 0) return -1;
+  const next = current + 1;
+  if (next < length) return next;
+  return loop ? 0 : length - 1;
+}
+
+export function wrapPrev(
+  current: number,
+  length: number,
+  loop: boolean
+): number {
+  if (length === 0) return -1;
+  const prev = current - 1;
+  if (prev >= 0) return prev;
+  return loop ? length - 1 : 0;
+}
+
+// The next item (circularly, starting after fromIndex) whose text begins with
+// query. Returns -1 when nothing matches.
+export function matchTypeahead(
+  labels: string[],
+  query: string,
+  fromIndex: number
+): number {
+  const q = query.toLowerCase();
+  const n = labels.length;
+  for (let step = 1; step <= n; step++) {
+    const i = (fromIndex + step) % n;
+    if (labels[i].trim().toLowerCase().startsWith(q)) return i;
+  }
+  return -1;
+}
+
+// Enabled items inside `container` matching `selector`, in DOM order. When
+// `scopeSelector` is given, an item nested inside a closer same-role container
+// (a submenu) is excluded, so a parent's navigation skips a child's items.
+export function getItems(
+  container: HTMLElement,
+  selector: string,
+  scopeSelector?: string
+): HTMLElement[] {
+  const all = Array.from(container.querySelectorAll<HTMLElement>(selector));
+  if (!scopeSelector) return all;
+  return all.filter((el) => el.closest(scopeSelector) === container);
+}
+
+// --- the hook ---
+
+export type ListNavigationMode = 'roving' | 'activedescendant';
+
+export interface UseListNavigationOptions {
+  enabled: boolean;
+  containerRef: RefObject<HTMLElement>; // element holding the items
+  itemSelector: string;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  mode: ListNavigationMode;
+  loop?: boolean; // default true
+  typeahead?: boolean; // default true
+  scopeSelector?: string; // exclude nested same-role containers (menus)
+}
+
+export interface ListNavigation {
+  // Handle ArrowUp/Down, Home/End, and typeahead. Calls preventDefault on keys
+  // it consumes (so the caller can early-return on event.defaultPrevented).
+  onKeyDown: (event: KeyboardEvent) => void;
+  // Current enabled items (live DOM query).
+  getItems: () => HTMLElement[];
+  // Activate the item at `index`: set the active id and, in roving mode, move
+  // DOM focus; in activedescendant mode scroll it into view (focus stays put).
+  setActiveItem: (index: number) => void;
+}
+
+export function useListNavigation(
+  opts: UseListNavigationOptions
+): ListNavigation {
+  const {
+    enabled,
+    containerRef,
+    itemSelector,
+    activeId,
+    setActiveId,
+    mode,
+    loop = true,
+    typeahead = true,
+    scopeSelector,
+  } = opts;
+  const runTypeahead = useTypeahead();
+
+  const items = (): HTMLElement[] => {
+    const container = containerRef.current;
+    if (!container) return [];
+    return getItems(container, itemSelector, scopeSelector);
+  };
+
+  const activate = (list: HTMLElement[], index: number) => {
+    if (index < 0 || index >= list.length) return;
+    const el = list[index];
+    setActiveId(el.id);
+    if (mode === 'roving') {
+      el.focus();
+    } else {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (!enabled) return;
+    const list = items();
+    const current = list.findIndex((el) => el.id === activeId);
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        activate(list, wrapNext(current, list.length, loop));
+        return;
+      case 'ArrowUp':
+        event.preventDefault();
+        activate(list, wrapPrev(current, list.length, loop));
+        return;
+      case 'Home':
+        event.preventDefault();
+        activate(list, 0);
+        return;
+      case 'End':
+        event.preventDefault();
+        activate(list, list.length - 1);
+        return;
+    }
+
+    // Typeahead: single printable chars, never Space (Space selects/activates
+    // in both menu and listbox patterns) and never modifier combos.
+    if (
+      typeahead &&
+      event.key.length === 1 &&
+      event.key !== ' ' &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.altKey
+    ) {
+      const query = runTypeahead(event.key);
+      const labels = list.map((el) => el.textContent ?? '');
+      // Start the search after the current item on the first keystroke (repeats
+      // cycle); on a refining query start at current-1 so the current item is
+      // re-tested first and keeps the active state while it still matches.
+      const from = current < 0 ? -1 : current - (query.length > 1 ? 1 : 0);
+      const match = matchTypeahead(labels, query, from);
+      if (match >= 0) {
+        event.preventDefault();
+        activate(list, match);
+      }
+    }
+  };
+
+  return {
+    onKeyDown,
+    getItems: items,
+    setActiveItem: (i) => activate(items(), i),
+  };
+}

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -21,13 +21,7 @@ import { usePosition } from '../use-position.js';
 import type { Side, Align, PositionState } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useFocusReturn } from '../use-focus-return.js';
-import { useTypeahead } from '../use-typeahead.js';
-import {
-  wrapNext,
-  wrapPrev,
-  matchTypeahead,
-  getMenuItems,
-} from './navigation.js';
+import { useListNavigation } from '../list-navigation.js';
 import {
   MenuContext,
   useMenuContext,
@@ -334,7 +328,18 @@ export function MenuPopup(props: MenuPopupProps): VNode {
     ...rest
   } = props;
   const ctx = useMenuContext('Popup');
-  const runTypeahead = useTypeahead();
+
+  const nav = useListNavigation({
+    enabled: ctx.open,
+    containerRef: ctx.popupRef,
+    itemSelector: '[data-menu-item]:not([aria-disabled="true"])',
+    scopeSelector: '[role="menu"]',
+    activeId: ctx.activeId,
+    setActiveId: ctx.setActiveId,
+    mode: 'roving',
+    loop: ctx.loop,
+    typeahead: ctx.typeahead,
+  });
 
   useDismiss({
     enabled: ctx.open,
@@ -351,78 +356,25 @@ export function MenuPopup(props: MenuPopupProps): VNode {
   // On open, focus the first (or last, on ArrowUp open) enabled item.
   useLayoutEffect(() => {
     if (!ctx.open) return;
-    const surface = ctx.popupRef.current;
-    if (!surface) return;
-    const items = getMenuItems(surface);
-    if (items.length === 0) return;
-    const el =
-      ctx.pendingEdgeRef.current === 'last'
-        ? items[items.length - 1]
-        : items[0];
-    ctx.setActiveId(el.id);
-    el.focus();
+    const list = nav.getItems();
+    if (list.length === 0) return;
+    nav.setActiveItem(
+      ctx.pendingEdgeRef.current === 'last' ? list.length - 1 : 0
+    );
   }, [ctx.open]);
-
-  const focusIndex = (items: HTMLElement[], index: number) => {
-    if (index < 0 || index >= items.length) return;
-    const el = items[index];
-    ctx.setActiveId(el.id);
-    el.focus();
-  };
 
   const handleKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLDivElement>) => {
     onKeyDown?.(event);
     if (event.defaultPrevented) return;
-    const surface = ctx.popupRef.current;
-    if (!surface) return;
-    const items = getMenuItems(surface);
-    const current = items.findIndex((el) => el.id === ctx.activeId);
-
-    switch (event.key) {
-      case 'ArrowDown':
-        event.preventDefault();
-        focusIndex(items, wrapNext(current, items.length, ctx.loop));
-        return;
-      case 'ArrowUp':
-        event.preventDefault();
-        focusIndex(items, wrapPrev(current, items.length, ctx.loop));
-        return;
-      case 'Home':
-        event.preventDefault();
-        focusIndex(items, 0);
-        return;
-      case 'End':
-        event.preventDefault();
-        focusIndex(items, items.length - 1);
-        return;
-      case 'Tab':
-        ctx.setOpen(false);
-        return;
-      case 'Enter':
-      case ' ':
-        event.preventDefault();
-        if (current >= 0) items[current].click();
-        return;
-    }
-
-    if (
-      event.key.length === 1 &&
-      !event.ctrlKey &&
-      !event.metaKey &&
-      !event.altKey
-    ) {
-      const query = runTypeahead(event.key);
-      const labels = items.map((el) => el.textContent ?? '');
-      // matchTypeahead searches starting after `from`. On the first keystroke
-      // search after the current item (so repeats cycle); on a refining query
-      // search from current-1 so the current item is re-tested first and keeps
-      // focus while it still matches the growing query.
-      const from = current < 0 ? -1 : current - (query.length > 1 ? 1 : 0);
-      const match = matchTypeahead(labels, query, from);
-      if (match >= 0) {
-        event.preventDefault();
-        focusIndex(items, match);
-      }
+    nav.onKeyDown(event);
+    if (event.defaultPrevented) return;
+    const list = nav.getItems();
+    const current = list.findIndex((el) => el.id === ctx.activeId);
+    if (event.key === 'Tab') {
+      ctx.setOpen(false);
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (current >= 0) list[current].click();
     }
   };
 

--- a/packages/ui/src/menu/navigation.ts
+++ b/packages/ui/src/menu/navigation.ts
@@ -1,54 +1,13 @@
 // packages/ui/src/menu/navigation.ts
-//
-// Pure navigation helpers for the roving-tabindex menu. Index math is fully
-// pure; getMenuItems is DOM-only (no Preact).
+import { getItems } from '../list-navigation.js';
+export { wrapNext, wrapPrev, matchTypeahead } from '../list-navigation.js';
 
-// Navigable item roles carry data-menu-item; disabled items set
-// aria-disabled="true" and are excluded here.
+// Navigable menu item roles carry data-menu-item; disabled items set
+// aria-disabled="true" and are excluded.
 export const ITEM_SELECTOR = '[data-menu-item]:not([aria-disabled="true"])';
 
-export function wrapNext(
-  current: number,
-  length: number,
-  loop: boolean
-): number {
-  if (length === 0) return -1;
-  const next = current + 1;
-  if (next < length) return next;
-  return loop ? 0 : length - 1;
-}
-
-export function wrapPrev(
-  current: number,
-  length: number,
-  loop: boolean
-): number {
-  if (length === 0) return -1;
-  const prev = current - 1;
-  if (prev >= 0) return prev;
-  return loop ? length - 1 : 0;
-}
-
-// The next item (circularly, starting after fromIndex) whose text begins with
-// query. Returns -1 when nothing matches.
-export function matchTypeahead(
-  labels: string[],
-  query: string,
-  fromIndex: number
-): number {
-  const q = query.toLowerCase();
-  const n = labels.length;
-  for (let step = 1; step <= n; step++) {
-    const i = (fromIndex + step) % n;
-    if (labels[i].trim().toLowerCase().startsWith(q)) return i;
-  }
-  return -1;
-}
-
-// Enabled items belonging to exactly this surface (not a nested submenu), in
-// DOM order. Scoping by closest [role="menu"] keeps a submenu's items out of
-// the parent's navigation even though they are DOM descendants.
+// Enabled menu items belonging to exactly this surface (a submenu's items are
+// scoped out via their closer [role="menu"]).
 export function getMenuItems(surface: HTMLElement): HTMLElement[] {
-  const all = Array.from(surface.querySelectorAll<HTMLElement>(ITEM_SELECTOR));
-  return all.filter((el) => el.closest('[role="menu"]') === surface);
+  return getItems(surface, ITEM_SELECTOR, '[role="menu"]');
 }

--- a/packages/ui/src/select/context.ts
+++ b/packages/ui/src/select/context.ts
@@ -1,0 +1,51 @@
+// packages/ui/src/select/context.ts
+import { createContext, type RefObject } from 'preact';
+import { useContext } from 'preact/hooks';
+import type { Side, Align, PositionState } from '../use-position.js';
+
+// The value generic is erased to `unknown` at this module-level context (a
+// Preact context cannot carry a per-instance generic). The public Root/Option
+// props re-apply the generic; Root owns the comparator so all value handling
+// stays in one typed place.
+export interface SelectContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  multiple: boolean;
+  isSelected: (optionValue: unknown) => boolean;
+  toggle: (optionValue: unknown) => void;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  registerOption: (id: string, value: unknown, label: string) => () => void;
+  selectedLabels: () => string[];
+  anchorRef: RefObject<HTMLElement>;
+  floatingRef: RefObject<HTMLElement>;
+  listboxRef: RefObject<HTMLElement>;
+  arrowRef: RefObject<HTMLElement>;
+  triggerId: string;
+  listboxId: string;
+  disabled: boolean;
+  required: boolean;
+  side: Side;
+  align: Align;
+  offset: number;
+  loop: boolean;
+  typeahead: boolean;
+  position: PositionState;
+  setPosition: (p: PositionState) => void;
+}
+
+export const SelectContext = createContext<SelectContextValue | null>(null);
+
+export function useSelectContext(part: string): SelectContextValue {
+  const ctx = useContext(SelectContext);
+  if (!ctx) {
+    throw new Error(`<Select.${part}> must be used within <Select.Root>`);
+  }
+  return ctx;
+}
+
+export interface SelectOptionGroupContextValue {
+  labelId: string;
+}
+export const SelectOptionGroupContext =
+  createContext<SelectOptionGroupContextValue | null>(null);

--- a/packages/ui/src/select/index.ts
+++ b/packages/ui/src/select/index.ts
@@ -1,0 +1,45 @@
+export {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+  SelectOptionGroup,
+  SelectOptionGroupLabel,
+  SelectArrow,
+  OPTION_SELECTOR,
+  type SelectRootProps,
+  type SelectTriggerProps,
+  type SelectValueProps,
+  type SelectPositionerProps,
+  type SelectPopupProps,
+  type SelectOptionProps,
+  type SelectOptionGroupProps,
+  type SelectOptionGroupLabelProps,
+  type SelectArrowProps,
+} from './select.js';
+
+import {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectPositioner,
+  SelectPopup,
+  SelectOption,
+  SelectOptionGroup,
+  SelectOptionGroupLabel,
+  SelectArrow,
+} from './select.js';
+
+export const Select = {
+  Root: SelectRoot,
+  Trigger: SelectTrigger,
+  Value: SelectValue,
+  Positioner: SelectPositioner,
+  Popup: SelectPopup,
+  Option: SelectOption,
+  OptionGroup: SelectOptionGroup,
+  OptionGroupLabel: SelectOptionGroupLabel,
+  Arrow: SelectArrow,
+};

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -1,0 +1,276 @@
+// packages/ui/src/select/select.tsx
+import { h, type ComponentChildren, type JSX, type VNode } from 'preact';
+import { useCallback, useId, useMemo, useRef, useState } from 'preact/hooks';
+import { useRender, type RenderProp } from '../use-render.js';
+import { useControllableState } from '../use-controllable-state.js';
+import type { Side, Align, PositionState } from '../use-position.js';
+import { SelectContext, useSelectContext } from './context.js';
+
+interface OptionEntry {
+  id: string;
+  value: unknown;
+  label: string;
+}
+
+export interface SelectRootProps<Value = string> {
+  value?: Value | Value[];
+  defaultValue?: Value | Value[];
+  onValueChange?: (value: Value | Value[]) => void;
+  multiple?: boolean;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  name?: string;
+  disabled?: boolean;
+  required?: boolean;
+  isValueEqual?: (a: Value, b: Value) => boolean;
+  serializeValue?: (value: Value) => string;
+  side?: Side; // default 'bottom'
+  align?: Align; // default 'start'
+  offset?: number; // default 8
+  loop?: boolean; // default true
+  typeahead?: boolean; // default true
+  children?: ComponentChildren;
+}
+
+export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
+  const {
+    value: valueProp,
+    defaultValue,
+    onValueChange,
+    multiple = false,
+    open: openProp,
+    defaultOpen,
+    onOpenChange,
+    disabled = false,
+    required = false,
+    isValueEqual,
+    side = 'bottom',
+    align = 'start',
+    offset = 8,
+    loop = true,
+    typeahead = true,
+    children,
+  } = props;
+
+  const emptyDefault = (multiple ? [] : undefined) as
+    | Value
+    | Value[]
+    | undefined;
+  const [value, setValue] = useControllableState<Value | Value[] | undefined>({
+    value: valueProp,
+    defaultValue: defaultValue ?? emptyDefault,
+    onChange: (v) => v !== undefined && onValueChange?.(v),
+  });
+
+  const [open, setOpen] = useControllableState<boolean>({
+    value: openProp,
+    defaultValue: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  const anchorRef = useRef<HTMLElement>(null);
+  const floatingRef = useRef<HTMLElement>(null);
+  const listboxRef = useRef<HTMLElement>(null);
+  const arrowRef = useRef<HTMLElement>(null);
+  const baseId = useId();
+  const triggerId = `${baseId}-trigger`;
+  const listboxId = `${baseId}-listbox`;
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [position, setPosition] = useState<PositionState>({
+    side,
+    align,
+    arrowX: null,
+    arrowY: null,
+  });
+
+  // The comparator is the one place the generic is re-applied. Object.is
+  // accepts unknowns; a user comparator is adapted here (the sole
+  // generic-erasure boundary of the component).
+  const equal = useCallback(
+    (a: unknown, b: unknown): boolean => {
+      if (!isValueEqual) return Object.is(a, b);
+      return isValueEqual(a as Value, b as Value);
+    },
+    [isValueEqual]
+  );
+
+  const valuesArray = useCallback((): unknown[] => {
+    if (value === undefined) return [];
+    return Array.isArray(value) ? value : [value];
+  }, [value]);
+
+  const isSelected = useCallback(
+    (optionValue: unknown) => valuesArray().some((v) => equal(v, optionValue)),
+    [valuesArray, equal]
+  );
+
+  const toggle = useCallback(
+    (optionValue: unknown) => {
+      if (multiple) {
+        const current = valuesArray();
+        const next = current.some((v) => equal(v, optionValue))
+          ? current.filter((v) => !equal(v, optionValue))
+          : [...current, optionValue];
+        setValue(next as Value[]);
+      } else {
+        setValue(optionValue as Value);
+        setOpen(false);
+      }
+    },
+    [multiple, valuesArray, equal, setValue, setOpen]
+  );
+
+  const registry = useRef<OptionEntry[]>([]);
+  const [, force] = useState(0);
+  const registerOption = useCallback(
+    (id: string, optionValue: unknown, label: string) => {
+      registry.current = [
+        ...registry.current,
+        { id, value: optionValue, label },
+      ];
+      force((n) => n + 1);
+      return () => {
+        registry.current = registry.current.filter((e) => e.id !== id);
+        force((n) => n + 1);
+      };
+    },
+    []
+  );
+  const selectedLabels = useCallback(
+    () =>
+      registry.current.filter((e) => isSelected(e.value)).map((e) => e.label),
+    [isSelected]
+  );
+
+  const ctx = useMemo(
+    () => ({
+      open,
+      setOpen,
+      multiple,
+      isSelected,
+      toggle,
+      activeId,
+      setActiveId,
+      registerOption,
+      selectedLabels,
+      anchorRef,
+      floatingRef,
+      listboxRef,
+      arrowRef,
+      triggerId,
+      listboxId,
+      disabled,
+      required,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+      setPosition,
+    }),
+    [
+      open,
+      setOpen,
+      multiple,
+      isSelected,
+      toggle,
+      activeId,
+      registerOption,
+      selectedLabels,
+      baseId,
+      disabled,
+      required,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+    ]
+  );
+
+  return h(SelectContext.Provider, { value: ctx }, children);
+}
+
+export type SelectTriggerProps = {
+  render?: RenderProp<{ open: boolean }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'children'>;
+
+export function SelectTrigger(props: SelectTriggerProps): VNode {
+  const { render, children, onClick, onKeyDown, ...rest } = props;
+  const ctx = useSelectContext('Trigger');
+
+  const handleClick = (event: JSX.TargetedMouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    if (ctx.disabled) return;
+    ctx.setOpen(!ctx.open);
+  };
+  const handleKeyDown = (
+    event: JSX.TargetedKeyboardEvent<HTMLButtonElement>
+  ) => {
+    onKeyDown?.(event);
+    if (ctx.disabled || event.defaultPrevented) return;
+    if (
+      !ctx.open &&
+      (event.key === 'ArrowDown' ||
+        event.key === 'ArrowUp' ||
+        event.key === 'Enter' ||
+        event.key === ' ')
+    ) {
+      event.preventDefault();
+      ctx.setOpen(true);
+    }
+  };
+
+  return useRender<{ open: boolean }>({
+    render,
+    defaultTag: 'button',
+    props: {
+      ...rest,
+      ref: ctx.anchorRef,
+      type: 'button',
+      role: 'combobox',
+      'aria-haspopup': 'listbox',
+      'aria-expanded': ctx.open,
+      'aria-controls': ctx.listboxId,
+      'aria-activedescendant': ctx.open
+        ? (ctx.activeId ?? undefined)
+        : undefined,
+      'aria-required': ctx.required ? true : undefined,
+      id: ctx.triggerId,
+      disabled: ctx.disabled,
+      'data-state': ctx.open ? 'open' : 'closed',
+      onClick: handleClick,
+      onKeyDown: handleKeyDown,
+    },
+    state: { open: ctx.open },
+    children,
+  });
+}
+
+export type SelectValueProps = {
+  placeholder?: string;
+  render?: RenderProp<{ selectedLabels: string[] }>;
+  children?: (value: { selectedLabels: string[] }) => ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLSpanElement>, 'children'>;
+
+export function SelectValue(props: SelectValueProps): VNode {
+  const { placeholder, render, children, ...rest } = props;
+  const ctx = useSelectContext('Value');
+  const labels = ctx.selectedLabels();
+  const display = labels.length > 0 ? labels.join(', ') : (placeholder ?? '');
+  const content = children ? children({ selectedLabels: labels }) : display;
+  return useRender<{ selectedLabels: string[] }>({
+    render,
+    defaultTag: 'span',
+    props: {
+      ...rest,
+      'data-placeholder': labels.length === 0 ? '' : undefined,
+    },
+    state: { selectedLabels: labels },
+    children: content,
+  });
+}

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -1,10 +1,25 @@
 // packages/ui/src/select/select.tsx
 import { h, type ComponentChildren, type JSX, type VNode } from 'preact';
-import { useCallback, useId, useMemo, useRef, useState } from 'preact/hooks';
+import {
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
+import { usePosition } from '../use-position.js';
 import type { Side, Align, PositionState } from '../use-position.js';
-import { SelectContext, useSelectContext } from './context.js';
+import { useDismiss } from '../use-dismiss.js';
+import { useListNavigation } from '../list-navigation.js';
+import {
+  SelectContext,
+  useSelectContext,
+  SelectOptionGroupContext,
+} from './context.js';
 
 interface OptionEntry {
   id: string;
@@ -194,6 +209,12 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
   return h(SelectContext.Provider, { value: ctx }, children);
 }
 
+function supportsPopover(el: HTMLElement): boolean {
+  return typeof el.showPopover === 'function';
+}
+
+export const OPTION_SELECTOR = '[role="option"]:not([aria-disabled="true"])';
+
 export type SelectTriggerProps = {
   render?: RenderProp<{ open: boolean }>;
   children?: ComponentChildren;
@@ -202,6 +223,30 @@ export type SelectTriggerProps = {
 export function SelectTrigger(props: SelectTriggerProps): VNode {
   const { render, children, onClick, onKeyDown, ...rest } = props;
   const ctx = useSelectContext('Trigger');
+
+  // Focus stays on the trigger; navigation moves aria-activedescendant over the
+  // options in the (separate) listbox.
+  const nav = useListNavigation({
+    enabled: ctx.open,
+    containerRef: ctx.listboxRef,
+    itemSelector: OPTION_SELECTOR,
+    activeId: ctx.activeId,
+    setActiveId: ctx.setActiveId,
+    mode: 'activedescendant',
+    loop: ctx.loop,
+    typeahead: ctx.typeahead,
+  });
+
+  // On open, set the active descendant to the selected option (or the first).
+  useLayoutEffect(() => {
+    if (!ctx.open) return;
+    const list = nav.getItems();
+    if (list.length === 0) return;
+    const selectedIdx = list.findIndex(
+      (el) => el.getAttribute('aria-selected') === 'true'
+    );
+    nav.setActiveItem(selectedIdx >= 0 ? selectedIdx : 0);
+  }, [ctx.open]);
 
   const handleClick = (event: JSX.TargetedMouseEvent<HTMLButtonElement>) => {
     onClick?.(event);
@@ -213,15 +258,30 @@ export function SelectTrigger(props: SelectTriggerProps): VNode {
   ) => {
     onKeyDown?.(event);
     if (ctx.disabled || event.defaultPrevented) return;
-    if (
-      !ctx.open &&
-      (event.key === 'ArrowDown' ||
+    if (!ctx.open) {
+      if (
+        event.key === 'ArrowDown' ||
         event.key === 'ArrowUp' ||
         event.key === 'Enter' ||
-        event.key === ' ')
-    ) {
+        event.key === ' '
+      ) {
+        event.preventDefault();
+        ctx.setOpen(true);
+      }
+      return;
+    }
+    nav.onKeyDown(event);
+    if (event.defaultPrevented) return;
+    const list = nav.getItems();
+    const current = list.findIndex((el) => el.id === ctx.activeId);
+    if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      ctx.setOpen(true);
+      if (current >= 0) list[current].click();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      ctx.setOpen(false);
+    } else if (event.key === 'Tab') {
+      ctx.setOpen(false);
     }
   };
 
@@ -272,5 +332,241 @@ export function SelectValue(props: SelectValueProps): VNode {
     },
     state: { selectedLabels: labels },
     children: content,
+  });
+}
+
+export type SelectPositionerProps = {
+  render?: RenderProp<{ side: Side; align: Align }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectPositioner(props: SelectPositionerProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useSelectContext('Positioner');
+
+  const position = usePosition({
+    open: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+  });
+
+  useLayoutEffect(() => {
+    ctx.setPosition(position);
+  }, [position.side, position.align, position.arrowX, position.arrowY]);
+
+  // Promote to the native top layer where supported, only while open.
+  useLayoutEffect(() => {
+    const el = ctx.floatingRef.current;
+    if (!ctx.open || !el || !supportsPopover(el)) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      el.hidePopover();
+      el.removeAttribute('popover');
+    };
+  }, [ctx.open]);
+
+  // Always rendered so options register their labels; `hidden` while closed
+  // makes it inert and invisible without consumer CSS, and composes with the
+  // Popover-API promotion (which only runs while open).
+  return useRender<{ side: Side; align: Align }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.floatingRef,
+      hidden: ctx.open ? undefined : true,
+      'data-side': position.side,
+      'data-align': position.align,
+      style: {
+        position: 'fixed',
+        inset: 'auto',
+        margin: 0,
+        overflow: 'visible',
+        border: 0,
+        padding: 0,
+        background: 'transparent',
+      },
+    },
+    state: { side: position.side, align: position.align },
+    children,
+  });
+}
+
+export type SelectPopupProps = {
+  render?: RenderProp<{ open: boolean }>;
+  'aria-label'?: string;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectPopup(props: SelectPopupProps): VNode {
+  const { render, children, 'aria-label': ariaLabel, ...rest } = props;
+  const ctx = useSelectContext('Popup');
+
+  useDismiss({
+    enabled: ctx.open,
+    refs: [ctx.floatingRef, ctx.anchorRef],
+    escape: true,
+    outsidePress: true,
+    onDismiss: () => ctx.setOpen(false),
+  });
+
+  return useRender<{ open: boolean }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.listboxRef,
+      role: 'listbox',
+      id: ctx.listboxId,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabel ? undefined : ctx.triggerId,
+      'aria-multiselectable': ctx.multiple ? true : undefined,
+      'data-state': ctx.open ? 'open' : 'closed',
+    },
+    state: { open: ctx.open },
+    children,
+  });
+}
+
+export type SelectOptionProps<Value = string> = {
+  value: Value;
+  render?: RenderProp<{
+    selected: boolean;
+    disabled: boolean;
+    highlighted: boolean;
+  }>;
+  disabled?: boolean;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectOption<Value = string>(
+  props: SelectOptionProps<Value>
+): VNode {
+  const {
+    value,
+    render,
+    children,
+    disabled = false,
+    onClick,
+    onPointerEnter,
+    ...rest
+  } = props;
+  const ctx = useSelectContext('Option');
+  const id = useId();
+  const selected = ctx.isSelected(value);
+  const highlighted = ctx.activeId === id;
+
+  // Register this option's label (its text content) for the trigger auto-label.
+  useLayoutEffect(() => {
+    const label =
+      typeof children === 'string'
+        ? children
+        : (document.getElementById(id)?.textContent ?? '');
+    return ctx.registerOption(id, value, label);
+  }, [id, value, ctx.registerOption]);
+
+  const handleClick = (event: JSX.TargetedMouseEvent<HTMLDivElement>) => {
+    onClick?.(event);
+    if (disabled) return;
+    ctx.toggle(value);
+  };
+  const handlePointerEnter = (
+    event: JSX.TargetedPointerEvent<HTMLDivElement>
+  ) => {
+    onPointerEnter?.(event);
+    if (disabled) return;
+    ctx.setActiveId(id);
+  };
+
+  return useRender<{
+    selected: boolean;
+    disabled: boolean;
+    highlighted: boolean;
+  }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      id,
+      role: 'option',
+      'aria-selected': selected,
+      'aria-disabled': disabled ? 'true' : undefined,
+      'data-selected': selected ? '' : undefined,
+      'data-highlighted': highlighted ? '' : undefined,
+      'data-disabled': disabled ? '' : undefined,
+      onClick: handleClick,
+      onPointerEnter: handlePointerEnter,
+    },
+    state: { selected, disabled, highlighted },
+    children,
+  });
+}
+
+export type SelectOptionGroupProps = {
+  render?: RenderProp;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+// Return type left inferred: h(Context.Provider, ...) yields a VNode with more
+// specific props than VNode<{}> (matches the MenuGroup precedent).
+export function SelectOptionGroup(props: SelectOptionGroupProps) {
+  const { render, children, ...rest } = props;
+  const labelId = useId();
+  const node = useRender({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, role: 'group', 'aria-labelledby': labelId },
+    children,
+  });
+  return h(SelectOptionGroupContext.Provider, { value: { labelId } }, node);
+}
+
+export type SelectOptionGroupLabelProps = {
+  render?: RenderProp;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectOptionGroupLabel(
+  props: SelectOptionGroupLabelProps
+): VNode {
+  const { render, children, ...rest } = props;
+  const group = useContext(SelectOptionGroupContext);
+  return useRender({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, id: group?.labelId },
+    children,
+  });
+}
+
+export type SelectArrowProps = {
+  render?: RenderProp<{ side: Side }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function SelectArrow(props: SelectArrowProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useSelectContext('Arrow');
+  const { side, arrowX, arrowY } = ctx.position;
+  return useRender<{ side: Side }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.arrowRef,
+      'data-side': side,
+      style: {
+        position: 'absolute',
+        left: arrowX != null ? `${arrowX}px` : undefined,
+        top: arrowY != null ? `${arrowY}px` : undefined,
+      },
+    },
+    state: { side },
+    children,
   });
 }

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -1,5 +1,11 @@
 // packages/ui/src/select/select.tsx
-import { h, type ComponentChildren, type JSX, type VNode } from 'preact';
+import {
+  h,
+  Fragment,
+  type ComponentChildren,
+  type JSX,
+  type VNode,
+} from 'preact';
 import {
   useCallback,
   useContext,
@@ -57,9 +63,11 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
     open: openProp,
     defaultOpen,
     onOpenChange,
+    name,
     disabled = false,
     required = false,
     isValueEqual,
+    serializeValue,
     side = 'bottom',
     align = 'start',
     offset = 8,
@@ -108,6 +116,14 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
       return isValueEqual(a as Value, b as Value);
     },
     [isValueEqual]
+  );
+
+  // String form of a value for the hidden form field. Same generic-erasure
+  // seam as `equal`: only consulted when `name` is set.
+  const serialize = useCallback(
+    (v: unknown): string =>
+      serializeValue ? serializeValue(v as Value) : String(v),
+    [serializeValue]
   );
 
   const valuesArray = useCallback((): unknown[] => {
@@ -206,7 +222,27 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
     ]
   );
 
-  return h(SelectContext.Provider, { value: ctx }, children);
+  // Hidden native field(s) so the value submits in a real form. Single: one
+  // input; multi: one per selected value (repeated name, the native
+  // multi-select convention). Real inputs, so the value is present pre-hydration.
+  const hiddenFields =
+    name == null
+      ? null
+      : valuesArray().map((v, i) =>
+          h('input', {
+            key: `${name}-${i}`,
+            type: 'hidden',
+            name,
+            value: serialize(v),
+            disabled: disabled || undefined,
+          })
+        );
+
+  return h(
+    SelectContext.Provider,
+    { value: ctx },
+    h(Fragment, null, children, hiddenFields)
+  );
 }
 
 function supportsPopover(el: HTMLElement): boolean {

--- a/scripts/client-size-config.mjs
+++ b/scripts/client-size-config.mjs
@@ -73,6 +73,7 @@ export const COMPONENT_MODULES = {
   tooltip: ['tooltip/index.js'],
   menu: ['menu/index.js'],
   'context-menu': ['context-menu/index.js'],
+  select: ['select/index.js'],
 };
 
 // Section B: ordered prefix -> bucket for the site's emitted chunks. A prefix
@@ -90,6 +91,7 @@ export const CHUNK_PREFIXES = [
   ['tooltip', 'components'],
   ['menu', 'components'],
   ['context-menu', 'components'],
+  ['select', 'components'],
   ['use-position', 'components'],
   ['use-dismiss', 'components'],
   ['use-render', 'components'],


### PR DESCRIPTION
Implements **Phase 4** of the headless components roadmap: a headless `Select` (custom listbox) for `@hono-preact/ui` with single + multiple selection, a generic value type, and HTML form submission. Also promotes `useListNavigation` (roving + activedescendant) as a public primitive and refactors Menu onto it.

Spec: `docs/superpowers/specs/2026-06-06-select-design.md`
Plan: `docs/superpowers/plans/2026-06-06-select.md`

## What's new
- **`useListNavigation`** public primitive unifying movement across roving (Menu) and `aria-activedescendant` (Select); pure helpers (`wrapNext`/`wrapPrev`/`matchTypeahead`/`getItems`) and `useTypeahead` promoted to public exports. **Menu refactored onto it** (behavior-preserving, full menu suite green).
- **`Select.*`**: `Root` (generic `<Value>`, `multiple`, `name`, `isValueEqual`, `serializeValue`), `Trigger` (`role="combobox"`, focus-stays-put), `Value` (auto-label + placeholder + render-prop), `Positioner`, `Popup` (`role="listbox"`), `Option`, `OptionGroup`/`OptionGroupLabel`, `Arrow`.
- Single selects + closes; multi toggles + stays open (`aria-multiselectable`). Hidden native field per `name` for form submission (one input single, one per value multi).
- Always-mounted listbox (hidden when closed) so the trigger auto-shows the selected label.
- Docs: `/docs/components/select` (CSS + Tailwind) + a `useListNavigation` Foundations page; `select` added to client-size tracking.

## Accessibility
APG select-only-combobox / listbox pattern, documented keyboard map, `aria-activedescendant` navigation, typeahead.

## Test plan
- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1102 passed; `@hono-preact/ui` 151)
- [x] `pnpm test:integration` (4 passed)
- [x] `pnpm --filter site build`

## Deferred (tracked for follow-up)
Vestigial `menu/navigation.ts` cleanup, `SelectOption` label re-register on text-only change, typeahead-while-closed, option virtualization, async options, constraint validation; standing `usePresence` + styling-variant. Phase 5 Combobox reuses `useListNavigation` + this trigger shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)