### PR TITLE
refactor(ui): dedup the 5 Positioners into usePositioner; require Popover API

### DIFF
--- a/apps/site/src/pages/docs/components/combobox.mdx
+++ b/apps/site/src/pages/docs/components/combobox.mdx
@@ -460,8 +460,7 @@ register their labels even while closed. Default element `<div>`.
 | `...props` | `JSX.HTMLAttributes<HTMLDivElement>`       | -       | Forwarded. Style positioning via `class`. |
 
 Sets `position: fixed`, resolved `data-side` / `data-align`, and `hidden`
-while closed. Promotes to the browser top layer via the Popover API where
-supported.
+while closed. Promotes to the browser top layer via the Popover API.
 
 ### Combobox.Popup
 

--- a/apps/site/src/pages/docs/components/context-menu.mdx
+++ b/apps/site/src/pages/docs/components/context-menu.mdx
@@ -240,9 +240,8 @@ menu is open (mount on open). Default element `<div>`.
 | `children` | `ComponentChildren`                        | -       | The popup (and optional arrow).                          |
 | `...props` | `JSX.HTMLAttributes<HTMLDivElement>`       | -       | Forwarded to the element. Style positioning via `class`. |
 
-Sets `position: fixed` and the resolved `data-side` / `data-align`. Where the
-browser supports the Popover API, the element is promoted to the top layer so it
-escapes ancestor clipping.
+Sets `position: fixed` and the resolved `data-side` / `data-align`. The element
+is promoted to the top layer via the Popover API, so it escapes ancestor clipping.
 
 ### ContextMenu.Popup
 

--- a/apps/site/src/pages/docs/components/index.mdx
+++ b/apps/site/src/pages/docs/components/index.mdx
@@ -2,10 +2,11 @@
 
 hono-preact ships a set of headless, accessible UI primitives that lean on the
 platform: the native `<dialog>` element and top layer, a battle-tested positioning
-library, and a thin ARIA, keyboard, and collection layer on top. Every
-primitive works on all current browser versions; newer platform features such
-as the Popover API and CSS anchor positioning are used only as progressive
-enhancement.
+library, and a thin ARIA, keyboard, and collection layer on top. The popup
+components (Popover, Tooltip, Menu, Select, Combobox) promote their surfaces into
+the top layer with the Popover API and require it; Dialog builds on the native
+`<dialog>` element. Positioning is computed in JavaScript, so CSS anchor
+positioning is not used.
 
 ## What's here
 

--- a/apps/site/src/pages/docs/components/menu.mdx
+++ b/apps/site/src/pages/docs/components/menu.mdx
@@ -7,7 +7,7 @@ import { MenuDemo } from '../../../components/docs/MenuDemo.js';
 A button-triggered dropdown of commands: a list of actions, toggles, and
 single-select choices that opens from a trigger and closes when you pick
 something or dismiss it. Positioning runs on Floating UI; the popup renders in
-place and promotes to the browser top layer where the Popover API is available.
+place and promotes to the browser top layer using the Popover API.
 It ships unstyled: style it through the `data-state`, `data-highlighted`,
 `data-disabled`, `data-side`, and `data-align` contract.
 
@@ -260,9 +260,8 @@ menu is open (mount on open). Default element `<div>`.
 | `children` | `ComponentChildren`                        | -       | The popup (and optional arrow).                          |
 | `...props` | `JSX.HTMLAttributes<HTMLDivElement>`       | -       | Forwarded to the element. Style positioning via `class`. |
 
-Sets `position: fixed` and the resolved `data-side` / `data-align`. Where the
-browser supports the Popover API, the element is promoted to the top layer so it
-escapes ancestor clipping.
+Sets `position: fixed` and the resolved `data-side` / `data-align`. The element
+is promoted to the top layer via the Popover API, so it escapes ancestor clipping.
 
 ### Menu.Popup
 

--- a/apps/site/src/pages/docs/components/popover.mdx
+++ b/apps/site/src/pages/docs/components/popover.mdx
@@ -6,8 +6,8 @@ import { PopoverDemo } from '../../../components/docs/PopoverDemo.js';
 
 A non-modal, anchored overlay for interactive content: menus of actions, small
 forms, or detail panels. Positioning runs on Floating UI; the overlay renders
-in place and promotes to the browser top layer where the Popover API is
-available. It ships unstyled: style it through the `data-state`, `data-side`,
+in place and promotes to the browser top layer using the Popover API.
+It ships unstyled: style it through the `data-state`, `data-side`,
 and `data-align` contract.
 
 ## Demo
@@ -222,9 +222,8 @@ popover is open (mount on open). Default element `<div>`.
 | `children` | `ComponentChildren`                        | -       | The popup (and optional arrow).                          |
 | `...props` | `JSX.HTMLAttributes<HTMLDivElement>`       | -       | Forwarded to the element. Style positioning via `class`. |
 
-Sets `position: fixed` and the resolved `data-side` / `data-align`. Where the
-browser supports the Popover API, the element is promoted to the top layer so it
-escapes ancestor clipping.
+Sets `position: fixed` and the resolved `data-side` / `data-align`. The element
+is promoted to the top layer via the Popover API, so it escapes ancestor clipping.
 
 ### Popover.Popup
 
@@ -312,7 +311,5 @@ name with a `Popover.Title` (wired through `aria-labelledby`) or by passing
   control moves into the rest of the page, and the page stays interactive.
 - Escape closes the popover; an outside pointer press closes it; nested overlays
   close innermost-first.
-- Where the Popover API is supported the popup renders in the top layer; where it
-  is not, it renders inline with `position: fixed`. An ancestor with a
-  `transform`, `filter`, `contain`, or `will-change` can still clip the inline
-  fallback, so prefer not to anchor a popover inside one.
+- The popup renders in the top layer via the Popover API, so an ancestor
+  `transform`, `filter`, `contain`, or `will-change` does not clip it.

--- a/apps/site/src/pages/docs/components/select.mdx
+++ b/apps/site/src/pages/docs/components/select.mdx
@@ -9,8 +9,8 @@ A custom listbox select: a button that opens a popup of options and writes the
 chosen value back. It supports single and multiple selection, carries a generic
 value type so an option's `value` is your own data rather than a string, and
 submits in a real form through a `name`. Positioning runs on Floating UI; the
-popup renders in place and promotes to the browser top layer where the Popover
-API is available. It ships unstyled: style it through the `data-state`,
+popup renders in place and promotes to the browser top layer using the Popover
+API. It ships unstyled: style it through the `data-state`,
 `data-highlighted`, `data-selected`, `data-disabled`, `data-placeholder`,
 `data-side`, and `data-align` contract.
 
@@ -350,8 +350,8 @@ register their labels) and `hidden` while closed. Default element `<div>`.
 | `...props` | `JSX.HTMLAttributes<HTMLDivElement>`       | -       | Forwarded to the element. Style positioning via `class`. |
 
 Sets `position: fixed`, the resolved `data-side` / `data-align`, and `hidden`
-while closed. Where the browser supports the Popover API, the element is promoted
-to the top layer so it escapes ancestor clipping.
+while closed. The element is promoted to the top layer via the Popover API, so it
+escapes ancestor clipping.
 
 ### Select.Popup
 

--- a/apps/site/src/pages/docs/components/tooltip.mdx
+++ b/apps/site/src/pages/docs/components/tooltip.mdx
@@ -179,9 +179,8 @@ tooltip is open (mount on open). Default element `<div>`.
 | `children` | `ComponentChildren`                        | -       | The popup (and optional arrow).                          |
 | `...props` | `JSX.HTMLAttributes<HTMLDivElement>`       | -       | Forwarded to the element. Style positioning via `class`. |
 
-Sets `position: fixed` and the resolved `data-side` / `data-align`. Where the
-browser supports the Popover API, the element is promoted to the top layer so it
-escapes ancestor clipping.
+Sets `position: fixed` and the resolved `data-side` / `data-align`. The element
+is promoted to the top layer via the Popover API, so it escapes ancestor clipping.
 
 ### Tooltip.Popup
 

