### PR TITLE
feat(ui): usePresence exit animations across all overlays

### DIFF
--- a/apps/site/src/components/docs/UsePresenceDemo.tsx
+++ b/apps/site/src/components/docs/UsePresenceDemo.tsx
@@ -1,0 +1,25 @@
+import { usePresence } from '@hono-preact/ui';
+import { useState } from 'preact/hooks';
+
+// A box that mounts on open and animates out on close using usePresence. The
+// styling lives in apps/site/src/styles/root.css (.docs-presence*).
+export function UsePresenceDemo() {
+  const [open, setOpen] = useState(false);
+  const presence = usePresence(open);
+  return (
+    <div class="docs-presence">
+      <button class="docs-presence-trigger" onClick={() => setOpen((o) => !o)}>
+        {open ? 'Hide' : 'Show'}
+      </button>
+      {presence.isPresent ? (
+        <div
+          ref={presence.ref}
+          class="docs-presence-box"
+          data-state={presence.status === 'open' ? 'open' : 'closed'}
+        >
+          I fade + slide out before unmounting.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/site/src/pages/docs/components/combobox.mdx
+++ b/apps/site/src/pages/docs/components/combobox.mdx
@@ -232,6 +232,15 @@ a starting point in either flavor:
     transform: translateY(-4px);
   }
 }
+.docs-cb[data-state='closed'] {
+  animation: docs-cb-out 120ms ease-in forwards;
+}
+@keyframes docs-cb-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 .docs-cb__option {
   display: flex;
   align-items: center;
@@ -272,6 +281,12 @@ a starting point in either flavor:
   .docs-cb__option[data-highlighted] {
     background: #fafafa;
     color: #18181b;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-cb[data-state='open'],
+  .docs-cb[data-state='closed'] {
+    animation: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/combobox.mdx
+++ b/apps/site/src/pages/docs/components/combobox.mdx
@@ -307,7 +307,7 @@ a starting point in either flavor:
 }
 
 <Combobox.Positioner className="z-50">
-  <Combobox.Popup className="min-w-64 max-h-64 overflow-y-auto rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
+  <Combobox.Popup className="min-w-64 max-h-64 overflow-y-auto rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 data-[state=closed]:opacity-0 data-[state=closed]:-translate-y-1 motion-reduce:transition-none dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
     <Combobox.Option className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none data-[highlighted]:bg-zinc-900 data-[highlighted]:text-zinc-50 data-[selected]:after:content-['✓'] data-[selected]:after:ml-auto data-[disabled]:pointer-events-none data-[disabled]:text-zinc-400 dark:data-[highlighted]:bg-zinc-50 dark:data-[highlighted]:text-zinc-900">
       Apple
     </Combobox.Option>

--- a/apps/site/src/pages/docs/components/combobox.mdx
+++ b/apps/site/src/pages/docs/components/combobox.mdx
@@ -222,24 +222,21 @@ a starting point in either flavor:
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
   outline: none;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-cb[data-state='open'] {
-  animation: docs-cb-in 120ms ease-out;
-}
-@keyframes docs-cb-in {
-  from {
+@starting-style {
+  .docs-cb[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
 }
 .docs-cb[data-state='closed'] {
-  animation: docs-cb-out 120ms ease-in forwards;
-}
-@keyframes docs-cb-out {
-  to {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
+  opacity: 0;
+  transform: translateY(-4px);
 }
 .docs-cb__option {
   display: flex;
@@ -284,9 +281,8 @@ a starting point in either flavor:
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-cb[data-state='open'],
-  .docs-cb[data-state='closed'] {
-    animation: none;
+  .docs-cb {
+    transition: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/context-menu.mdx
+++ b/apps/site/src/pages/docs/components/context-menu.mdx
@@ -113,6 +113,15 @@ exactly like a `Menu.Popup`; the demo above uses the styles below:
     transform: translateY(-4px);
   }
 }
+.docs-menu[data-state='closed'] {
+  animation: docs-menu-out 120ms ease-in forwards;
+}
+@keyframes docs-menu-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 .docs-menu__item {
   display: flex;
   align-items: center;
@@ -156,6 +165,12 @@ exactly like a `Menu.Popup`; the demo above uses the styles below:
   }
   .docs-menu__separator {
     background: #27272a;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-menu[data-state='open'],
+  .docs-menu[data-state='closed'] {
+    animation: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/context-menu.mdx
+++ b/apps/site/src/pages/docs/components/context-menu.mdx
@@ -180,7 +180,7 @@ exactly like a `Menu.Popup`; the demo above uses the styles below:
   Right-click here
 </ContextMenu.Trigger>
 <ContextMenu.Positioner className="z-50">
-  <ContextMenu.Popup className="min-w-48 rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
+  <ContextMenu.Popup className="min-w-48 rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 data-[state=closed]:opacity-0 data-[state=closed]:-translate-y-1 motion-reduce:transition-none dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
     <ContextMenu.Item className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none cursor-pointer data-[highlighted]:bg-zinc-900 data-[highlighted]:text-zinc-50 data-[disabled]:pointer-events-none data-[disabled]:text-zinc-400 dark:data-[highlighted]:bg-zinc-50 dark:data-[highlighted]:text-zinc-900">
       Copy
     </ContextMenu.Item>

--- a/apps/site/src/pages/docs/components/context-menu.mdx
+++ b/apps/site/src/pages/docs/components/context-menu.mdx
@@ -103,24 +103,21 @@ exactly like a `Menu.Popup`; the demo above uses the styles below:
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
   outline: none;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-menu[data-state='open'] {
-  animation: docs-menu-in 120ms ease-out;
-}
-@keyframes docs-menu-in {
-  from {
+@starting-style {
+  .docs-menu[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
 }
 .docs-menu[data-state='closed'] {
-  animation: docs-menu-out 120ms ease-in forwards;
-}
-@keyframes docs-menu-out {
-  to {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
+  opacity: 0;
+  transform: translateY(-4px);
 }
 .docs-menu__item {
   display: flex;
@@ -168,9 +165,8 @@ exactly like a `Menu.Popup`; the demo above uses the styles below:
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-menu[data-state='open'],
-  .docs-menu[data-state='closed'] {
-    animation: none;
+  .docs-menu {
+    transition: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/dialog.mdx
+++ b/apps/site/src/pages/docs/components/dialog.mdx
@@ -49,7 +49,7 @@ The demo above uses the styles below; copy a starting point in either flavor:
    that normally centers a modal <dialog>. Keep centering in `transform`, not the
    standalone `translate` property: a rule that sets both can have its `translate`
    dropped by a CSS minifier, silently un-centering the dialog in a production
-   build. The entry animation folds the offset into its own transform. */
+   build. */
 dialog[data-state='open'] {
   position: fixed;
   top: 50%;
@@ -62,10 +62,11 @@ dialog[data-state='open'] {
   border-radius: 14px;
   background: #fff;
   color: #18181b;
-  transform: translate(-50%, -50%);
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.2),
     0 4px 6px -4px rgb(0 0 0 / 0.2);
+  opacity: 1;
+  transform: translate(-50%, -50%);
   transition:
     opacity 160ms ease,
     transform 160ms ease;
@@ -81,6 +82,14 @@ dialog[data-state='open'] {
 dialog::backdrop {
   background: rgb(0 0 0 / 0.5);
   backdrop-filter: blur(2px);
+  opacity: 1;
+  transition: opacity 160ms ease;
+}
+
+@starting-style {
+  dialog[open]::backdrop {
+    opacity: 0;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -101,9 +110,20 @@ dialog[data-state='closed'] {
   }
 }
 
+dialog[data-state='closed']::backdrop {
+  animation: dialog-backdrop-out 160ms ease-in forwards;
+}
+@keyframes dialog-backdrop-out {
+  to {
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   dialog[data-state='open'],
-  dialog[data-state='closed'] {
+  dialog[data-state='closed'],
+  dialog::backdrop,
+  dialog[data-state='closed']::backdrop {
     transition: none;
     animation: none;
   }

--- a/apps/site/src/pages/docs/components/dialog.mdx
+++ b/apps/site/src/pages/docs/components/dialog.mdx
@@ -117,6 +117,8 @@ dialog[data-state='closed'] {
          rounded-2xl border border-zinc-200 bg-white p-6 text-zinc-900 shadow-xl
          opacity-100 transition-[opacity,transform] duration-[160ms] ease-out
          starting:opacity-0 starting:[transform:translate(-50%,calc(-50%_+_8px))_scale(0.98)]
+         data-[state=closed]:opacity-0 data-[state=closed]:[transform:translate(-50%,calc(-50%_+_8px))_scale(0.98)]
+         motion-reduce:transition-none
          backdrop:bg-black/50 backdrop:backdrop-blur-sm
          dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
 >

--- a/apps/site/src/pages/docs/components/dialog.mdx
+++ b/apps/site/src/pages/docs/components/dialog.mdx
@@ -91,9 +91,21 @@ dialog::backdrop {
   }
 }
 
+dialog[data-state='closed'] {
+  animation: dialog-out 160ms ease-in forwards;
+}
+@keyframes dialog-out {
+  to {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 8px)) scale(0.98);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  dialog[data-state='open'] {
+  dialog[data-state='open'],
+  dialog[data-state='closed'] {
     transition: none;
+    animation: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/menu.mdx
+++ b/apps/site/src/pages/docs/components/menu.mdx
@@ -106,6 +106,15 @@ either flavor:
     transform: translateY(-4px);
   }
 }
+.docs-menu[data-state='closed'] {
+  animation: docs-menu-out 120ms ease-in forwards;
+}
+@keyframes docs-menu-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 /* Items are roving-tabindex rows; the active row is highlighted via the
    data-attribute the component sets on hover and arrow navigation. */
 .docs-menu__item {
@@ -151,6 +160,12 @@ either flavor:
   }
   .docs-menu__separator {
     background: #27272a;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-menu[data-state='open'],
+  .docs-menu[data-state='closed'] {
+    animation: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/menu.mdx
+++ b/apps/site/src/pages/docs/components/menu.mdx
@@ -172,7 +172,7 @@ either flavor:
 
 ```tsx
 <Menu.Positioner className="z-50">
-  <Menu.Popup className="min-w-48 rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
+  <Menu.Popup className="min-w-48 rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 data-[state=closed]:opacity-0 data-[state=closed]:-translate-y-1 motion-reduce:transition-none dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
     <Menu.Item className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none cursor-pointer data-[highlighted]:bg-zinc-900 data-[highlighted]:text-zinc-50 data-[disabled]:pointer-events-none data-[disabled]:text-zinc-400 dark:data-[highlighted]:bg-zinc-50 dark:data-[highlighted]:text-zinc-900">
       New file
     </Menu.Item>

--- a/apps/site/src/pages/docs/components/menu.mdx
+++ b/apps/site/src/pages/docs/components/menu.mdx
@@ -96,24 +96,21 @@ either flavor:
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
   outline: none;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-menu[data-state='open'] {
-  animation: docs-menu-in 120ms ease-out;
-}
-@keyframes docs-menu-in {
-  from {
+@starting-style {
+  .docs-menu[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
 }
 .docs-menu[data-state='closed'] {
-  animation: docs-menu-out 120ms ease-in forwards;
-}
-@keyframes docs-menu-out {
-  to {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
+  opacity: 0;
+  transform: translateY(-4px);
 }
 /* Items are roving-tabindex rows; the active row is highlighted via the
    data-attribute the component sets on hover and arrow navigation. */
@@ -163,9 +160,8 @@ either flavor:
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-menu[data-state='open'],
-  .docs-menu[data-state='closed'] {
-    animation: none;
+  .docs-menu {
+    transition: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/popover.mdx
+++ b/apps/site/src/pages/docs/components/popover.mdx
@@ -84,6 +84,15 @@ demo above uses the styles below; copy a starting point in either flavor:
     transform: translateY(-4px);
   }
 }
+.docs-popover[data-state='closed'] {
+  animation: docs-popover-out 120ms ease-in forwards;
+}
+@keyframes docs-popover-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 /* The arrow is a rotated square; the component sets position:absolute and the
    cross-axis offset, the per-side rules place it on the edge facing the anchor.
    The Positioner already clears the UA top-layer styles, so nothing else is
@@ -127,6 +136,12 @@ demo above uses the styles below; copy a starting point in either flavor:
   .docs-popover__arrow {
     background: #18181b;
     border-color: #27272a;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-popover[data-state='open'],
+  .docs-popover[data-state='closed'] {
+    animation: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/popover.mdx
+++ b/apps/site/src/pages/docs/components/popover.mdx
@@ -148,7 +148,7 @@ demo above uses the styles below; copy a starting point in either flavor:
 
 ```tsx
 <Popover.Positioner className="z-50">
-  <Popover.Popup className="w-64 rounded-[0.625rem] border border-zinc-200 bg-white p-4 text-zinc-900 shadow-xl opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
+  <Popover.Popup className="w-64 rounded-[0.625rem] border border-zinc-200 bg-white p-4 text-zinc-900 shadow-xl opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 data-[state=closed]:opacity-0 data-[state=closed]:-translate-y-1 motion-reduce:transition-none dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
     <Popover.Title className="text-sm font-semibold">Settings</Popover.Title>
     <Popover.Description className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
       Adjust your preferences.

--- a/apps/site/src/pages/docs/components/popover.mdx
+++ b/apps/site/src/pages/docs/components/popover.mdx
@@ -62,6 +62,11 @@ demo above uses the styles below; copy a starting point in either flavor:
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
 /* Compact popup typography so the title/description do not inherit page heading
    and paragraph margins. */
@@ -75,11 +80,8 @@ demo above uses the styles below; copy a starting point in either flavor:
   font-size: 0.875rem;
   color: #71717a;
 }
-.docs-popover[data-state='open'] {
-  animation: docs-popover-in 120ms ease-out;
-}
-@keyframes docs-popover-in {
-  from {
+@starting-style {
+  .docs-popover[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
@@ -139,7 +141,9 @@ demo above uses the styles below; copy a starting point in either flavor:
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-popover[data-state='open'],
+  .docs-popover {
+    transition: none;
+  }
   .docs-popover[data-state='closed'] {
     animation: none;
   }

--- a/apps/site/src/pages/docs/components/select.mdx
+++ b/apps/site/src/pages/docs/components/select.mdx
@@ -153,6 +153,15 @@ styles below; copy a starting point in either flavor:
     transform: translateY(-4px);
   }
 }
+.docs-select[data-state='closed'] {
+  animation: docs-select-out 120ms ease-in forwards;
+}
+@keyframes docs-select-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 /* Options: the active descendant is data-highlighted (set by hover and arrow
    keys); the selected option is data-selected. Both can be true at once. */
 .docs-select__option {
@@ -199,6 +208,12 @@ styles below; copy a starting point in either flavor:
   .docs-select__option[data-highlighted] {
     background: #fafafa;
     color: #18181b;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-select[data-state='open'],
+  .docs-select[data-state='closed'] {
+    animation: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/select.mdx
+++ b/apps/site/src/pages/docs/components/select.mdx
@@ -143,24 +143,21 @@ styles below; copy a starting point in either flavor:
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
   outline: none;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-select[data-state='open'] {
-  animation: docs-select-in 120ms ease-out;
-}
-@keyframes docs-select-in {
-  from {
+@starting-style {
+  .docs-select[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
 }
 .docs-select[data-state='closed'] {
-  animation: docs-select-out 120ms ease-in forwards;
-}
-@keyframes docs-select-out {
-  to {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
+  opacity: 0;
+  transform: translateY(-4px);
 }
 /* Options: the active descendant is data-highlighted (set by hover and arrow
    keys); the selected option is data-selected. Both can be true at once. */
@@ -211,9 +208,8 @@ styles below; copy a starting point in either flavor:
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-select[data-state='open'],
-  .docs-select[data-state='closed'] {
-    animation: none;
+  .docs-select {
+    transition: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/select.mdx
+++ b/apps/site/src/pages/docs/components/select.mdx
@@ -226,7 +226,7 @@ styles below; copy a starting point in either flavor:
   />
 </Select.Trigger>
 <Select.Positioner className="z-50">
-  <Select.Popup className="min-w-56 max-h-64 overflow-y-auto rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
+  <Select.Popup className="min-w-56 max-h-64 overflow-y-auto rounded-[0.625rem] border border-zinc-200 bg-white p-1 text-zinc-900 shadow-xl outline-none opacity-100 translate-y-0 transition-[opacity,translate] duration-[120ms] ease-out starting:opacity-0 starting:-translate-y-1 data-[state=closed]:opacity-0 data-[state=closed]:-translate-y-1 motion-reduce:transition-none dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100">
     <Select.Option className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm outline-none cursor-pointer data-[selected]:after:content-['✓'] data-[selected]:after:ml-auto data-[highlighted]:bg-zinc-900 data-[highlighted]:text-zinc-50 data-[disabled]:pointer-events-none data-[disabled]:text-zinc-400 dark:data-[highlighted]:bg-zinc-50 dark:data-[highlighted]:text-zinc-900">
       Apple
     </Select.Option>

--- a/apps/site/src/pages/docs/components/tooltip.mdx
+++ b/apps/site/src/pages/docs/components/tooltip.mdx
@@ -121,7 +121,7 @@ starting point in either flavor:
 
 ```tsx
 <Tooltip.Positioner className="z-50">
-  <Tooltip.Popup className="rounded-md bg-zinc-900 px-2.5 py-1.5 text-[13px] text-zinc-50 shadow-lg opacity-100 transition-opacity duration-100 ease-out starting:opacity-0">
+  <Tooltip.Popup className="rounded-md bg-zinc-900 px-2.5 py-1.5 text-[13px] text-zinc-50 shadow-lg opacity-100 transition-opacity duration-100 ease-out starting:opacity-0 data-[state=closed]:opacity-0 motion-reduce:transition-none">
     Saved to your library
   </Tooltip.Popup>
 </Tooltip.Positioner>

--- a/apps/site/src/pages/docs/components/tooltip.mdx
+++ b/apps/site/src/pages/docs/components/tooltip.mdx
@@ -74,6 +74,14 @@ starting point in either flavor:
     opacity: 0;
   }
 }
+.docs-tooltip[data-state='closed'] {
+  animation: docs-tooltip-out 100ms ease-in forwards;
+}
+@keyframes docs-tooltip-out {
+  to {
+    opacity: 0;
+  }
+}
 /* A solid rotated square, same color as the chip, straddling the edge facing
    the anchor. */
 .docs-tooltip__arrow {
@@ -101,6 +109,12 @@ starting point in either flavor:
   }
   .docs-tooltip__arrow {
     background: #27272a;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-tooltip[data-state='open'],
+  .docs-tooltip[data-state='closed'] {
+    animation: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/tooltip.mdx
+++ b/apps/site/src/pages/docs/components/tooltip.mdx
@@ -65,12 +65,11 @@ starting point in either flavor:
   color: #fafafa;
   font-size: 0.8125rem;
   box-shadow: 0 6px 18px rgb(0 0 0 / 0.18);
+  opacity: 1;
+  transition: opacity 100ms ease;
 }
-.docs-tooltip[data-state='open'] {
-  animation: docs-tooltip-in 100ms ease-out;
-}
-@keyframes docs-tooltip-in {
-  from {
+@starting-style {
+  .docs-tooltip[data-state='open'] {
     opacity: 0;
   }
 }
@@ -112,9 +111,8 @@ starting point in either flavor:
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-tooltip[data-state='open'],
-  .docs-tooltip[data-state='closed'] {
-    animation: none;
+  .docs-tooltip {
+    transition: none;
   }
 }
 ```

--- a/apps/site/src/pages/docs/components/use-presence.mdx
+++ b/apps/site/src/pages/docs/components/use-presence.mdx
@@ -1,0 +1,97 @@
+import { Example } from '../../../components/docs/Example.js';
+import { UsePresenceDemo } from '../../../components/docs/UsePresenceDemo.js';
+
+# usePresence
+
+`usePresence` keeps an element mounted while it animates out, then unmounts it.
+It is the primitive every overlay in this library uses to run a closing
+animation: on close it holds the element in the DOM, lets a `[data-state="closed"]`
+CSS animation run, and unmounts only once the animation finishes. Animation is
+opt-in: with no closing rule the element unmounts immediately, exactly as before.
+
+## Demo
+
+<Example>
+  <UsePresenceDemo />
+</Example>
+
+## Signature
+
+```ts
+import { usePresence } from '@hono-preact/ui';
+
+function usePresence(
+  present: boolean,
+  options?: UsePresenceOptions,
+): UsePresenceResult;
+
+interface UsePresenceOptions {
+  onExitComplete?: () => void; // fires when the exit resolves, before unmount
+  timeoutCap?: number; // ms cap on the exit wait (default 3000)
+}
+
+interface UsePresenceResult {
+  isPresent: boolean; // render the element while true (open or animating out)
+  status: 'open' | 'closing' | 'closed'; // map to data-state (closing -> "closed")
+  ref: (node: Element | null) => void; // attach to the animated element
+}
+```
+
+## Options
+
+| Option           | Type         | Default | Notes                                                                 |
+| ---------------- | ------------ | ------- | --------------------------------------------------------------------- |
+| `present`        | `boolean`    | none    | The desired visibility. Flip it to false to start the exit animation. |
+| `onExitComplete` | `() => void` | none    | Runs when the exit resolves, immediately before `isPresent` is false. |
+| `timeoutCap`     | `number`     | `3000`  | Safety cap (ms) so a stuck animation can never block teardown.        |
+
+Gate rendering on `isPresent`, attach `ref` to the element that carries the
+transition, and map `status` to `data-state` (both `closing` and `closed` map to
+`"closed"`, so one `[data-state="closed"]` rule styles the exit). It reads
+`Element.getAnimations()` after a forced reflow, races the animations' `finished`
+promises against `timeoutCap`, and short-circuits under
+`prefers-reduced-motion`. There is no exit on first mount or during SSR.
+
+## Example
+
+```tsx
+import { usePresence } from '@hono-preact/ui';
+import { useState } from 'preact/hooks';
+
+function Panel() {
+  const [open, setOpen] = useState(false);
+  const presence = usePresence(open);
+  return (
+    <div>
+      <button onClick={() => setOpen((o) => !o)}>Toggle</button>
+      {presence.isPresent ? (
+        <div
+          ref={presence.ref}
+          data-state={presence.status === 'open' ? 'open' : 'closed'}
+        >
+          Content
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+```css
+[data-state='open'] {
+  animation: panel-in 160ms ease-out;
+}
+[data-state='closed'] {
+  animation: panel-out 160ms ease-in forwards;
+}
+@keyframes panel-in {
+  from { opacity: 0; transform: translateY(-6px); }
+}
+@keyframes panel-out {
+  to { opacity: 0; transform: translateY(-6px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-state='open'],
+  [data-state='closed'] { animation: none; }
+}
+```

--- a/apps/site/src/pages/docs/components/use-presence.mdx
+++ b/apps/site/src/pages/docs/components/use-presence.mdx
@@ -22,7 +22,7 @@ import { usePresence } from '@hono-preact/ui';
 
 function usePresence(
   present: boolean,
-  options?: UsePresenceOptions,
+  options?: UsePresenceOptions
 ): UsePresenceResult;
 
 interface UsePresenceOptions {
@@ -85,13 +85,21 @@ function Panel() {
   animation: panel-out 160ms ease-in forwards;
 }
 @keyframes panel-in {
-  from { opacity: 0; transform: translateY(-6px); }
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
 }
 @keyframes panel-out {
-  to { opacity: 0; transform: translateY(-6px); }
+  to {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
 }
 @media (prefers-reduced-motion: reduce) {
   [data-state='open'],
-  [data-state='closed'] { animation: none; }
+  [data-state='closed'] {
+    animation: none;
+  }
 }
 ```

--- a/apps/site/src/pages/docs/components/use-presence.mdx
+++ b/apps/site/src/pages/docs/components/use-presence.mdx
@@ -6,8 +6,9 @@ import { UsePresenceDemo } from '../../../components/docs/UsePresenceDemo.js';
 `usePresence` keeps an element mounted while it animates out, then unmounts it.
 It is the primitive every overlay in this library uses to run a closing
 animation: on close it holds the element in the DOM, lets a `[data-state="closed"]`
-CSS animation run, and unmounts only once the animation finishes. Animation is
-opt-in: with no closing rule the element unmounts immediately, exactly as before.
+CSS **transition or keyframe animation** run, and unmounts only once it finishes.
+Animation is opt-in: with no closing rule the element unmounts immediately,
+exactly as before.
 
 ## Demo
 
@@ -103,3 +104,47 @@ function Panel() {
   }
 }
 ```
+
+## Transition or keyframes
+
+The exit can be a keyframe `animation` (above) or a plain CSS `transition`,
+`usePresence` waits for either. A transition is often simpler: put the resting
+values and a `transition` on the element, drive entry with `@starting-style`,
+and the exit values on `[data-state="closed"]`.
+
+```css
+[data-state] {
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+@starting-style {
+  [data-state='open'] {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+[data-state='closed'] {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-state] {
+    transition: none;
+  }
+}
+```
+
+Under the hood, `usePresence` reads `Element.getAnimations({ subtree: true })`,
+which reports both transitions and keyframe animations, and if nothing is
+running on the first read it waits for a `transitionrun`/`animationstart` to
+bubble up before deciding there is no exit. That `subtree`/event handling is why
+the animated element can be a child of the one you attach `ref` to, and why a
+child whose `data-state` flips a render-tick later still animates.
+
+**Exit animations must be finite.** An `animation-iteration-count: infinite`
+exit is ignored (it would never resolve, blocking teardown), so the element
+finalizes as if there were no exit, use a finite count with `forwards`. Entry
+animations may loop freely; only the closing animation is awaited.

--- a/apps/site/src/pages/docs/components/use-presence.mdx
+++ b/apps/site/src/pages/docs/components/use-presence.mdx
@@ -46,12 +46,15 @@ interface UsePresenceResult {
 | `onExitComplete` | `() => void` | none    | Runs when the exit resolves, immediately before `isPresent` is false. |
 | `timeoutCap`     | `number`     | `3000`  | Safety cap (ms) so a stuck animation can never block teardown.        |
 
-Gate rendering on `isPresent`, attach `ref` to the element that carries the
-transition, and map `status` to `data-state` (both `closing` and `closed` map to
-`"closed"`, so one `[data-state="closed"]` rule styles the exit). It reads
-`Element.getAnimations()` after a forced reflow, races the animations' `finished`
-promises against `timeoutCap`, and short-circuits under
-`prefers-reduced-motion`. There is no exit on first mount or during SSR.
+Gate rendering on `isPresent` and attach `ref` to the element that carries the
+exit animation — or an ancestor of it, but never a sibling — merged with your
+own ref via [mergeRefs](/docs/components/merge-refs). Drive `data-state` from
+`status` (both `closing` and `closed` map to `"closed"`, so one
+`[data-state="closed"]` rule styles the exit), or equivalently from your own
+open flag — the library's own components do the latter. It reads
+`Element.getAnimations({ subtree: true })` after a forced reflow, waits for every
+exit animation to finish (with a `timeoutCap` safety net), and short-circuits
+under `prefers-reduced-motion`. There is no exit on first mount or during SSR.
 
 ## Example
 

--- a/apps/site/src/pages/docs/nav.ts
+++ b/apps/site/src/pages/docs/nav.ts
@@ -152,6 +152,10 @@ export const nav: NavArea[] = [
             title: 'useSafeArea',
             route: '/docs/components/use-safe-area',
           },
+          {
+            title: 'usePresence',
+            route: '/docs/components/use-presence',
+          },
         ],
       },
     ],

--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -672,6 +672,13 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
 .docs-dialog::backdrop {
   background: rgb(0 0 0 / 0.5);
   backdrop-filter: blur(2px);
+  opacity: 1;
+  transition: opacity 160ms ease;
+}
+@starting-style {
+  .docs-dialog[open]::backdrop {
+    opacity: 0;
+  }
 }
 /* Compact dialog-local typography (overrides the .mdx-content h2/p defaults). */
 .docs-dialog h2 {
@@ -699,9 +706,19 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     transform: translate(-50%, calc(-50% + 8px)) scale(0.98);
   }
 }
+.docs-dialog[data-state='closed']::backdrop {
+  animation: docs-backdrop-out 160ms ease-in forwards;
+}
+@keyframes docs-backdrop-out {
+  to {
+    opacity: 0;
+  }
+}
 @media (prefers-reduced-motion: reduce) {
   .docs-dialog[data-state='open'],
-  .docs-dialog[data-state='closed'] {
+  .docs-dialog[data-state='closed'],
+  .docs-dialog::backdrop,
+  .docs-dialog[data-state='closed']::backdrop {
     transition: none;
     animation: none;
   }
@@ -828,12 +845,14 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   box-shadow:
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-popover[data-state='open'] {
-  animation: docs-popover-in 120ms ease-out;
-}
-@keyframes docs-popover-in {
-  from {
+@starting-style {
+  .docs-popover[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
@@ -897,7 +916,9 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   border-left: 0;
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-popover[data-state='open'],
+  .docs-popover {
+    transition: none;
+  }
   .docs-popover[data-state='closed'] {
     animation: none;
   }
@@ -939,12 +960,11 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   color: var(--background);
   font-size: 0.8125rem;
   box-shadow: 0 6px 18px rgb(0 0 0 / 0.18);
+  opacity: 1;
+  transition: opacity 100ms ease;
 }
-.docs-tooltip[data-state='open'] {
-  animation: docs-tooltip-in 100ms ease-out;
-}
-@keyframes docs-tooltip-in {
-  from {
+@starting-style {
+  .docs-tooltip[data-state='open'] {
     opacity: 0;
   }
 }
@@ -975,9 +995,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   right: -4px;
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-tooltip[data-state='open'],
-  .docs-tooltip[data-state='closed'] {
-    animation: none;
+  .docs-tooltip {
+    transition: none;
   }
 }
 
@@ -1250,24 +1269,21 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
   outline: none;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-menu[data-state='open'] {
-  animation: docs-menu-in 120ms ease-out;
-}
-@keyframes docs-menu-in {
-  from {
+@starting-style {
+  .docs-menu[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
 }
 .docs-menu[data-state='closed'] {
-  animation: docs-menu-out 120ms ease-in forwards;
-}
-@keyframes docs-menu-out {
-  to {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
+  opacity: 0;
+  transform: translateY(-4px);
 }
 /* Items: roving-tabindex rows; the active row is :focus, so highlight on
    data-highlighted (set by hover and arrow keys) reads in both modes. */
@@ -1344,9 +1360,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   color: var(--foreground);
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-menu[data-state='open'],
-  .docs-menu[data-state='closed'] {
-    animation: none;
+  .docs-menu {
+    transition: none;
   }
 }
 
@@ -1408,24 +1423,21 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
   outline: none;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-select[data-state='open'] {
-  animation: docs-select-in 120ms ease-out;
-}
-@keyframes docs-select-in {
-  from {
+@starting-style {
+  .docs-select[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
 }
 .docs-select[data-state='closed'] {
-  animation: docs-select-out 120ms ease-in forwards;
-}
-@keyframes docs-select-out {
-  to {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
+  opacity: 0;
+  transform: translateY(-4px);
 }
 /* Options: the active descendant is data-highlighted (set by hover and arrow
    keys); the selected option is data-selected. Both can be true at once. */
@@ -1467,9 +1479,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   color: var(--muted);
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-select[data-state='open'],
-  .docs-select[data-state='closed'] {
-    animation: none;
+  .docs-select {
+    transition: none;
   }
 }
 
@@ -1552,24 +1563,21 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     0 10px 15px -3px rgb(0 0 0 / 0.25),
     0 4px 6px -4px rgb(0 0 0 / 0.25);
   outline: none;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
-.docs-cb[data-state='open'] {
-  animation: docs-cb-in 120ms ease-out;
-}
-@keyframes docs-cb-in {
-  from {
+@starting-style {
+  .docs-cb[data-state='open'] {
     opacity: 0;
     transform: translateY(-4px);
   }
 }
 .docs-cb[data-state='closed'] {
-  animation: docs-cb-out 120ms ease-in forwards;
-}
-@keyframes docs-cb-out {
-  to {
-    opacity: 0;
-    transform: translateY(-4px);
-  }
+  opacity: 0;
+  transform: translateY(-4px);
 }
 .docs-cb__option {
   display: flex;
@@ -1630,9 +1638,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   opacity: 1;
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-cb[data-state='open'],
-  .docs-cb[data-state='closed'] {
-    animation: none;
+  .docs-cb {
+    transition: none;
   }
 }
 

--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -1575,3 +1575,66 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     animation: none;
   }
 }
+
+/* usePresence docs demo */
+.docs-presence {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+.docs-presence-trigger {
+  appearance: none;
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.875rem;
+  line-height: 1;
+  padding: 0.6rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+.docs-presence-trigger:hover {
+  background: var(--accent-hover);
+}
+.docs-presence-trigger:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+.docs-presence-box {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--foreground);
+}
+.docs-presence-box[data-state='open'] {
+  animation: docs-presence-in 160ms ease-out;
+}
+.docs-presence-box[data-state='closed'] {
+  animation: docs-presence-out 160ms ease-in forwards;
+}
+@keyframes docs-presence-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+@keyframes docs-presence-out {
+  to {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-presence-box[data-state='open'],
+  .docs-presence-box[data-state='closed'] {
+    animation: none;
+  }
+}

--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -690,9 +690,20 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   gap: 0.5rem;
   margin-top: 1.5rem;
 }
+.docs-dialog[data-state='closed'] {
+  animation: docs-dialog-out 160ms ease-in forwards;
+}
+@keyframes docs-dialog-out {
+  to {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 8px)) scale(0.98);
+  }
+}
 @media (prefers-reduced-motion: reduce) {
-  .docs-dialog {
+  .docs-dialog[data-state='open'],
+  .docs-dialog[data-state='closed'] {
     transition: none;
+    animation: none;
   }
 }
 
@@ -827,6 +838,15 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     transform: translateY(-4px);
   }
 }
+.docs-popover[data-state='closed'] {
+  animation: docs-popover-out 120ms ease-in forwards;
+}
+@keyframes docs-popover-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 /* Scope the popup typography by element so it overrides the .mdx-content prose
    h2/p (a BEM class would lose the specificity tie to `.mdx-content h2`). */
 .docs-popover h2 {
@@ -877,7 +897,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   border-left: 0;
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-popover {
+  .docs-popover[data-state='open'],
+  .docs-popover[data-state='closed'] {
     animation: none;
   }
 }
@@ -927,6 +948,14 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     opacity: 0;
   }
 }
+.docs-tooltip[data-state='closed'] {
+  animation: docs-tooltip-out 100ms ease-in forwards;
+}
+@keyframes docs-tooltip-out {
+  to {
+    opacity: 0;
+  }
+}
 .docs-tooltip__arrow {
   width: 8px;
   height: 8px;
@@ -946,7 +975,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   right: -4px;
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-tooltip {
+  .docs-tooltip[data-state='open'],
+  .docs-tooltip[data-state='closed'] {
     animation: none;
   }
 }
@@ -1230,6 +1260,15 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     transform: translateY(-4px);
   }
 }
+.docs-menu[data-state='closed'] {
+  animation: docs-menu-out 120ms ease-in forwards;
+}
+@keyframes docs-menu-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 /* Items: roving-tabindex rows; the active row is :focus, so highlight on
    data-highlighted (set by hover and arrow keys) reads in both modes. */
 .docs-menu__item {
@@ -1305,7 +1344,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   color: var(--foreground);
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-menu {
+  .docs-menu[data-state='open'],
+  .docs-menu[data-state='closed'] {
     animation: none;
   }
 }
@@ -1378,6 +1418,15 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     transform: translateY(-4px);
   }
 }
+.docs-select[data-state='closed'] {
+  animation: docs-select-out 120ms ease-in forwards;
+}
+@keyframes docs-select-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 /* Options: the active descendant is data-highlighted (set by hover and arrow
    keys); the selected option is data-selected. Both can be true at once. */
 .docs-select__option {
@@ -1418,7 +1467,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   color: var(--muted);
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-select {
+  .docs-select[data-state='open'],
+  .docs-select[data-state='closed'] {
     animation: none;
   }
 }
@@ -1512,6 +1562,15 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
     transform: translateY(-4px);
   }
 }
+.docs-cb[data-state='closed'] {
+  animation: docs-cb-out 120ms ease-in forwards;
+}
+@keyframes docs-cb-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
 .docs-cb__option {
   display: flex;
   align-items: center;
@@ -1571,7 +1630,8 @@ html:active-view-transition-type(docs-within)::view-transition-new(docs-topbar) 
   opacity: 1;
 }
 @media (prefers-reduced-motion: reduce) {
-  .docs-cb {
+  .docs-cb[data-state='open'],
+  .docs-cb[data-state='closed'] {
     animation: none;
   }
 }

--- a/docs/superpowers/plans/2026-06-08-use-presence-exit-animations.md
+++ b/docs/superpowers/plans/2026-06-08-use-presence-exit-animations.md
@@ -1,0 +1,1682 @@
+# usePresence Exit Animations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a public `usePresence` primitive built on `Element.getAnimations()` to `@hono-preact/ui` and wire it into all seven overlay components so they animate out as they close.
+
+**Architecture:** A single hook runs a phase state machine (`open` → `closing` → `closed`). On close it keeps the element mounted/shown, lets the `[data-state="closed"]` CSS exit animation run, awaits `getAnimations({subtree:true}).finished` (raced against a timeout), then finalizes (unmount for custom overlays; `close()` via `onExitComplete` for the native dialog). Animation is opt-in CSS, so a consumer with no closing rule gets an empty animation set and finalizes synchronously, i.e. today's behavior.
+
+**Tech Stack:** Preact (`preact/hooks`), TypeScript, Vitest + `@testing-library/preact` (happy-dom), the existing `mergeRefs` helper.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-use-presence-exit-animations-design.md`
+
+**Base branch:** Build on a branch off `origin/main` (commit `3c2c0f5` or later) so the Combobox source is present. The spec commit (`52c22aa`) is local/unpushed on `main`; carry it onto the feature branch (cherry-pick) or push it so it rides the PR.
+
+---
+
+## File Structure
+
+**Created:**
+- `packages/ui/src/use-presence.ts` — the hook + its phase state machine.
+- `packages/ui/src/__tests__/use-presence.test.tsx` — unit tests.
+- `packages/ui/src/__tests__/presence-helpers.ts` — shared `getAnimations` mock (not a `.test.*` file, so not collected as a suite; reused by integration tests).
+- `apps/site/src/pages/docs/components/use-presence.mdx` — Foundations docs page.
+- `apps/site/src/components/docs/UsePresenceDemo.tsx` — live demo for the docs page.
+
+**Modified (one edit each, integration):**
+- `packages/ui/src/dialog/dialog.tsx` — defer `close()` to `onExitComplete`; intercept `cancel`.
+- `packages/ui/src/popover/popover.tsx` — `PopoverPositioner`.
+- `packages/ui/src/tooltip/tooltip.tsx` — `TooltipPositioner`.
+- `packages/ui/src/menu/menu.tsx` — `MenuPositioner` (covers Menu, Submenu, ContextMenu).
+- `packages/ui/src/select/select.tsx` — `SelectPositioner`.
+- `packages/ui/src/combobox/combobox.tsx` — `ComboboxPositioner`.
+
+**Modified (wiring/docs):**
+- `packages/ui/src/index.ts` — export `usePresence`.
+- `scripts/client-size-config.mjs` — `UI_CORE_MODULES` + `CHUNK_PREFIXES`.
+- `apps/site/src/pages/docs/nav.ts` — Foundations nav entry.
+- `apps/site/src/styles/root.css` — exit-animation CSS for the seven demos.
+- The seven component `.mdx` pages — exit rule in each `## Styling` CSS tab.
+
+---
+
+## Task 1: The `usePresence` primitive
+
+**Files:**
+- Create: `packages/ui/src/use-presence.ts`
+- Create: `packages/ui/src/__tests__/presence-helpers.ts`
+- Create: `packages/ui/src/__tests__/use-presence.test.tsx`
+- Modify: `packages/ui/src/index.ts`
+
+- [ ] **Step 1: Write the test helper (the `getAnimations` mock)**
+
+Create `packages/ui/src/__tests__/presence-helpers.ts`:
+
+```ts
+import { vi } from 'vitest';
+
+// A controllable stand-in for a CSS Animation. happy-dom has no getAnimations,
+// so usePresence finalizes instantly there unless we install fakes like these.
+export interface FakeAnimation {
+  finished: Promise<void>;
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+  effect: { getComputedTiming: () => { endTime: number; iterations: number } };
+}
+
+export function makeAnimation(opts: { endTime?: number; iterations?: number } = {}): FakeAnimation {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const finished = new Promise<void>((res, rej) => {
+    resolve = () => res();
+    reject = (reason?: unknown) => rej(reason);
+  });
+  // Swallow rejection so an unresolved/abandoned animation never logs an
+  // unhandled rejection in the test runner.
+  finished.catch(() => {});
+  return {
+    finished,
+    resolve,
+    reject,
+    effect: {
+      getComputedTiming: () => ({
+        endTime: opts.endTime ?? 200,
+        iterations: opts.iterations ?? 1,
+      }),
+    },
+  };
+}
+
+// Install a getAnimations() on Element.prototype that returns the given fakes.
+// Test-only DOM-API stub: the structural mismatch with the real Animation type
+// is an accepted mock boundary. Returns a restore() to remove it.
+export function installGetAnimations(animations: FakeAnimation[]): () => void {
+  const value = vi.fn(() => animations);
+  Object.defineProperty(Element.prototype, 'getAnimations', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+  return () => {
+    Reflect.deleteProperty(Element.prototype, 'getAnimations');
+  };
+}
+
+// Force matchMedia('(prefers-reduced-motion: reduce)') to a fixed result.
+export function installReducedMotion(matches: boolean): () => void {
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    }),
+    configurable: true,
+    writable: true,
+  });
+  return () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  };
+}
+```
+
+- [ ] **Step 2: Write the failing unit tests**
+
+Create `packages/ui/src/__tests__/use-presence.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, act, cleanup } from '@testing-library/preact';
+import { usePresence } from '../use-presence.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+  installReducedMotion,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Harness({
+  present,
+  onExitComplete,
+}: {
+  present: boolean;
+  onExitComplete?: () => void;
+}) {
+  const p = usePresence(present, { onExitComplete });
+  return (
+    <div>
+      <span data-testid="status">{p.status}</span>
+      {p.isPresent ? (
+        <div
+          ref={p.ref}
+          data-testid="box"
+          data-state={p.status === 'open' ? 'open' : 'closed'}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+const flush = () => act(async () => {});
+
+describe('usePresence', () => {
+  it('renders open immediately when present is true', () => {
+    const { getByTestId } = render(<Harness present />);
+    expect(getByTestId('status').textContent).toBe('open');
+    expect(getByTestId('box').getAttribute('data-state')).toBe('open');
+  });
+
+  it('renders nothing when present is false on first mount (no exit on mount)', () => {
+    const { getByTestId, queryByTestId } = render(<Harness present={false} />);
+    expect(getByTestId('status').textContent).toBe('closed');
+    expect(queryByTestId('box')).toBeNull();
+  });
+
+  it('finalizes synchronously when there is no animation (empty set)', async () => {
+    const restore = installGetAnimations([]);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+  });
+
+  it('stays present in closing while an animation runs, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { rerender, getByTestId, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    // Still mounted, marked closing/closed for the exit CSS.
+    expect(getByTestId('status').textContent).toBe('closing');
+    expect(getByTestId('box').getAttribute('data-state')).toBe('closed');
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+  });
+
+  it('fires onExitComplete before unmounting', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const seenWhileMounted: boolean[] = [];
+    const onExitComplete = vi.fn(() => {
+      seenWhileMounted.push(document.querySelector('[data-testid="box"]') != null);
+    });
+    const { rerender } = render(<Harness present onExitComplete={onExitComplete} />);
+    await act(async () => rerender(<Harness present={false} onExitComplete={onExitComplete} />));
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(onExitComplete).toHaveBeenCalledTimes(1);
+    // The box was still in the DOM at the moment onExitComplete ran.
+    expect(seenWhileMounted).toEqual([true]);
+    restore();
+  });
+
+  it('cancels the exit and stays open when reopened mid-exit', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { rerender, getByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(getByTestId('status').textContent).toBe('closing');
+    await act(async () => rerender(<Harness present />)); // reopen
+    expect(getByTestId('status').textContent).toBe('open');
+    // Resolving the stale animation must not unmount.
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(getByTestId('box').getAttribute('data-state')).toBe('open');
+    restore();
+  });
+
+  it('finalizes synchronously under prefers-reduced-motion', async () => {
+    const anim = makeAnimation();
+    const restoreAnim = installGetAnimations([anim]);
+    const restoreRM = installReducedMotion(true);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(queryByTestId('box')).toBeNull(); // did not wait for anim
+    restoreRM();
+    restoreAnim();
+  });
+
+  it('ignores infinite-iteration animations (treats as empty)', async () => {
+    const anim = makeAnimation({ iterations: Infinity });
+    const restore = installGetAnimations([anim]);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+  });
+
+  it('finalizes via the timeout when an animation never resolves', async () => {
+    vi.useFakeTimers();
+    const anim = makeAnimation({ endTime: 200 });
+    const restore = installGetAnimations([anim]);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    rerender(<Harness present={false} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-presence.test.tsx`
+Expected: FAIL — `Failed to resolve import "../use-presence.js"` (the module does not exist yet).
+
+- [ ] **Step 4: Implement the hook**
+
+Create `packages/ui/src/use-presence.ts`:
+
+```ts
+import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
+
+export type PresenceStatus = 'open' | 'closing' | 'closed';
+
+export interface UsePresenceOptions {
+  // Fires when the exit animation resolves, immediately before isPresent flips
+  // false. Dialog passes close() here so native focus return runs before unmount.
+  onExitComplete?: () => void;
+  // Hard cap (ms) on the exit-timeout race; guards a stuck or under-reported
+  // animation, or a backgrounded tab. Default 3000.
+  timeoutCap?: number;
+}
+
+export interface UsePresenceResult {
+  // Render the element while true (open OR animating out).
+  isPresent: boolean;
+  // 'open' | 'closing' | 'closed'. Map to data-state: closing -> "closed".
+  status: PresenceStatus;
+  // Attach to the element carrying the exit transition. Merge with the
+  // component's own ref via mergeRefs.
+  ref: (node: Element | null) => void;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+function exitTimeout(animations: Animation[], cap: number): number {
+  let max = 0;
+  for (const a of animations) {
+    const timing = a.effect?.getComputedTiming();
+    const end = typeof timing?.endTime === 'number' ? timing.endTime : 0;
+    if (end > max) max = end;
+  }
+  return Math.min(max > 0 ? max + 100 : cap, cap);
+}
+
+export function usePresence(
+  present: boolean,
+  options: UsePresenceOptions = {}
+): UsePresenceResult {
+  const { onExitComplete, timeoutCap = 3000 } = options;
+
+  const [status, setStatus] = useState<PresenceStatus>(
+    present ? 'open' : 'closed'
+  );
+
+  const nodeRef = useRef<Element | null>(null);
+  const prevPresent = useRef(present);
+  const genRef = useRef(0);
+
+  // Keep the latest callback/cap without re-running the exit effect.
+  const onExitCompleteRef = useRef(onExitComplete);
+  onExitCompleteRef.current = onExitComplete;
+  const timeoutCapRef = useRef(timeoutCap);
+  timeoutCapRef.current = timeoutCap;
+
+  const ref = useCallback((node: Element | null) => {
+    nodeRef.current = node;
+  }, []);
+
+  // React to present transitions. On first mount prevPresent === present, so
+  // this never produces a 'closing' on the initial render (no exit on mount/SSR).
+  useLayoutEffect(() => {
+    if (present === prevPresent.current) return;
+    prevPresent.current = present;
+    genRef.current++;
+    setStatus(present ? 'open' : 'closing');
+  }, [present]);
+
+  // Entering 'closing' runs this AFTER the data-state=closed render commits, so
+  // the exit animation is live in the DOM when we read it.
+  useLayoutEffect(() => {
+    if (status !== 'closing') return;
+    const myGen = genRef.current;
+    const node = nodeRef.current;
+
+    const finalize = () => {
+      if (genRef.current !== myGen) return; // reopened mid-exit; abandon
+      onExitCompleteRef.current?.();
+      setStatus('closed');
+    };
+
+    if (
+      !node ||
+      typeof node.getAnimations !== 'function' ||
+      prefersReducedMotion()
+    ) {
+      finalize();
+      return;
+    }
+
+    // Forced reflow so the just-applied closed-state styles register as an
+    // animation/transition. Use getBoundingClientRect (Element) to avoid a cast;
+    // never rAF (throttled/paused in background tabs).
+    node.getBoundingClientRect();
+
+    const animations = node
+      .getAnimations({ subtree: true })
+      .filter((a) => a.effect?.getComputedTiming().iterations !== Infinity);
+
+    if (animations.length === 0) {
+      finalize();
+      return;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, exitTimeout(animations, timeoutCapRef.current));
+    });
+    void Promise.race([
+      Promise.allSettled(animations.map((a) => a.finished)),
+      timeout,
+    ]).then(() => {
+      if (timer !== undefined) clearTimeout(timer);
+      finalize();
+    });
+
+    return () => {
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [status]);
+
+  return {
+    isPresent: present || status === 'closing',
+    status,
+    ref,
+  };
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-presence.test.tsx`
+Expected: PASS (9 tests).
+
+- [ ] **Step 6: Export from the package barrel**
+
+In `packages/ui/src/index.ts`, after the `useFocusReturn` export (currently lines 17-20) and before `useSafeArea` (line 21), add:
+
+```ts
+export {
+  usePresence,
+  type UsePresenceOptions,
+  type UsePresenceResult,
+  type PresenceStatus,
+} from './use-presence.js';
+```
+
+- [ ] **Step 7: Typecheck and commit**
+
+Run: `pnpm --filter '@hono-preact/*' build && pnpm typecheck`
+Expected: no errors.
+
+```bash
+git add packages/ui/src/use-presence.ts packages/ui/src/__tests__/use-presence.test.tsx packages/ui/src/__tests__/presence-helpers.ts packages/ui/src/index.ts
+git commit -m "feat(ui): usePresence exit-animation primitive
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Dialog integration (validator)
+
+Dialog keeps the native `<dialog>` mounted and finalizes via `close()`. We move the `close()` out of the open-effect and into `onExitComplete`, keep `showModal()`, intercept the native `cancel` (Esc) so it animates, and merge `presence.ref` onto the dialog.
+
+**Files:**
+- Modify: `packages/ui/src/dialog/dialog.tsx`
+- Test: `packages/ui/src/__tests__/dialog-presence.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `packages/ui/src/__tests__/dialog-presence.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Dialog } from '../dialog/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>open</Dialog.Trigger>
+      <Dialog.Popup data-testid="dlg">
+        <Dialog.Title>Title</Dialog.Title>
+        <Dialog.Close>close</Dialog.Close>
+      </Dialog.Popup>
+    </Dialog.Root>
+  );
+}
+
+describe('Dialog exit animation', () => {
+  it('defers close() until the exit animation resolves', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, getByTestId } = render(<Setup />);
+    await act(async () => fireEvent.click(getByText('open')));
+    const dlg = getByTestId('dlg') as HTMLDialogElement;
+    expect(dlg.open).toBe(true);
+
+    await act(async () => fireEvent.click(getByText('close')));
+    // Still open (deferred), marked closed for the exit CSS.
+    expect(dlg.open).toBe(true);
+    expect(dlg.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(dlg.open).toBe(false);
+    restore();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/dialog-presence.test.tsx`
+Expected: FAIL — `dlg.open` is `false` right after the close click (close is not deferred yet).
+
+- [ ] **Step 3: Edit `dialog.tsx` — imports**
+
+At the top of `packages/ui/src/dialog/dialog.tsx`, add `mergeRefs` and `usePresence` imports after the existing `useControllableState` import (line 12):
+
+```ts
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
+```
+
+- [ ] **Step 4: Edit `DialogPopup` — defer close(), add presence + cancel interception**
+
+In `DialogPopup`, after the `openRef` block (lines 145-146) add the presence hook:
+
+```ts
+  const presence = usePresence(ctx.open, {
+    onExitComplete: () => ctx.dialogRef.current?.close(),
+  });
+```
+
+Replace the open-effect (current lines 150-155) so it only opens (the `close()` now runs in `onExitComplete` after the exit animation):
+
+```ts
+  // Open imperatively; the close is deferred to the exit animation
+  // (usePresence.onExitComplete), so the dialog stays in the top layer with
+  // inert/focus-trap/::backdrop intact while it animates out.
+  useLayoutEffect(() => {
+    const el = ctx.dialogRef.current;
+    if (!el) return;
+    if (ctx.open && !el.open) el.showModal();
+  }, [ctx.open]);
+```
+
+After the existing native-`close` listener effect (current lines 161-169), add a `cancel` interceptor so Esc routes through the animated close instead of the native instant close:
+
+```ts
+  // Esc fires `cancel` then natively closes instantly. Intercept it and route
+  // through state so the close animates like every other close path.
+  useEffect(() => {
+    const el = ctx.dialogRef.current;
+    if (!el) return;
+    const onCancel = (event: Event) => {
+      event.preventDefault();
+      ctx.setOpen(false);
+    };
+    el.addEventListener('cancel', onCancel);
+    return () => el.removeEventListener('cancel', onCancel);
+  }, [ctx.setOpen]);
+```
+
+In the `useRender` props (current line 184), merge the presence ref onto the dialog:
+
+```ts
+      ref: mergeRefs(ctx.dialogRef, presence.ref),
+```
+
+(The `data-state` line stays `ctx.open ? 'open' : 'closed'` — `ctx.open` is already false during the exit, so it renders `"closed"`. An external `close()` / `method="dialog"` submit still fires the existing `close` listener, which sets state false; the dialog is already closed so `getAnimations` is empty and finalize is instant.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/dialog-presence.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full Dialog suite (no regressions)**
+
+Run: `pnpm exec vitest run dialog`
+Expected: PASS (existing Dialog tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/dialog/dialog.tsx packages/ui/src/__tests__/dialog-presence.test.tsx
+git commit -m "feat(ui): animate Dialog out via usePresence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Popover integration
+
+`PopoverPositioner` is mount-on-open. Drive the mount gate, the `showPopover` effect, and `usePosition` off `presence.isPresent` so the popup stays positioned and in the top layer through the exit; merge `presence.ref` onto `floatingRef`. `data-state` (on the Popup) stays keyed to `ctx.open`.
+
+**Files:**
+- Modify: `packages/ui/src/popover/popover.tsx`
+- Test: `packages/ui/src/__tests__/popover-presence.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `packages/ui/src/__tests__/popover-presence.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Popover } from '../popover/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Popover.Root>
+      <Popover.Trigger>open</Popover.Trigger>
+      <Popover.Positioner>
+        <Popover.Popup data-testid="pop">hi</Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Root>
+  );
+}
+
+describe('Popover exit animation', () => {
+  it('keeps the popup mounted through the exit, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, queryByTestId } = render(<Setup />);
+    await act(async () => fireEvent.click(getByText('open')));
+    expect(queryByTestId('pop')).not.toBeNull();
+
+    await act(async () => fireEvent.click(getByText('open'))); // toggle closed
+    // Still mounted, marked closed for the exit CSS.
+    expect(queryByTestId('pop')).not.toBeNull();
+    expect(queryByTestId('pop')!.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('pop')).toBeNull();
+    restore();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/popover-presence.test.tsx`
+Expected: FAIL — the popup unmounts immediately on close (no closing phase yet).
+
+- [ ] **Step 3: Edit imports**
+
+In `packages/ui/src/popover/popover.tsx`, add after the `useControllableState` import (line 15):
+
+```ts
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
+```
+
+- [ ] **Step 4: Edit `PopoverPositioner`**
+
+At the top of `PopoverPositioner` (after `const ctx = usePopoverContext('Positioner');`, line 174), add:
+
+```ts
+  const presence = usePresence(ctx.open);
+```
+
+Change the `usePosition` call (line 176-184) `open` argument from `ctx.open` to `presence.isPresent`:
+
+```ts
+  const position = usePosition({
+    open: presence.isPresent,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+  });
+```
+
+Change the `showPopover` effect (lines 193-205) to key on `presence.isPresent`:
+
+```ts
+  useLayoutEffect(() => {
+    const el = ctx.floatingRef.current;
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      el.hidePopover();
+      el.removeAttribute('popover');
+    };
+  }, [presence.isPresent]);
+```
+
+Change the mount gate (line 207):
+
+```ts
+  if (!presence.isPresent) return null;
+```
+
+In the `useRender` props (line 212-213), merge the presence ref onto `floatingRef`:
+
+```ts
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/popover-presence.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full Popover suite**
+
+Run: `pnpm exec vitest run popover`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/popover/popover.tsx packages/ui/src/__tests__/popover-presence.test.tsx
+git commit -m "feat(ui): animate Popover out via usePresence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Tooltip integration
+
+Identical pattern to Popover, in `TooltipPositioner`.
+
+**Files:**
+- Modify: `packages/ui/src/tooltip/tooltip.tsx`
+- Test: `packages/ui/src/__tests__/tooltip-presence.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `packages/ui/src/__tests__/tooltip-presence.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Tooltip } from '../tooltip/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger>hover</Tooltip.Trigger>
+      <Tooltip.Positioner>
+        <Tooltip.Popup data-testid="tip">hi</Tooltip.Popup>
+      </Tooltip.Positioner>
+    </Tooltip.Root>
+  );
+}
+
+describe('Tooltip exit animation', () => {
+  it('keeps the popup mounted through the exit, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, queryByTestId } = render(<Setup />);
+    await act(async () => fireEvent.focus(getByText('hover')));
+    expect(queryByTestId('tip')).not.toBeNull();
+
+    await act(async () => fireEvent.blur(getByText('hover')));
+    expect(queryByTestId('tip')).not.toBeNull();
+    expect(queryByTestId('tip')!.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('tip')).toBeNull();
+    restore();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/tooltip-presence.test.tsx`
+Expected: FAIL — the tooltip unmounts immediately on blur.
+
+- [ ] **Step 3: Edit imports**
+
+In `packages/ui/src/tooltip/tooltip.tsx`, add (after the existing render/state imports, matching Popover's import block):
+
+```ts
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
+```
+
+- [ ] **Step 4: Edit `TooltipPositioner`**
+
+After `const ctx = useTooltipContext('Positioner');` add:
+
+```ts
+  const presence = usePresence(ctx.open);
+```
+
+If `TooltipPositioner` calls `usePosition`, change its `open` argument from `ctx.open` to `presence.isPresent` (same as Popover Step 4).
+
+Change the `showPopover` effect (lines 213-225) to key on `presence.isPresent`:
+
+```ts
+  useLayoutEffect(() => {
+    const el = ctx.floatingRef.current;
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      el.hidePopover();
+      el.removeAttribute('popover');
+    };
+  }, [presence.isPresent]);
+```
+
+Change the mount gate (line 227):
+
+```ts
+  if (!presence.isPresent) return null;
+```
+
+In the `useRender` props, merge the presence ref onto `floatingRef`:
+
+```ts
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/tooltip-presence.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full Tooltip suite**
+
+Run: `pnpm exec vitest run tooltip`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/tooltip/tooltip.tsx packages/ui/src/__tests__/tooltip-presence.test.tsx
+git commit -m "feat(ui): animate Tooltip out via usePresence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Menu family integration (Menu + Submenu + ContextMenu)
+
+Submenu wraps `MenuPositioner` with its own context, and ContextMenu provides a `MenuContext` the consumer composes with `MenuPositioner`. So editing `MenuPositioner` once covers all three; `ctx.open` is the right open state for each (submenu's is `sub.open` via `menuCtx`).
+
+**Files:**
+- Modify: `packages/ui/src/menu/menu.tsx`
+- Test: `packages/ui/src/__tests__/menu-presence.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `packages/ui/src/__tests__/menu-presence.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Menu } from '../menu/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Menu.Root>
+      <Menu.Trigger>open</Menu.Trigger>
+      <Menu.Positioner>
+        <Menu.Popup data-testid="menu">
+          <Menu.Item>One</Menu.Item>
+        </Menu.Popup>
+      </Menu.Positioner>
+    </Menu.Root>
+  );
+}
+
+describe('Menu exit animation', () => {
+  it('keeps the popup mounted through the exit, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, queryByTestId } = render(<Setup />);
+    await act(async () => fireEvent.click(getByText('open')));
+    expect(queryByTestId('menu')).not.toBeNull();
+
+    await act(async () => fireEvent.click(getByText('open'))); // toggle closed
+    expect(queryByTestId('menu')).not.toBeNull();
+    expect(queryByTestId('menu')!.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('menu')).toBeNull();
+    restore();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/menu-presence.test.tsx`
+Expected: FAIL — the menu unmounts immediately on close.
+
+- [ ] **Step 3: Edit imports**
+
+In `packages/ui/src/menu/menu.tsx`, add (matching the existing import block):
+
+```ts
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
+```
+
+- [ ] **Step 4: Edit `MenuPositioner`**
+
+After `const ctx = useMenuContext('Positioner');` (near the top of `MenuPositioner`), add:
+
+```ts
+  const presence = usePresence(ctx.open);
+```
+
+If `MenuPositioner` calls `usePosition`, change its `open` argument from `ctx.open` to `presence.isPresent`.
+
+Change the `showPopover` effect (lines 273-285) to key on `presence.isPresent`:
+
+```ts
+  useLayoutEffect(() => {
+    const el = ctx.floatingRef.current;
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      el.hidePopover();
+      el.removeAttribute('popover');
+    };
+  }, [presence.isPresent]);
+```
+
+Change the mount gate (line 287):
+
+```ts
+  if (!presence.isPresent) return null;
+```
+
+In the `useRender` props, merge the presence ref onto `floatingRef`:
+
+```ts
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/menu-presence.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run the Menu, Submenu, and ContextMenu suites (all three ride MenuPositioner)**
+
+Run: `pnpm exec vitest run menu`
+Expected: PASS (the `menu` filter also matches `context-menu` and submenu test files).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/menu/menu.tsx packages/ui/src/__tests__/menu-presence.test.tsx
+git commit -m "feat(ui): animate Menu/Submenu/ContextMenu out via usePresence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Select integration
+
+`SelectPositioner` keeps the listbox always-mounted and toggles `hidden` (for label registration). Drive `hidden` off `presence.isPresent` (visible through the exit, hidden on finalize), key `showPopover` on `presence.isPresent`, and merge `presence.ref` onto `floatingRef`. `data-state` (on `SelectPopup`) stays keyed to `ctx.open`. There is no mount gate to change.
+
+**Files:**
+- Modify: `packages/ui/src/select/select.tsx`
+- Test: `packages/ui/src/__tests__/select-presence.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `packages/ui/src/__tests__/select-presence.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Select } from '../select/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Select.Root>
+      <Select.Trigger>
+        <Select.Value placeholder="Pick" />
+      </Select.Trigger>
+      <Select.Positioner>
+        <Select.Popup data-testid="lb">
+          <Select.Option value="a">A</Select.Option>
+        </Select.Popup>
+      </Select.Positioner>
+    </Select.Root>
+  );
+}
+
+describe('Select exit animation', () => {
+  it('keeps the listbox visible through the exit, then hides it', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByTestId, getByRole } = render(<Setup />);
+    await act(async () => fireEvent.click(getByRole('combobox')));
+    const lb = getByTestId('lb');
+    expect(lb.hidden).toBe(false);
+
+    await act(async () => fireEvent.click(getByRole('combobox'))); // toggle closed
+    // Still visible (animating), marked closed for the exit CSS.
+    expect(lb.hidden).toBe(false);
+    expect(lb.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(lb.hidden).toBe(true);
+    restore();
+  });
+});
+```
+
+(If `getByRole('combobox')` does not resolve the trigger in this setup, query the trigger by its text/testid instead; the Select trigger has `role="combobox"` per the listbox-select ARIA pattern.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/select-presence.test.tsx`
+Expected: FAIL — `lb.hidden` becomes `true` immediately on close.
+
+- [ ] **Step 3: Edit imports**
+
+In `packages/ui/src/select/select.tsx`, add (matching the existing import block):
+
+```ts
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
+```
+
+(`mergeRefs` may already be imported for the listbox ref; if so, do not duplicate it.)
+
+- [ ] **Step 4: Edit `SelectPositioner`**
+
+After `const ctx = useSelectContext('Positioner');` (near the top of `SelectPositioner`), add:
+
+```ts
+  const presence = usePresence(ctx.open);
+```
+
+If `SelectPositioner` calls `usePosition`, change its `open` argument from `ctx.open` to `presence.isPresent`.
+
+Change the `showPopover` effect (lines 320-329) to key on `presence.isPresent`:
+
+```ts
+  useLayoutEffect(() => {
+    const el = ctx.floatingRef.current;
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      el.hidePopover();
+      el.removeAttribute('popover');
+    };
+  }, [presence.isPresent]);
+```
+
+Change the `hidden` attribute (line 340) from `ctx.open` to `presence.isPresent`:
+
+```ts
+      hidden: presence.isPresent ? undefined : true,
+```
+
+In the `useRender` props for the Positioner element, merge the presence ref onto `floatingRef`. If the element already passes `ref: ctx.floatingRef`, change it to:
+
+```ts
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/select-presence.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full Select suite**
+
+Run: `pnpm exec vitest run select`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/select/select.tsx packages/ui/src/__tests__/select-presence.test.tsx
+git commit -m "feat(ui): animate Select listbox out via usePresence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Combobox integration
+
+Same always-mounted/`hidden` pattern as Select. Combobox calls `showPopover()` **unconditionally** (no `supportsPopover` guard, by design); preserve that and only re-key the effect.
+
+**Files:**
+- Modify: `packages/ui/src/combobox/combobox.tsx`
+- Test: `packages/ui/src/__tests__/combobox-presence.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `packages/ui/src/__tests__/combobox-presence.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Combobox } from '../combobox/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Combobox.Root>
+      <Combobox.Input data-testid="input" />
+      <Combobox.Positioner>
+        <Combobox.Popup data-testid="lb">
+          <Combobox.Option value="a">A</Combobox.Option>
+        </Combobox.Popup>
+      </Combobox.Positioner>
+    </Combobox.Root>
+  );
+}
+
+describe('Combobox exit animation', () => {
+  it('keeps the listbox visible through the exit, then hides it', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByTestId } = render(<Setup />);
+    await act(async () => fireEvent.focus(getByTestId('input'))); // openOnFocus default
+    const lb = getByTestId('lb');
+    expect(lb.hidden).toBe(false);
+
+    await act(async () => fireEvent.keyDown(getByTestId('input'), { key: 'Escape' }));
+    expect(lb.hidden).toBe(false);
+    expect(lb.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(lb.hidden).toBe(true);
+    restore();
+  });
+});
+```
+
+(If `Escape` does not close in one press given the Model-A two-stage Escape, close by toggling focus/clicking out instead; the point is to assert the listbox stays visible until the animation resolves.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/combobox-presence.test.tsx`
+Expected: FAIL — `lb.hidden` becomes `true` immediately on close.
+
+- [ ] **Step 3: Edit imports**
+
+In `packages/ui/src/combobox/combobox.tsx`, add (matching the existing import block; do not duplicate `mergeRefs` if already imported):
+
+```ts
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
+```
+
+- [ ] **Step 4: Edit `ComboboxPositioner`**
+
+After `const ctx = useComboboxContext('Positioner');` add:
+
+```ts
+  const presence = usePresence(ctx.open);
+```
+
+If `ComboboxPositioner` calls `usePosition`, change its `open` argument from `ctx.open` to `presence.isPresent`.
+
+Change the `showPopover` effect (lines 287-296) to key on `presence.isPresent` (keep the unconditional `showPopover()`):
+
+```ts
+  useLayoutEffect(() => {
+    const el = ctx.floatingRef.current;
+    if (!presence.isPresent || !el) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      el.hidePopover();
+      el.removeAttribute('popover');
+    };
+  }, [presence.isPresent]);
+```
+
+Change the `hidden` attribute (line 304) from `ctx.open` to `presence.isPresent`:
+
+```ts
+      hidden: presence.isPresent ? undefined : true,
+```
+
+Merge the presence ref onto `floatingRef` in the Positioner's `useRender` props:
+
+```ts
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/combobox-presence.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full Combobox suite**
+
+Run: `pnpm exec vitest run combobox`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/ui/src/combobox/combobox.tsx packages/ui/src/__tests__/combobox-presence.test.tsx
+git commit -m "feat(ui): animate Combobox listbox out via usePresence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Size tracking config
+
+`usePresence` is used by all overlays, so it goes in the UI core floor. Config-only on the branch; do NOT regenerate `client-size-report.json` / history (the post-merge build-and-tag job does that — keeping the baseline equal to main's).
+
+**Files:**
+- Modify: `scripts/client-size-config.mjs`
+
+- [ ] **Step 1: Add to `UI_CORE_MODULES`**
+
+In `scripts/client-size-config.mjs`, change `UI_CORE_MODULES` (lines 64-68) to:
+
+```javascript
+export const UI_CORE_MODULES = [
+  'use-render.js',
+  'merge-refs.js',
+  'use-controllable-state.js',
+  'use-presence.js',
+];
+```
+
+- [ ] **Step 2: Add the docs-chunk prefix**
+
+In `CHUNK_PREFIXES`, after the `['use-controllable-state', 'components'],` entry, add:
+
+```javascript
+  ['use-presence', 'components'],
+```
+
+- [ ] **Step 3: Verify the config loads**
+
+Run: `node -e "import('./scripts/client-size-config.mjs').then(m => console.log(m.UI_CORE_MODULES))"`
+Expected: prints the array including `use-presence.js`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/client-size-config.mjs
+git commit -m "chore(size): track use-presence in the UI core floor
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Foundations docs page + demo
+
+Match the sibling Foundations hook pages (e.g. `use-focus-return.mdx`): H1, prose, `## Signature`, `## Options`, explanation, `## Example`. Add a small live `## Demo` since exit animation is visual.
+
+**Files:**
+- Create: `apps/site/src/components/docs/UsePresenceDemo.tsx`
+- Create: `apps/site/src/pages/docs/components/use-presence.mdx`
+- Modify: `apps/site/src/pages/docs/nav.ts`
+- Modify: `apps/site/src/styles/root.css` (demo styles)
+
+- [ ] **Step 1: Create the demo component**
+
+Create `apps/site/src/components/docs/UsePresenceDemo.tsx`:
+
+```tsx
+import { usePresence } from '@hono-preact/ui';
+import { useState } from 'preact/hooks';
+
+// A box that mounts on open and animates out on close using usePresence. The
+// styling lives in apps/site/src/styles/root.css (.docs-presence*).
+export function UsePresenceDemo() {
+  const [open, setOpen] = useState(false);
+  const presence = usePresence(open);
+  return (
+    <div class="docs-presence">
+      <button class="docs-presence-trigger" onClick={() => setOpen((o) => !o)}>
+        {open ? 'Hide' : 'Show'}
+      </button>
+      {presence.isPresent ? (
+        <div
+          ref={presence.ref}
+          class="docs-presence-box"
+          data-state={presence.status === 'open' ? 'open' : 'closed'}
+        >
+          I fade + slide out before unmounting.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add demo styles**
+
+In `apps/site/src/styles/root.css`, append (near the other `.docs-*` demo blocks):
+
+```css
+/* usePresence docs demo */
+.docs-presence {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+.docs-presence-box {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  color: var(--foreground);
+}
+.docs-presence-box[data-state='open'] {
+  animation: docs-presence-in 160ms ease-out;
+}
+.docs-presence-box[data-state='closed'] {
+  animation: docs-presence-out 160ms ease-in forwards;
+}
+@keyframes docs-presence-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+@keyframes docs-presence-out {
+  to {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .docs-presence-box[data-state='open'],
+  .docs-presence-box[data-state='closed'] {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 3: Create the docs page**
+
+Create `apps/site/src/pages/docs/components/use-presence.mdx`:
+
+```mdx
+import { Example } from '../../../components/docs/Example.js';
+import { UsePresenceDemo } from '../../../components/docs/UsePresenceDemo.js';
+
+# usePresence
+
+`usePresence` keeps an element mounted while it animates out, then unmounts it.
+It is the primitive every overlay in this library uses to run a closing
+animation: on close it holds the element in the DOM, lets a `[data-state="closed"]`
+CSS animation run, and unmounts only once the animation finishes. Animation is
+opt-in: with no closing rule the element unmounts immediately, exactly as before.
+
+## Demo
+
+<Example>
+  <UsePresenceDemo />
+</Example>
+
+## Signature
+
+```ts
+import { usePresence } from '@hono-preact/ui';
+
+function usePresence(
+  present: boolean,
+  options?: UsePresenceOptions,
+): UsePresenceResult;
+
+interface UsePresenceOptions {
+  onExitComplete?: () => void; // fires when the exit resolves, before unmount
+  timeoutCap?: number; // ms cap on the exit wait (default 3000)
+}
+
+interface UsePresenceResult {
+  isPresent: boolean; // render the element while true (open or animating out)
+  status: 'open' | 'closing' | 'closed'; // map to data-state (closing -> "closed")
+  ref: (node: Element | null) => void; // attach to the animated element
+}
+```
+
+## Options
+
+| Option           | Type         | Default | Notes                                                                 |
+| ---------------- | ------------ | ------- | --------------------------------------------------------------------- |
+| `present`        | `boolean`    | none    | The desired visibility. Flip it to false to start the exit animation. |
+| `onExitComplete` | `() => void` | none    | Runs when the exit resolves, immediately before `isPresent` is false. |
+| `timeoutCap`     | `number`     | `3000`  | Safety cap (ms) so a stuck animation can never block teardown.        |
+
+Gate rendering on `isPresent`, attach `ref` to the element that carries the
+transition, and map `status` to `data-state` (both `closing` and `closed` map to
+`"closed"`, so one `[data-state="closed"]` rule styles the exit). It reads
+`Element.getAnimations()` after a forced reflow, races the animations' `finished`
+promises against `timeoutCap`, and short-circuits under
+`prefers-reduced-motion`. There is no exit on first mount or during SSR.
+
+## Example
+
+```tsx
+import { usePresence } from '@hono-preact/ui';
+import { useState } from 'preact/hooks';
+
+function Panel() {
+  const [open, setOpen] = useState(false);
+  const presence = usePresence(open);
+  return (
+    <div>
+      <button onClick={() => setOpen((o) => !o)}>Toggle</button>
+      {presence.isPresent ? (
+        <div
+          ref={presence.ref}
+          data-state={presence.status === 'open' ? 'open' : 'closed'}
+        >
+          Content
+        </div>
+      ) : null}
+    </div>
+  );
+}
+```
+
+```css
+[data-state='open'] {
+  animation: panel-in 160ms ease-out;
+}
+[data-state='closed'] {
+  animation: panel-out 160ms ease-in forwards;
+}
+@keyframes panel-in {
+  from { opacity: 0; transform: translateY(-6px); }
+}
+@keyframes panel-out {
+  to { opacity: 0; transform: translateY(-6px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-state='open'],
+  [data-state='closed'] { animation: none; }
+}
+```
+```
+
+- [ ] **Step 4: Register the nav entry**
+
+In `apps/site/src/pages/docs/nav.ts`, in the Foundations `entries` array, add after the `useFocusReturn` entry:
+
+```typescript
+        {
+          title: 'usePresence',
+          route: '/docs/components/use-presence',
+        },
+```
+
+- [ ] **Step 5: Build the site to verify the page compiles and routes**
+
+Run: `pnpm --filter '@hono-preact/*' build && pnpm --filter site build`
+Expected: build succeeds; no MDX/route errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/site/src/components/docs/UsePresenceDemo.tsx apps/site/src/pages/docs/components/use-presence.mdx apps/site/src/pages/docs/nav.ts apps/site/src/styles/root.css
+git commit -m "docs(ui): usePresence Foundations page + live demo
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Exit-animation sweep across the seven component demos
+
+Each demo currently animates entry only, via `@keyframes docs-<x>-in` on `.docs-<x>[data-state='open']` (see `.docs-popover` lines 821-829, `.docs-tooltip` lines 922-929). Add the mirrored exit half so the live demos and copyable examples show the close animation that `usePresence` now enables.
+
+**Pattern to apply per component** (read the existing `@keyframes docs-<x>-in` to mirror the same opacity/transform):
+
+```css
+.docs-<x>[data-state='closed'] {
+  animation: docs-<x>-out <same-duration> ease-in forwards;
+}
+@keyframes docs-<x>-out {
+  to {
+    /* the END state of the entry's `from` (e.g. opacity: 0; transform: translateY(-4px);) */
+  }
+}
+```
+
+And update each component's reduced-motion rule to cover both states with matching specificity:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .docs-<x>[data-state='open'],
+  .docs-<x>[data-state='closed'] {
+    animation: none;
+  }
+}
+```
+
+**Files:**
+- Modify: `apps/site/src/styles/root.css`
+- Modify: each of `apps/site/src/pages/docs/components/{dialog,popover,tooltip,menu,context-menu,select,combobox}.mdx`
+
+- [ ] **Step 1: Popover (worked example)**
+
+In `apps/site/src/styles/root.css`, after the `@keyframes docs-popover-in` block (line 829), add:
+
+```css
+.docs-popover[data-state='closed'] {
+  animation: docs-popover-out 120ms ease-in forwards;
+}
+@keyframes docs-popover-out {
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+```
+
+And change the popover reduced-motion rule (lines 879-883) to:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .docs-popover[data-state='open'],
+  .docs-popover[data-state='closed'] {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 2: Apply the same pattern to the other six demos in `root.css`**
+
+For each of `tooltip`, `menu`, `context-menu` (if it has its own `.docs-*` block; otherwise it reuses the menu block), `select`, `combobox`, and `dialog`:
+- Read the existing `@keyframes docs-<x>-in` (the `from {}` state) and `.docs-<x>[data-state='open']` rule.
+- Add the mirrored `.docs-<x>[data-state='closed'] { animation: docs-<x>-out <dur> ease-in forwards; }` + `@keyframes docs-<x>-out { to { <the from-state values> } }`.
+- Update the reduced-motion rule to list both `[data-state='open']` and `[data-state='closed']`.
+
+For **Dialog**, the entry animates `.docs-dialog[open]` and its `::backdrop`. Add `.docs-dialog[data-state='closed'] { animation: docs-dialog-out <dur> ease-in forwards; }` (the dialog stays `[open]` during the deferred close, so key the exit on `[data-state='closed']`), plus a `::backdrop` exit if the entry animates the backdrop. Tooltip example (opacity only):
+
+```css
+.docs-tooltip[data-state='closed'] {
+  animation: docs-tooltip-out 100ms ease-in forwards;
+}
+@keyframes docs-tooltip-out {
+  to {
+    opacity: 0;
+  }
+}
+```
+
+- [ ] **Step 3: Mirror the exit rule into each component page's Styling CSS tab**
+
+Each component `.mdx` has a `## Styling` `<CodeTabs labels={['CSS','Tailwind']}>` whose CSS tab is the copyable class rules. Add the same `[data-state='closed']` exit rule (and the reduced-motion update) to the CSS tab of each page so what's documented matches the live demo. The Tailwind tab stays the bare markup stub (no change).
+
+- [ ] **Step 4: Build the site to verify CSS + MDX compile**
+
+Run: `pnpm --filter site build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/site/src/styles/root.css apps/site/src/pages/docs/components/
+git commit -m "docs(ui): exit animations on the overlay demos and copyable examples
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Full verification (CI mirror)
+
+Run the same six checks CI runs, in order (per the repo's pre-push guidance).
+
+- [ ] **Step 1: Build framework dist**
+
+Run: `pnpm --filter '@hono-preact/*' --filter hono-preact build`
+Expected: success.
+
+- [ ] **Step 2: Format check**
+
+Run: `pnpm format:check`
+Expected: pass. If it fails, run `pnpm format` and commit the result.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Unit tests + coverage**
+
+Run: `pnpm test:coverage`
+Expected: all green, including the 9 `use-presence` unit tests and the 6 component presence integration tests.
+
+- [ ] **Step 5: Integration tests**
+
+Run: `pnpm test:integration`
+Expected: pass.
+
+- [ ] **Step 6: Site build**
+
+Run: `pnpm --filter site build`
+Expected: success.
+
+- [ ] **Step 7: Manual-verification checklist (real browser; happy-dom cannot emulate `getAnimations()`)**
+
+Document these as PR checklist items to verify with `pnpm --filter site dev`:
+- Each overlay visibly fades/slides out on close (Dialog, Popover, Tooltip, Menu, ContextMenu, submenu, Select, Combobox).
+- The Dialog retains its top layer / `inert` / focus trap during the exit, and focus returns to the trigger after it finishes; `::backdrop` fades (best-effort).
+- Esc on the Dialog animates the close (does not snap shut).
+- Reopening an overlay mid-exit reverses cleanly (no fl:cker, element never unmounts).
+- `prefers-reduced-motion: reduce` (toggle in devtools) makes every close instant.
+- The popup does not jump position during the exit (positioning persists because `usePosition` is keyed on `presence.isPresent`).
+
+---
+
+## Notes for the implementer
+
+- **`act()` for raw events.** Where a test dispatches a raw event or resolves a fake animation that triggers `setState`, wrap it in `act(...)` from `@testing-library/preact` (Preact reschedules renders on a microtask). The provided tests already do this.
+- **`getAnimations` is absent in happy-dom.** Tests that don't install the mock will see `usePresence` finalize synchronously (the `typeof node.getAnimations !== 'function'` guard), which is the correct fallback. Only the exit-timing tests install the mock.
+- **No `client-size-report.json` regen.** Task 8 is config-only; the baseline stays equal to main's.
+- **Run `pnpm format` once at the end** (it globs `packages/**`), then re-run `format:check`, to avoid orphaning format changes in sibling files across per-task commits.
+- **If `usePosition` reset-on-close needs handling:** Tasks 3-7 key `usePosition`'s `open` on `presence.isPresent` precisely so positioning persists through the exit. If a component's `usePosition` call uses a differently-named flag, apply the same substitution.
+</content>

--- a/docs/superpowers/specs/2026-06-08-use-presence-exit-animations-design.md
+++ b/docs/superpowers/specs/2026-06-08-use-presence-exit-animations-design.md
@@ -1,0 +1,344 @@
+# usePresence exit animations: design spec
+
+Date: 2026-06-08
+Status: design approved (brainstorming), not yet planned or built
+Predecessors: [Dialog (Phase 1)](./2026-06-01-ui-dialog-slice-design.md) §7 (the vetted exit-animation mechanism), [headless components investigation](./2026-05-31-headless-components-investigation.md)
+
+## 1. Goal and scope
+
+Ship `usePresence`, a public Foundations primitive in `@hono-preact/ui`, and wire it
+into all seven overlay components so they can animate **out** as they close. Today the
+library animates entry only (CSS `@starting-style` on `[data-state="open"]`); closing
+removes the element from the DOM (or the top layer) immediately, so any exit transition
+is cut off. `usePresence` keeps the element alive for the duration of a CSS exit
+transition, then finalizes (unmount, or `close()` for the native dialog).
+
+The mechanism is not new: it was designed and vetted on 2026-06-01 and recorded in the
+Dialog slice spec §7 as "deferred to a separate `usePresence` increment." This spec
+promotes that mechanism into a real primitive and rolls it out across the cluster.
+
+In scope for v1:
+
+- A public `usePresence(present, options?)` hook built on `Element.getAnimations()`.
+- Exit-animation support in all seven overlays: Dialog, Popover, Tooltip, Menu,
+  ContextMenu, Select, Combobox (and Menu/ContextMenu submenus).
+- The consumer styling contract: a single `[data-state="closed"]` exit rule per
+  component, reduced-motion handling, and updated copyable examples (CSS + Tailwind)
+  on every component docs page.
+- A `/docs/components/use-presence` Foundations page.
+
+Out of scope for v1: see Section 9. Notably: View Transitions as the animation
+substrate (Section 8 explains why), exit animation as anything other than opt-in CSS,
+and any framework (`@hono-preact/iso`) coupling.
+
+## 2. Locked decisions (from brainstorming)
+
+1. **Substrate: `Element.getAnimations()`, not View Transitions or CSS
+   `allow-discrete`/`overlay`.** `getAnimations()` is Baseline Widely Available
+   (since ~2020) and is the only option that satisfies the library's
+   all-current-browsers constraint. View Transitions are rejected as the baseline
+   (Section 8). CSS `transition-behavior: allow-discrete` / the `overlay` property are
+   not yet reliable across current browsers (the `overlay` property is Chromium-only),
+   so a CSS-only exit shows nothing on Firefox/Safari.
+2. **Breadth: all seven overlays.** Animation is opt-in via CSS, so a component whose
+   consumer authored no closing transition behaves exactly as today (empty animation
+   set → synchronous finalize). The machinery is therefore zero-cost for non-animating
+   consumers, which makes uniform adoption safe.
+3. **Public surface: a public Foundations primitive.** `usePresence` is exported from
+   the package root and documented, alongside `usePosition` / `useDismiss` /
+   `useFocusReturn` / `useListNavigation` / `useControllableState`. Consumers can use it
+   for their own custom mount/unmount overlays.
+4. **API shape: `{ isPresent, status, ref }` (Radix-shaped).** The consumer gates
+   rendering on `isPresent`, maps `status` to `data-state`, and attaches `ref` to the
+   element carrying the transition. The two finalize modes (unmount for custom overlays,
+   `close()` for the native dialog) collapse to a single hook via an `onExitComplete`
+   option; no separate public variant.
+5. **Entry animation is unchanged.** Entry stays pure CSS `@starting-style` on
+   `[data-state="open"]` (no JS). `usePresence` governs the **exit/persistence** phase
+   only.
+6. **Standalone, no framework coupling.** `usePresence` lives in `@hono-preact/ui` and
+   depends only on the platform + existing internal helpers (`mergeRefs`). It does not
+   reach into `@hono-preact/iso`'s View Transitions toolkit.
+
+## 3. Architecture
+
+### 3.1 The primitive: `src/use-presence.ts`
+
+A single hook backed by an internal phase state machine that runs the
+`getAnimations()` timing logic. The public hook models the **mount/unmount** case
+(the general one); the native-dialog **deferred-`close()`** case is expressed by the
+caller via `onExitComplete`, so there is one hook, not two.
+
+### 3.2 Two finalize shapes (confirmed against current code)
+
+- **Custom overlays** (Popover, Tooltip, Menu, ContextMenu, Select, Combobox): the
+  Positioner part is **mount-on-open** (`if (!ctx.open) return null`). Finalize =
+  unmount. The hook's `isPresent` becomes the mount gate.
+- **Dialog**: the native `<dialog>` element **stays mounted**; an effect toggles
+  `showModal()` / `close()` off `ctx.open`. Finalize = `close()` (which the caller
+  supplies through `onExitComplete`), keeping the element mounted. `isPresent` is not a
+  mount gate here.
+
+### 3.3 Dependencies
+
+`getAnimations()`, `getComputedStyle()` / `offsetHeight` (forced reflow),
+`matchMedia('(prefers-reduced-motion: reduce)')`, and the existing internal
+`mergeRefs`. No new package dependency.
+
+## 4. The state machine
+
+### 4.1 Phases
+
+`status` is one of:
+
+- `"open"` — `present` is true and settled. `isPresent` is true.
+- `"closing"` — `present` flipped to false and an exit animation is in flight. The
+  element is still mounted (custom overlays) or still open (dialog). `isPresent` is
+  still true.
+- `"closed"` — finalized. `isPresent` is false; custom overlays unmount, the dialog has
+  been `close()`d.
+
+The DOM attribute stays **two-valued**: `closing` and `closed` both render
+`data-state="closed"`, so authors write a single `[data-state="closed"]` rule. The
+recommended mapping is `data-state={status === 'open' ? 'open' : 'closed'}`.
+
+### 4.2 Transitions and the load-bearing details
+
+These mirror Dialog spec §7 and must not be skipped:
+
+1. **First mount / SSR: phase derived synchronously from `present`; never `"closing"`
+   on the first render.** No exit animation on mount. (A first-run guard.)
+2. **`present` → false:** enter `"closing"`, then **force a style flush**
+   (`el.offsetHeight` or `getComputedStyle`) — never read animations synchronously in
+   the same task, and never via `requestAnimationFrame` (throttled/paused in background
+   tabs); otherwise the set is empty and the element closes instantly on every browser.
+3. Read `el.getAnimations({ subtree: true })`, **filter out infinite-iteration
+   animations** (`getComputedTiming().iterations === Infinity`), and `Promise.allSettled`
+   the remaining `.finished` promises, **raced against a timeout** derived from the
+   animations' end times with a hard cap (~3s). The timeout guarantees a stuck or
+   under-reported animation can never leave a modal open and blocking the page.
+4. **An empty animation set finalizes synchronously** (no exit). Never gate finalize on
+   a `transitionend`/`animationend` event — it never fires in the empty case and hangs
+   the element open.
+5. **`{ subtree: true }`** so a transition on a child or `::backdrop` is awaited;
+   pseudo-element coverage still varies across browsers, so key finalize timing off the
+   target element and treat `::backdrop` as best-effort/cosmetic.
+6. **Reopen mid-exit:** tag each exit with a **generation token**; a later
+   `present` → true bumps the token so the in-flight finalize becomes a no-op, `status`
+   returns to `"open"`, and the element is never torn down. A cancelled `.finished`
+   rejects with `AbortError`, which is swallowed (`allSettled`), not thrown.
+7. **Finalize order:** fire `onExitComplete` **before** flipping `isPresent`/`status` to
+   closed. For Dialog this is where `close()` runs, so native focus return lands on the
+   trigger before unmount.
+8. **`prefers-reduced-motion: reduce`:** short-circuit to synchronous finalize (still
+   fires `onExitComplete`). Examples also zero the transition under the media query.
+
+## 5. Public API
+
+```ts
+export interface UsePresenceOptions {
+  /** Fires when the exit animation has resolved, immediately before isPresent flips
+   *  false. Used by Dialog to call close() (focus return) before unmount. */
+  onExitComplete?: () => void;
+  /** Hard cap (ms) on the exit timeout race. Defaults to ~3000. */
+  timeoutCap?: number;
+}
+
+export interface UsePresenceResult {
+  /** Mount gate: true while open OR exiting. Render the element while true. */
+  isPresent: boolean;
+  /** 'open' | 'closing' | 'closed'. Drives data-state (closing → "closed"). */
+  status: PresenceStatus;
+  /** Callback ref for the element carrying the transition. Merge with the
+   *  component's own ref via mergeRefs. */
+  ref: (node: Element | null) => void;
+}
+
+export type PresenceStatus = 'open' | 'closing' | 'closed';
+
+export function usePresence(
+  present: boolean,
+  options?: UsePresenceOptions,
+): UsePresenceResult;
+```
+
+Consumer pattern (custom overlay):
+
+```tsx
+const presence = usePresence(open);
+if (!presence.isPresent) return null;
+return (
+  <div ref={presence.ref} data-state={presence.status === 'open' ? 'open' : 'closed'}>
+    ...
+  </div>
+);
+```
+
+## 6. Component integration
+
+### 6.1 Dialog
+
+`usePresence(ctx.open, { onExitComplete: () => dialogRef.current?.close() })`.
+
+- Keep the `showModal()` half of the open-effect; **remove the `close()` half** — the
+  close now runs in `onExitComplete`.
+- On close: the `<dialog>` stays open through the `"closing"` phase, so the top layer,
+  `inert`, focus trap, Esc, and `::backdrop` are all retained while the exit animates.
+- Merge `presence.ref` onto the `<dialog>` element so `getAnimations` reads it.
+- **Intercept native Esc:** listen for the dialog `cancel` event, `preventDefault()`,
+  and route through the controlled close (set `open` false) so Esc animates too.
+- **Desync guard:** if `dialog.open` flips false externally (a `method="dialog"` submit,
+  an external `close()`), finalize instantly rather than hang in `"closing"`.
+
+### 6.2 The six custom overlays
+
+Popover, Tooltip, Menu, ContextMenu, Select, Combobox Positioners each:
+
+- add `const presence = usePresence(ctx.open)`,
+- change the gate to `if (!presence.isPresent) return null`,
+- merge `presence.ref` into the element ref,
+- map `data-state={presence.status === 'open' ? 'open' : 'closed'}`.
+
+**The load-bearing change: re-key the `showPopover()` effect from `[ctx.open]` to
+`[presence.isPresent]`.** Today the effect's cleanup `hidePopover()` runs when `ctx.open`
+flips false; left as-is it would pull the element out of the top layer mid-exit. Keyed on
+`isPresent`, the element stays shown through `"closing"` and only hides on the finalizing
+unmount.
+
+Menu/ContextMenu **submenus** (which key on `sub.open`) get the same treatment:
+`usePresence(sub.open)`, gate on `isPresent`, re-key `showPopover`.
+
+### 6.3 Confirm during planning
+
+- Whether any inner Dialog part (Backdrop, Content) is itself mount-on-open and needs
+  the gate updated, or whether keying the whole exit off the `<dialog>` element suffices.
+- That merging `presence.ref` does not disturb existing `useRender`/`mergeRefs` ref
+  chains in each part.
+
+## 7. Cross-cutting concerns
+
+### 7.1 Data-attribute / CSS contract
+
+- **Entry:** unchanged — CSS `@starting-style` on `[data-state="open"]`. Baseline Newly
+  available; degrades to no entry animation.
+- **Exit:** a `transition` on the animated element plus a single `[data-state="closed"]`
+  rule (covers `closing` and `closed`).
+- **Reduced motion:** examples zero the transition under
+  `@media (prefers-reduced-motion: reduce)`; the hook also short-circuits.
+
+### 7.2 SSR and hydration
+
+`usePresence` reads `getAnimations()` only in the browser and only on a
+`present` → false transition, which can only happen post-hydration. SSR and the initial
+hydration render derive `status` synchronously from `present` (open → `"open"`,
+isPresent true), so there is no server/client snapshot mismatch and no need for a
+hydration flag. No `useSyncExternalStore`.
+
+### 7.3 Documentation (apps/site)
+
+- New Foundations page `/docs/components/use-presence` following the component-docs
+  template: a live `## Demo`, `## Usage` (one full example + brief variations), and
+  exactly one `## Styling` CodeTabs (CSS = class rules; Tailwind = markup stub). Add it
+  to the Components nav under Foundations.
+- Each of the seven component docs pages gains an exit transition in its examples (CSS
+  tab adds the `[data-state="closed"]` rule + reduced-motion media query; the live demo
+  shows it). Match each sibling page's existing section structure.
+
+### 7.4 Size tracking
+
+`usePresence` is used by all seven overlays, so add it to `UI_CORE_MODULES` in
+`scripts/client-size-config.mjs` (alongside `useRender`/`mergeRefs`/`useControllableState`),
+not to a single component's marginal. Config-only on the branch; do **not** regenerate or
+commit `client-size-report.json` / history — the post-merge build-and-tag job does that.
+
+### 7.5 Testing
+
+- **Unit (happy-dom, `getAnimations()` mocked):** empty-set synchronous finalize;
+  non-empty await → finalize; reopen-mid-exit generation token; reduced-motion
+  short-circuit; timeout-vs-`.finished` race; no-exit-on-first-mount; `onExitComplete`
+  fires before `isPresent` flips false; infinite-iteration animations filtered.
+- **Component integration (happy-dom, mocked animations):** each overlay stays mounted
+  through `"closing"` and unmounts on finalize; `data-state` flips open → closed;
+  `showPopover`/`hidePopover` timing (shown through closing, hidden on unmount);
+  Dialog `close()` deferred to `onExitComplete`; Esc `cancel` interception.
+- **Manual-verification items (real browser, flagged in the plan; happy-dom cannot
+  emulate `getAnimations()`/real transitions):** the actual exit animation per
+  component, Dialog top-layer/`inert` retention during the deferred `close()`,
+  `::backdrop` fade.
+
+### 7.6 Accessibility
+
+No new ARIA. The win is that Dialog retains its focus trap, `inert`, and focus-return
+semantics across the exit (the `<dialog>` is genuinely open during `"closing"`), and Esc
+still closes (now animated). Reduced-motion is honored.
+
+## 8. Alternatives considered
+
+### 8.1 View Transitions as the exit substrate (rejected)
+
+Tempting because the framework already ships a View Transitions toolkit
+(`@hono-preact/iso`: the route dispatcher, cold-nav coordinator,
+`subscribeViewTransitionTypes`). Rejected for the standalone primitive for three
+independent reasons:
+
+1. **Browser-support constraint.** Same-document View Transitions are at best Baseline
+   Newly available (Firefox shipped same-document VT only recently), so under the
+   library's "Widely Available only; Newly available is progressive enhancement only"
+   rule they cannot be the dependable substrate. `getAnimations()` has been Widely
+   Available since ~2020.
+2. **Document-global serialization, colliding with route VTs.** `startViewTransition`
+   snapshots the whole document and only one runs at a time; a closing tooltip or
+   dropdown would collide with an in-flight route VT — exactly the collision class the
+   framework's cold-nav coordinator exists to manage. That coordinator lives in
+   `@hono-preact/iso`; `@hono-preact/ui` is standalone (only `@floating-ui/dom`), so it
+   has no coordinator and must not reintroduce the collisions.
+3. **Styling model mismatch.** VT animates through document-global
+   `::view-transition-old(name)` pseudo-elements keyed by `view-transition-name`, which
+   fights the scoped, per-component `data-state` + local CSS transition contract the rest
+   of the library uses.
+
+Additionally, VT would not reduce the work: it relocates the await
+(`transition.finished` instead of `getAnimations().finished`) while still requiring the
+generation token, reopen handling, reduced-motion short-circuit, and SSR guard, and it
+adds document-global coordination cost. VT's actual strength (snapshot-based morphs
+between two layouts) is not what a one-sided overlay exit needs. If VT-for-overlays is
+ever wanted, its home is **framework-side** (`@hono-preact/iso`, where the coordinator
+lives), layered on top of this same `data-state` contract — not in the standalone
+primitive.
+
+### 8.2 CSS `transition-behavior: allow-discrete` / `overlay` (rejected)
+
+Not reliable across current browsers; the `overlay` property is Chromium-only, so a
+CSS-only exit animates nothing on Firefox/Safari and fails the all-browsers bar.
+
+### 8.3 Event-based finalize (`transitionend`/`animationend`) (rejected)
+
+Hangs forever in the empty-animation case and is fragile with multiple/child
+animations. The `getAnimations().finished` + timeout race handles the empty case
+synchronously and bounds the worst case.
+
+## 9. Deferred / future work
+
+- **`usePresence` as a framework-side View Transitions enhancement.** A future
+  `@hono-preact/iso` layer could opt overlays into VT on top of the `data-state`
+  contract, using the existing route coordinator. Not in this slice.
+- **Entry animation via JS.** Stays CSS `@starting-style` only; no plan to move it into
+  the hook.
+- **Per-component exit-timing config / variants.** The styling-variant runtime helper
+  (investigation §6.4 option 2) remains future-optional and separate.
+
+## 10. Open items for the implementation plan
+
+1. Exact timeout derivation (max animation end time vs a fixed default) and the hard cap
+   value.
+2. Whether any inner Dialog part needs its own gate, or keying the whole exit off the
+   `<dialog>` element is sufficient (Section 6.3).
+3. The precise `getAnimations()` mock shape for unit tests (a fake `Animation` with a
+   controllable `.finished` and `getComputedTiming()`), and a shared test helper for it.
+4. Whether submenus need a distinct generation scope from their parent menu, or share
+   the same `usePresence` instance semantics cleanly.
+5. Ordering of the build: land `use-presence.ts` + its unit tests first (the primitive),
+   then integrate Dialog (the validating case), then the six custom overlays, then the
+   docs sweep.
+</content>
+</invoke>

--- a/packages/ui/src/__tests__/combobox-presence.test.tsx
+++ b/packages/ui/src/__tests__/combobox-presence.test.tsx
@@ -2,10 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, act, cleanup, fireEvent } from '@testing-library/preact';
 import { Combobox } from '../combobox/index.js';
-import {
-  makeAnimation,
-  installGetAnimations,
-} from './presence-helpers.js';
+import { makeAnimation, installGetAnimations } from './presence-helpers.js';
 
 afterEach(cleanup);
 
@@ -36,7 +33,7 @@ describe('Combobox exit animation', () => {
 
     // Single Escape closes without reverting (Model A two-stage).
     await act(async () =>
-      fireEvent.keyDown(getByTestId('input'), { key: 'Escape' }),
+      fireEvent.keyDown(getByTestId('input'), { key: 'Escape' })
     );
     // Still visible (animating out), marked closed for exit CSS.
     expect(positioner.hidden).toBe(false);

--- a/packages/ui/src/__tests__/combobox-presence.test.tsx
+++ b/packages/ui/src/__tests__/combobox-presence.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Combobox } from '../combobox/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Combobox.Root>
+      <Combobox.Input data-testid="input" />
+      <Combobox.Positioner>
+        <Combobox.Popup data-testid="lb">
+          <Combobox.Option value="a">A</Combobox.Option>
+        </Combobox.Popup>
+      </Combobox.Positioner>
+    </Combobox.Root>
+  );
+}
+
+describe('Combobox exit animation', () => {
+  it('keeps the listbox visible through the exit, then hides it', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByTestId } = render(<Setup />);
+    // Focus opens the listbox (openOnFocus default).
+    await act(async () => fireEvent.focus(getByTestId('input')));
+    const lb = getByTestId('lb');
+    // `hidden` is on the Positioner (parent); `data-state` is on the Popup (lb).
+    const positioner = lb.parentElement!;
+    expect(positioner.hidden).toBe(false);
+
+    // Single Escape closes without reverting (Model A two-stage).
+    await act(async () =>
+      fireEvent.keyDown(getByTestId('input'), { key: 'Escape' }),
+    );
+    // Still visible (animating out), marked closed for exit CSS.
+    expect(positioner.hidden).toBe(false);
+    expect(lb.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(positioner.hidden).toBe(true);
+    restore();
+  });
+});

--- a/packages/ui/src/__tests__/dialog-presence.test.tsx
+++ b/packages/ui/src/__tests__/dialog-presence.test.tsx
@@ -2,10 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, act, cleanup, fireEvent } from '@testing-library/preact';
 import { Dialog } from '../dialog/index.js';
-import {
-  makeAnimation,
-  installGetAnimations,
-} from './presence-helpers.js';
+import { makeAnimation, installGetAnimations } from './presence-helpers.js';
 
 afterEach(cleanup);
 

--- a/packages/ui/src/__tests__/dialog-presence.test.tsx
+++ b/packages/ui/src/__tests__/dialog-presence.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Dialog } from '../dialog/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>open</Dialog.Trigger>
+      <Dialog.Popup data-testid="dlg">
+        <Dialog.Title>Title</Dialog.Title>
+        <Dialog.Close>close</Dialog.Close>
+      </Dialog.Popup>
+    </Dialog.Root>
+  );
+}
+
+describe('Dialog exit animation', () => {
+  it('defers close() until the exit animation resolves', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, getByTestId } = render(<Setup />);
+    await act(async () => fireEvent.click(getByText('open')));
+    const dlg = getByTestId('dlg') as HTMLDialogElement;
+    expect(dlg.open).toBe(true);
+
+    await act(async () => fireEvent.click(getByText('close')));
+    // Still open (deferred), marked closed for the exit CSS.
+    expect(dlg.open).toBe(true);
+    expect(dlg.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(dlg.open).toBe(false);
+    restore();
+  });
+});

--- a/packages/ui/src/__tests__/menu-presence.test.tsx
+++ b/packages/ui/src/__tests__/menu-presence.test.tsx
@@ -2,10 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, act, cleanup, fireEvent } from '@testing-library/preact';
 import { Menu } from '../menu/index.js';
-import {
-  makeAnimation,
-  installGetAnimations,
-} from './presence-helpers.js';
+import { makeAnimation, installGetAnimations } from './presence-helpers.js';
 
 afterEach(cleanup);
 

--- a/packages/ui/src/__tests__/menu-presence.test.tsx
+++ b/packages/ui/src/__tests__/menu-presence.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Menu } from '../menu/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Menu.Root>
+      <Menu.Trigger>open</Menu.Trigger>
+      <Menu.Positioner>
+        <Menu.Popup data-testid="menu">
+          <Menu.Item>One</Menu.Item>
+        </Menu.Popup>
+      </Menu.Positioner>
+    </Menu.Root>
+  );
+}
+
+describe('Menu exit animation', () => {
+  it('keeps the popup mounted through the exit, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, queryByTestId } = render(<Setup />);
+    await act(async () => fireEvent.click(getByText('open')));
+    expect(queryByTestId('menu')).not.toBeNull();
+
+    await act(async () => fireEvent.click(getByText('open'))); // toggle closed
+    expect(queryByTestId('menu')).not.toBeNull();
+    expect(queryByTestId('menu')!.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('menu')).toBeNull();
+    restore();
+  });
+});

--- a/packages/ui/src/__tests__/popover-presence.test.tsx
+++ b/packages/ui/src/__tests__/popover-presence.test.tsx
@@ -2,10 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, act, cleanup, fireEvent } from '@testing-library/preact';
 import { Popover } from '../popover/index.js';
-import {
-  makeAnimation,
-  installGetAnimations,
-} from './presence-helpers.js';
+import { makeAnimation, installGetAnimations } from './presence-helpers.js';
 
 afterEach(cleanup);
 

--- a/packages/ui/src/__tests__/popover-presence.test.tsx
+++ b/packages/ui/src/__tests__/popover-presence.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Popover } from '../popover/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Popover.Root>
+      <Popover.Trigger>open</Popover.Trigger>
+      <Popover.Positioner>
+        <Popover.Popup data-testid="pop">hi</Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Root>
+  );
+}
+
+describe('Popover exit animation', () => {
+  it('keeps the popup mounted through the exit, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, queryByTestId } = render(<Setup />);
+    await act(async () => fireEvent.click(getByText('open')));
+    expect(queryByTestId('pop')).not.toBeNull();
+
+    await act(async () => fireEvent.click(getByText('open'))); // toggle closed
+    // Still mounted, marked closed for the exit CSS.
+    expect(queryByTestId('pop')).not.toBeNull();
+    expect(queryByTestId('pop')!.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('pop')).toBeNull();
+    restore();
+  });
+});

--- a/packages/ui/src/__tests__/presence-helpers.ts
+++ b/packages/ui/src/__tests__/presence-helpers.ts
@@ -9,7 +9,9 @@ export interface FakeAnimation {
   effect: { getComputedTiming: () => { endTime: number; iterations: number } };
 }
 
-export function makeAnimation(opts: { endTime?: number; iterations?: number } = {}): FakeAnimation {
+export function makeAnimation(
+  opts: { endTime?: number; iterations?: number } = {}
+): FakeAnimation {
   let resolve!: () => void;
   let reject!: (reason?: unknown) => void;
   const finished = new Promise<void>((res, rej) => {

--- a/packages/ui/src/__tests__/presence-helpers.ts
+++ b/packages/ui/src/__tests__/presence-helpers.ts
@@ -1,0 +1,74 @@
+import { vi } from 'vitest';
+
+// A controllable stand-in for a CSS Animation. happy-dom has no getAnimations,
+// so usePresence finalizes instantly there unless we install fakes like these.
+export interface FakeAnimation {
+  finished: Promise<void>;
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+  effect: { getComputedTiming: () => { endTime: number; iterations: number } };
+}
+
+export function makeAnimation(opts: { endTime?: number; iterations?: number } = {}): FakeAnimation {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const finished = new Promise<void>((res, rej) => {
+    resolve = () => res();
+    reject = (reason?: unknown) => rej(reason);
+  });
+  // Swallow rejection so an unresolved/abandoned animation never logs an
+  // unhandled rejection in the test runner.
+  finished.catch(() => {});
+  return {
+    finished,
+    resolve,
+    reject,
+    effect: {
+      getComputedTiming: () => ({
+        endTime: opts.endTime ?? 200,
+        iterations: opts.iterations ?? 1,
+      }),
+    },
+  };
+}
+
+// Install a getAnimations() on Element.prototype that returns the given fakes.
+// Test-only DOM-API stub: the structural mismatch with the real Animation type
+// is an accepted mock boundary. Returns a restore() to remove it.
+export function installGetAnimations(animations: FakeAnimation[]): () => void {
+  const value = vi.fn(() => animations);
+  Object.defineProperty(Element.prototype, 'getAnimations', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+  return () => {
+    Reflect.deleteProperty(Element.prototype, 'getAnimations');
+  };
+}
+
+// Force matchMedia('(prefers-reduced-motion: reduce)') to a fixed result.
+export function installReducedMotion(matches: boolean): () => void {
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    }),
+    configurable: true,
+    writable: true,
+  });
+  return () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  };
+}

--- a/packages/ui/src/__tests__/select-presence.test.tsx
+++ b/packages/ui/src/__tests__/select-presence.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Select } from '../select/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Select.Root>
+      <Select.Trigger>
+        <Select.Value placeholder="Pick" />
+      </Select.Trigger>
+      <Select.Positioner>
+        <Select.Popup data-testid="lb">
+          <Select.Option value="a">A</Select.Option>
+        </Select.Popup>
+      </Select.Positioner>
+    </Select.Root>
+  );
+}
+
+describe('Select exit animation', () => {
+  it('keeps the listbox visible through the exit, then hides it', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByTestId, getByRole } = render(<Setup />);
+    await act(async () => fireEvent.click(getByRole('combobox')));
+    const lb = getByTestId('lb');
+    // `hidden` is on the Positioner (parent); `data-state` is on the Popup (lb).
+    const positioner = lb.parentElement!;
+    expect(positioner.hidden).toBe(false);
+
+    await act(async () => fireEvent.click(getByRole('combobox'))); // toggle closed
+    // Still visible (animating), marked closed for the exit CSS.
+    expect(positioner.hidden).toBe(false);
+    expect(lb.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(positioner.hidden).toBe(true);
+    restore();
+  });
+});

--- a/packages/ui/src/__tests__/select-presence.test.tsx
+++ b/packages/ui/src/__tests__/select-presence.test.tsx
@@ -2,10 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, act, cleanup, fireEvent } from '@testing-library/preact';
 import { Select } from '../select/index.js';
-import {
-  makeAnimation,
-  installGetAnimations,
-} from './presence-helpers.js';
+import { makeAnimation, installGetAnimations } from './presence-helpers.js';
 
 afterEach(cleanup);
 

--- a/packages/ui/src/__tests__/tooltip-presence.test.tsx
+++ b/packages/ui/src/__tests__/tooltip-presence.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, act, cleanup, fireEvent } from '@testing-library/preact';
+import { Tooltip } from '../tooltip/index.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Setup() {
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger>hover</Tooltip.Trigger>
+      <Tooltip.Positioner>
+        <Tooltip.Popup data-testid="tip">hi</Tooltip.Popup>
+      </Tooltip.Positioner>
+    </Tooltip.Root>
+  );
+}
+
+describe('Tooltip exit animation', () => {
+  it('keeps the popup mounted through the exit, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { getByText, queryByTestId } = render(<Setup />);
+    await act(async () => fireEvent.focus(getByText('hover')));
+    expect(queryByTestId('tip')).not.toBeNull();
+
+    await act(async () => fireEvent.blur(getByText('hover')));
+    expect(queryByTestId('tip')).not.toBeNull();
+    expect(queryByTestId('tip')!.getAttribute('data-state')).toBe('closed');
+
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('tip')).toBeNull();
+    restore();
+  });
+});

--- a/packages/ui/src/__tests__/tooltip-presence.test.tsx
+++ b/packages/ui/src/__tests__/tooltip-presence.test.tsx
@@ -2,10 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, act, cleanup, fireEvent } from '@testing-library/preact';
 import { Tooltip } from '../tooltip/index.js';
-import {
-  makeAnimation,
-  installGetAnimations,
-} from './presence-helpers.js';
+import { makeAnimation, installGetAnimations } from './presence-helpers.js';
 
 afterEach(cleanup);
 

--- a/packages/ui/src/__tests__/use-presence.test.tsx
+++ b/packages/ui/src/__tests__/use-presence.test.tsx
@@ -45,10 +45,52 @@ describe('usePresence', () => {
     expect(queryByTestId('box')).toBeNull();
   });
 
-  it('finalizes synchronously when there is no animation (empty set)', async () => {
+  it('holds in closing then finalizes via the fallback when no animation starts', async () => {
+    vi.useFakeTimers();
     const restore = installGetAnimations([]);
-    const { rerender, queryByTestId } = render(<Harness present />);
+    const { rerender, getByTestId, queryByTestId } = render(
+      <Harness present />
+    );
+    rerender(<Harness present={false} />);
+    // No animation is running on the first read, so the element is NOT removed
+    // synchronously — it waits for one to start (it may be a child whose
+    // data-state flips a tick later).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getByTestId('status').textContent).toBe('closing');
+    expect(queryByTestId('box')).not.toBeNull();
+    // After the no-animation fallback elapses, it finalizes.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+    vi.useRealTimers();
+  });
+
+  it('waits for a late-starting transition (empty read, then transitionrun)', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([]); // nothing running yet
+    const { rerender, getByTestId, queryByTestId } = render(
+      <Harness present />
+    );
     await act(async () => rerender(<Harness present={false} />));
+    // Held in closing, awaiting a transition.
+    expect(getByTestId('status').textContent).toBe('closing');
+    expect(queryByTestId('box')).not.toBeNull();
+    // The child's transition starts: getAnimations now reports it and a
+    // transitionrun bubbles up to the ref'd element.
+    installGetAnimations([anim]);
+    await act(async () => {
+      getByTestId('box').dispatchEvent(
+        new Event('transitionrun', { bubbles: true })
+      );
+    });
+    expect(queryByTestId('box')).not.toBeNull(); // now awaiting the real animation
+    await act(async () => {
+      anim.resolve();
+    });
     expect(queryByTestId('box')).toBeNull();
     restore();
   });
@@ -118,13 +160,18 @@ describe('usePresence', () => {
     restoreAnim();
   });
 
-  it('ignores infinite-iteration animations (treats as empty)', async () => {
+  it('ignores infinite-iteration animations (treated as no exit; finalizes via fallback)', async () => {
+    vi.useFakeTimers();
     const anim = makeAnimation({ iterations: Infinity });
     const restore = installGetAnimations([anim]);
     const { rerender, queryByTestId } = render(<Harness present />);
-    await act(async () => rerender(<Harness present={false} />));
+    rerender(<Harness present={false} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
     expect(queryByTestId('box')).toBeNull();
     restore();
+    vi.useRealTimers();
   });
 
   it('finalizes via the timeout when an animation never resolves', async () => {
@@ -164,5 +211,28 @@ describe('usePresence', () => {
     expect(onExitComplete).toHaveBeenCalledTimes(1);
     restore();
     vi.useRealTimers();
+  });
+
+  it('never drops isPresent to false on the close render (no unmount/display flash)', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const seen: boolean[] = [];
+    function Rec({ present }: { present: boolean }) {
+      const p = usePresence(present);
+      seen.push(p.isPresent);
+      return p.isPresent ? <div ref={p.ref} data-testid="box" /> : null;
+    }
+    const { rerender } = render(<Rec present />);
+    seen.length = 0; // ignore the initial open renders
+    // Closing: isPresent must stay true across every render until finalize, or
+    // the element unmounts/hides for a frame and the exit animation is cancelled.
+    await act(async () => rerender(<Rec present={false} />));
+    expect(seen.every((v) => v === true)).toBe(true);
+    // Only after the animation resolves does isPresent flip false.
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(seen[seen.length - 1]).toBe(false);
+    restore();
   });
 });

--- a/packages/ui/src/__tests__/use-presence.test.tsx
+++ b/packages/ui/src/__tests__/use-presence.test.tsx
@@ -60,9 +60,14 @@ describe('usePresence', () => {
     });
     expect(getByTestId('status').textContent).toBe('closing');
     expect(queryByTestId('box')).not.toBeNull();
-    // After the no-animation fallback elapses, it finalizes.
+    // Still held just under the fallback window.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(queryByTestId('box')).not.toBeNull();
+    // Past the no-animation fallback (~250ms), it finalizes.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
     });
     expect(queryByTestId('box')).toBeNull();
     restore();
@@ -90,6 +95,42 @@ describe('usePresence', () => {
     expect(queryByTestId('box')).not.toBeNull(); // now awaiting the real animation
     await act(async () => {
       anim.resolve();
+    });
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+  });
+
+  it('tracks a second exit animation that starts after the first (rescue path)', async () => {
+    const a1 = makeAnimation({ endTime: 100 });
+    const a2 = makeAnimation({ endTime: 300 });
+    const restore = installGetAnimations([]); // empty first read -> rescue path
+    const { rerender, getByTestId, queryByTestId } = render(
+      <Harness present />
+    );
+    await act(async () => rerender(<Harness present={false} />));
+    // First (short) transition starts.
+    installGetAnimations([a1]);
+    await act(async () => {
+      getByTestId('box').dispatchEvent(
+        new Event('transitionrun', { bubbles: true })
+      );
+    });
+    // A second, longer transition starts a tick later (e.g. opacity then a
+    // longer transform). The listeners stay live, so it is tracked too.
+    installGetAnimations([a1, a2]);
+    await act(async () => {
+      getByTestId('box').dispatchEvent(
+        new Event('transitionrun', { bubbles: true })
+      );
+    });
+    // Resolving only the first must NOT finalize — the longer one is still going.
+    await act(async () => {
+      a1.resolve();
+    });
+    expect(queryByTestId('box')).not.toBeNull();
+    // Resolving the longer one finalizes.
+    await act(async () => {
+      a2.resolve();
     });
     expect(queryByTestId('box')).toBeNull();
     restore();
@@ -167,7 +208,7 @@ describe('usePresence', () => {
     const { rerender, queryByTestId } = render(<Harness present />);
     rerender(<Harness present={false} />);
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      await vi.advanceTimersByTimeAsync(300);
     });
     expect(queryByTestId('box')).toBeNull();
     restore();

--- a/packages/ui/src/__tests__/use-presence.test.tsx
+++ b/packages/ui/src/__tests__/use-presence.test.tsx
@@ -56,7 +56,9 @@ describe('usePresence', () => {
   it('stays present in closing while an animation runs, then unmounts', async () => {
     const anim = makeAnimation();
     const restore = installGetAnimations([anim]);
-    const { rerender, getByTestId, queryByTestId } = render(<Harness present />);
+    const { rerender, getByTestId, queryByTestId } = render(
+      <Harness present />
+    );
     await act(async () => rerender(<Harness present={false} />));
     expect(getByTestId('status').textContent).toBe('closing');
     expect(getByTestId('box').getAttribute('data-state')).toBe('closed');
@@ -72,10 +74,16 @@ describe('usePresence', () => {
     const restore = installGetAnimations([anim]);
     const seenWhileMounted: boolean[] = [];
     const onExitComplete = vi.fn(() => {
-      seenWhileMounted.push(document.querySelector('[data-testid="box"]') != null);
+      seenWhileMounted.push(
+        document.querySelector('[data-testid="box"]') != null
+      );
     });
-    const { rerender } = render(<Harness present onExitComplete={onExitComplete} />);
-    await act(async () => rerender(<Harness present={false} onExitComplete={onExitComplete} />));
+    const { rerender } = render(
+      <Harness present onExitComplete={onExitComplete} />
+    );
+    await act(async () =>
+      rerender(<Harness present={false} onExitComplete={onExitComplete} />)
+    );
     await act(async () => {
       anim.resolve();
     });

--- a/packages/ui/src/__tests__/use-presence.test.tsx
+++ b/packages/ui/src/__tests__/use-presence.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, act, cleanup } from '@testing-library/preact';
+import { usePresence } from '../use-presence.js';
+import {
+  makeAnimation,
+  installGetAnimations,
+  installReducedMotion,
+} from './presence-helpers.js';
+
+afterEach(cleanup);
+
+function Harness({
+  present,
+  onExitComplete,
+}: {
+  present: boolean;
+  onExitComplete?: () => void;
+}) {
+  const p = usePresence(present, { onExitComplete });
+  return (
+    <div>
+      <span data-testid="status">{p.status}</span>
+      {p.isPresent ? (
+        <div
+          ref={p.ref}
+          data-testid="box"
+          data-state={p.status === 'open' ? 'open' : 'closed'}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+describe('usePresence', () => {
+  it('renders open immediately when present is true', () => {
+    const { getByTestId } = render(<Harness present />);
+    expect(getByTestId('status').textContent).toBe('open');
+    expect(getByTestId('box').getAttribute('data-state')).toBe('open');
+  });
+
+  it('renders nothing when present is false on first mount (no exit on mount)', () => {
+    const { getByTestId, queryByTestId } = render(<Harness present={false} />);
+    expect(getByTestId('status').textContent).toBe('closed');
+    expect(queryByTestId('box')).toBeNull();
+  });
+
+  it('finalizes synchronously when there is no animation (empty set)', async () => {
+    const restore = installGetAnimations([]);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+  });
+
+  it('stays present in closing while an animation runs, then unmounts', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { rerender, getByTestId, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(getByTestId('status').textContent).toBe('closing');
+    expect(getByTestId('box').getAttribute('data-state')).toBe('closed');
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+  });
+
+  it('fires onExitComplete before unmounting', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const seenWhileMounted: boolean[] = [];
+    const onExitComplete = vi.fn(() => {
+      seenWhileMounted.push(document.querySelector('[data-testid="box"]') != null);
+    });
+    const { rerender } = render(<Harness present onExitComplete={onExitComplete} />);
+    await act(async () => rerender(<Harness present={false} onExitComplete={onExitComplete} />));
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(onExitComplete).toHaveBeenCalledTimes(1);
+    expect(seenWhileMounted).toEqual([true]);
+    restore();
+  });
+
+  it('cancels the exit and stays open when reopened mid-exit', async () => {
+    const anim = makeAnimation();
+    const restore = installGetAnimations([anim]);
+    const { rerender, getByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(getByTestId('status').textContent).toBe('closing');
+    await act(async () => rerender(<Harness present />));
+    expect(getByTestId('status').textContent).toBe('open');
+    await act(async () => {
+      anim.resolve();
+    });
+    expect(getByTestId('box').getAttribute('data-state')).toBe('open');
+    restore();
+  });
+
+  it('finalizes synchronously under prefers-reduced-motion', async () => {
+    const anim = makeAnimation();
+    const restoreAnim = installGetAnimations([anim]);
+    const restoreRM = installReducedMotion(true);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(queryByTestId('box')).toBeNull();
+    restoreRM();
+    restoreAnim();
+  });
+
+  it('ignores infinite-iteration animations (treats as empty)', async () => {
+    const anim = makeAnimation({ iterations: Infinity });
+    const restore = installGetAnimations([anim]);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    await act(async () => rerender(<Harness present={false} />));
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+  });
+
+  it('finalizes via the timeout when an animation never resolves', async () => {
+    vi.useFakeTimers();
+    const anim = makeAnimation({ endTime: 200 });
+    const restore = installGetAnimations([anim]);
+    const { rerender, queryByTestId } = render(<Harness present />);
+    rerender(<Harness present={false} />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    expect(queryByTestId('box')).toBeNull();
+    restore();
+    vi.useRealTimers();
+  });
+
+  it('does not finalize twice when the timeout fires then a late animation settles', async () => {
+    vi.useFakeTimers();
+    const a1 = makeAnimation({ endTime: 100 });
+    const a2 = makeAnimation({ endTime: 100 });
+    const restore = installGetAnimations([a1, a2]);
+    const onExitComplete = vi.fn();
+    const Wrapper = ({ present }: { present: boolean }) => {
+      const p = usePresence(present, { onExitComplete });
+      return p.isPresent ? <div ref={p.ref} data-testid="box" /> : null;
+    };
+    const { rerender, queryByTestId } = render(<Wrapper present />);
+    rerender(<Wrapper present={false} />);
+    await act(async () => {
+      a1.resolve();
+      await vi.advanceTimersByTimeAsync(500); // timeout fires -> finalize once
+    });
+    expect(queryByTestId('box')).toBeNull();
+    await act(async () => {
+      a2.resolve(); // late settle must NOT finalize again
+    });
+    expect(onExitComplete).toHaveBeenCalledTimes(1);
+    restore();
+    vi.useRealTimers();
+  });
+});

--- a/packages/ui/src/combobox/combobox.tsx
+++ b/packages/ui/src/combobox/combobox.tsx
@@ -15,6 +15,8 @@ import {
   useRef,
   useState,
 } from 'preact/hooks';
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
 import { useControllableState } from '../use-controllable-state.js';
 import { usePosition } from '../use-position.js';
 import type { Side, Align, PositionState } from '../use-position.js';
@@ -258,6 +260,7 @@ export type ComboboxPositionerProps = {
 export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
   const { render, children, ...rest } = props;
   const ctx = useComboboxContext('Positioner');
+  const presence = usePresence(ctx.open);
 
   // Anchor to the <Combobox.Anchor> field if one is rendered, else the input.
   // Both refs are stable, so the callback is stable (no autoUpdate churn).
@@ -270,7 +273,7 @@ export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
   );
 
   const position = usePosition({
-    open: ctx.open,
+    open: presence.isPresent,
     anchorRef: ctx.inputRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
@@ -286,22 +289,22 @@ export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
 
   useLayoutEffect(() => {
     const el = ctx.floatingRef.current;
-    if (!ctx.open || !el) return;
+    if (!presence.isPresent || !el) return;
     el.setAttribute('popover', 'manual');
     el.showPopover();
     return () => {
       el.hidePopover();
       el.removeAttribute('popover');
     };
-  }, [ctx.open]);
+  }, [presence.isPresent]);
 
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
     props: {
       ...rest,
-      ref: ctx.floatingRef,
-      hidden: ctx.open ? undefined : true,
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
+      hidden: presence.isPresent ? undefined : true,
       'data-side': position.side,
       'data-align': position.align,
       style: {

--- a/packages/ui/src/dialog/dialog.tsx
+++ b/packages/ui/src/dialog/dialog.tsx
@@ -10,6 +10,8 @@ import {
 } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
 import { DialogContext, useDialogContext } from './context.js';
 
 export interface DialogRootProps {
@@ -145,13 +147,17 @@ export function DialogPopup(props: DialogPopupProps): VNode {
   const openRef = useRef(ctx.open);
   openRef.current = ctx.open;
 
-  // Drive the native element from open-state. showModal/close live in a
-  // layout effect (client only), so the server never touches the DOM.
+  const presence = usePresence(ctx.open, {
+    onExitComplete: () => ctx.dialogRef.current?.close(),
+  });
+
+  // Open imperatively; the close is deferred to the exit animation
+  // (usePresence.onExitComplete), so the dialog stays in the top layer with
+  // inert/focus-trap/::backdrop intact while it animates out.
   useLayoutEffect(() => {
     const el = ctx.dialogRef.current;
     if (!el) return;
     if (ctx.open && !el.open) el.showModal();
-    else if (!ctx.open && el.open) el.close();
   }, [ctx.open]);
 
   // Native dismissal (Escape, programmatic close()) fires `close`; mirror it
@@ -168,6 +174,19 @@ export function DialogPopup(props: DialogPopupProps): VNode {
     return () => el.removeEventListener('close', onClose);
   }, [ctx.setOpen]);
 
+  // Esc fires `cancel` then natively closes instantly. Intercept it and route
+  // through state so the close animates like every other close path.
+  useEffect(() => {
+    const el = ctx.dialogRef.current;
+    if (!el) return;
+    const onCancel = (event: Event) => {
+      event.preventDefault();
+      ctx.setOpen(false);
+    };
+    el.addEventListener('cancel', onCancel);
+    return () => el.removeEventListener('cancel', onCancel);
+  }, [ctx.setOpen]);
+
   const handleClick = (event: JSX.TargetedMouseEvent<HTMLDialogElement>) => {
     onClick?.(event);
     // A modal <dialog> reports backdrop clicks as targeting the element itself.
@@ -181,7 +200,7 @@ export function DialogPopup(props: DialogPopupProps): VNode {
     defaultTag: 'dialog',
     props: {
       ...rest,
-      ref: ctx.dialogRef,
+      ref: mergeRefs(ctx.dialogRef, presence.ref),
       id: ctx.popupId,
       'data-state': ctx.open ? 'open' : 'closed',
       'aria-label': ariaLabel,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,6 +18,12 @@ export {
   useFocusReturn,
   type UseFocusReturnOptions,
 } from './use-focus-return.js';
+export {
+  usePresence,
+  type UsePresenceOptions,
+  type UsePresenceResult,
+  type PresenceStatus,
+} from './use-presence.js';
 export { useSafeArea, type UseSafeAreaOptions } from './use-safe-area.js';
 export {
   Dialog,

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -22,6 +22,8 @@ import type { Side, Align, PositionState } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useFocusReturn } from '../use-focus-return.js';
 import { useListNavigation } from '../list-navigation.js';
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
 import {
   MenuContext,
   useMenuContext,
@@ -253,8 +255,10 @@ export function MenuPositioner(props: MenuPositionerProps): VNode | null {
   const { render, children, ...rest } = props;
   const ctx = useMenuContext('Positioner');
 
+  const presence = usePresence(ctx.open);
+
   const position = usePosition({
-    open: ctx.open,
+    open: presence.isPresent,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
@@ -272,26 +276,26 @@ export function MenuPositioner(props: MenuPositionerProps): VNode | null {
   // Applied imperatively so there is no SSR/hydration attribute mismatch.
   useLayoutEffect(() => {
     const el = ctx.floatingRef.current;
-    // Runs when open flips true and the element has mounted (refs are assigned
+    // Runs when isPresent flips true and the element has mounted (refs are assigned
     // before layout effects). Empty deps would never re-run, so showPopover
     // would never fire on a mount-on-open element.
-    if (!ctx.open || !el || !supportsPopover(el)) return;
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
     el.setAttribute('popover', 'manual');
     el.showPopover();
     return () => {
       el.hidePopover();
       el.removeAttribute('popover');
     };
-  }, [ctx.open]);
+  }, [presence.isPresent]);
 
-  if (!ctx.open) return null;
+  if (!presence.isPresent) return null;
 
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
     props: {
       ...rest,
-      ref: ctx.floatingRef,
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
       'data-side': position.side,
       'data-align': position.align,
       // Neutralize the UA [popover] rule that applies once the element is

--- a/packages/ui/src/popover/popover.tsx
+++ b/packages/ui/src/popover/popover.tsx
@@ -13,6 +13,8 @@ import { useDismiss } from '../use-dismiss.js';
 import { useFocusReturn } from '../use-focus-return.js';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
 import type { Side, Align, PositionState } from '../use-position.js';
 import { PopoverContext, usePopoverContext } from './context.js';
 
@@ -173,8 +175,10 @@ export function PopoverPositioner(props: PopoverPositionerProps): VNode | null {
   const { render, children, ...rest } = props;
   const ctx = usePopoverContext('Positioner');
 
+  const presence = usePresence(ctx.open);
+
   const position = usePosition({
-    open: ctx.open,
+    open: presence.isPresent,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
@@ -192,26 +196,26 @@ export function PopoverPositioner(props: PopoverPositionerProps): VNode | null {
   // Applied imperatively so there is no SSR/hydration attribute mismatch.
   useLayoutEffect(() => {
     const el = ctx.floatingRef.current;
-    // Runs when open flips true and the element has mounted (refs are assigned
-    // before layout effects). Empty deps would never re-run, so showPopover
-    // would never fire on a mount-on-open element.
-    if (!ctx.open || !el || !supportsPopover(el)) return;
+    // Runs when isPresent flips true and the element has mounted (refs are
+    // assigned before layout effects). Stays mounted through the exit animation
+    // so hidePopover fires only after the closing transition completes.
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
     el.setAttribute('popover', 'manual');
     el.showPopover();
     return () => {
       el.hidePopover();
       el.removeAttribute('popover');
     };
-  }, [ctx.open]);
+  }, [presence.isPresent]);
 
-  if (!ctx.open) return null;
+  if (!presence.isPresent) return null;
 
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
     props: {
       ...rest,
-      ref: ctx.floatingRef,
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
       'data-side': position.side,
       'data-align': position.align,
       // The Positioner is a framework-owned layout wrapper (style the Popup, not

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -21,6 +21,8 @@ import type { Side, Align, PositionState } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useListNavigation } from '../list-navigation.js';
 import { useListboxSelection, OPTION_SELECTOR } from '../listbox/selection.js';
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
 import {
   SelectContext,
   useSelectContext,
@@ -302,8 +304,10 @@ export function SelectPositioner(props: SelectPositionerProps): VNode {
   const { render, children, ...rest } = props;
   const ctx = useSelectContext('Positioner');
 
+  const presence = usePresence(ctx.open);
+
   const position = usePosition({
-    open: ctx.open,
+    open: presence.isPresent,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
@@ -316,28 +320,29 @@ export function SelectPositioner(props: SelectPositionerProps): VNode {
     ctx.setPosition(position);
   }, [position.side, position.align, position.arrowX, position.arrowY]);
 
-  // Promote to the native top layer where supported, only while open.
+  // Promote to the native top layer where supported, while present (open or
+  // animating out), so exit animations play in the top layer.
   useLayoutEffect(() => {
     const el = ctx.floatingRef.current;
-    if (!ctx.open || !el || !supportsPopover(el)) return;
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
     el.setAttribute('popover', 'manual');
     el.showPopover();
     return () => {
       el.hidePopover();
       el.removeAttribute('popover');
     };
-  }, [ctx.open]);
+  }, [presence.isPresent]);
 
-  // Always rendered so options register their labels; `hidden` while closed
-  // makes it inert and invisible without consumer CSS, and composes with the
-  // Popover-API promotion (which only runs while open).
+  // Always rendered so options register their labels; `hidden` while not
+  // present makes it inert and invisible without consumer CSS, and composes
+  // with the Popover-API promotion (which only runs while present).
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
     props: {
       ...rest,
-      ref: ctx.floatingRef,
-      hidden: ctx.open ? undefined : true,
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
+      hidden: presence.isPresent ? undefined : true,
       'data-side': position.side,
       'data-align': position.align,
       style: {

--- a/packages/ui/src/tooltip/tooltip.tsx
+++ b/packages/ui/src/tooltip/tooltip.tsx
@@ -19,6 +19,8 @@ import {
 } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useSafeArea } from '../use-safe-area.js';
+import { mergeRefs } from '../merge-refs.js';
+import { usePresence } from '../use-presence.js';
 import { TooltipContext, useTooltipContext } from './context.js';
 
 export interface TooltipRootProps {
@@ -196,8 +198,10 @@ export function TooltipPositioner(props: TooltipPositionerProps): VNode | null {
   const { render, children, ...rest } = props;
   const ctx = useTooltipContext('Positioner');
 
+  const presence = usePresence(ctx.open);
+
   const position = usePosition({
-    open: ctx.open,
+    open: presence.isPresent,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
@@ -212,26 +216,26 @@ export function TooltipPositioner(props: TooltipPositionerProps): VNode | null {
 
   useLayoutEffect(() => {
     const el = ctx.floatingRef.current;
-    // Runs when open flips true and the element has mounted (refs are assigned
-    // before layout effects). Empty deps would never re-run, so showPopover
-    // would never fire on a mount-on-open element.
-    if (!ctx.open || !el || !supportsPopover(el)) return;
+    // Runs when isPresent flips true and the element has mounted (refs are
+    // assigned before layout effects). Empty deps would never re-run, so
+    // showPopover would never fire on a mount-on-open element.
+    if (!presence.isPresent || !el || !supportsPopover(el)) return;
     el.setAttribute('popover', 'manual');
     el.showPopover();
     return () => {
       el.hidePopover();
       el.removeAttribute('popover');
     };
-  }, [ctx.open]);
+  }, [presence.isPresent]);
 
-  if (!ctx.open) return null;
+  if (!presence.isPresent) return null;
 
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
     props: {
       ...rest,
-      ref: ctx.floatingRef,
+      ref: mergeRefs(ctx.floatingRef, presence.ref),
       'data-side': position.side,
       'data-align': position.align,
       // Neutralize the UA [popover] rule that applies in the top layer

--- a/packages/ui/src/use-presence.ts
+++ b/packages/ui/src/use-presence.ts
@@ -72,17 +72,31 @@ export function usePresence(
     setStatus(present ? 'open' : 'closing');
   }, [present]);
 
-  // Entering 'closing' runs this AFTER the data-state=closed render commits, so
-  // the exit animation is live in the DOM when we read it.
+  // Run the exit when we enter 'closing'. The element that actually animates is
+  // often a CHILD of the ref'd node whose `data-state` flips a render-tick later
+  // (it is consumer/context-driven), so an empty animation set on the first
+  // synchronous read does NOT mean "no exit animation". We read synchronously
+  // first (covers the native-dialog case, where the animated element IS the
+  // ref'd element); if empty, we wait briefly for a transition/animation to
+  // START (transitionrun/animationstart bubble up from the child) before
+  // concluding there is none.
   useLayoutEffect(() => {
     if (status !== 'closing') return;
     const myGen = genRef.current;
     const node = nodeRef.current;
     let finalized = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      node?.removeEventListener('transitionrun', onStart);
+      node?.removeEventListener('animationstart', onStart);
+    };
 
     const finalize = () => {
       if (finalized) return;
       finalized = true;
+      cleanup();
       if (genRef.current !== myGen) return; // reopened mid-exit; abandon
       onExitCompleteRef.current?.();
       setStatus('closed');
@@ -97,50 +111,64 @@ export function usePresence(
       return;
     }
 
-    // Forced reflow so the just-applied closed-state styles register as an
-    // animation/transition. Use getBoundingClientRect (Element) to avoid a cast;
-    // never rAF (throttled/paused in background tabs).
+    const getActive = (): Animation[] =>
+      node
+        .getAnimations({ subtree: true })
+        .filter((a) => a.effect?.getComputedTiming().iterations !== Infinity);
+
+    const awaitAll = (animations: Animation[]) => {
+      cleanup(); // drop the start-listeners and the no-animation fallback timer
+      if (finalized) return;
+      let remaining = animations.length;
+      const onSettled = () => {
+        remaining--;
+        if (remaining === 0) finalize();
+      };
+      timer = setTimeout(
+        finalize,
+        exitTimeout(animations, timeoutCapRef.current)
+      );
+      for (const a of animations) a.finished.then(onSettled, onSettled);
+    };
+
+    function onStart() {
+      const active = getActive();
+      if (active.length > 0) awaitAll(active);
+    }
+
+    // Forced reflow so any already-applied closed-state styles register, then
+    // read. getBoundingClientRect (Element) avoids a cast; never rAF (paused in
+    // background tabs).
     node.getBoundingClientRect();
-
-    const animations = node
-      .getAnimations({ subtree: true })
-      .filter((a) => a.effect?.getComputedTiming().iterations !== Infinity);
-
-    if (animations.length === 0) {
-      finalize();
-      return;
+    const initial = getActive();
+    if (initial.length > 0) {
+      awaitAll(initial);
+    } else {
+      // Nothing is running yet: the animated child may flip `data-state` a tick
+      // after this effect. Wait for a transition/animation to start; if none
+      // does shortly, there is no exit animation, so finalize.
+      node.addEventListener('transitionrun', onStart);
+      node.addEventListener('animationstart', onStart);
+      timer = setTimeout(finalize, 100);
     }
 
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    let remaining = animations.length;
-
-    const onSettled = () => {
-      remaining--;
-      if (remaining === 0) {
-        if (timer !== undefined) clearTimeout(timer);
-        finalize();
-      }
-    };
-
-    timer = setTimeout(
-      () => {
-        finalize();
-      },
-      exitTimeout(animations, timeoutCapRef.current)
-    );
-
-    for (const a of animations) {
-      a.finished.then(onSettled, onSettled);
-    }
-
-    return () => {
-      finalized = true;
-      if (timer !== undefined) clearTimeout(timer);
-    };
+    // Cleanup on reopen/unmount: finalize is generation-guarded (it will not
+    // fire onExitComplete / setStatus once the generation advanced on reopen)
+    // and tears down the listeners + timer.
+    return finalize;
   }, [status]);
 
   return {
-    isPresent: present || status === 'closing',
+    // `status !== 'closed'` (not `=== 'closing'`): the closing transition is set
+    // in a layout effect that runs AFTER the close render commits, so on that
+    // first `present === false` render `status` is still 'open'. Keying off
+    // 'closing' would drop isPresent false for that one committed render,
+    // unmounting / `display:none`-ing the element and cancelling its exit
+    // animation (the always-mounted Select/Combobox never animated; the others
+    // only survived via a wasteful unmount/remount). Staying present until
+    // 'closed' keeps the element rendered continuously so a transition/animation
+    // on the `data-state` flip plays.
+    isPresent: present || status !== 'closed',
     status,
     ref,
   };

--- a/packages/ui/src/use-presence.ts
+++ b/packages/ui/src/use-presence.ts
@@ -3,23 +3,43 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
 export type PresenceStatus = 'open' | 'closing' | 'closed';
 
 export interface UsePresenceOptions {
-  // Fires when the exit animation resolves, immediately before isPresent flips
-  // false. Dialog passes close() here so native focus return runs before unmount.
+  // Fires when the exit resolves, immediately before isPresent flips false.
+  // Dialog passes close() here so native focus return runs before unmount.
+  // Intentionally argument-less; if a "why did it finalize" reason is ever
+  // wanted, add it as an optional arg (non-breaking for existing callers).
   onExitComplete?: () => void;
-  // Hard cap (ms) on the exit-timeout race; guards a stuck or under-reported
-  // animation, or a backgrounded tab. Default 3000.
+  // Hard cap (ms) on the wait once an exit animation is RUNNING; guards a stuck
+  // or under-reported animation, or a backgrounded tab. Default 3000. It does
+  // not bound the separate, shorter wait for an animation to START
+  // (NO_ANIMATION_FALLBACK_MS).
   timeoutCap?: number;
 }
 
 export interface UsePresenceResult {
   // Render the element while true (open OR animating out).
   isPresent: boolean;
-  // 'open' | 'closing' | 'closed'. Map to data-state: closing -> "closed".
+  // 'open' | 'closing' | 'closed'. Map to a data-state attribute, collapsing
+  // closing+closed to "closed". Mapping your own open flag is equivalent (during
+  // closing the element is logically closed); the library's own components do
+  // that. `status` is here for consumers who want to react to the closing phase.
   status: PresenceStatus;
-  // Attach to the element carrying the exit transition. Merge with the
-  // component's own ref via mergeRefs.
+  // Attach to the element carrying the exit animation, OR an ancestor of it
+  // (reads use getAnimations({ subtree: true })) — never a sibling. Merge with
+  // the component's own ref via mergeRefs.
   ref: (node: Element | null) => void;
 }
+
+// How long to wait for an exit transition/animation to START before concluding
+// there is none. The animated element is often a child that flips its
+// data-state a render-tick after this hook's effect runs, so an empty first
+// read is not proof of "no exit". This is a "did anything start?" detector, NOT
+// an animation timer, and is unrelated to timeoutCap. Erring high avoids
+// silently skipping the exit on a slow commit; it only delays teardown when
+// there is genuinely no exit animation.
+const NO_ANIMATION_FALLBACK_MS = 250;
+// Grace added to the longest running animation's end time before the safety cap.
+const TIMEOUT_SLACK_MS = 100;
+const DEFAULT_TIMEOUT_CAP_MS = 3000;
 
 function prefersReducedMotion(): boolean {
   return (
@@ -29,6 +49,8 @@ function prefersReducedMotion(): boolean {
   );
 }
 
+// Longest end time across the given animations + slack, capped. Assumes
+// infinite-iteration animations are already filtered out.
 function exitTimeout(animations: Animation[], cap: number): number {
   let max = 0;
   for (const a of animations) {
@@ -36,14 +58,14 @@ function exitTimeout(animations: Animation[], cap: number): number {
     const end = typeof timing?.endTime === 'number' ? timing.endTime : 0;
     if (end > max) max = end;
   }
-  return Math.min(max > 0 ? max + 100 : cap, cap);
+  return Math.min(max > 0 ? max + TIMEOUT_SLACK_MS : cap, cap);
 }
 
 export function usePresence(
   present: boolean,
   options: UsePresenceOptions = {}
 ): UsePresenceResult {
-  const { onExitComplete, timeoutCap = 3000 } = options;
+  const { onExitComplete, timeoutCap = DEFAULT_TIMEOUT_CAP_MS } = options;
 
   const [status, setStatus] = useState<PresenceStatus>(
     present ? 'open' : 'closed'
@@ -72,32 +94,30 @@ export function usePresence(
     setStatus(present ? 'open' : 'closing');
   }, [present]);
 
-  // Run the exit when we enter 'closing'. The element that actually animates is
-  // often a CHILD of the ref'd node whose `data-state` flips a render-tick later
-  // (it is consumer/context-driven), so an empty animation set on the first
-  // synchronous read does NOT mean "no exit animation". We read synchronously
-  // first (covers the native-dialog case, where the animated element IS the
-  // ref'd element); if empty, we wait briefly for a transition/animation to
-  // START (transitionrun/animationstart bubble up from the child) before
-  // concluding there is none.
+  // Drive the exit once we enter 'closing'.
+  //
+  // The animated element is often a CHILD of the ref'd node, and its data-state
+  // flips a render-tick after this effect runs (it is consumer/context-driven),
+  // so an empty getAnimations() on the first read does NOT mean "no exit". We
+  // read once after a forced reflow (covers the native-dialog case, where the
+  // animated element IS the ref'd element); if nothing is running we keep
+  // transitionrun/animationstart listeners attached and collect each animation
+  // as it starts (they bubble up from the child), so staggered or
+  // different-duration exits are all awaited. We finalize when every tracked
+  // animation has settled, fall back to finalizing if none ever starts, and cap
+  // the total wait as a stuck-animation safety net.
+  //
+  // Locals: track() collects newly-started exit animations; onSettled finalizes
+  // once all tracked ones end; finalize is the single-fire, generation-guarded
+  // teardown and is also the effect's cleanup, so reopen/unmount aborts cleanly.
   useLayoutEffect(() => {
     if (status !== 'closing') return;
-    const myGen = genRef.current;
     const node = nodeRef.current;
-    let finalized = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    const myGen = genRef.current;
 
-    const cleanup = () => {
-      if (timer !== undefined) clearTimeout(timer);
-      node?.removeEventListener('transitionrun', onStart);
-      node?.removeEventListener('animationstart', onStart);
-    };
-
-    const finalize = () => {
-      if (finalized) return;
-      finalized = true;
-      cleanup();
-      if (genRef.current !== myGen) return; // reopened mid-exit; abandon
+    // Commit the close, unless a reopen advanced the generation in the meantime.
+    const commit = () => {
+      if (genRef.current !== myGen) return;
       onExitCompleteRef.current?.();
       setStatus('closed');
     };
@@ -107,67 +127,86 @@ export function usePresence(
       typeof node.getAnimations !== 'function' ||
       prefersReducedMotion()
     ) {
-      finalize();
+      commit();
       return;
     }
 
-    const getActive = (): Animation[] =>
-      node
+    let finalized = false;
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+    let capTimer: ReturnType<typeof setTimeout> | undefined;
+    const tracked = new Set<Animation>();
+    let pending = 0;
+
+    const stop = () => {
+      if (fallbackTimer !== undefined) clearTimeout(fallbackTimer);
+      if (capTimer !== undefined) clearTimeout(capTimer);
+      node.removeEventListener('transitionrun', onStart);
+      node.removeEventListener('animationstart', onStart);
+    };
+
+    const finalize = () => {
+      if (finalized) return;
+      finalized = true;
+      stop();
+      commit();
+    };
+
+    const onSettled = () => {
+      pending--;
+      if (pending === 0) finalize();
+    };
+
+    const track = () => {
+      const active = node
         .getAnimations({ subtree: true })
         .filter((a) => a.effect?.getComputedTiming().iterations !== Infinity);
-
-    const awaitAll = (animations: Animation[]) => {
-      cleanup(); // drop the start-listeners and the no-animation fallback timer
-      if (finalized) return;
-      let remaining = animations.length;
-      const onSettled = () => {
-        remaining--;
-        if (remaining === 0) finalize();
-      };
-      timer = setTimeout(
-        finalize,
-        exitTimeout(animations, timeoutCapRef.current)
-      );
-      for (const a of animations) a.finished.then(onSettled, onSettled);
+      for (const a of active) {
+        if (tracked.has(a)) continue;
+        tracked.add(a);
+        pending++;
+        a.finished.then(onSettled, onSettled);
+      }
+      if (tracked.size > 0) {
+        // An exit animation is running: drop the no-animation fallback and
+        // (re)arm the safety cap to cover the longest tracked animation.
+        if (fallbackTimer !== undefined) {
+          clearTimeout(fallbackTimer);
+          fallbackTimer = undefined;
+        }
+        if (capTimer !== undefined) clearTimeout(capTimer);
+        capTimer = setTimeout(
+          finalize,
+          exitTimeout([...tracked], timeoutCapRef.current)
+        );
+      }
     };
 
     function onStart() {
-      const active = getActive();
-      if (active.length > 0) awaitAll(active);
+      track();
     }
 
-    // Forced reflow so any already-applied closed-state styles register, then
-    // read. getBoundingClientRect (Element) avoids a cast; never rAF (paused in
-    // background tabs).
+    // Forced reflow so just-applied closed-state styles register, then read.
+    // getBoundingClientRect (Element) avoids a cast; never rAF (paused in
+    // background tabs, which would hang the close).
     node.getBoundingClientRect();
-    const initial = getActive();
-    if (initial.length > 0) {
-      awaitAll(initial);
-    } else {
-      // Nothing is running yet: the animated child may flip `data-state` a tick
-      // after this effect. Wait for a transition/animation to start; if none
-      // does shortly, there is no exit animation, so finalize.
+    track();
+    if (pending === 0) {
       node.addEventListener('transitionrun', onStart);
       node.addEventListener('animationstart', onStart);
-      timer = setTimeout(finalize, 100);
+      fallbackTimer = setTimeout(finalize, NO_ANIMATION_FALLBACK_MS);
     }
 
-    // Cleanup on reopen/unmount: finalize is generation-guarded (it will not
-    // fire onExitComplete / setStatus once the generation advanced on reopen)
-    // and tears down the listeners + timer.
     return finalize;
   }, [status]);
 
+  // isPresent stays true until status is 'closed' (not merely while 'closing'):
+  // the 'closing' status is set in the layout effect above, which runs AFTER the
+  // close render commits, so on that first present===false render status is
+  // still 'open'. Keying off 'closing' would drop isPresent false for that one
+  // committed render, unmounting / display:none-ing the element and cancelling
+  // its exit before it starts. Staying present until 'closed' keeps the element
+  // rendered continuously so the exit animation plays.
   return {
-    // `status !== 'closed'` (not `=== 'closing'`): the closing transition is set
-    // in a layout effect that runs AFTER the close render commits, so on that
-    // first `present === false` render `status` is still 'open'. Keying off
-    // 'closing' would drop isPresent false for that one committed render,
-    // unmounting / `display:none`-ing the element and cancelling its exit
-    // animation (the always-mounted Select/Combobox never animated; the others
-    // only survived via a wasteful unmount/remount). Staying present until
-    // 'closed' keeps the element rendered continuously so a transition/animation
-    // on the `data-state` flip plays.
     isPresent: present || status !== 'closed',
     status,
     ref,

--- a/packages/ui/src/use-presence.ts
+++ b/packages/ui/src/use-presence.ts
@@ -122,9 +122,12 @@ export function usePresence(
       }
     };
 
-    timer = setTimeout(() => {
-      finalize();
-    }, exitTimeout(animations, timeoutCapRef.current));
+    timer = setTimeout(
+      () => {
+        finalize();
+      },
+      exitTimeout(animations, timeoutCapRef.current)
+    );
 
     for (const a of animations) {
       a.finished.then(onSettled, onSettled);

--- a/packages/ui/src/use-presence.ts
+++ b/packages/ui/src/use-presence.ts
@@ -1,0 +1,144 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'preact/hooks';
+
+export type PresenceStatus = 'open' | 'closing' | 'closed';
+
+export interface UsePresenceOptions {
+  // Fires when the exit animation resolves, immediately before isPresent flips
+  // false. Dialog passes close() here so native focus return runs before unmount.
+  onExitComplete?: () => void;
+  // Hard cap (ms) on the exit-timeout race; guards a stuck or under-reported
+  // animation, or a backgrounded tab. Default 3000.
+  timeoutCap?: number;
+}
+
+export interface UsePresenceResult {
+  // Render the element while true (open OR animating out).
+  isPresent: boolean;
+  // 'open' | 'closing' | 'closed'. Map to data-state: closing -> "closed".
+  status: PresenceStatus;
+  // Attach to the element carrying the exit transition. Merge with the
+  // component's own ref via mergeRefs.
+  ref: (node: Element | null) => void;
+}
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+function exitTimeout(animations: Animation[], cap: number): number {
+  let max = 0;
+  for (const a of animations) {
+    const timing = a.effect?.getComputedTiming();
+    const end = typeof timing?.endTime === 'number' ? timing.endTime : 0;
+    if (end > max) max = end;
+  }
+  return Math.min(max > 0 ? max + 100 : cap, cap);
+}
+
+export function usePresence(
+  present: boolean,
+  options: UsePresenceOptions = {}
+): UsePresenceResult {
+  const { onExitComplete, timeoutCap = 3000 } = options;
+
+  const [status, setStatus] = useState<PresenceStatus>(
+    present ? 'open' : 'closed'
+  );
+
+  const nodeRef = useRef<Element | null>(null);
+  const prevPresent = useRef(present);
+  const genRef = useRef(0);
+
+  // Keep the latest callback/cap without re-running the exit effect.
+  const onExitCompleteRef = useRef(onExitComplete);
+  onExitCompleteRef.current = onExitComplete;
+  const timeoutCapRef = useRef(timeoutCap);
+  timeoutCapRef.current = timeoutCap;
+
+  const ref = useCallback((node: Element | null) => {
+    nodeRef.current = node;
+  }, []);
+
+  // React to present transitions. On first mount prevPresent === present, so
+  // this never produces a 'closing' on the initial render (no exit on mount/SSR).
+  useLayoutEffect(() => {
+    if (present === prevPresent.current) return;
+    prevPresent.current = present;
+    genRef.current++;
+    setStatus(present ? 'open' : 'closing');
+  }, [present]);
+
+  // Entering 'closing' runs this AFTER the data-state=closed render commits, so
+  // the exit animation is live in the DOM when we read it.
+  useLayoutEffect(() => {
+    if (status !== 'closing') return;
+    const myGen = genRef.current;
+    const node = nodeRef.current;
+    let finalized = false;
+
+    const finalize = () => {
+      if (finalized) return;
+      finalized = true;
+      if (genRef.current !== myGen) return; // reopened mid-exit; abandon
+      onExitCompleteRef.current?.();
+      setStatus('closed');
+    };
+
+    if (
+      !node ||
+      typeof node.getAnimations !== 'function' ||
+      prefersReducedMotion()
+    ) {
+      finalize();
+      return;
+    }
+
+    // Forced reflow so the just-applied closed-state styles register as an
+    // animation/transition. Use getBoundingClientRect (Element) to avoid a cast;
+    // never rAF (throttled/paused in background tabs).
+    node.getBoundingClientRect();
+
+    const animations = node
+      .getAnimations({ subtree: true })
+      .filter((a) => a.effect?.getComputedTiming().iterations !== Infinity);
+
+    if (animations.length === 0) {
+      finalize();
+      return;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let remaining = animations.length;
+
+    const onSettled = () => {
+      remaining--;
+      if (remaining === 0) {
+        if (timer !== undefined) clearTimeout(timer);
+        finalize();
+      }
+    };
+
+    timer = setTimeout(() => {
+      finalize();
+    }, exitTimeout(animations, timeoutCapRef.current));
+
+    for (const a of animations) {
+      a.finished.then(onSettled, onSettled);
+    }
+
+    return () => {
+      finalized = true;
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [status]);
+
+  return {
+    isPresent: present || status === 'closing',
+    status,
+    ref,
+  };
+}

--- a/scripts/client-size-config.mjs
+++ b/scripts/client-size-config.mjs
@@ -65,6 +65,7 @@ export const UI_CORE_MODULES = [
   'use-render.js',
   'merge-refs.js',
   'use-controllable-state.js',
+  'use-presence.js',
 ];
 
 export const COMPONENT_MODULES = {
@@ -98,6 +99,7 @@ export const CHUNK_PREFIXES = [
   ['use-dismiss', 'components'],
   ['use-render', 'components'],
   ['use-controllable-state', 'components'],
+  ['use-presence', 'components'],
   ['merge-refs', 'components'],
   ['components', 'components'], // the Components-area landing page chunk
   ['guard', 'guards'],


### PR DESCRIPTION
## Summary

- New public **`usePresence`** Foundations primitive (`@hono-preact/ui`), built on `Element.getAnimations()`: keeps an overlay element mounted/visible while a `[data-state="closed"]` CSS animation runs, then finalizes (unmount, or `close()` for the native dialog via `onExitComplete`). Zero-config: with no closing CSS the animation set is empty and finalize is synchronous, i.e. today's behavior.
- Wired into **all seven overlays**:
  - **Dialog** — defers `close()` to `onExitComplete` (keeps top-layer/`inert`/focus-trap/`::backdrop` through the exit), intercepts native `cancel` so Esc animates.
  - **Popover, Tooltip, Menu** (one `MenuPositioner` edit also covers **Submenu** + **ContextMenu**) — mount gate, `usePosition`, and `showPopover` all keyed on `presence.isPresent`.
  - **Select, Combobox** — listbox stays mounted (for option/label registration); `hidden` is driven off `presence.isPresent`.
- State machine handles: forced reflow before read (not rAF), `{subtree:true}`, infinite-iteration filter, timeout-cap race (default 3s), generation token for reopen-mid-exit, single-fire guard, `prefers-reduced-motion` short-circuit, no exit on first mount/SSR.
- Public API exported; `usePresence` added to `UI_CORE_MODULES`; Foundations docs page + live demo; exit-animation CSS for the seven demos with **CSS↔Tailwind parity**.
- View Transitions were considered and rejected as the substrate (Baseline-only-newly-available, document-global collision with route VTs, scoped-styling mismatch); see the spec's Alternatives section.

Spec: `docs/superpowers/specs/2026-06-08-use-presence-exit-animations-design.md`
Plan: `docs/superpowers/plans/2026-06-08-use-presence-exit-animations.md`

## Test Plan

- [x] 1166 unit + 4 integration tests pass; `build`, `format:check`, `typecheck`, `site build` all green (full CI mirror).
- [x] Unit-tested state machine (getAnimations mocked): empty-set sync finalize, await→finalize, reopen-mid-exit, reduced-motion, timeout, no-exit-on-mount, `onExitComplete`-before-unmount, single-fire guard, infinite-iteration filter.
- [ ] **Manual (real browser — happy-dom can't run `getAnimations()`):**
  - [ ] Each overlay visibly fades/slides out on close (Dialog, Popover, Tooltip, Menu, ContextMenu, submenu, Select, Combobox).
  - [ ] Dialog keeps top-layer/`inert`/focus-trap during the exit; focus returns to trigger after; `::backdrop` persists through the exit.
  - [ ] Esc on Dialog animates the close (no snap-shut).
  - [ ] Reopen mid-exit reverses cleanly (no flicker; element never unmounts).
  - [ ] `prefers-reduced-motion: reduce` makes every close instant.
  - [ ] Popups don't jump position during the exit.

## Deferred follow-up (non-blocking, from review)

- Make the Dialog external-close (`method="dialog"` / external `close()`) finalize guard explicit, rather than relying on the empty-animation-set synchronous finalize (no hang today; that path just skips its exit animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)