--- a/docs/superpowers/plans/2026-06-10-positioner-dedup.md
+++ b/docs/superpowers/plans/2026-06-10-positioner-dedup.md
@@ -1,0 +1,751 @@
+# Positioner dedup via `usePositioner` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the five near-identical `XPositioner` bodies (Popover, Tooltip, Menu, Select, Combobox) into one internal `usePositioner` hook, and make the Popover API a hard dependency (remove the `supportsPopover` gate).
+
+**Architecture:** A new internal hook `usePositioner` owns the shared mechanism (`usePresence` → `usePosition` → the `setPosition` publish effect → the unconditional top-layer promotion effect → the neutralize `style`). Each `XPositioner` becomes a ~12-line wrapper that reads its own typed context and passes a thin slice to the hook. Behavior-preserving except the gate removal, so the existing per-component test suites are the safety net; a new direct hook test covers the extracted unit.
+
+**Tech Stack:** Preact, `@floating-ui/dom` (via `usePosition`), Vitest + happy-dom + `@testing-library/preact`, the native Popover API.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-positioner-dedup-design.md`
+
+---
+
+## File structure
+
+- **`packages/ui/src/use-positioner.ts`** (new) — the shared hook + `POSITIONER_STYLE` constant. One responsibility: the Positioner mechanism. Not exported from `index.ts` (internal primitive, like `use-position.ts`).
+- **`packages/ui/src/__tests__/use-positioner.test.tsx`** (new) — direct hook test.
+- **`packages/ui/src/{popover/popover,tooltip/tooltip,menu/menu,select/select,combobox/combobox}.tsx`** (modify) — replace the Positioner body, delete the local `supportsPopover` helper (4 of 5), remove orphaned imports.
+- **`apps/site/src/pages/docs/components/index.mdx`** (modify) — update the browser-support paragraph to state the Popover API is required.
+
+**Do NOT touch** `scripts/client-size-config.mjs` or any `client-size-report.json`/history: `use-positioner` is a shared internal module attributed per-component (matching the `use-position` / `listbox/selection` precedent), and the post-merge build job regenerates baselines. Keep the size baseline equal to main's.
+
+---
+
+### Task 1: Create the `usePositioner` hook
+
+**Files:**
+- Test: `packages/ui/src/__tests__/use-positioner.test.tsx`
+- Create: `packages/ui/src/use-positioner.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ui/src/__tests__/use-positioner.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { usePositioner } from '../use-positioner.js';
+import type { PositionState, ClientRectGetter } from '../use-position.js';
+
+afterEach(cleanup);
+
+function Harness(props: {
+  open: boolean;
+  mount: 'unmount' | 'hidden';
+  getAnchorRect?: ClientRectGetter;
+  onPosition?: (p: PositionState) => void;
+}) {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+  const arrowRef = useRef<HTMLDivElement>(null);
+  const { isPresent, positionerProps } = usePositioner({
+    open: props.open,
+    anchorRef,
+    floatingRef,
+    arrowRef,
+    side: 'bottom',
+    align: 'start',
+    offset: 8,
+    getAnchorRect: props.getAnchorRect,
+    setPosition: (p) => props.onPosition?.(p),
+    mount: props.mount,
+  });
+  return (
+    <div>
+      <button ref={anchorRef}>anchor</button>
+      <span data-testid="present">{String(isPresent)}</span>
+      {props.mount === 'unmount' && !isPresent ? null : (
+        <div data-testid="floating" {...positionerProps} />
+      )}
+    </div>
+  );
+}
+
+describe('usePositioner', () => {
+  it('unmount mode: not present when closed, present when open', () => {
+    const closed = render(<Harness open={false} mount="unmount" />);
+    expect(closed.getByTestId('present').textContent).toBe('false');
+    expect(closed.queryByTestId('floating')).toBeNull();
+    cleanup();
+    const open = render(<Harness open mount="unmount" />);
+    expect(open.getByTestId('present').textContent).toBe('true');
+    expect(open.queryByTestId('floating')).not.toBeNull();
+    expect(open.getByTestId('floating').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('hidden mode: stays mounted; hidden toggles with open', () => {
+    const closed = render(<Harness open={false} mount="hidden" />);
+    // Always rendered, but hidden while closed.
+    expect(closed.queryByTestId('floating')).not.toBeNull();
+    expect(closed.getByTestId('floating').hasAttribute('hidden')).toBe(true);
+    cleanup();
+    const open = render(<Harness open mount="hidden" />);
+    expect(open.getByTestId('floating').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('emits the neutralize style and data-side/data-align', () => {
+    const { getByTestId } = render(<Harness open mount="unmount" />);
+    const el = getByTestId('floating');
+    expect(el.style.position).toBe('fixed');
+    expect(el.getAttribute('data-side')).toBe('bottom');
+    expect(el.getAttribute('data-align')).toBe('start');
+  });
+
+  it('publishes the resolved position via setPosition', () => {
+    const seen: PositionState[] = [];
+    render(<Harness open mount="unmount" onPosition={(p) => seen.push(p)} />);
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0].side).toBe('bottom');
+    expect(seen[0].align).toBe('start');
+  });
+
+  it('forwards getAnchorRect to usePosition', async () => {
+    const getAnchorRect = vi.fn(() => ({
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    }));
+    render(<Harness open mount="unmount" getAnchorRect={getAnchorRect} />);
+    await waitFor(() => expect(getAnchorRect).toHaveBeenCalled());
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-positioner.test.tsx`
+Expected: FAIL — cannot resolve `'../use-positioner.js'` / `usePositioner is not a function`.
+
+- [ ] **Step 3: Create the hook**
+
+Create `packages/ui/src/use-positioner.ts`:
+
+```ts
+import type { JSX, RefObject } from 'preact';
+import { useLayoutEffect } from 'preact/hooks';
+import { usePosition } from './use-position.js';
+import type {
+  Side,
+  Align,
+  PositionState,
+  ClientRectGetter,
+} from './use-position.js';
+import { usePresence } from './use-presence.js';
+import { mergeRefs } from './merge-refs.js';
+
+// The framework-owned layout wrapper's style. Besides positioning, it
+// neutralizes the UA [popover] rule that applies once the element is promoted
+// to the top layer (overflow/inset/margin/border/padding/background): without
+// this the UA `overflow: auto` clips the popup's box-shadow and `inset: 0`
+// fights the computed left/top. One stable reference (shared by all 5).
+const POSITIONER_STYLE: JSX.CSSProperties = {
+  position: 'fixed',
+  inset: 'auto',
+  margin: 0,
+  overflow: 'visible',
+  border: 0,
+  padding: 0,
+  background: 'transparent',
+};
+
+export interface UsePositionerOptions {
+  open: boolean;
+  // usePosition anchor (the Combobox passes its inputRef here).
+  anchorRef: RefObject<HTMLElement>;
+  floatingRef: RefObject<HTMLElement>;
+  arrowRef: RefObject<HTMLElement>;
+  side: Side;
+  align: Align;
+  offset: number;
+  // Position against a point/virtual element instead of anchorRef (context-menu
+  // pointer anchor, combobox anchor-or-input). Undefined for the common case.
+  getAnchorRect?: ClientRectGetter;
+  // Publish the resolved position so an Arrow part can read it.
+  setPosition: (p: PositionState) => void;
+  // 'unmount': the component returns null while closed (branch on isPresent).
+  // 'hidden': the element stays mounted (so options can register their labels)
+  // and is `hidden` while closed.
+  mount: 'unmount' | 'hidden';
+}
+
+export interface PositionerProps {
+  ref: (node: HTMLElement | null) => void;
+  hidden?: true;
+  'data-side': Side;
+  'data-align': Align;
+  style: JSX.CSSProperties;
+}
+
+export interface UsePositionerResult {
+  // Raw presence value. 'unmount' components branch on this (`return null`);
+  // 'hidden' components ignore it (the hook bakes `hidden` into the props).
+  isPresent: boolean;
+  positionerProps: PositionerProps;
+  state: { side: Side; align: Align };
+}
+
+export function usePositioner(opts: UsePositionerOptions): UsePositionerResult {
+  const presence = usePresence(opts.open);
+
+  const position = usePosition({
+    open: presence.isPresent,
+    anchorRef: opts.anchorRef,
+    floatingRef: opts.floatingRef,
+    arrowRef: opts.arrowRef,
+    side: opts.side,
+    align: opts.align,
+    offset: opts.offset,
+    getAnchorRect: opts.getAnchorRect,
+  });
+
+  // Publish the resolved position so Arrow (and any consumer) can read it.
+  useLayoutEffect(() => {
+    opts.setPosition(position);
+  }, [position.side, position.align, position.arrowX, position.arrowY]);
+
+  // Promote to the native top layer. The Popover API is a hard dependency of
+  // these components; on a browser without it showPopover() throws (no
+  // fallback). Applied imperatively so there is no SSR/hydration mismatch, and
+  // it stays mounted through the exit animation so hidePopover fires only after
+  // the closing transition completes.
+  useLayoutEffect(() => {
+    const el = opts.floatingRef.current;
+    if (!presence.isPresent || !el) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      // Best-effort un-promotion: hidePopover() throws if the element already
+      // left the top layer (closed by another path or disconnected). Either way
+      // the goal state (not promoted) is met, so ignore the throw.
+      try {
+        el.hidePopover();
+      } catch {
+        // already hidden / disconnected
+      }
+      el.removeAttribute('popover');
+    };
+  }, [presence.isPresent]);
+
+  return {
+    isPresent: presence.isPresent,
+    positionerProps: {
+      ref: mergeRefs(opts.floatingRef, presence.ref),
+      hidden: opts.mount === 'hidden' && !presence.isPresent ? true : undefined,
+      'data-side': position.side,
+      'data-align': position.align,
+      style: POSITIONER_STYLE,
+    },
+    state: { side: position.side, align: position.align },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-positioner.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --filter '@hono-preact/*' build && pnpm typecheck`
+Expected: exit 0 (the new module compiles; nothing else changed yet).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/use-positioner.ts packages/ui/src/__tests__/use-positioner.test.tsx
+git commit -m "feat(ui): add usePositioner hook (shared Positioner mechanism)"
+```
+
+---
+
+### Task 2: Refactor `PopoverPositioner` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/popover/popover.tsx`
+
+- [ ] **Step 1: Replace the Positioner body, delete `supportsPopover`, fix imports**
+
+In `packages/ui/src/popover/popover.tsx`:
+
+1. Delete the `supportsPopover` helper function entirely:
+
+```ts
+function supportsPopover(el: HTMLElement): boolean {
+  return typeof el.showPopover === 'function';
+}
+```
+
+2. Replace the whole `PopoverPositioner` function with:
+
+```tsx
+export function PopoverPositioner(props: PopoverPositionerProps): VNode | null {
+  const { render, children, ...rest } = props;
+  const ctx = usePopoverContext('Positioner');
+  const { isPresent, positionerProps, state } = usePositioner({
+    open: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+    setPosition: ctx.setPosition,
+    mount: 'unmount',
+  });
+  if (!isPresent) return null;
+  return useRender<{ side: Side; align: Align }>({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, ...positionerProps },
+    state,
+    children,
+  });
+}
+```
+
+3. Remove the now-orphaned imports (each used only in the old Positioner): the `usePosition`, `usePresence`, and `mergeRefs` import lines. Add the hook import alongside the other `../use-*.js` imports:
+
+```ts
+import { usePositioner } from '../use-positioner.js';
+```
+
+Keep `useLayoutEffect` (still used by `PopoverDescription`), and keep `type { Side, Align, PositionState }` (used by the Root's `useState<PositionState>` and the Positioner's `useRender<{side, align}>` generic / props type).
+
+- [ ] **Step 2: Typecheck (catches any missed/over-removed import)**
+
+Run: `pnpm typecheck`
+Expected: exit 0. If it reports an unused import (`noUnusedLocals`) or a missing symbol, fix exactly what it names and re-run.
+
+- [ ] **Step 3: Run the Popover tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/popover-popup.test.tsx packages/ui/src/__tests__/popover-parts.test.tsx packages/ui/src/__tests__/popover-presence.test.tsx packages/ui/src/__tests__/popover-ssr.test.tsx packages/ui/src/__tests__/popover-root.test.tsx packages/ui/src/__tests__/popover-anchor.test.tsx`
+Expected: PASS (all green, behavior preserved).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/popover/popover.tsx
+git commit -m "refactor(ui): PopoverPositioner onto usePositioner; require Popover API"
+```
+
+---
+
+### Task 3: Refactor `TooltipPositioner` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/tooltip/tooltip.tsx`
+
+- [ ] **Step 1: Replace the Positioner body, delete `supportsPopover`, fix imports**
+
+In `packages/ui/src/tooltip/tooltip.tsx`:
+
+1. Delete the `supportsPopover` helper:
+
+```ts
+function supportsPopover(el: HTMLElement): boolean {
+  return typeof el.showPopover === 'function';
+}
+```
+
+2. Replace the whole `TooltipPositioner` function with:
+
+```tsx
+export function TooltipPositioner(props: TooltipPositionerProps): VNode | null {
+  const { render, children, ...rest } = props;
+  const ctx = useTooltipContext('Positioner');
+  const { isPresent, positionerProps, state } = usePositioner({
+    open: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+    setPosition: ctx.setPosition,
+    mount: 'unmount',
+  });
+  if (!isPresent) return null;
+  return useRender<{ side: Side; align: Align }>({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, ...positionerProps },
+    state,
+    children,
+  });
+}
+```
+
+3. Fix imports: remove `usePosition`, `usePresence`, `mergeRefs`, AND `useLayoutEffect` (in tooltip.tsx the only `useLayoutEffect` uses are the two effects now inside the hook). Keep `type PositionState` (Root `useState`) and `Side`/`Align`. Note `usePosition` and `type PositionState` are imported together from `../use-position.js`; keep that import but drop only `usePosition`, e.g.:
+
+```ts
+import type { Side, Align, PositionState } from '../use-position.js';
+```
+
+Add:
+
+```ts
+import { usePositioner } from '../use-positioner.js';
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: exit 0. Fix any `noUnusedLocals`/missing-symbol error exactly as named and re-run.
+
+- [ ] **Step 3: Run the Tooltip tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/tooltip-popup.test.tsx packages/ui/src/__tests__/tooltip-presence.test.tsx packages/ui/src/__tests__/tooltip-safe-area.test.tsx packages/ui/src/__tests__/tooltip-ssr.test.tsx packages/ui/src/__tests__/tooltip-trigger.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/tooltip/tooltip.tsx
+git commit -m "refactor(ui): TooltipPositioner onto usePositioner; require Popover API"
+```
+
+---
+
+### Task 4: Refactor `MenuPositioner` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/menu/menu.tsx`
+
+- [ ] **Step 1: Replace the Positioner body, delete `supportsPopover`, fix imports**
+
+In `packages/ui/src/menu/menu.tsx`:
+
+1. Delete the `supportsPopover` helper:
+
+```ts
+function supportsPopover(el: HTMLElement): boolean {
+  return typeof el.showPopover === 'function';
+}
+```
+
+2. Replace the whole `MenuPositioner` function with (note the `getAnchorRect: ctx.getAnchorRect` — Menu shares this context with ContextMenu, whose pointer anchor lives there):
+
+```tsx
+export function MenuPositioner(props: MenuPositionerProps): VNode | null {
+  const { render, children, ...rest } = props;
+  const ctx = useMenuContext('Positioner');
+  const { isPresent, positionerProps, state } = usePositioner({
+    open: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+    getAnchorRect: ctx.getAnchorRect,
+    setPosition: ctx.setPosition,
+    mount: 'unmount',
+  });
+  if (!isPresent) return null;
+  return useRender<{ side: Side; align: Align }>({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, ...positionerProps },
+    state,
+    children,
+  });
+}
+```
+
+3. Fix imports: remove `usePosition`, `usePresence`, `mergeRefs`. Keep `useLayoutEffect` (used by the open-focus effect elsewhere in the file) and `type { Side, Align, PositionState }`. Add:
+
+```ts
+import { usePositioner } from '../use-positioner.js';
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: exit 0. Fix any flagged import/symbol exactly and re-run.
+
+- [ ] **Step 3: Run the Menu + ContextMenu tests (they share `MenuPositioner`)**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/menu-structure.test.tsx packages/ui/src/__tests__/menu-navigation-dom.test.tsx packages/ui/src/__tests__/menu-presence.test.tsx packages/ui/src/__tests__/menu-ssr.test.tsx packages/ui/src/__tests__/menu-submenu.test.tsx packages/ui/src/__tests__/menu-submenu-safe-area.test.tsx packages/ui/src/__tests__/menu-trigger.test.tsx packages/ui/src/__tests__/menu-item.test.tsx packages/ui/src/__tests__/menu-checkable.test.tsx packages/ui/src/__tests__/context-menu.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/menu/menu.tsx
+git commit -m "refactor(ui): MenuPositioner onto usePositioner; require Popover API"
+```
+
+---
+
+### Task 5: Refactor `SelectPositioner` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/select/select.tsx`
+
+- [ ] **Step 1: Replace the Positioner body, delete `supportsPopover`, fix imports**
+
+In `packages/ui/src/select/select.tsx`:
+
+1. Delete the `supportsPopover` helper:
+
+```ts
+function supportsPopover(el: HTMLElement): boolean {
+  return typeof el.showPopover === 'function';
+}
+```
+
+2. Replace the whole `SelectPositioner` function with (`mount: 'hidden'` — the listbox stays mounted while closed so options keep registering their labels for the trigger auto-label):
+
+```tsx
+export function SelectPositioner(props: SelectPositionerProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useSelectContext('Positioner');
+  // Always rendered (mount: 'hidden') so options register their labels; the
+  // hook drives `hidden` while not present, which composes with the top-layer
+  // promotion (active only while present).
+  const { positionerProps, state } = usePositioner({
+    open: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+    setPosition: ctx.setPosition,
+    mount: 'hidden',
+  });
+  return useRender<{ side: Side; align: Align }>({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, ...positionerProps },
+    state,
+    children,
+  });
+}
+```
+
+3. Fix imports: remove `usePosition`, `usePresence`, `mergeRefs`. Keep `useLayoutEffect` (Trigger open-focus + Option registration) and `type { Side, Align, PositionState }`. Add:
+
+```ts
+import { usePositioner } from '../use-positioner.js';
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: exit 0. Fix any flagged import/symbol exactly and re-run.
+
+- [ ] **Step 3: Run the Select tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/select-trigger.test.tsx packages/ui/src/__tests__/select-option.test.tsx packages/ui/src/__tests__/select-nav.test.tsx packages/ui/src/__tests__/select-form.test.tsx packages/ui/src/__tests__/select-presence.test.tsx packages/ui/src/__tests__/select-ssr.test.tsx packages/ui/src/__tests__/listbox-selection.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/select/select.tsx
+git commit -m "refactor(ui): SelectPositioner onto usePositioner; require Popover API"
+```
+
+---
+
+### Task 6: Refactor `ComboboxPositioner` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/combobox/combobox.tsx`
+
+- [ ] **Step 1: Replace the Positioner body, fix imports (no `supportsPopover` here)**
+
+In `packages/ui/src/combobox/combobox.tsx`:
+
+1. Replace the whole `ComboboxPositioner` function with (keeps its local `getAnchorRect`; positions against `inputRef`; `mount: 'hidden'`):
+
+```tsx
+export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useComboboxContext('Positioner');
+  // Anchor to the <Combobox.Anchor> field if one is rendered, else the input.
+  // Both refs are stable, so the callback is stable (no autoUpdate churn).
+  const getAnchorRect = useCallback(
+    () =>
+      (
+        ctx.anchorRef.current ?? ctx.inputRef.current
+      )?.getBoundingClientRect() ?? null,
+    [ctx.anchorRef, ctx.inputRef]
+  );
+  const { positionerProps, state } = usePositioner({
+    open: ctx.open,
+    anchorRef: ctx.inputRef,
+    floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+    getAnchorRect,
+    setPosition: ctx.setPosition,
+    mount: 'hidden',
+  });
+  return useRender<{ side: Side; align: Align }>({
+    render,
+    defaultTag: 'div',
+    props: { ...rest, ...positionerProps },
+    state,
+    children,
+  });
+}
+```
+
+2. Fix imports: remove `usePosition`, `usePresence`, `mergeRefs`. Keep `useCallback` (still used by the local `getAnchorRect` and elsewhere), `useLayoutEffect`, and `type { Side, Align, PositionState }`. Add:
+
+```ts
+import { usePositioner } from '../use-positioner.js';
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: exit 0. Fix any flagged import/symbol exactly and re-run.
+
+- [ ] **Step 3: Run the Combobox tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/combobox-root.test.tsx packages/ui/src/__tests__/combobox-input.test.tsx packages/ui/src/__tests__/combobox-popup.test.tsx packages/ui/src/__tests__/combobox-option.test.tsx packages/ui/src/__tests__/combobox-value.test.tsx packages/ui/src/__tests__/combobox-status.test.tsx packages/ui/src/__tests__/combobox-autocomplete.test.ts packages/ui/src/__tests__/combobox-inline.test.tsx packages/ui/src/__tests__/combobox-controls.test.tsx packages/ui/src/__tests__/combobox-anchor-focus.test.tsx packages/ui/src/__tests__/combobox-presence.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/combobox/combobox.tsx
+git commit -m "refactor(ui): ComboboxPositioner onto usePositioner"
+```
+
+---
+
+### Task 7: Update the Popover-API browser-support note in docs
+
+**Files:**
+- Modify: `apps/site/src/pages/docs/components/index.mdx`
+
+- [ ] **Step 1: Replace the browser-support paragraph**
+
+In `apps/site/src/pages/docs/components/index.mdx`, replace this paragraph (currently lines 3-8):
+
+```mdx
+hono-preact ships a set of headless, accessible UI primitives that lean on the
+platform: the native `<dialog>` element and top layer, a battle-tested positioning
+library, and a thin ARIA, keyboard, and collection layer on top. Every
+primitive works on all current browser versions; newer platform features such
+as the Popover API and CSS anchor positioning are used only as progressive
+enhancement.
+```
+
+with:
+
+```mdx
+hono-preact ships a set of headless, accessible UI primitives that lean on the
+platform: the native `<dialog>` element and top layer, a battle-tested positioning
+library, and a thin ARIA, keyboard, and collection layer on top. The popup
+components (Popover, Tooltip, Menu, Select, Combobox) promote their surfaces into
+the top layer with the Popover API and require it; Dialog builds on the native
+`<dialog>` element. Positioning is computed in JavaScript, so CSS anchor
+positioning is not used.
+```
+
+- [ ] **Step 2: Build the site to confirm the MDX still compiles**
+
+Run: `pnpm --filter site build`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/site/src/pages/docs/components/index.mdx
+git commit -m "docs(ui): note the popup components require the Popover API"
+```
+
+---
+
+### Task 8: Full CI mirror + final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full CI mirror in CI order**
+
+Run each, expecting exit 0:
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test
+pnpm test:integration
+pnpm --filter site build
+```
+
+Expected: all pass. `pnpm test` should report the full unit suite green including the new `use-positioner.test.tsx` (5 tests) and all five components' suites. If `format:check` fails, run `pnpm format`, re-run `format:check`, and commit the formatting fix:
+
+```bash
+git add -A && git commit -m "chore(ui): pnpm format"
+```
+
+- [ ] **Step 2: Confirm the diff is what was intended**
+
+Run: `git diff main...HEAD --stat`
+Expected: `use-positioner.ts` + its test added; the 5 component files shrunk (Positioner bodies + `supportsPopover` removed); `index.mdx` paragraph changed. No `client-size-config.mjs` / `client-size-report.json` changes.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/ui-positioner-dedup
+gh pr create --base main --head feat/ui-positioner-dedup \
+  --title "refactor(ui): dedup the 5 Positioners into usePositioner; require Popover API" \
+  --body "<summarize: usePositioner hook extraction, per-component thin wrappers, supportsPopover gate removed (Popover API now required for all popup components), docs note, behavior-preserving except the gate removal; full CI mirror green>"
+```
+
+---
+
+## Post-merge follow-up (NOT part of this plan's commits)
+
+- Update the `project_browser_support_constraint` memory to record that the Popover API is now a hard dependency for the popup components (CSS anchor positioning remains unused).
+
+## Notes for the implementer
+
+- **Keep tests green at every task.** This is a behavior-preserving refactor (except the gate removal, which no existing test exercises, since happy-dom implements `showPopover` and SSR runs no layout effects). If any component test goes red after its refactor, the refactor diverged from the original, compare against `git show main:packages/ui/src/<file>` and reconcile before committing.
+- **`useRender` is hook-free** (just `cloneElement`/`h`), so the conditional `useRender` call after `if (!isPresent) return null` in unmount-mode components is safe.
+- **Do not add `use-positioner` to the size config or regenerate baselines.** Shared internal modules are attributed per-component (the `use-position` / `listbox/selection` precedent); the post-merge build job regenerates the size report.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Shared `usePositioner` hook (spec §Design/The hook) → Task 1. ✔
+- Per-component thin wrappers with the variation mapping (spec §Design/wrappers + table) → Tasks 2-6 (Popover/Tooltip = unmount/anchorRef; Menu = unmount/anchorRef/`ctx.getAnchorRect`; Select = hidden/anchorRef; Combobox = hidden/inputRef/local getAnchorRect). ✔
+- Popover API required: gate + four `supportsPopover` helpers removed, unconditional top-layer effect (spec §Design/Popover API now required) → hook in Task 1 + helper deletions in Tasks 2-5 (Combobox has none). ✔
+- Throw on unsupported browser → hook calls `showPopover()` unconditionally. ✔
+- Docs note in one shared location (spec §Design + §Files) → Task 7. ✔
+- Testing: existing suites stay green + new direct hook test (spec §Testing) → Tasks 2-6 run per-component suites; Task 1 adds `use-positioner.test.tsx`; Task 8 full suite. ✔
+- Memory update (spec §Files, post-merge) → noted in Post-merge follow-up. ✔
+
+**Placeholder scan:** No TBD/TODO. The only "fix what typecheck names" steps are deterministic verification procedures with the exact symbols to remove already listed per task; no code step omits its code.
+
+**Type consistency:** `usePositioner` / `UsePositionerOptions` / `UsePositionerResult` / `PositionerProps` names match across Task 1 and every consumer in Tasks 2-6. Hook opts (`open`, `anchorRef`, `floatingRef`, `arrowRef`, `side`, `align`, `offset`, `getAnchorRect?`, `setPosition`, `mount`) match every call site. Return (`isPresent`, `positionerProps`, `state`) destructured consistently (unmount tasks take `isPresent`; hidden tasks omit it). `mount` values `'unmount'`/`'hidden'` used consistently.

--- a/docs/superpowers/specs/2026-06-10-positioner-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-10-positioner-dedup-design.md
@@ -1,0 +1,222 @@
+# Positioner dedup via `usePositioner`
+
+**Date:** 2026-06-10
+**Status:** Approved (brainstorming) — ready for implementation plan
+**Scope:** `@hono-preact/ui` (unreleased, `0.0.0`/private)
+
+## Motivation
+
+The five popup-bearing components (Popover, Tooltip, Menu, Select, Combobox) each
+define an `XPositioner` part: the framework-owned layout wrapper that computes the
+floating position, promotes the element into the top layer, and renders a
+neutralized `<div>` around the consumer's Popup. All five are ~50 lines of nearly
+identical mechanism. The duplication is a realized maintenance cost, not a
+hypothetical: the recent `hidePopover` guard and the PR #81 `usePresence` rollout
+each required editing the same block in all five files, and the neutralize-`style`
+/ top-layer code is exactly the kind of subtle popup mechanics where a single
+stale copy fails silently in production (and is invisible to happy-dom).
+
+This effort extracts the shared mechanism into one internal hook and collapses each
+`XPositioner` to a thin, explicit wrapper. It also folds in a policy change agreed
+during brainstorming: the Popover API becomes a hard dependency for these
+components (it was previously gated as progressive enhancement in four of the five).
+
+This is the first of two independent dedups; the `useMenuCore` Root dedup is a
+separate, later effort and is out of scope here.
+
+## Goals
+
+- One shared `usePositioner` hook owns: `usePresence`, `usePosition`, the
+  `setPosition` publish effect, the top-layer promotion effect, and the neutralize
+  `style`.
+- Each `XPositioner` becomes a ~12-line named, typed function that reads its own
+  context and passes a thin slice to the hook. Real stack frames preserved.
+- Remove the `supportsPopover` gate and the four copy-pasted helper functions; the
+  top-layer effect runs unconditionally (Popover API required).
+- Behavior-preserving for everything except the gate removal. No public API change.
+
+## Non-goals
+
+- The `useMenuCore` Root dedup (separate effort).
+- Dialog (uses native `<dialog>`/`showModal`, no Positioner, unaffected).
+- Any change to `usePosition`, `usePresence`, or `useRender` internals.
+- A factory/HOC approach (explicitly rejected in favor of the explicit hook).
+
+## Design
+
+### The hook: `packages/ui/src/use-positioner.ts`
+
+Internal module (one hook per file, matching `use-position.ts` / `use-presence.ts`
+/ `use-safe-area.ts`). **Not** exported from `index.ts`.
+
+```ts
+export interface UsePositionerOptions {
+  open: boolean;
+  anchorRef: RefObject<HTMLElement>;   // usePosition anchor (inputRef for Combobox)
+  floatingRef: RefObject<HTMLElement>;
+  arrowRef: RefObject<HTMLElement>;
+  side: Side;
+  align: Align;
+  offset: number;
+  getAnchorRect?: ClientRectGetter;    // undefined | ctx.getAnchorRect | local
+  setPosition: (p: PositionState) => void; // publish resolved position for Arrow
+  mount: 'unmount' | 'hidden';
+}
+
+export interface UsePositionerResult {
+  // Raw presence value. Unmount-mode components branch on this (`return null`);
+  // hidden-mode components ignore it (the hook bakes `hidden` into the props).
+  isPresent: boolean;
+  positionerProps: {
+    ref: (node: Element | null) => void;
+    hidden?: true; // set only in 'hidden' mode while !isPresent
+    'data-side': Side;
+    'data-align': Align;
+    style: JSX.CSSProperties; // the shared neutralize block (stable constant)
+  };
+  state: { side: Side; align: Align };
+}
+
+export function usePositioner(opts: UsePositionerOptions): UsePositionerResult;
+```
+
+Internals (each step lifted verbatim from the current Positioners):
+
+1. `const presence = usePresence(opts.open)`
+2. `const position = usePosition({ open: presence.isPresent, anchorRef, floatingRef, arrowRef, side, align, offset, getAnchorRect })`
+3. Publish effect: `useLayoutEffect(() => opts.setPosition(position), [position.side, position.align, position.arrowX, position.arrowY])` — deps unchanged; `setPosition` intentionally omitted from deps (stable `useState` setter), as today.
+4. Top-layer promotion effect, **unconditional** (no `supportsPopover` gate):
+   ```ts
+   useLayoutEffect(() => {
+     const el = opts.floatingRef.current;
+     if (!presence.isPresent || !el) return;
+     el.setAttribute('popover', 'manual');
+     el.showPopover();
+     return () => {
+       try { el.hidePopover(); } catch { /* already hidden / disconnected */ }
+       el.removeAttribute('popover');
+     };
+   }, [presence.isPresent]);
+   ```
+5. Return: `isPresent`, the `positionerProps` (with `hidden = opts.mount === 'hidden' && !presence.isPresent ? true : undefined`, `ref = mergeRefs(opts.floatingRef, presence.ref)`, `data-*` from `position`, `style = POSITIONER_STYLE`), and `state = { side: position.side, align: position.align }`.
+
+`POSITIONER_STYLE` is a module-level constant carrying the neutralize block
+(`position:fixed; inset:auto; margin:0; overflow:visible; border:0; padding:0;
+background:transparent`) and its explanatory comment (neutralizes the UA
+`[popover]` rule so `overflow:auto` doesn't clip the popup box-shadow and
+`inset:0` doesn't fight the computed left/top). Using one stable reference instead
+of an inline per-render object is behavior-equivalent (identical CSS) and a minor
+render win.
+
+### The per-component wrappers
+
+Each `XPositioner` stays an explicit, named, typed function. The control-flow
+difference between mount modes is honest and preserved:
+
+- **`unmount`** (Popover, Tooltip, Menu): keep the `if (!isPresent) return null`
+  line; return type `VNode | null`.
+- **`hidden`** (Select, Combobox): no guard (the listbox stays mounted-but-`hidden`
+  so options keep registering their labels); return type `VNode`.
+
+```tsx
+// hidden-mode example (Select)
+export function SelectPositioner(props: SelectPositionerProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useSelectContext('Positioner');
+  const { positionerProps, state } = usePositioner({
+    open: ctx.open, anchorRef: ctx.anchorRef, floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef, side: ctx.side, align: ctx.align, offset: ctx.offset,
+    setPosition: ctx.setPosition, mount: 'hidden',
+  });
+  return useRender<{ side: Side; align: Align }>({
+    render, defaultTag: 'div', props: { ...rest, ...positionerProps }, state, children,
+  });
+}
+
+// unmount-mode example (Popover)
+export function PopoverPositioner(props: PopoverPositionerProps): VNode | null {
+  const { render, children, ...rest } = props;
+  const ctx = usePopoverContext('Positioner');
+  const { isPresent, positionerProps, state } = usePositioner({
+    open: ctx.open, anchorRef: ctx.anchorRef, floatingRef: ctx.floatingRef,
+    arrowRef: ctx.arrowRef, side: ctx.side, align: ctx.align, offset: ctx.offset,
+    setPosition: ctx.setPosition, mount: 'unmount',
+  });
+  if (!isPresent) return null;
+  return useRender<{ side: Side; align: Align }>({
+    render, defaultTag: 'div', props: { ...rest, ...positionerProps }, state, children,
+  });
+}
+```
+
+### Per-component variation mapping
+
+| Component | `anchorRef` | `getAnchorRect` | `mount` |
+|---|---|---|---|
+| Popover | `ctx.anchorRef` | — | `unmount` |
+| Tooltip | `ctx.anchorRef` | — | `unmount` |
+| Menu | `ctx.anchorRef` | `ctx.getAnchorRect` (ContextMenu pointer anchor) | `unmount` |
+| Select | `ctx.anchorRef` | — | `hidden` |
+| Combobox | `ctx.inputRef` | local `useCallback` (`anchorRef ?? inputRef`) | `hidden` |
+
+Combobox computes its local `getAnchorRect` in the component (it closes over
+`ctx.anchorRef`/`ctx.inputRef`) and passes it in. Every other variation is a plain
+opt value. `useRender` is hook-free (verified), so the conditional call after
+`return null` in unmount mode is safe.
+
+### Popover API now required
+
+- Delete the `supportsPopover` helper from `popover.tsx`, `tooltip.tsx`,
+  `menu.tsx`, `select.tsx` (Combobox has none). Confirm no other consumer exists
+  (current grep: Positioner-only).
+- The hook's top-layer effect is unconditional. On a browser without the Popover
+  API, `el.showPopover()` throws a `TypeError` inside the layout effect, the
+  explicit "required" contract, parity with today's Combobox. No soft fallback.
+- **Docs:** add one concise "Requires the Popover API" note in a single shared
+  location (the Components-area overview / a Foundations "Browser support" note),
+  not duplicated across five pages. Phrased as what-is, per the docs philosophy.
+- **Memory:** update `project_browser_support_constraint` post-merge to record that
+  the Popover API is now a hard dependency for the popup components (CSS anchor
+  positioning remains unused; positioning is `@floating-ui/dom`).
+
+## Testing
+
+Behavior-preserving refactor: the existing suite is the primary safety net. Every
+Positioner / SSR / presence / nav / dismiss test for all five components must stay
+green throughout (keep-green-at-each-step). The gate removal is verified by the
+fact that the previously-gated components run their top-layer path in happy-dom
+(which implements `showPopover`, since Combobox already relies on it); confirm
+during implementation. No existing test exercises the no-Popover-API fallback (SSR
+tests render to string with no layout effects; happy-dom has the API), so removing
+the gate breaks nothing.
+
+Add a focused `__tests__/use-positioner.test.tsx` (per the per-primitive
+convention, `use-position`/`use-presence`/`use-safe-area`/etc. each have a direct
+test) covering:
+
+- `mount: 'unmount'` reports `isPresent` correctly (false when closed) and emits no
+  `hidden`.
+- `mount: 'hidden'` always reports `isPresent`-driven `hidden` (`true` when closed,
+  absent when open) and never asks the component to unmount.
+- `getAnchorRect` is forwarded to `usePosition`.
+- `setPosition` is published with the resolved `side`/`align`.
+- `data-side`/`data-align`/`style` are present on `positionerProps`.
+
+## Files
+
+- **New:** `packages/ui/src/use-positioner.ts`, `packages/ui/src/__tests__/use-positioner.test.tsx`
+- **Modified:** `popover/popover.tsx`, `tooltip/tooltip.tsx`, `menu/menu.tsx`,
+  `select/select.tsx`, `combobox/combobox.tsx` (Positioner bodies replaced,
+  `supportsPopover` helpers removed)
+- **Docs:** one shared Popover-API-requirement note
+- **Memory (post-merge):** `project_browser_support_constraint`
+
+## Open questions
+
+Resolved during brainstorming:
+- Unsupported-browser behavior → **throw** (parity with Combobox), no soft no-op.
+- Hook location → **new `use-positioner.ts`** module.
+- Factoring style → **explicit hook**, not a factory.
+- Docs note → **single shared note**, not per-page.
+
+None remaining.

--- a/packages/ui/src/__tests__/use-positioner.test.tsx
+++ b/packages/ui/src/__tests__/use-positioner.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { usePositioner } from '../use-positioner.js';
+import type { PositionState, ClientRectGetter } from '../use-position.js';
+
+afterEach(cleanup);
+
+function Harness(props: {
+  open: boolean;
+  mount: 'unmount' | 'hidden';
+  getAnchorRect?: ClientRectGetter;
+  onPosition?: (p: PositionState) => void;
+}) {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+  const arrowRef = useRef<HTMLDivElement>(null);
+  const { isPresent, positionerProps } = usePositioner({
+    open: props.open,
+    anchorRef,
+    floatingRef,
+    arrowRef,
+    side: 'bottom',
+    align: 'start',
+    offset: 8,
+    getAnchorRect: props.getAnchorRect,
+    setPosition: (p) => props.onPosition?.(p),
+    mount: props.mount,
+  });
+  return (
+    <div>
+      <button ref={anchorRef}>anchor</button>
+      <span data-testid="present">{String(isPresent)}</span>
+      {props.mount === 'unmount' && !isPresent ? null : (
+        <div data-testid="floating" {...positionerProps} />
+      )}
+    </div>
+  );
+}
+
+describe('usePositioner', () => {
+  it('unmount mode: not present when closed, present when open', () => {
+    const closed = render(<Harness open={false} mount="unmount" />);
+    expect(closed.getByTestId('present').textContent).toBe('false');
+    expect(closed.queryByTestId('floating')).toBeNull();
+    cleanup();
+    const open = render(<Harness open mount="unmount" />);
+    expect(open.getByTestId('present').textContent).toBe('true');
+    expect(open.queryByTestId('floating')).not.toBeNull();
+    expect(open.getByTestId('floating').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('hidden mode: stays mounted; hidden toggles with open', () => {
+    const closed = render(<Harness open={false} mount="hidden" />);
+    // Always rendered, but hidden while closed.
+    expect(closed.queryByTestId('floating')).not.toBeNull();
+    expect(closed.getByTestId('floating').hasAttribute('hidden')).toBe(true);
+    cleanup();
+    const open = render(<Harness open mount="hidden" />);
+    expect(open.getByTestId('floating').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('emits the neutralize style and data-side/data-align', () => {
+    const { getByTestId } = render(<Harness open mount="unmount" />);
+    const el = getByTestId('floating');
+    expect(el.style.position).toBe('fixed');
+    expect(el.getAttribute('data-side')).toBe('bottom');
+    expect(el.getAttribute('data-align')).toBe('start');
+  });
+
+  it('publishes the resolved position via setPosition', () => {
+    const seen: PositionState[] = [];
+    render(<Harness open mount="unmount" onPosition={(p) => seen.push(p)} />);
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen[0].side).toBe('bottom');
+    expect(seen[0].align).toBe('start');
+  });
+
+  it('forwards getAnchorRect to usePosition', async () => {
+    const getAnchorRect = vi.fn(() => ({
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    }));
+    render(<Harness open mount="unmount" getAnchorRect={getAnchorRect} />);
+    await waitFor(() => expect(getAnchorRect).toHaveBeenCalled());
+  });
+});

--- a/packages/ui/src/combobox/combobox.tsx
+++ b/packages/ui/src/combobox/combobox.tsx
@@ -15,11 +15,9 @@ import {
   useRef,
   useState,
 } from 'preact/hooks';
-import { mergeRefs } from '../merge-refs.js';
-import { usePresence } from '../use-presence.js';
 import { useControllableState } from '../use-controllable-state.js';
-import { usePosition } from '../use-position.js';
 import type { Side, Align, PositionState } from '../use-position.js';
+import { usePositioner } from '../use-positioner.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useListboxSelection, OPTION_SELECTOR } from '../listbox/selection.js';
@@ -260,8 +258,6 @@ export type ComboboxPositionerProps = {
 export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
   const { render, children, ...rest } = props;
   const ctx = useComboboxContext('Positioner');
-  const presence = usePresence(ctx.open);
-
   // Anchor to the <Combobox.Anchor> field if one is rendered, else the input.
   // Both refs are stable, so the callback is stable (no autoUpdate churn).
   const getAnchorRect = useCallback(
@@ -271,9 +267,8 @@ export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
       )?.getBoundingClientRect() ?? null,
     [ctx.anchorRef, ctx.inputRef]
   );
-
-  const position = usePosition({
-    open: presence.isPresent,
+  const { positionerProps, state } = usePositioner({
+    open: ctx.open,
     anchorRef: ctx.inputRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
@@ -281,50 +276,14 @@ export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
     align: ctx.align,
     offset: ctx.offset,
     getAnchorRect,
+    setPosition: ctx.setPosition,
+    mount: 'hidden',
   });
-
-  useLayoutEffect(() => {
-    ctx.setPosition(position);
-  }, [position.side, position.align, position.arrowX, position.arrowY]);
-
-  useLayoutEffect(() => {
-    const el = ctx.floatingRef.current;
-    if (!presence.isPresent || !el) return;
-    el.setAttribute('popover', 'manual');
-    el.showPopover();
-    return () => {
-      // Best-effort un-promotion: hidePopover() throws if the element already
-      // left the top layer (closed by another path or disconnected). Either way
-      // the goal state (not promoted) is met, so ignore the throw.
-      try {
-        el.hidePopover();
-      } catch {
-        // already hidden / disconnected
-      }
-      el.removeAttribute('popover');
-    };
-  }, [presence.isPresent]);
-
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: mergeRefs(ctx.floatingRef, presence.ref),
-      hidden: presence.isPresent ? undefined : true,
-      'data-side': position.side,
-      'data-align': position.align,
-      style: {
-        position: 'fixed',
-        inset: 'auto',
-        margin: 0,
-        overflow: 'visible',
-        border: 0,
-        padding: 0,
-        background: 'transparent',
-      },
-    },
-    state: { side: position.side, align: position.align },
+    props: { ...rest, ...positionerProps },
+    state,
     children,
   });
 }

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -17,13 +17,11 @@ import {
 } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import { usePosition } from '../use-position.js';
 import type { Side, Align, PositionState } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useFocusReturn } from '../use-focus-return.js';
 import { useListNavigation } from '../list-navigation.js';
-import { mergeRefs } from '../merge-refs.js';
-import { usePresence } from '../use-presence.js';
+import { usePositioner } from '../use-positioner.js';
 import {
   MenuContext,
   useMenuContext,
@@ -242,10 +240,6 @@ export function MenuItem(props: MenuItemProps): VNode {
   });
 }
 
-function supportsPopover(el: HTMLElement): boolean {
-  return typeof el.showPopover === 'function';
-}
-
 export type MenuPositionerProps = {
   render?: RenderProp<{ side: Side; align: Align }>;
   children?: ComponentChildren;
@@ -254,11 +248,8 @@ export type MenuPositionerProps = {
 export function MenuPositioner(props: MenuPositionerProps): VNode | null {
   const { render, children, ...rest } = props;
   const ctx = useMenuContext('Positioner');
-
-  const presence = usePresence(ctx.open);
-
-  const position = usePosition({
-    open: presence.isPresent,
+  const { isPresent, positionerProps, state } = usePositioner({
+    open: ctx.open,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
@@ -266,60 +257,15 @@ export function MenuPositioner(props: MenuPositionerProps): VNode | null {
     align: ctx.align,
     offset: ctx.offset,
     getAnchorRect: ctx.getAnchorRect,
+    setPosition: ctx.setPosition,
+    mount: 'unmount',
   });
-
-  useLayoutEffect(() => {
-    ctx.setPosition(position);
-  }, [position.side, position.align, position.arrowX, position.arrowY]);
-
-  // Promote to the native top layer where supported (progressive enhancement).
-  // Applied imperatively so there is no SSR/hydration attribute mismatch.
-  useLayoutEffect(() => {
-    const el = ctx.floatingRef.current;
-    // Runs when isPresent flips true and the element has mounted (refs are assigned
-    // before layout effects). Empty deps would never re-run, so showPopover
-    // would never fire on a mount-on-open element.
-    if (!presence.isPresent || !el || !supportsPopover(el)) return;
-    el.setAttribute('popover', 'manual');
-    el.showPopover();
-    return () => {
-      // Best-effort un-promotion: hidePopover() throws if the element already
-      // left the top layer (closed by another path or disconnected). Either way
-      // the goal state (not promoted) is met, so ignore the throw.
-      try {
-        el.hidePopover();
-      } catch {
-        // already hidden / disconnected
-      }
-      el.removeAttribute('popover');
-    };
-  }, [presence.isPresent]);
-
-  if (!presence.isPresent) return null;
-
+  if (!isPresent) return null;
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: mergeRefs(ctx.floatingRef, presence.ref),
-      'data-side': position.side,
-      'data-align': position.align,
-      // Neutralize the UA [popover] rule that applies once the element is
-      // promoted to the top layer (overflow/inset/margin/border/padding/
-      // background): the UA `overflow: auto` would clip the popup's box-shadow
-      // and `inset: 0` would fight the computed left/top.
-      style: {
-        position: 'fixed',
-        inset: 'auto',
-        margin: 0,
-        overflow: 'visible',
-        border: 0,
-        padding: 0,
-        background: 'transparent',
-      },
-    },
-    state: { side: position.side, align: position.align },
+    props: { ...rest, ...positionerProps },
+    state,
     children,
   });
 }

--- a/packages/ui/src/popover/popover.tsx
+++ b/packages/ui/src/popover/popover.tsx
@@ -8,14 +8,12 @@ import {
   useRef,
   useState,
 } from 'preact/hooks';
-import { usePosition } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useFocusReturn } from '../use-focus-return.js';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import { mergeRefs } from '../merge-refs.js';
-import { usePresence } from '../use-presence.js';
 import type { Side, Align, PositionState } from '../use-position.js';
+import { usePositioner } from '../use-positioner.js';
 import { PopoverContext, usePopoverContext } from './context.js';
 
 export interface PopoverRootProps {
@@ -162,10 +160,6 @@ export function PopoverAnchor(props: PopoverAnchorProps): VNode {
   });
 }
 
-function supportsPopover(el: HTMLElement): boolean {
-  return typeof el.showPopover === 'function';
-}
-
 export type PopoverPositionerProps = {
   render?: RenderProp<{ side: Side; align: Align }>;
   children?: ComponentChildren;
@@ -174,74 +168,23 @@ export type PopoverPositionerProps = {
 export function PopoverPositioner(props: PopoverPositionerProps): VNode | null {
   const { render, children, ...rest } = props;
   const ctx = usePopoverContext('Positioner');
-
-  const presence = usePresence(ctx.open);
-
-  const position = usePosition({
-    open: presence.isPresent,
+  const { isPresent, positionerProps, state } = usePositioner({
+    open: ctx.open,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
     side: ctx.side,
     align: ctx.align,
     offset: ctx.offset,
+    setPosition: ctx.setPosition,
+    mount: 'unmount',
   });
-
-  // Publish the resolved position so Arrow (and any consumer) can read it.
-  useLayoutEffect(() => {
-    ctx.setPosition(position);
-  }, [position.side, position.align, position.arrowX, position.arrowY]);
-
-  // Promote to the native top layer where supported (progressive enhancement).
-  // Applied imperatively so there is no SSR/hydration attribute mismatch.
-  useLayoutEffect(() => {
-    const el = ctx.floatingRef.current;
-    // Runs when isPresent flips true and the element has mounted (refs are
-    // assigned before layout effects). Stays mounted through the exit animation
-    // so hidePopover fires only after the closing transition completes.
-    if (!presence.isPresent || !el || !supportsPopover(el)) return;
-    el.setAttribute('popover', 'manual');
-    el.showPopover();
-    return () => {
-      // Best-effort un-promotion: hidePopover() throws if the element already
-      // left the top layer (closed by another path or disconnected). Either way
-      // the goal state (not promoted) is met, so ignore the throw.
-      try {
-        el.hidePopover();
-      } catch {
-        // already hidden / disconnected
-      }
-      el.removeAttribute('popover');
-    };
-  }, [presence.isPresent]);
-
-  if (!presence.isPresent) return null;
-
+  if (!isPresent) return null;
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: mergeRefs(ctx.floatingRef, presence.ref),
-      'data-side': position.side,
-      'data-align': position.align,
-      // The Positioner is a framework-owned layout wrapper (style the Popup, not
-      // this). Besides positioning, the style neutralizes the UA [popover]
-      // rule that applies once the element is promoted to the top layer
-      // (overflow/inset/margin/border/padding/background): without this the UA
-      // `overflow: auto` clips the popup's box-shadow and `inset: 0` fights the
-      // computed left/top.
-      style: {
-        position: 'fixed',
-        inset: 'auto',
-        margin: 0,
-        overflow: 'visible',
-        border: 0,
-        padding: 0,
-        background: 'transparent',
-      },
-    },
-    state: { side: position.side, align: position.align },
+    props: { ...rest, ...positionerProps },
+    state,
     children,
   });
 }

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -16,13 +16,11 @@ import {
 } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import { usePosition } from '../use-position.js';
 import type { Side, Align, PositionState } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useListNavigation } from '../list-navigation.js';
 import { useListboxSelection, OPTION_SELECTOR } from '../listbox/selection.js';
-import { mergeRefs } from '../merge-refs.js';
-import { usePresence } from '../use-presence.js';
+import { usePositioner } from '../use-positioner.js';
 import {
   SelectContext,
   useSelectContext,
@@ -169,10 +167,6 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
   );
 }
 
-function supportsPopover(el: HTMLElement): boolean {
-  return typeof el.showPopover === 'function';
-}
-
 export { OPTION_SELECTOR } from '../listbox/selection.js';
 
 export type SelectTriggerProps = {
@@ -303,66 +297,25 @@ export type SelectPositionerProps = {
 export function SelectPositioner(props: SelectPositionerProps): VNode {
   const { render, children, ...rest } = props;
   const ctx = useSelectContext('Positioner');
-
-  const presence = usePresence(ctx.open);
-
-  const position = usePosition({
-    open: presence.isPresent,
+  // Always rendered (mount: 'hidden') so options register their labels; the
+  // hook drives `hidden` while not present, which composes with the top-layer
+  // promotion (active only while present).
+  const { positionerProps, state } = usePositioner({
+    open: ctx.open,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
     side: ctx.side,
     align: ctx.align,
     offset: ctx.offset,
+    setPosition: ctx.setPosition,
+    mount: 'hidden',
   });
-
-  useLayoutEffect(() => {
-    ctx.setPosition(position);
-  }, [position.side, position.align, position.arrowX, position.arrowY]);
-
-  // Promote to the native top layer where supported, while present (open or
-  // animating out), so exit animations play in the top layer.
-  useLayoutEffect(() => {
-    const el = ctx.floatingRef.current;
-    if (!presence.isPresent || !el || !supportsPopover(el)) return;
-    el.setAttribute('popover', 'manual');
-    el.showPopover();
-    return () => {
-      // Best-effort un-promotion: hidePopover() throws if the element already
-      // left the top layer (closed by another path or disconnected). Either way
-      // the goal state (not promoted) is met, so ignore the throw.
-      try {
-        el.hidePopover();
-      } catch {
-        // already hidden / disconnected
-      }
-      el.removeAttribute('popover');
-    };
-  }, [presence.isPresent]);
-
-  // Always rendered so options register their labels; `hidden` while not
-  // present makes it inert and invisible without consumer CSS, and composes
-  // with the Popover-API promotion (which only runs while present).
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: mergeRefs(ctx.floatingRef, presence.ref),
-      hidden: presence.isPresent ? undefined : true,
-      'data-side': position.side,
-      'data-align': position.align,
-      style: {
-        position: 'fixed',
-        inset: 'auto',
-        margin: 0,
-        overflow: 'visible',
-        border: 0,
-        padding: 0,
-        background: 'transparent',
-      },
-    },
-    state: { side: position.side, align: position.align },
+    props: { ...rest, ...positionerProps },
+    state,
     children,
   });
 }

--- a/packages/ui/src/tooltip/tooltip.tsx
+++ b/packages/ui/src/tooltip/tooltip.tsx
@@ -10,11 +10,7 @@ import {
 } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import {
-  type Side,
-  type Align,
-  type PositionState,
-} from '../use-position.js';
+import { type Side, type Align, type PositionState } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useSafeArea } from '../use-safe-area.js';
 import { usePositioner } from '../use-positioner.js';

--- a/packages/ui/src/tooltip/tooltip.tsx
+++ b/packages/ui/src/tooltip/tooltip.tsx
@@ -4,7 +4,6 @@ import {
   useCallback,
   useEffect,
   useId,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -12,15 +11,13 @@ import {
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
 import {
-  usePosition,
   type Side,
   type Align,
   type PositionState,
 } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useSafeArea } from '../use-safe-area.js';
-import { mergeRefs } from '../merge-refs.js';
-import { usePresence } from '../use-presence.js';
+import { usePositioner } from '../use-positioner.js';
 import { TooltipContext, useTooltipContext } from './context.js';
 
 export interface TooltipRootProps {
@@ -185,10 +182,6 @@ export function TooltipTrigger(props: TooltipTriggerProps): VNode {
   });
 }
 
-function supportsPopover(el: HTMLElement): boolean {
-  return typeof el.showPopover === 'function';
-}
-
 export type TooltipPositionerProps = {
   render?: RenderProp<{ side: Side; align: Align }>;
   children?: ComponentChildren;
@@ -197,69 +190,23 @@ export type TooltipPositionerProps = {
 export function TooltipPositioner(props: TooltipPositionerProps): VNode | null {
   const { render, children, ...rest } = props;
   const ctx = useTooltipContext('Positioner');
-
-  const presence = usePresence(ctx.open);
-
-  const position = usePosition({
-    open: presence.isPresent,
+  const { isPresent, positionerProps, state } = usePositioner({
+    open: ctx.open,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
     arrowRef: ctx.arrowRef,
     side: ctx.side,
     align: ctx.align,
     offset: ctx.offset,
+    setPosition: ctx.setPosition,
+    mount: 'unmount',
   });
-
-  useLayoutEffect(() => {
-    ctx.setPosition(position);
-  }, [position.side, position.align, position.arrowX, position.arrowY]);
-
-  useLayoutEffect(() => {
-    const el = ctx.floatingRef.current;
-    // Runs when isPresent flips true and the element has mounted (refs are
-    // assigned before layout effects). Empty deps would never re-run, so
-    // showPopover would never fire on a mount-on-open element.
-    if (!presence.isPresent || !el || !supportsPopover(el)) return;
-    el.setAttribute('popover', 'manual');
-    el.showPopover();
-    return () => {
-      // Best-effort un-promotion: hidePopover() throws if the element already
-      // left the top layer (closed by another path or disconnected). Either way
-      // the goal state (not promoted) is met, so ignore the throw.
-      try {
-        el.hidePopover();
-      } catch {
-        // already hidden / disconnected
-      }
-      el.removeAttribute('popover');
-    };
-  }, [presence.isPresent]);
-
-  if (!presence.isPresent) return null;
-
+  if (!isPresent) return null;
   return useRender<{ side: Side; align: Align }>({
     render,
     defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: mergeRefs(ctx.floatingRef, presence.ref),
-      'data-side': position.side,
-      'data-align': position.align,
-      // Neutralize the UA [popover] rule that applies in the top layer
-      // (overflow/inset/margin/border/padding/background): the UA
-      // `overflow: auto` would clip the popup's box-shadow and `inset: 0`
-      // would fight the computed left/top.
-      style: {
-        position: 'fixed',
-        inset: 'auto',
-        margin: 0,
-        overflow: 'visible',
-        border: 0,
-        padding: 0,
-        background: 'transparent',
-      },
-    },
-    state: { side: position.side, align: position.align },
+    props: { ...rest, ...positionerProps },
+    state,
     children,
   });
 }

--- a/packages/ui/src/use-positioner.ts
+++ b/packages/ui/src/use-positioner.ts
@@ -1,0 +1,117 @@
+import type { JSX, RefObject } from 'preact';
+import { useLayoutEffect } from 'preact/hooks';
+import { usePosition } from './use-position.js';
+import type {
+  Side,
+  Align,
+  PositionState,
+  ClientRectGetter,
+} from './use-position.js';
+import { usePresence } from './use-presence.js';
+import { mergeRefs } from './merge-refs.js';
+
+// The framework-owned layout wrapper's style. Besides positioning, it
+// neutralizes the UA [popover] rule that applies once the element is promoted
+// to the top layer (overflow/inset/margin/border/padding/background): without
+// this the UA `overflow: auto` clips the popup's box-shadow and `inset: 0`
+// fights the computed left/top. One stable reference (shared by all 5).
+const POSITIONER_STYLE: JSX.CSSProperties = {
+  position: 'fixed',
+  inset: 'auto',
+  margin: 0,
+  overflow: 'visible',
+  border: 0,
+  padding: 0,
+  background: 'transparent',
+};
+
+export interface UsePositionerOptions {
+  open: boolean;
+  // usePosition anchor (the Combobox passes its inputRef here).
+  anchorRef: RefObject<HTMLElement>;
+  floatingRef: RefObject<HTMLElement>;
+  arrowRef: RefObject<HTMLElement>;
+  side: Side;
+  align: Align;
+  offset: number;
+  // Position against a point/virtual element instead of anchorRef (context-menu
+  // pointer anchor, combobox anchor-or-input). Undefined for the common case.
+  getAnchorRect?: ClientRectGetter;
+  // Publish the resolved position so an Arrow part can read it.
+  setPosition: (p: PositionState) => void;
+  // 'unmount': the component returns null while closed (branch on isPresent).
+  // 'hidden': the element stays mounted (so options can register their labels)
+  // and is `hidden` while closed.
+  mount: 'unmount' | 'hidden';
+}
+
+export interface PositionerProps {
+  ref: (node: HTMLElement | null) => void;
+  hidden?: true;
+  'data-side': Side;
+  'data-align': Align;
+  style: JSX.CSSProperties;
+}
+
+export interface UsePositionerResult {
+  // Raw presence value. 'unmount' components branch on this (`return null`);
+  // 'hidden' components ignore it (the hook bakes `hidden` into the props).
+  isPresent: boolean;
+  positionerProps: PositionerProps;
+  state: { side: Side; align: Align };
+}
+
+export function usePositioner(opts: UsePositionerOptions): UsePositionerResult {
+  const presence = usePresence(opts.open);
+
+  const position = usePosition({
+    open: presence.isPresent,
+    anchorRef: opts.anchorRef,
+    floatingRef: opts.floatingRef,
+    arrowRef: opts.arrowRef,
+    side: opts.side,
+    align: opts.align,
+    offset: opts.offset,
+    getAnchorRect: opts.getAnchorRect,
+  });
+
+  // Publish the resolved position so Arrow (and any consumer) can read it.
+  useLayoutEffect(() => {
+    opts.setPosition(position);
+  }, [position.side, position.align, position.arrowX, position.arrowY]);
+
+  // Promote to the native top layer. The Popover API is a hard dependency of
+  // these components; on a browser without it showPopover() throws (no
+  // fallback). Applied imperatively so there is no SSR/hydration mismatch, and
+  // it stays mounted through the exit animation so hidePopover fires only after
+  // the closing transition completes.
+  useLayoutEffect(() => {
+    const el = opts.floatingRef.current;
+    if (!presence.isPresent || !el) return;
+    el.setAttribute('popover', 'manual');
+    el.showPopover();
+    return () => {
+      // Best-effort un-promotion: hidePopover() throws if the element already
+      // left the top layer (closed by another path or disconnected). Either way
+      // the goal state (not promoted) is met, so ignore the throw.
+      try {
+        el.hidePopover();
+      } catch {
+        // already hidden / disconnected
+      }
+      el.removeAttribute('popover');
+    };
+  }, [presence.isPresent]);
+
+  return {
+    isPresent: presence.isPresent,
+    positionerProps: {
+      ref: mergeRefs(opts.floatingRef, presence.ref),
+      hidden: opts.mount === 'hidden' && !presence.isPresent ? true : undefined,
+      'data-side': position.side,
+      'data-align': position.align,
+      style: POSITIONER_STYLE,
+    },
+    state: { side: position.side, align: position.align },
+  };
+}


### PR DESCRIPTION
Extracts the five near-identical `XPositioner` bodies (Popover, Tooltip, Menu, Select, Combobox) into one internal `usePositioner` hook, and makes the Popover API a hard dependency (removes the `supportsPopover` gate).

## What changed
- **New `packages/ui/src/use-positioner.ts`** owns the shared mechanism: `usePresence` → `usePosition` → the `setPosition` publish effect → the (now unconditional) top-layer promotion effect → the neutralize `style` (one stable `POSITIONER_STYLE`). Returns `{ isPresent, positionerProps, state }`. Direct unit test added (5 tests).
- **Each `XPositioner` is now a ~12-line explicit wrapper** that reads its own typed context and passes a thin slice to the hook. Per-component variation: Menu passes `getAnchorRect: ctx.getAnchorRect` (ContextMenu pointer anchor); Combobox keeps its local `anchorRef ?? inputRef` getAnchorRect and positions against `inputRef`; Popover/Tooltip/Menu use `mount: 'unmount'` (keep the `return null` guard); Select/Combobox use `mount: 'hidden'` (listbox stays mounted so options register their labels).
- **Popover API now required.** The four `supportsPopover` helpers and the gate are deleted; the top-layer effect runs unconditionally (parity with Combobox). On a browser without the API, `showPopover()` throws, the explicit "required" contract, no silent fallback. Docs note updated on the Components landing page.

## Behavior
Behavior-preserving except the gate removal. The five components' full test suites stay green; no existing test exercised the no-Popover-API fallback (SSR renders to string; happy-dom implements `showPopover`).

## Verification
Full CI mirror green: build, format:check, typecheck, **1177 unit** (1172 + 5 new) + 4 integration, site build. Size config untouched (shared module attributed per-component; the post-merge build job regenerates baselines).

Spec: `docs/superpowers/specs/2026-06-10-positioner-dedup-design.md` · Plan: `docs/superpowers/plans/2026-06-10-positioner-dedup.md` (both ride this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)