### PR TITLE
refactor(ui): dedup the 3 Menu Roots into useMenuCore

### DIFF
--- a/docs/superpowers/plans/2026-06-10-menu-core-dedup.md
+++ b/docs/superpowers/plans/2026-06-10-menu-core-dedup.md
@@ -1,0 +1,616 @@
+# `useMenuCore` Root dedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the triplicated `MenuContextValue` setup + assembly from `MenuRoot`, `SubmenuRoot`, and `ContextMenuRoot` into one internal `useMenuCore` hook, collapsing each Root to a thin wrapper.
+
+**Architecture:** A new `packages/ui/src/menu/use-menu-core.ts` owns `useControllableState`, the five refs, the ids, `activeId`/`position` state, the `closeAll` default, the ContextMenu pointer-anchor machinery (`pointRef`/`getAnchorRect`/`openAt`, gated by a `pointerAnchored` flag so the hook owns the `setOpen`/`pendingEdgeRef` they close over), and the assembled `MenuContextValue`. Each Root resolves its own prop defaults and calls the hook. Pure dedup, no behavior change.
+
+**Tech Stack:** Preact, Vitest + happy-dom + `@testing-library/preact`.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-menu-core-dedup-design.md`
+
+---
+
+## File structure
+
+- **`packages/ui/src/menu/use-menu-core.ts`** (new) — the hook. One responsibility: build a `MenuContextValue` + expose the raw pieces. Internal (not exported from `index.ts`).
+- **`packages/ui/src/__tests__/use-menu-core.test.tsx`** (new) — direct hook unit test.
+- **`packages/ui/src/menu/menu.tsx`** (modify `MenuRoot` only).
+- **`packages/ui/src/context-menu/context-menu.tsx`** (modify `ContextMenuRoot` only).
+- **`packages/ui/src/menu/submenu.tsx`** (modify `SubmenuRoot` only; keep its hover timer + `submenuCtx`).
+
+No `index.ts` change. **Do NOT touch** `scripts/client-size-config.mjs` or any `client-size-report.json` (shared internal module, attributed per-component; the post-merge build job regenerates baselines).
+
+---
+
+### Task 1: Create the `useMenuCore` hook
+
+**Files:**
+- Test: `packages/ui/src/__tests__/use-menu-core.test.tsx`
+- Create: `packages/ui/src/menu/use-menu-core.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ui/src/__tests__/use-menu-core.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/preact';
+import { useMenuCore, type UseMenuCoreOptions } from '../menu/use-menu-core.js';
+import type { MenuContextValue } from '../menu/context.js';
+
+afterEach(cleanup);
+
+const BASE: UseMenuCoreOptions = {
+  side: 'bottom',
+  align: 'start',
+  offset: 8,
+  loop: true,
+  typeahead: true,
+};
+
+function renderCore(opts: UseMenuCoreOptions) {
+  const cap: { ctx: MenuContextValue } = {
+    ctx: undefined as unknown as MenuContextValue,
+  };
+  function Harness() {
+    const core = useMenuCore(opts);
+    cap.ctx = core.menuCtx;
+    return <span data-testid="open">{String(core.open)}</span>;
+  }
+  const utils = render(<Harness />);
+  return { cap, utils };
+}
+
+describe('useMenuCore', () => {
+  it('closeAll defaults to setOpen(false)', () => {
+    const { cap, utils } = renderCore({ ...BASE, defaultOpen: true });
+    expect(cap.ctx.open).toBe(true);
+    act(() => cap.ctx.closeAll());
+    expect(utils.getByTestId('open').textContent).toBe('false');
+  });
+
+  it('uses an injected closeAll instead of the default', () => {
+    const closeAll = vi.fn();
+    const { cap, utils } = renderCore({ ...BASE, defaultOpen: true, closeAll });
+    act(() => cap.ctx.closeAll());
+    expect(closeAll).toHaveBeenCalledTimes(1);
+    // open is unchanged: the injected closeAll did not touch our state
+    expect(utils.getByTestId('open').textContent).toBe('true');
+  });
+
+  it('passes through parentDismissId (default null)', () => {
+    const a = renderCore({ ...BASE });
+    expect(a.cap.ctx.parentDismissId).toBeNull();
+    cleanup();
+    const b = renderCore({ ...BASE, parentDismissId: 'parent-9' });
+    expect(b.cap.ctx.parentDismissId).toBe('parent-9');
+  });
+
+  it('pointerAnchored: openAt captures the point, opens, pends first; getAnchorRect returns the point rect', () => {
+    const { cap, utils } = renderCore({ ...BASE, pointerAnchored: true });
+    expect(cap.ctx.open).toBe(false);
+    const { openAt, getAnchorRect } = cap.ctx;
+    expect(openAt).toBeTypeOf('function');
+    expect(getAnchorRect).toBeTypeOf('function');
+    act(() => openAt?.(10, 20));
+    expect(utils.getByTestId('open').textContent).toBe('true');
+    expect(cap.ctx.pendingEdgeRef.current).toBe('first');
+    expect(getAnchorRect?.()).toMatchObject({
+      x: 10,
+      y: 20,
+      top: 20,
+      left: 10,
+      right: 10,
+      bottom: 20,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('without pointerAnchored, getAnchorRect and openAt are undefined', () => {
+    const { cap } = renderCore({ ...BASE });
+    expect(cap.ctx.getAnchorRect).toBeUndefined();
+    expect(cap.ctx.openAt).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-menu-core.test.tsx`
+Expected: FAIL — cannot resolve `'../menu/use-menu-core.js'` / `useMenuCore is not a function`.
+
+- [ ] **Step 3: Create the hook**
+
+Create `packages/ui/src/menu/use-menu-core.ts`:
+
+```ts
+import type { RefObject } from 'preact';
+import { useCallback, useId, useMemo, useRef, useState } from 'preact/hooks';
+import { useControllableState } from '../use-controllable-state.js';
+import type { Side, Align, PositionState } from '../use-position.js';
+import type { MenuContextValue } from './context.js';
+
+export interface UseMenuCoreOptions {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  // Resolved values — each Root applies its own prop defaults before calling.
+  side: Side;
+  align: Align;
+  offset: number;
+  loop: boolean;
+  typeahead: boolean;
+  // Default: a hook-owned () => setOpen(false). SubmenuRoot passes parent.closeAll
+  // so activating a nested item collapses the whole tree.
+  closeAll?: () => void;
+  // Default: null. SubmenuRoot passes parent.dismissId to link the dismiss tree.
+  parentDismissId?: string | null;
+  // ContextMenu only (default false): position against a captured pointer via a
+  // virtual anchor and expose openAt(x, y).
+  pointerAnchored?: boolean;
+}
+
+export interface MenuCore {
+  menuCtx: MenuContextValue;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  anchorRef: RefObject<HTMLElement>;
+  floatingRef: RefObject<HTMLElement>;
+  popupRef: RefObject<HTMLElement>;
+  arrowRef: RefObject<HTMLElement>;
+  pendingEdgeRef: RefObject<'first' | 'last'>;
+  baseId: string;
+  triggerId: string;
+  popupId: string;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  position: PositionState;
+  setPosition: (p: PositionState) => void;
+}
+
+export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
+  const {
+    open: openProp,
+    defaultOpen,
+    onOpenChange,
+    side,
+    align,
+    offset,
+    loop,
+    typeahead,
+    closeAll: closeAllProp,
+    parentDismissId = null,
+    pointerAnchored = false,
+  } = opts;
+
+  const [open, setOpen] = useControllableState<boolean>({
+    value: openProp,
+    defaultValue: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  const anchorRef = useRef<HTMLElement>(null);
+  const floatingRef = useRef<HTMLElement>(null);
+  const popupRef = useRef<HTMLElement>(null);
+  const arrowRef = useRef<HTMLElement>(null);
+  const pendingEdgeRef = useRef<'first' | 'last'>('first');
+
+  const baseId = useId();
+  const triggerId = `${baseId}-trigger`;
+  const popupId = `${baseId}-popup`;
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [position, setPosition] = useState<PositionState>({
+    side,
+    align,
+    arrowX: null,
+    arrowY: null,
+  });
+
+  // closeAll defaults to closing this menu; a parent's closeAll is injected for
+  // submenus. ownCloseAll is always created (hooks can't be conditional).
+  const ownCloseAll = useCallback(() => setOpen(false), [setOpen]);
+  const closeAll = closeAllProp ?? ownCloseAll;
+
+  // Pointer-anchor machinery (ContextMenu): always created but only wired into
+  // the context when pointerAnchored. The hook owns setOpen + pendingEdgeRef +
+  // pointRef, so it can build openAt/getAnchorRect itself.
+  const pointRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const getAnchorRect = useCallback(() => {
+    const { x, y } = pointRef.current;
+    return { width: 0, height: 0, x, y, top: y, left: x, right: x, bottom: y };
+  }, []);
+  const openAt = useCallback(
+    (x: number, y: number) => {
+      pointRef.current = { x, y };
+      pendingEdgeRef.current = 'first';
+      setOpen(true);
+    },
+    [setOpen]
+  );
+
+  const menuCtx = useMemo<MenuContextValue>(
+    () => ({
+      open,
+      setOpen,
+      closeAll,
+      dismissId: baseId,
+      parentDismissId,
+      anchorRef,
+      floatingRef,
+      popupRef,
+      arrowRef,
+      triggerId,
+      popupId,
+      activeId,
+      setActiveId,
+      pendingEdgeRef,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+      setPosition,
+      getAnchorRect: pointerAnchored ? getAnchorRect : undefined,
+      openAt: pointerAnchored ? openAt : undefined,
+    }),
+    [
+      open,
+      setOpen,
+      closeAll,
+      baseId,
+      parentDismissId,
+      activeId,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+      pointerAnchored,
+      getAnchorRect,
+      openAt,
+    ]
+  );
+
+  return {
+    menuCtx,
+    open,
+    setOpen,
+    anchorRef,
+    floatingRef,
+    popupRef,
+    arrowRef,
+    pendingEdgeRef,
+    baseId,
+    triggerId,
+    popupId,
+    activeId,
+    setActiveId,
+    position,
+    setPosition,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-menu-core.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Build + typecheck**
+
+Run: `pnpm --filter '@hono-preact/*' build && pnpm typecheck`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/menu/use-menu-core.ts packages/ui/src/__tests__/use-menu-core.test.tsx
+git commit -m "feat(ui): add useMenuCore hook (shared Menu Root context assembly)"
+```
+
+---
+
+### Task 2: Refactor `MenuRoot` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/menu/menu.tsx`
+
+- [ ] **Step 1: Replace `MenuRoot` and fix imports**
+
+In `packages/ui/src/menu/menu.tsx`, replace the entire `MenuRoot` function (the `closeAll` `useCallback`, the refs, ids, `activeId`/`position` state, and the `ctx` `useMemo`) with:
+
+```tsx
+export function MenuRoot(props: MenuRootProps) {
+  const {
+    open,
+    defaultOpen,
+    onOpenChange,
+    side = 'bottom',
+    align = 'start',
+    offset = 8,
+    loop = true,
+    typeahead = true,
+    children,
+  } = props;
+  const core = useMenuCore({
+    open,
+    defaultOpen,
+    onOpenChange,
+    side,
+    align,
+    offset,
+    loop,
+    typeahead,
+  });
+  return h(MenuContext.Provider, { value: core.menuCtx }, children);
+}
+```
+
+Then fix imports. Add:
+
+```ts
+import { useMenuCore } from './use-menu-core.js';
+```
+
+Remove the now-orphaned imports (MenuRoot was their only user in this file): from the `preact/hooks` import remove `useCallback`, `useRef`, `useState` (keep `useContext`, `useId`, `useLayoutEffect`, `useMemo` — all still used by other parts). From the `../use-position.js` type import remove `PositionState` (keep `Side`, `Align`). Keep `useControllableState` (used by `MenuCheckboxItem`/`MenuRadioGroup`).
+
+- [ ] **Step 2: Typecheck (authority on imports)**
+
+Run: `pnpm typecheck`
+Expected: exit 0. If it flags an unused import or a missing symbol (`noUnusedLocals`), fix exactly what it names and re-run until clean.
+
+- [ ] **Step 3: Run the Menu + ContextMenu tests (ContextMenu shares this file's parts indirectly; run both to be safe)**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/menu-structure.test.tsx packages/ui/src/__tests__/menu-navigation-dom.test.tsx packages/ui/src/__tests__/menu-trigger.test.tsx packages/ui/src/__tests__/menu-item.test.tsx packages/ui/src/__tests__/menu-checkable.test.tsx packages/ui/src/__tests__/menu-presence.test.tsx packages/ui/src/__tests__/menu-ssr.test.tsx packages/ui/src/__tests__/menu-submenu.test.tsx packages/ui/src/__tests__/menu-submenu-safe-area.test.tsx packages/ui/src/__tests__/context-menu.test.tsx`
+Expected: PASS (behavior preserved).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/menu/menu.tsx
+git commit -m "refactor(ui): MenuRoot onto useMenuCore"
+```
+
+---
+
+### Task 3: Refactor `ContextMenuRoot` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/context-menu/context-menu.tsx`
+
+- [ ] **Step 1: Replace `ContextMenuRoot` and fix imports**
+
+In `packages/ui/src/context-menu/context-menu.tsx`, replace the entire `ContextMenuRoot` function (the refs, `pointRef`, ids, `activeId`/`position` state, `closeAll`, `getAnchorRect`, `openAt`, and the `ctx` `useMemo`) with:
+
+```tsx
+export function ContextMenuRoot(props: ContextMenuRootProps) {
+  const {
+    open,
+    defaultOpen,
+    onOpenChange,
+    side = 'bottom',
+    align = 'start',
+    offset = 0,
+    loop = true,
+    typeahead = true,
+    children,
+  } = props;
+  const core = useMenuCore({
+    open,
+    defaultOpen,
+    onOpenChange,
+    side,
+    align,
+    offset,
+    loop,
+    typeahead,
+    pointerAnchored: true,
+  });
+  return h(MenuContext.Provider, { value: core.menuCtx }, children);
+}
+```
+
+Then fix imports:
+- Remove the entire `import { useCallback, useId, useMemo, useRef, useState } from 'preact/hooks';` line — after the refactor `ContextMenuTrigger` uses no `preact/hooks` (it uses `useMenuContext` + `useRender`).
+- Remove `import { useControllableState } from '../use-controllable-state.js';`.
+- From `import type { Side, Align, PositionState } from '../use-position.js';` remove `PositionState` (keep `Side`, `Align` — used by `ContextMenuRootProps`).
+- Add: `import { useMenuCore } from '../menu/use-menu-core.js';`.
+- Keep `import { h, type ComponentChildren, type JSX, type VNode } from 'preact';` and `import { MenuContext, useMenuContext } from '../menu/context.js';` (still used).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: exit 0. Fix any flagged import/symbol exactly and re-run.
+
+- [ ] **Step 3: Run the ContextMenu tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/context-menu.test.tsx`
+Expected: PASS (the pointer-anchor `openAt`/`getAnchorRect` now come from the hook).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/context-menu/context-menu.tsx
+git commit -m "refactor(ui): ContextMenuRoot onto useMenuCore"
+```
+
+---
+
+### Task 4: Refactor `SubmenuRoot` onto the hook
+
+**Files:**
+- Modify: `packages/ui/src/menu/submenu.tsx`
+
+- [ ] **Step 1: Replace `SubmenuRoot` and fix imports**
+
+In `packages/ui/src/menu/submenu.tsx`, replace the entire `SubmenuRoot` function. Keep the submenu-only machinery (the hover open-timer and the `submenuCtx`); drop the shared setup (`useControllableState`, the five refs, `baseId`/ids, `activeId`/`position` state) and the `menuCtx` `useMemo`:
+
+```tsx
+export function SubmenuRoot(props: SubmenuRootProps) {
+  const {
+    open,
+    defaultOpen,
+    onOpenChange,
+    side = 'right',
+    align = 'start',
+    offset = 0,
+    openDelay = 100,
+    closeDelay = 300,
+    children,
+  } = props;
+  const parent = useMenuContext('SubmenuRoot');
+
+  const core = useMenuCore({
+    open,
+    defaultOpen,
+    onOpenChange,
+    side,
+    align,
+    offset,
+    loop: parent.loop,
+    typeahead: parent.typeahead,
+    closeAll: parent.closeAll,
+    parentDismissId: parent.dismissId,
+  });
+
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelOpen = useCallback(() => {
+    if (openTimer.current != null) {
+      clearTimeout(openTimer.current);
+      openTimer.current = null;
+    }
+  }, []);
+  const scheduleOpen = useCallback(() => {
+    cancelOpen();
+    openTimer.current = setTimeout(() => core.setOpen(true), openDelay);
+  }, [cancelOpen, core.setOpen, openDelay]);
+  // Clear a pending open if the SubmenuRoot unmounts mid-delay.
+  useEffect(() => cancelOpen, [cancelOpen]);
+
+  const submenuCtx = useMemo<SubmenuContextValue>(
+    () => ({
+      menuCtx: core.menuCtx,
+      open: core.open,
+      setOpen: core.setOpen,
+      triggerId: core.triggerId,
+      popupId: core.popupId,
+      anchorRef: core.anchorRef,
+      floatingRef: core.floatingRef,
+      pendingEdgeRef: core.pendingEdgeRef,
+      scheduleOpen,
+      cancelOpen,
+      closeDelay,
+    }),
+    [
+      core.menuCtx,
+      core.open,
+      core.setOpen,
+      core.triggerId,
+      core.popupId,
+      scheduleOpen,
+      cancelOpen,
+      closeDelay,
+    ]
+  );
+
+  return h(SubmenuContext.Provider, { value: submenuCtx }, children);
+}
+```
+
+Then fix imports. Add:
+
+```ts
+import { useMenuCore } from './use-menu-core.js';
+```
+
+Remove the now-orphaned imports: `import { useControllableState } from '../use-controllable-state.js';` (only `SubmenuRoot` used it); from the `preact/hooks` import remove `useId` and `useState` (keep `useCallback`, `useContext`, `useEffect`, `useMemo`, `useRef` — all still used by the timer / `submenuCtx` / `SubmenuTrigger`). From `import type { Side, Align, PositionState } from '../use-position.js';` remove `PositionState` (keep `Side`, `Align`). Keep the `type MenuContextValue` import from `./context.js` (the `SubmenuContextValue` interface still references it).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: exit 0. Fix any flagged import/symbol exactly and re-run.
+
+- [ ] **Step 3: Run the Submenu tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/menu-submenu.test.tsx packages/ui/src/__tests__/menu-submenu-safe-area.test.tsx packages/ui/src/__tests__/menu-structure.test.tsx`
+Expected: PASS (the hover timer + submenu nesting behavior preserved).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/menu/submenu.tsx
+git commit -m "refactor(ui): SubmenuRoot onto useMenuCore"
+```
+
+---
+
+### Task 5: Full CI mirror + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full CI mirror in CI order**
+
+Run each, expecting exit 0:
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test
+pnpm test:integration
+pnpm --filter site build
+```
+
+If `format:check` fails, run `pnpm format`, re-run `format:check`, and commit:
+
+```bash
+git add -A && git commit -m "chore(ui): pnpm format"
+```
+
+Expected: all pass. `pnpm test` should report the full unit suite green including the new `use-menu-core.test.tsx` (5 tests) and all menu/submenu/context-menu suites.
+
+- [ ] **Step 2: Confirm scope**
+
+Run: `git diff main...HEAD --stat`
+Expected: `use-menu-core.ts` + its test added; `menu.tsx` / `submenu.tsx` / `context-menu.tsx` each net-reduced (Root setup + assembly removed). No `index.ts` / `client-size-config.mjs` / `client-size-report.json` changes.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/ui-menu-core-dedup
+gh pr create --base main --head feat/ui-menu-core-dedup \
+  --title "refactor(ui): dedup the 3 Menu Roots into useMenuCore" \
+  --body "<summarize: useMenuCore hook extraction, MenuRoot/ContextMenuRoot/SubmenuRoot collapsed onto it, pointer-anchor machinery (openAt/getAnchorRect) moved into the hook behind a pointerAnchored flag, behavior-preserving pure dedup, full CI mirror green>"
+```
+
+---
+
+## Notes for the implementer
+
+- **Keep tests green at every task.** This is a behavior-preserving refactor. If any menu/submenu/context-menu test goes red after its Root refactor, the refactor diverged, compare against `git show main:packages/ui/src/<file>` and reconcile before committing.
+- **Imports:** `noUnusedLocals` is on, so `pnpm typecheck` is the authority. The per-task import guidance above is the expected set, but always let typecheck confirm and name anything missed.
+- **Do not add `use-menu-core` to the size config or regenerate baselines.**
+- The `SubmenuRoot` `submenuCtx` `useMemo` dep array intentionally omits the stable refs (`anchorRef`/`floatingRef`/`pendingEdgeRef`) — they are present in the object body but not the deps, matching the pre-PR code (stable `RefObject`s).
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- `useMenuCore` hook owning controllable-state + setup + closeAll default + pointer machinery + assembly (spec §Design/The hook) → Task 1. ✔
+- Pointer-anchor wrinkle resolved via the hook owning setOpen/pendingEdgeRef/pointRef, gated by `pointerAnchored` (spec §Design + §Open questions) → Task 1 hook body + Task 3 ContextMenu. ✔
+- Each Root collapse with the right per-Root opts (spec §Design/Each Root + variation table): MenuRoot (defaults, no flags) → Task 2; ContextMenuRoot (`pointerAnchored: true`, offset 0) → Task 3; SubmenuRoot (`closeAll: parent.closeAll`, `parentDismissId: parent.dismissId`, `loop`/`typeahead` from parent, keeps timer + submenuCtx) → Task 4. ✔
+- Submenu hover timer + `submenuCtx` stay component-specific (spec §Non-goals) → Task 4 preserves them. ✔
+- Testing: existing suites stay green + new direct hook test (spec §Testing) → Tasks 2-4 run the suites; Task 1 adds `use-menu-core.test.tsx`; Task 5 full suite. ✔
+- No `index.ts`/size-config change (spec §Files) → File structure note + Task 5 Step 2 check. ✔
+
+**Placeholder scan:** No TBD/TODO. Import-cleanup steps name the exact symbols to add/remove, with typecheck as the deterministic verifier; no code step omits its code.
+
+**Type consistency:** `useMenuCore`/`UseMenuCoreOptions`/`MenuCore` names match across Task 1 and every call site (Tasks 2-4). Opts (`open`/`defaultOpen`/`onOpenChange`/`side`/`align`/`offset`/`loop`/`typeahead`/`closeAll?`/`parentDismissId?`/`pointerAnchored?`) match every Root's call. Return fields (`menuCtx`, `open`, `setOpen`, the four refs + `pendingEdgeRef`, `baseId`/`triggerId`/`popupId`, `activeId`/`setActiveId`, `position`/`setPosition`) match `SubmenuRoot`'s usage in Task 4. `MenuContextValue` shape (from `menu/context.ts`) unchanged.

--- a/docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md
+++ b/docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md
@@ -1,0 +1,172 @@
+# Framework primitives deep review: long-term DX, simplicity, and composability
+
+**Date:** 2026-06-10
+**Status:** Research / design review only (no implementation intent)
+**Question:** Reviewing every concept across `packages/`, how healthy are the framework primitives for long-term developer experience? What does `apps/site`'s actual usage reveal, and what should guide future work to keep the framework simple and composable?
+
+## TL;DR
+
+- **The conceptual core is good.** One outcome vocabulary end to end, a fail-loud build layer, a consistent render-prop + data-attribute contract across all 7 UI overlays, and a real adapter seam.
+- **The risk is distribution, not concepts.** The same semantics are implemented in multiple places (envelope decoded twice on the client, outcome translation welded into four server channels, route matching implemented three times, cross-package string literals with no shared constant).
+- **The public/internal boundary is eroding from both sides.** Framework-private factories ride public entries; the main barrel re-exports `internal/` modules; `/internal` cannot actually be unstable because generated code depends on it; in `ui`, micro-helpers are public while the most load-bearing hooks (`usePositioner`, `useListboxSelection`) are internal.
+- **The site is a precise spec for six missing primitives**, each hand-rolled twice or more: form success lifecycle, client-visible auth state / imperative navigate, prefetching links, typed route params, single-source page guards, content/MDX sub-routing.
+- **Guidance:** consolidate semantics before adding surface, redraw the boundary before v1 freezes it, build the six site-discovered primitives, trim vestigial exports now, move the `ui` dedup trigger from "fifth copy" to "second copy", and adopt dogfood-or-delete plus contracts-start-shared as standing rules.
+
+## Method
+
+Six parallel read-only review agents covered: iso routing/loaders/actions/middleware; iso view transitions/streaming/config + umbrella export map; the server runtime + adapters; the vite plugin + scaffolder; `@hono-preact/ui`; and a usage audit of `apps/site/src`. Findings below are synthesized from their reports, with file citations preserved.
+
+## What is healthy and worth protecting
+
+- **Outcomes as shared currency.** `redirect`/`deny`/`render`/`timeout` are pure data + guards (`packages/iso/src/outcomes.ts`), consumed identically by the middleware runner, `useAction`, `Form`, and `PageMiddlewareHost`. The cleanest seam in the framework.
+- **One middleware composition rule**, `[...appConfig.use, ...pageUse, ...unit.use]` outer-to-inner, documented identically in both server handlers (`loaders-handler.ts:264-269`, `page-action-handler.ts:219-223`), with return-vs-throw outcome normalization and consistent timeout discrimination.
+- **Fail-loud build layer.** The vite plugin converts would-be silent failures into build errors with remediation text: `.server.*` export-shape validation, api.ts route-shadowing detection via AST walk, app-config default-export check (`packages/vite/src/server-entry.ts:122-220, 338-350`). Unusually defensive for a young framework.
+- **The adapter interface** (`packages/vite/src/adapter.ts`: `name`, `vitePlugins(ctx)`, `wrapEntry(ctx)`) is a small, public, proven seam; the node adapter implements the hard case in ~190 lines from outside knowledge.
+- **CSRF by mount order** (user `api.ts` mounts ahead of all framework POST handlers, verified by test) is a convention rather than an API, and it works.
+- **UI contracts.** The `render` prop (`use-render.ts`) and the `data-state`/`data-side`/`data-align`/`data-highlighted` styling contract are highly consistent across Dialog, Popover, Tooltip, Menu, ContextMenu, Select, Combobox. The controlled/uncontrolled triplet (`value`/`defaultValue`/`onXChange` via `useControllableState`) is uniform. Standalone primitives (`usePosition`, `usePresence`, `useDismiss`, `useSafeArea`, `useListNavigation`, `useTypeahead`, `useControllableState`) are genuinely context-free and reusable.
+- **Three-layer routing stack** `useRouteMatch` → `useRouteActive` → `NavLink`, and the `useOptimistic` → `useOptimisticAction` → `Form` composition through the `OPTIMISTIC_BRAND` symbol (no casts at the seam).
+- **`useListboxSelection`'s sole `as Value` cast confinement** (`packages/ui/src/listbox/selection.ts`) matches the repo cast policy.
+
+## Cross-cutting findings
+
+### 1. One vocabulary, many translators
+
+The same semantics live in N implementations that must agree:
+
+- **Envelope decode ×2 (client).** `Form` (`form.tsx:107-159`) and `useAction` (`action.ts:405-477`) independently parse the `__outcome` wire format with diverging edges: Form treats `timeout` as unknown-outcome fallthrough (`form.tsx:152`) while `useAction` raises a typed `TimeoutError`; Form falls back to `window.location.reload()` on malformed bodies (`form.tsx:104`).
+- **Outcome translation ×4 (server).** `translateRootOutcome` (`render.tsx:56`), `translateOutcomeForLoader` (`loaders-handler.ts:146`), `serializeActionOutcome` (iso `internal/action-envelope.ts`), plus the action HTML/PE branch (`page-action-handler.ts:326-390`). The tell: the "render outcome is page-scope only" defense exists in three separate files.
+- **Route matching ×3.** The preact-iso client matcher plus identical hand-mirrored `urlPathMatchesPattern`/`patternScore` copies in `route-server-modules.ts:36-65` and `page-action-resolvers.ts:51-72`.
+- **Cross-package string literals with no shared constant.** `static/client.js` (hardcoded in `packages/vite/src/hono-preact.ts:82` and `packages/iso/src/client-script.tsx:5`); `/__loaders` in three places across two packages; the dev script URL `/@id/__x00__virtual:hono-preact/client` encoding both Vite's `\0` convention and the virtual id; the generated entry path agreed between plugin constant and scaffolded `wrangler.jsonc` only textually. `__moduleKey` parity between client stubs and server injection is held together by a parity test; the runtime failure mode is a 404 at request time.
+- **Resolver duplication ×2 (server).** `makePageUseResolvers` and `makePageActionResolvers` are near-isomorphic (thunk cache, ancestor walk, dev-rebuild, best-pattern scan); a third per-module-export concept clones it a third time.
+
+### 2. The public/internal boundary erodes from both directions
+
+- **Server:** framework-private factories (`routeServerModules`, `makePageUseResolvers`, `makePageActionResolvers`) ride the public `hono-preact/server` entry with JSDoc-only privacy ("Reach for it at your own risk", `route-server-modules.ts:117`). `pickAccept` is module-public "for unit testing only". `LoadersHandlerOptions` is not re-exported from the index, so the documented custom-wiring path cannot name its own options type.
+- **Iso:** the main barrel re-exports `internal/` modules directly: `getViewTransitionDirection` is a barrel rename of internal `getNavDirection` (`index.ts:147`); `ViewTransitionEvent` is a stable type on the main barrel but an unstable value on `/internal`. The public semantics of the VT types/lifecycle APIs are defined entirely inside `internal/route-change.ts`.
+- **`/internal` cannot actually be unstable.** The generated client entry hard-depends on it (`installHistoryShim`, `installNavTransitionScheduler`, `installStreamRegistry`, `client-entry.ts:18`) and `packages/server/src/sse.ts` imports the fan helpers from it. Its instability disclaimer applies to a subpath the framework's own emitted code requires at runtime. Docs already point into it once (`OptimisticOverlay` in optimistic-ui.mdx), and each such pointer converts an unstable export into a de-facto stable one.
+- **UI, inverted:** micro-helpers (`getItems`, `wrapNext`, `wrapPrev`, `matchTypeahead`, `OPTION_SELECTOR`, `matchSubstring`) are public, while `usePositioner` (top-layer promotion, the UA-`[popover]` style neutralization in `POSITIONER_STYLE`, presence interplay, `mount` strategy; `use-positioner.ts`) and `useListboxSelection` (registry/version threading encoding the PR #82 stale-label fix, hidden-field form serialization) are internal. The knowledge in `usePositioner` is not re-derivable from docs; anyone building a custom anchored overlay from the public hooks must rediscover UA quirks the framework already paid for.
+- **SSE codec split across stability tiers:** decoder `readSSE` is iso `/internal`; encoder `sseGeneratorResponse` is public `@hono-preact/server`.
+
+### 3. Copy-then-dedup is the growth mode, and dedups lag
+
+Both completed UI extractions (`usePositioner` PR #83, `useListboxSelection` PR #80) and the pending `useMenuCore` (spec at `docs/superpowers/specs/2026-06-10-menu-core-dedup-design.md`) formed only after 3 to 5 copies existed. Post-dedup residue today:
+
+- Arrow part byte-near-identical ×5 (`popover.tsx:234-254`, `tooltip.tsx:276-296`, `menu.tsx:609-629`, `select.tsx:476-496`, `combobox.tsx:363-383`)
+- OptionGroup/GroupLabel labelId-context pattern ×3; Option registration layout-effect ×2 (same comment verbatim); description registration ×2 (`dialog.tsx:49-53`, `popover.tsx:57-61`); on-open highlight-selected effect ×2
+- Position-state plumbing through 6 Roots solely so Arrow can read it
+- Hand-maintained context memo dep arrays ×7 Roots (Combobox's is 28 entries)
+
+### 4. Global singletons coordinate the client runtime
+
+History shim (monkey-patched `history`), nav-transition scheduler (sole owner of `options.debounceRendering`, with module-level `loadingDepth`/`navGen`/`transitionActive`), stream registry (`window.__HP_STREAM__`), Persist registry, dismiss-stack singleton (`packages/ui/src/dismiss-stack.ts:20`), mutable `env` export, and the `globalThis` loader-cache map whose own comment calls it "an implicit footgun" to fix "in v0.2" (`define-loader.ts:108-120`, still present). Each is individually justified; collectively, correctness depends on install order and single-owner assumptions.
+
+### 5. Hidden placement and coupling knowledge
+
+- `useAction`'s `invalidate` behavior silently changes with the enclosing Boundary's "active loader" context (`action.ts:117-134, 223-224`).
+- Public `Routes` is silently load-bearing for cold-nav view transitions via `onLoadStart`/`onLoadEnd` (`define-routes.tsx:470-477`); dropping to raw `Router` (also exported from the barrel) loses coordination with no warning.
+- `useViewTransitionTypes` vs `subscribeViewTransitionTypes` requires hook-lifecycle blind-spot knowledge; lifecycle has no subscribe twin despite the same blind spot.
+- `defineLoader` without the vite transform produces an unkeyed loader that throws at render; nothing in the type distinguishes it.
+- `#app` and `<ClientScript/>` come from the user's Layout; renaming or omitting them silently produces a dead page.
+- Cookies must be set before a streaming loader's first yield (`render.tsx:328-337`).
+- `SubmenuPopup` outside `SubmenuPositioner` silently binds to the parent menu's context (`submenu.tsx:306-319`); the only silent wrong-context failure in `ui`.
+
+### 6. Smaller per-package frictions worth recording
+
+**Iso (routing/loaders/actions):**
+- Route params untyped everywhere (`pathParams: Record<string,string>`); `defineLoader`'s `params` cache-key list is stringly and unchecked against the route pattern.
+- `LoaderRef` is a god-object: fn + cache + 2 hooks + 2 components + middleware + timeout + plugin metadata; the data half is inseparable from the rendering half.
+- `RenderOutcome` type and `isRender` guard are public but there is no public `render()` constructor.
+- Three names around refresh (`useReload`, `invalidate`, View's `reload` arg); `useAction` exists as both free hook and stub method.
+- Casts at public seams: `defineAction`'s dual-shape `as unknown as ActionStub` (`action.ts:88-114`), `useData() as T`, `useActionResult` payload casts with an admitted type/runtime mismatch for form posts, `collectFormData(fd) as TPayload`.
+- `useActionResult`/`useFormStatus` are backed by module+action-keyed global stores, so two forms sharing an action share status.
+- Single-entry loader cache with `locKey: null` matches-any back-compat semantics; prefetch must know about the collision (`prefetch.ts:93-96`).
+
+**Iso (VT/streaming/config):**
+- The VT surface is a 2×2 (hook/component × name/class) plus a hook/subscribe duality applied inconsistently (types has both, lifecycle has hook only). `ViewTransitionGroup` is named for the pseudo-element it targets, not the property it sets.
+- `useRouteChange` is undocumented and strictly subsumed by `useViewTransitionLifecycle.onAfterSwap` (same internal slot, `internal/route-change.ts:121-126`).
+- Scheduler heuristics are tuned magic: `COLD_COMMIT_TIMEOUT_MS = 500`, `MORPH_PARTNER_GRACE_MS = 150`, a `[style*="view-transition-name"]` DOM scan.
+- `ViewTransitionEvent.set/get` is an unkeyed `Map<unknown, unknown>` stash on a public type; invites untypeable cross-phase protocols.
+- `speculation: boolean` with hardcoded rule JSON is the classic boolean-that-becomes-an-object.
+- `env` is a mutable exported let on the main barrel next to `isBrowser()`; user code can corrupt SSR detection.
+- Iso's `./page` subpath maps to `page-only.ts` while `page.tsx` is the `<Page>` component; maintainer-side grep trap.
+
+**Server:**
+- `pageActionHandler` takes its own sibling `renderPage` and `resolvePageNode` as injected options; forgetting `resolvePageUseByPath` silently drops page middleware on actions (`page-action-handler.ts:38-41`). A hand-rolled entry must replicate ~10 lines of resolver plumbing exactly.
+- `appConfig`/`dev`/`defaultTimeoutMs`/`onError` are threaded per handler with no shared server-config object; `onError` ctx shapes differ only in a field name.
+- `serverLoaders` accepts a raw-function shape that exists "(used by unit-test fixtures)" per its own comment (`loaders-handler.ts:64-83`); `serverActions` metadata rides non-enumerable function properties (`page-action-resolvers.ts:25-33`).
+- Reserved path `/__actions` has no runtime handler anywhere; vestige of the pre-Spec-C design.
+- HTML assembly is a weld: head injection by string-replacing `</head>`, the `startsWithHtml` shell heuristic, and the `__HP_STREAM__` pump (~150 bespoke lines, the third streaming wire format alongside the two SSE pumps).
+
+**Vite plugin / scaffolder:**
+- The `.server.*` suffix regex is inlined in at least 5 files; the 5-export allowlist is closed (extending means forking three plugins' shared contract).
+- `moduleKeyPlugin` only rewrites top-level `defineLoader` calls (`module-key-plugin.ts:108-110`); a loader built through a helper silently misses key threading.
+- Any unrelated file named `*.server.ts` is conscripted into the convention by filename alone.
+- The generated core app is string-concatenated codegen with no injection point; custom 404 or SSR wrapper means abandoning `serverEntryPlugin` (possible via `hono-preact/server` exports, undocumented as a path).
+- `loaderUse`/`actionUse` are recognized, validated, stubbed, and unread (`server-exports-contract.ts:20-25`): convention surface shipped ahead of behavior.
+- Scaffolder: CLI prints hardcoded `0.1.0` while package.json says `0.5.0` (`lib/cli.mjs:38`); the two templates' `src/` trees are byte-identical by discipline only; templates pin `preact-iso` to a git ref; no template demonstrates actions, `pageUse`, app-config, view transitions, or speculation, so the sharpest-edged conventions have no scaffolded example.
+- Node adapter's `injectWebSocket` is a magic optional export name on `api.ts`, documented nowhere in types; `apiModuleId` widened the shared adapter context for this one case (the canonical adapter-interface growth pattern).
+
+**UI:**
+- Root prop counts: Dialog 4, Popover 7, Tooltip 9, Menu 9, ContextMenu 9, Submenu 9, Select 17, Combobox 21. No shared positioning-props or selection-props type, so drift is structural.
+- `onValueChange?: (value: Value | Value[]) => void` forces hand-narrowing; `multiple` is not in the type.
+- Delay props: Tooltip `delay`/`closeDelay` vs Submenu `openDelay`/`closeDelay`. Default `align` and `offset` diverge per component, undocumented.
+- `data-state` overloaded to `"checked"/"unchecked"` on MenuCheckboxItem/MenuRadioItem (`menu.tsx:432,542`) vs `"open"/"closed"` everywhere else; a future Checkbox/Switch could fork a third way.
+- Two different "Value" part models: `SelectValue` (function-as-children + `render`, `{selectedLabels}`) vs `ComboboxValue` (function-as-children only, bare Fragment, `{selectedItems, remove}`); `ComboboxValueState` is the one public leak of generic erasure (`value: unknown`, `remove: (value: unknown) => void`, `combobox.tsx:906-909`).
+- `useRender` contains no hooks; four components legally early-return before calling it (`popover.tsx:182`, `tooltip.tsx:200`, `menu.tsx:263`, `combobox.tsx:897`). Any future hook inside it, or enabling eslint-plugin-react-hooks, breaks/flags all four. The name misstates the contract.
+- Menu items' `onSelect` receives a synthetic cancelable `Event` as the keep-open channel (`menu.tsx:204`); a pattern appearing nowhere else; Select/Combobox options have no per-option callback.
+- Hardcoded English strings in Combobox (Status text, trigger/clear aria-labels) with inconsistent override mechanisms; the library's only user-visible strings.
+- No contexts are exported, so a from-scratch custom part cannot reach e.g. Menu's `activeId`; safe-area geometry (`buildSafePolygon`) is internal, blocking custom corridors (RTL submenus).
+
+## What apps/site reveals (dogfood audit)
+
+**Blessed and working:** multi-loader pages with streaming generator loaders and `ctx.signal` abort checks; `View`-with-fallback composition; optimistic actions driving both list and `<Form>`; the public VT API end to end (`subscribeViewTransitionTypes` in `docs-transition.ts`, persistent-layout `useViewTransitionTypes`, `ViewTransitionName` morphs); UI demos that import only the barrel, use namespace parts, style purely via the data-attribute contract, and collectively cover nearly every component part with zero backdoors.
+
+**Hand-rolled 2+ times, i.e. missing primitives:**
+
+1. **Form success lifecycle.** Success-detection effect with manual dedup, twice, differently: ref-dedup (`project-issues.tsx:15-22`) and key-remount + invalidate (`issue.tsx:135,161-166`). `Form` has no `onSuccess`/`reset`/`invalidate`; `useAction` does have `onSuccess`.
+2. **Client-visible auth state / post-action navigation.** A localStorage session hint written, self-healed, cleared, and read across four files (`login.tsx:17-24`, `projects.tsx:46-53`, `projects.tsx:17-21`, `guard.ts:36`), with comments documenting the races; logout is a full `window.location.assign` because there is no imperative client navigate outside middleware.
+3. **Prefetching link.** Manual `onMouseEnter`/`onFocus` wiring plus a copy-declared route-pattern string next to the `href` (`IssueRow.tsx:9,17-20`); nothing connects `prefetch()`, the manifest, and `NavLink`.
+4. **Typed route params.** `(route.pathParams as { projectId?: string })` (`project-layout.tsx:7`); stringly param reads in all three `.server.ts` loaders.
+5. **Single-source page guards.** The `use` + `pageUse` mirror copy-pasted across 3 page pairs; a forgotten `pageUse` is an auth hole.
+6. **Content/MDX sub-routing.** `DocsRoute.tsx` is a hand-built glob router with a slug deriver, a per-MDX `<article>` wrapper working around Fragment-root hydration inside Suspense, and the same-component-reference trick to make docs→docs navs non-route-changes (`DocsRoute.tsx:8-13,51-58`). Deep preact-iso internals knowledge living in app code.
+
+**Never exercised by the site (real code):** `defineApp` (no app-config file at all), `speculation` (the docs tell users to enable it; the site doesn't), `createCache`, timeouts, `defineStreamObserver`, `Persist`/`PersistHost`, `useRouteMatch`, `useReload`, `useOptimistic` (raw), `Page`, `Routes`-as-import, `isBrowser` (site hand-rolls `typeof window` twice), `ViewTransitionGroup`, the VT lifecycle hook, and every `ui` primitive hook (`usePosition`, `useDismiss`, `useListNavigation`, `useSafeArea`, `useFocusReturn`, `useTypeahead`, `mergeRefs`, `useRender`, `useControllableState`): their docs pages are snippet-only, no live demos, so those public APIs are executed nowhere in the repo. Also unused parts: `PopoverAnchor`, Menu/Select/Combobox `Arrow`, `Combobox.Clear`. Cosmetic drift: 4 files import `Route`/`Router`/`useLocation` from `preact-iso` directly instead of the umbrella. Orphan file: `apps/site/src/pages/noop.tsx`.
+
+## Guidance for future work
+
+### A. Consolidate semantics before adding surface
+
+1. **Single envelope codec** shared by `Form` and `useAction`; single outcome-translation registry on the server. Same shape of work as the Positioner dedup: one meaning, one implementation.
+2. **One route matcher** shared by the two server resolver files, ideally derived from the matcher preact-iso uses.
+3. **Shared constants module** for cross-package literals (`/__loaders`, `static/client.js`, virtual ids, generated paths), following the `server-exports-contract.ts` precedent, which exists because this drift class already bit once.
+4. **Merge the resolver-factory twins** before a third per-module-export concept clones the pattern.
+
+### B. Redraw the public/internal boundary deliberately, before v1 freezes it by accident
+
+Adopt one rule, e.g. "public means documented with a live demo; everything else is `/internal`". Then:
+- Move the server resolver factories (and `pickAccept`) off the public `/server` entry; re-export `LoadersHandlerOptions` properly.
+- Stop re-exporting `internal/` modules from the iso main barrel.
+- Split `/internal` into a stable framework-emitted tier (the generated entry's dependencies can never be unstable) and a true escape-hatch tier.
+- In `ui`: promote `usePositioner` and `useListboxSelection` (they encode knowledge users cannot re-derive); consider demoting the micro-helpers; export or wrap contexts enough that a custom part can participate (e.g. read `activeId`).
+- Reunite the SSE codec on one subpath/stability tier.
+
+### C. Build the six site-discovered primitives instead of new feature areas
+
+Form `onSuccess`/`invalidate`; imperative client `navigate`; prefetch-on-intent in `NavLink`; typed route params (even a manual generic on `defineRoutes` beats casts); manifest-level `use` to kill the `pageUse` mirror; a content-glob route helper subsuming `DocsRoute.tsx` (hydration workaround included). Each deletes documented workaround code from the flagship app, the strongest signal they're right.
+
+### D. Trim vestigial surface now, while it is cheap
+
+`useRouteChange` (subsumed); `getViewTransitionDirection` (orphaned, undocumented); mutable `env` export (export only `isBrowser`); the dead `/__actions` reservation; `loaderUse`/`actionUse` (unread convention surface); the missing public `render()` constructor (add it or unexport the type+guard); the site's `noop.tsx`; the scaffolder's hardcoded CLI version string; and rename `useRender` (it is not a hook, and four components depend on that secret).
+
+### E. UI: move the dedup trigger from "fifth copy" to "second copy"
+
+Ship `useMenuCore` (spec fd2541f), then in the same spirit extract the Arrow part, the group-label context, and the position-state plumbing before the next slice replicates them. Standardize the small contract forks while there are only seven components: one delay vocabulary (`openDelay`/`closeDelay`), one `Value` part model, `data-checked` instead of overloading `data-state`, one popup-id prop name. Introduce shared `PositioningProps`/`SelectionProps` types so per-Root defaults are declared divergence, not drift. Fix the one public erasure leak (`ComboboxValueState`).
+
+### F. Standing rules
+
+1. **Dogfood-or-delete.** A public export the site neither uses nor live-demos is a candidate for `/internal` or removal. `defineApp.use`, `speculation`, timeouts, observers, and `Persist` should each gain a real site usage or a conscious keep-undemoed decision. Primitive docs pages should get live demos; they are currently the only untested public surface.
+2. **Contracts start shared.** When a new feature needs cross-package agreement (a path, a shape, an export name), it starts life in a shared contract module, not as matching string literals.
+
+## Closing observation
+
+The framework's simplicity is real but it currently lives in discipline: identical doc comments in two handlers, byte-identical template trees, parity tests for independently derived keys, JSDoc privacy notes. The work above is mostly about converting that discipline into structure so it survives contributors who have not read the whole codebase.

--- a/docs/superpowers/specs/2026-06-10-menu-core-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-10-menu-core-dedup-design.md
@@ -1,0 +1,196 @@
+# `useMenuCore` Root dedup
+
+**Date:** 2026-06-10
+**Status:** Approved (brainstorming) — ready for implementation plan
+**Scope:** `@hono-preact/ui` (unreleased, `0.0.0`/private)
+
+## Motivation
+
+`MenuRoot`, `SubmenuRoot`, and `ContextMenuRoot` each hand-build the same
+`MenuContextValue` (~22 fields) plus the same setup before it: `useControllableState`
+for open/setOpen, five refs (`anchorRef`/`floatingRef`/`popupRef`/`arrowRef`/
+`pendingEdgeRef`), `baseId` → `triggerId`/`popupId`, `activeId` state, and `position`
+state. That is ~60 lines repeated three times, differing only in a handful of fields.
+Every cross-cutting change to menu context shape is a three-file edit.
+
+This is the second of the two structural dedups (the Positioner dedup, PR #83, was the
+first). It extracts the shared setup + context assembly into one internal hook,
+`useMenuCore`, and collapses each Root to a thin wrapper. Pure dedup; no behavior change.
+
+## Goals
+
+- One `useMenuCore` hook owns: `useControllableState`, the five refs, the ids,
+  `activeId`/`position` state, the `closeAll` default, the ContextMenu pointer-anchor
+  machinery, and the assembled `MenuContextValue`.
+- Each Root collapses to a thin wrapper that resolves its own prop defaults and calls
+  the hook.
+- Behavior-preserving. No public API change. `menu/context.ts` (`MenuContextValue`)
+  unchanged.
+
+## Non-goals
+
+- The Submenu hover open-timer (`scheduleOpen`/`cancelOpen`) and `SubmenuContextValue`
+  stay in `SubmenuRoot` (submenu-specific).
+- ContextMenu's `contextmenu`-event Trigger stays in `context-menu.tsx`.
+- No change to `MenuPositioner`/`MenuPopup`/items or any non-Root part.
+- No `index.ts` export change (the hook is internal).
+
+## Design
+
+### The hook: `packages/ui/src/menu/use-menu-core.ts`
+
+Menu-specific (returns a `MenuContextValue`), so it lives in `menu/`. `context-menu.tsx`
+imports it via `../menu/use-menu-core.js` (it already imports `../menu/context.js`).
+Not exported from `index.ts`.
+
+```ts
+export interface UseMenuCoreOptions {
+  // Controllable open state (each Root forwards its own public props).
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  // Resolved values — each Root applies its own prop defaults before calling.
+  side: Side;
+  align: Align;
+  offset: number;
+  loop: boolean;
+  typeahead: boolean;
+  // Default: a hook-owned `() => setOpen(false)`. SubmenuRoot passes parent.closeAll
+  // so activating a nested item collapses the whole tree.
+  closeAll?: () => void;
+  // Default: null. SubmenuRoot passes parent.dismissId to link the dismiss tree.
+  parentDismissId?: string | null;
+  // ContextMenu only (default false): position against a captured pointer via a
+  // virtual anchor, and expose `openAt(x, y)`.
+  pointerAnchored?: boolean;
+}
+
+export interface MenuCore {
+  menuCtx: MenuContextValue; // fully assembled
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  anchorRef: RefObject<HTMLElement>;
+  floatingRef: RefObject<HTMLElement>;
+  popupRef: RefObject<HTMLElement>;
+  arrowRef: RefObject<HTMLElement>;
+  pendingEdgeRef: RefObject<'first' | 'last'>;
+  baseId: string;
+  triggerId: string;
+  popupId: string;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  position: PositionState;
+  setPosition: (p: PositionState) => void;
+}
+
+export function useMenuCore(opts: UseMenuCoreOptions): MenuCore;
+```
+
+**Internals:**
+
+1. `const [open, setOpen] = useControllableState<boolean>({ value: opts.open, defaultValue: opts.defaultOpen ?? false, onChange: opts.onOpenChange })`.
+2. The five refs; `baseId = useId()`; `triggerId = ` `${baseId}-trigger` `; popupId = ` `${baseId}-popup` `.
+3. `const [activeId, setActiveId] = useState<string | null>(null)`.
+4. `const [position, setPosition] = useState<PositionState>({ side: opts.side, align: opts.align, arrowX: null, arrowY: null })`.
+5. `const ownCloseAll = useCallback(() => setOpen(false), [setOpen]); const closeAll = opts.closeAll ?? ownCloseAll;` (always create `ownCloseAll`; pick per opt — never a conditional hook).
+6. Pointer-anchor machinery, **always created** (hook rules forbid conditional hooks), only wired into `menuCtx` when `pointerAnchored`:
+   ```ts
+   const pointRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+   const getAnchorRect = useCallback(() => {
+     const { x, y } = pointRef.current;
+     return { width: 0, height: 0, x, y, top: y, left: x, right: x, bottom: y };
+   }, []);
+   const openAt = useCallback((x: number, y: number) => {
+     pointRef.current = { x, y };
+     pendingEdgeRef.current = 'first';
+     setOpen(true);
+   }, [setOpen]);
+   ```
+7. Assemble the one `menuCtx = useMemo<MenuContextValue>(() => ({ open, setOpen, closeAll, dismissId: baseId, parentDismissId: opts.parentDismissId ?? null, anchorRef, floatingRef, popupRef, arrowRef, triggerId, popupId, activeId, setActiveId, pendingEdgeRef, side: opts.side, align: opts.align, offset: opts.offset, loop: opts.loop, typeahead: opts.typeahead, position, setPosition, getAnchorRect: opts.pointerAnchored ? getAnchorRect : undefined, openAt: opts.pointerAnchored ? openAt : undefined }), [open, setOpen, closeAll, baseId, opts.parentDismissId, activeId, opts.side, opts.align, opts.offset, opts.loop, opts.typeahead, position, opts.pointerAnchored, getAnchorRect, openAt])`. (`getAnchorRect`/`openAt` are stable `useCallback`s, safe in deps.)
+8. Return `menuCtx` plus the raw pieces (`open`, `setOpen`, the four refs + `pendingEdgeRef`, `baseId`, `triggerId`, `popupId`, `activeId`, `setActiveId`, `position`, `setPosition`).
+
+Note: the pre-PR `MenuRoot`/`ContextMenuRoot` set `openAt`/`getAnchorRect` to `undefined`
+or omit them; reading `ctx.openAt` yields `undefined` either way, so setting
+`openAt: undefined` for non-pointer menus is behavior-equivalent.
+
+### Each Root
+
+**`MenuRoot`** (defaults side `bottom`/align `start`/offset `8`):
+
+```tsx
+export function MenuRoot(props: MenuRootProps) {
+  const { open, defaultOpen, onOpenChange, side = 'bottom', align = 'start',
+    offset = 8, loop = true, typeahead = true, children } = props;
+  const core = useMenuCore({ open, defaultOpen, onOpenChange, side, align, offset, loop, typeahead });
+  return h(MenuContext.Provider, { value: core.menuCtx }, children);
+}
+```
+
+**`ContextMenuRoot`** (defaults side `bottom`/align `start`/offset `0`): identical shape,
+plus `pointerAnchored: true`. The `pointRef`/`getAnchorRect`/`openAt` move into the hook;
+the Root no longer builds them.
+
+```tsx
+const core = useMenuCore({ open, defaultOpen, onOpenChange, side, align, offset,
+  loop, typeahead, pointerAnchored: true });
+return h(MenuContext.Provider, { value: core.menuCtx }, children);
+```
+
+**`SubmenuRoot`** (defaults side `right`/align `start`/offset `0`): calls the hook with
+the parent-derived variant fields, then keeps its submenu-only machinery.
+
+```tsx
+const parent = useMenuContext('SubmenuRoot');
+const core = useMenuCore({ open, defaultOpen, onOpenChange, side, align, offset,
+  loop: parent.loop, typeahead: parent.typeahead,
+  closeAll: parent.closeAll, parentDismissId: parent.dismissId });
+// hover open-timer (unchanged): openTimer ref + cancelOpen + scheduleOpen + the
+// `useEffect(() => cancelOpen, [cancelOpen])` cleanup, using core.setOpen.
+// submenuCtx (unchanged shape) built from core.menuCtx + core.{open,setOpen,
+// triggerId,popupId,anchorRef,floatingRef,pendingEdgeRef} + scheduleOpen/cancelOpen/closeDelay.
+return h(SubmenuContext.Provider, { value: submenuCtx }, children);
+```
+
+`SubmenuRoot` does not render `MenuContext.Provider` itself; `core.menuCtx` rides inside
+`submenuCtx.menuCtx` exactly as today.
+
+### Per-Root variation mapping (what each passes)
+
+| Root | `closeAll` | `parentDismissId` | `loop`/`typeahead` | `pointerAnchored` | side/align/offset |
+|---|---|---|---|---|---|
+| MenuRoot | default | default (null) | props | false (default) | bottom/start/8 |
+| ContextMenuRoot | default | default (null) | props | **true** | bottom/start/0 |
+| SubmenuRoot | `parent.closeAll` | `parent.dismissId` | `parent.*` | false (default) | right/start/0 |
+
+## Testing
+
+Behavior-preserving: the existing suites are the safety net and must stay green at each
+step, `menu-structure`, `menu-navigation-dom`, `menu-trigger`, `menu-item`,
+`menu-checkable`, `menu-submenu`, `menu-submenu-safe-area`, `menu-presence`, `menu-ssr`,
+and `context-menu`.
+
+Add a focused `__tests__/use-menu-core.test.tsx` for the branching the hook now centralizes:
+- `closeAll` default invokes `setOpen(false)`; an injected `closeAll` is used instead.
+- `parentDismissId` passthrough (default `null`; a passed value appears on `menuCtx`).
+- `pointerAnchored: true` → `menuCtx.openAt(x, y)` sets the point, sets `pendingEdgeRef`
+  to `'first'`, and opens; `menuCtx.getAnchorRect()` returns the captured-point rect.
+- `pointerAnchored: false` (default) → `menuCtx.getAnchorRect` and `menuCtx.openAt` are
+  both `undefined`.
+
+## Files
+
+- **New:** `packages/ui/src/menu/use-menu-core.ts`, `packages/ui/src/__tests__/use-menu-core.test.tsx`
+- **Modified:** `packages/ui/src/menu/menu.tsx` (MenuRoot), `packages/ui/src/menu/submenu.tsx`
+  (SubmenuRoot), `packages/ui/src/context-menu/context-menu.tsx` (ContextMenuRoot)
+- No `index.ts` / `scripts/client-size-config.mjs` changes.
+
+## Open questions
+
+Resolved during brainstorming:
+- Core depth → **fat core** (returns the fully-assembled `MenuContextValue`).
+- The ordering wrinkle → the hook owns `setOpen`/`pendingEdgeRef`/`pointRef`, so it builds
+  `openAt`/`getAnchorRect` itself, gated by `pointerAnchored`.
+- The hook owns `useControllableState`, and the pointer callbacks are always created but
+  only wired in when `pointerAnchored`. **Approved.**
+
+None remaining.

--- a/packages/ui/src/__tests__/use-menu-core.test.tsx
+++ b/packages/ui/src/__tests__/use-menu-core.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, act } from '@testing-library/preact';
+import { useMenuCore, type UseMenuCoreOptions } from '../menu/use-menu-core.js';
+import type { MenuContextValue } from '../menu/context.js';
+
+afterEach(cleanup);
+
+const BASE: UseMenuCoreOptions = {
+  side: 'bottom',
+  align: 'start',
+  offset: 8,
+  loop: true,
+  typeahead: true,
+};
+
+function renderCore(opts: UseMenuCoreOptions) {
+  const cap: { ctx: MenuContextValue } = {
+    ctx: undefined as unknown as MenuContextValue,
+  };
+  function Harness() {
+    const core = useMenuCore(opts);
+    cap.ctx = core.menuCtx;
+    return <span data-testid="open">{String(core.open)}</span>;
+  }
+  const utils = render(<Harness />);
+  return { cap, utils };
+}
+
+describe('useMenuCore', () => {
+  it('closeAll defaults to setOpen(false)', () => {
+    const { cap, utils } = renderCore({ ...BASE, defaultOpen: true });
+    expect(cap.ctx.open).toBe(true);
+    act(() => cap.ctx.closeAll());
+    expect(utils.getByTestId('open').textContent).toBe('false');
+  });
+
+  it('uses an injected closeAll instead of the default', () => {
+    const closeAll = vi.fn();
+    const { cap, utils } = renderCore({ ...BASE, defaultOpen: true, closeAll });
+    act(() => cap.ctx.closeAll());
+    expect(closeAll).toHaveBeenCalledTimes(1);
+    // open is unchanged: the injected closeAll did not touch our state
+    expect(utils.getByTestId('open').textContent).toBe('true');
+  });
+
+  it('passes through parentDismissId (default null)', () => {
+    const a = renderCore({ ...BASE });
+    expect(a.cap.ctx.parentDismissId).toBeNull();
+    cleanup();
+    const b = renderCore({ ...BASE, parentDismissId: 'parent-9' });
+    expect(b.cap.ctx.parentDismissId).toBe('parent-9');
+  });
+
+  it('pointerAnchored: openAt captures the point, opens, pends first; getAnchorRect returns the point rect', () => {
+    const { cap, utils } = renderCore({ ...BASE, pointerAnchored: true });
+    expect(cap.ctx.open).toBe(false);
+    const { openAt, getAnchorRect } = cap.ctx;
+    expect(openAt).toBeTypeOf('function');
+    expect(getAnchorRect).toBeTypeOf('function');
+    act(() => openAt?.(10, 20));
+    expect(utils.getByTestId('open').textContent).toBe('true');
+    expect(cap.ctx.pendingEdgeRef.current).toBe('first');
+    expect(getAnchorRect?.()).toMatchObject({
+      x: 10,
+      y: 20,
+      top: 20,
+      left: 10,
+      right: 10,
+      bottom: 20,
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('without pointerAnchored, getAnchorRect and openAt are undefined', () => {
+    const { cap } = renderCore({ ...BASE });
+    expect(cap.ctx.getAnchorRect).toBeUndefined();
+    expect(cap.ctx.openAt).toBeUndefined();
+  });
+});

--- a/packages/ui/src/context-menu/context-menu.tsx
+++ b/packages/ui/src/context-menu/context-menu.tsx
@@ -1,10 +1,9 @@
 // packages/ui/src/context-menu/context-menu.tsx
 import { h, type ComponentChildren, type JSX, type VNode } from 'preact';
-import { useCallback, useId, useMemo, useRef, useState } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
-import { useControllableState } from '../use-controllable-state.js';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 import { MenuContext, useMenuContext } from '../menu/context.js';
+import { useMenuCore } from '../menu/use-menu-core.js';
 
 export interface ContextMenuRootProps {
   open?: boolean;
@@ -20,7 +19,7 @@ export interface ContextMenuRootProps {
 
 export function ContextMenuRoot(props: ContextMenuRootProps) {
   const {
-    open: openProp,
+    open,
     defaultOpen,
     onOpenChange,
     side = 'bottom',
@@ -30,93 +29,18 @@ export function ContextMenuRoot(props: ContextMenuRootProps) {
     typeahead = true,
     children,
   } = props;
-
-  const [open, setOpen] = useControllableState<boolean>({
-    value: openProp,
-    defaultValue: defaultOpen ?? false,
-    onChange: onOpenChange,
-  });
-
-  const anchorRef = useRef<HTMLElement>(null);
-  const floatingRef = useRef<HTMLElement>(null);
-  const popupRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
-  const pendingEdgeRef = useRef<'first' | 'last'>('first');
-  const pointRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
-  const baseId = useId();
-  const triggerId = `${baseId}-trigger`;
-  const popupId = `${baseId}-popup`;
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const [position, setPosition] = useState<PositionState>({
+  const core = useMenuCore({
+    open,
+    defaultOpen,
+    onOpenChange,
     side,
     align,
-    arrowX: null,
-    arrowY: null,
+    offset,
+    loop,
+    typeahead,
+    pointerAnchored: true,
   });
-
-  const closeAll = useCallback(() => setOpen(false), [setOpen]);
-
-  // Virtual anchor: a zero-size rect at the captured pointer.
-  const getAnchorRect = useCallback(() => {
-    const { x, y } = pointRef.current;
-    return { width: 0, height: 0, x, y, top: y, left: x, right: x, bottom: y };
-  }, []);
-
-  const openAt = useCallback(
-    (x: number, y: number) => {
-      pointRef.current = { x, y };
-      pendingEdgeRef.current = 'first';
-      setOpen(true);
-    },
-    [setOpen]
-  );
-
-  const ctx = useMemo(
-    () => ({
-      open,
-      setOpen,
-      closeAll,
-      dismissId: baseId,
-      parentDismissId: null,
-      anchorRef,
-      floatingRef,
-      popupRef,
-      arrowRef,
-      triggerId,
-      popupId,
-      activeId,
-      setActiveId,
-      pendingEdgeRef,
-      side,
-      align,
-      offset,
-      loop,
-      typeahead,
-      position,
-      setPosition,
-      getAnchorRect,
-      openAt,
-    }),
-    [
-      open,
-      setOpen,
-      closeAll,
-      baseId,
-      triggerId,
-      popupId,
-      activeId,
-      side,
-      align,
-      offset,
-      loop,
-      typeahead,
-      position,
-      getAnchorRect,
-      openAt,
-    ]
-  );
-
-  return h(MenuContext.Provider, { value: ctx }, children);
+  return h(MenuContext.Provider, { value: core.menuCtx }, children);
 }
 
 export type ContextMenuTriggerProps = {

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -6,12 +6,7 @@ import {
   type JSX,
   type VNode,
 } from 'preact';
-import {
-  useContext,
-  useId,
-  useLayoutEffect,
-  useMemo,
-} from 'preact/hooks';
+import { useContext, useId, useLayoutEffect, useMemo } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
 import type { Side, Align } from '../use-position.js';

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -7,17 +7,15 @@ import {
   type VNode,
 } from 'preact';
 import {
-  useCallback,
   useContext,
   useId,
   useLayoutEffect,
   useMemo,
-  useRef,
-  useState,
 } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
+import { useMenuCore } from './use-menu-core.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useFocusReturn } from '../use-focus-return.js';
 import { useListNavigation } from '../list-navigation.js';
@@ -43,7 +41,7 @@ export interface MenuRootProps {
 
 export function MenuRoot(props: MenuRootProps) {
   const {
-    open: openProp,
+    open,
     defaultOpen,
     onOpenChange,
     side = 'bottom',
@@ -53,76 +51,17 @@ export function MenuRoot(props: MenuRootProps) {
     typeahead = true,
     children,
   } = props;
-
-  const [open, setOpen] = useControllableState<boolean>({
-    value: openProp,
-    defaultValue: defaultOpen ?? false,
-    onChange: onOpenChange,
-  });
-
-  const anchorRef = useRef<HTMLElement>(null);
-  const floatingRef = useRef<HTMLElement>(null);
-  const popupRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
-  const pendingEdgeRef = useRef<'first' | 'last'>('first');
-
-  const baseId = useId();
-  const triggerId = `${baseId}-trigger`;
-  const popupId = `${baseId}-popup`;
-
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const [position, setPosition] = useState<PositionState>({
+  const core = useMenuCore({
+    open,
+    defaultOpen,
+    onOpenChange,
     side,
     align,
-    arrowX: null,
-    arrowY: null,
+    offset,
+    loop,
+    typeahead,
   });
-
-  const closeAll = useCallback(() => setOpen(false), [setOpen]);
-
-  const ctx = useMemo(
-    () => ({
-      open,
-      setOpen,
-      closeAll,
-      dismissId: baseId,
-      parentDismissId: null,
-      anchorRef,
-      floatingRef,
-      popupRef,
-      arrowRef,
-      triggerId,
-      popupId,
-      activeId,
-      setActiveId,
-      pendingEdgeRef,
-      side,
-      align,
-      offset,
-      loop,
-      typeahead,
-      position,
-      setPosition,
-      getAnchorRect: undefined,
-    }),
-    [
-      open,
-      setOpen,
-      closeAll,
-      baseId,
-      triggerId,
-      popupId,
-      activeId,
-      side,
-      align,
-      offset,
-      loop,
-      typeahead,
-      position,
-    ]
-  );
-
-  return h(MenuContext.Provider, { value: ctx }, children);
+  return h(MenuContext.Provider, { value: core.menuCtx }, children);
 }
 
 export type MenuTriggerProps = {

--- a/packages/ui/src/menu/submenu.tsx
+++ b/packages/ui/src/menu/submenu.tsx
@@ -11,15 +11,13 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useId,
   useMemo,
   useRef,
-  useState,
 } from 'preact/hooks';
 import { useRender, type RenderProp } from '../use-render.js';
-import { useControllableState } from '../use-controllable-state.js';
 import { useSafeArea } from '../use-safe-area.js';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
+import { useMenuCore } from './use-menu-core.js';
 import {
   MenuContext,
   useMenuContext,
@@ -66,7 +64,7 @@ export interface SubmenuRootProps {
 
 export function SubmenuRoot(props: SubmenuRootProps) {
   const {
-    open: openProp,
+    open,
     defaultOpen,
     onOpenChange,
     side = 'right',
@@ -78,26 +76,17 @@ export function SubmenuRoot(props: SubmenuRootProps) {
   } = props;
   const parent = useMenuContext('SubmenuRoot');
 
-  const [open, setOpen] = useControllableState<boolean>({
-    value: openProp,
-    defaultValue: defaultOpen ?? false,
-    onChange: onOpenChange,
-  });
-
-  const anchorRef = useRef<HTMLElement>(null); // the SubmenuTrigger element
-  const floatingRef = useRef<HTMLElement>(null);
-  const popupRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
-  const pendingEdgeRef = useRef<'first' | 'last'>('first');
-  const baseId = useId();
-  const triggerId = `${baseId}-trigger`;
-  const popupId = `${baseId}-popup`;
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const [position, setPosition] = useState<PositionState>({
+  const core = useMenuCore({
+    open,
+    defaultOpen,
+    onOpenChange,
     side,
     align,
-    arrowX: null,
-    arrowY: null,
+    offset,
+    loop: parent.loop,
+    typeahead: parent.typeahead,
+    closeAll: parent.closeAll,
+    parentDismissId: parent.dismissId,
   });
 
   const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -109,77 +98,31 @@ export function SubmenuRoot(props: SubmenuRootProps) {
   }, []);
   const scheduleOpen = useCallback(() => {
     cancelOpen();
-    openTimer.current = setTimeout(() => setOpen(true), openDelay);
-  }, [cancelOpen, setOpen, openDelay]);
+    openTimer.current = setTimeout(() => core.setOpen(true), openDelay);
+  }, [cancelOpen, core.setOpen, openDelay]);
   // Clear a pending open if the SubmenuRoot unmounts mid-delay.
   useEffect(() => cancelOpen, [cancelOpen]);
 
-  // The submenu's own MenuContext: parentDismissId links it into the dismiss
-  // tree; closeAll is the parent's so activating a nested item collapses the
-  // whole tree.
-  const menuCtx = useMemo<MenuContextValue>(
-    () => ({
-      open,
-      setOpen,
-      closeAll: parent.closeAll,
-      dismissId: baseId,
-      parentDismissId: parent.dismissId,
-      anchorRef,
-      floatingRef,
-      popupRef,
-      arrowRef,
-      triggerId,
-      popupId,
-      activeId,
-      setActiveId,
-      pendingEdgeRef,
-      side,
-      align,
-      offset,
-      loop: parent.loop,
-      typeahead: parent.typeahead,
-      position,
-      setPosition,
-      getAnchorRect: undefined,
-    }),
-    [
-      open,
-      setOpen,
-      parent.closeAll,
-      parent.dismissId,
-      parent.loop,
-      parent.typeahead,
-      baseId,
-      triggerId,
-      popupId,
-      activeId,
-      side,
-      align,
-      offset,
-      position,
-    ]
-  );
-
   const submenuCtx = useMemo<SubmenuContextValue>(
     () => ({
-      menuCtx,
-      open,
-      setOpen,
-      triggerId,
-      popupId,
-      anchorRef,
-      floatingRef,
-      pendingEdgeRef,
+      menuCtx: core.menuCtx,
+      open: core.open,
+      setOpen: core.setOpen,
+      triggerId: core.triggerId,
+      popupId: core.popupId,
+      anchorRef: core.anchorRef,
+      floatingRef: core.floatingRef,
+      pendingEdgeRef: core.pendingEdgeRef,
       scheduleOpen,
       cancelOpen,
       closeDelay,
     }),
     [
-      menuCtx,
-      open,
-      setOpen,
-      triggerId,
-      popupId,
+      core.menuCtx,
+      core.open,
+      core.setOpen,
+      core.triggerId,
+      core.popupId,
       scheduleOpen,
       cancelOpen,
       closeDelay,

--- a/packages/ui/src/menu/use-menu-core.ts
+++ b/packages/ui/src/menu/use-menu-core.ts
@@ -1,0 +1,168 @@
+import type { RefObject } from 'preact';
+import { useCallback, useId, useMemo, useRef, useState } from 'preact/hooks';
+import { useControllableState } from '../use-controllable-state.js';
+import type { Side, Align, PositionState } from '../use-position.js';
+import type { MenuContextValue } from './context.js';
+
+export interface UseMenuCoreOptions {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  // Resolved values — each Root applies its own prop defaults before calling.
+  side: Side;
+  align: Align;
+  offset: number;
+  loop: boolean;
+  typeahead: boolean;
+  // Default: a hook-owned () => setOpen(false). SubmenuRoot passes parent.closeAll
+  // so activating a nested item collapses the whole tree.
+  closeAll?: () => void;
+  // Default: null. SubmenuRoot passes parent.dismissId to link the dismiss tree.
+  parentDismissId?: string | null;
+  // ContextMenu only (default false): position against a captured pointer via a
+  // virtual anchor and expose openAt(x, y).
+  pointerAnchored?: boolean;
+}
+
+export interface MenuCore {
+  menuCtx: MenuContextValue;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  anchorRef: RefObject<HTMLElement>;
+  floatingRef: RefObject<HTMLElement>;
+  popupRef: RefObject<HTMLElement>;
+  arrowRef: RefObject<HTMLElement>;
+  pendingEdgeRef: RefObject<'first' | 'last'>;
+  baseId: string;
+  triggerId: string;
+  popupId: string;
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  position: PositionState;
+  setPosition: (p: PositionState) => void;
+}
+
+export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
+  const {
+    open: openProp,
+    defaultOpen,
+    onOpenChange,
+    side,
+    align,
+    offset,
+    loop,
+    typeahead,
+    closeAll: closeAllProp,
+    parentDismissId = null,
+    pointerAnchored = false,
+  } = opts;
+
+  const [open, setOpen] = useControllableState<boolean>({
+    value: openProp,
+    defaultValue: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  const anchorRef = useRef<HTMLElement>(null);
+  const floatingRef = useRef<HTMLElement>(null);
+  const popupRef = useRef<HTMLElement>(null);
+  const arrowRef = useRef<HTMLElement>(null);
+  const pendingEdgeRef = useRef<'first' | 'last'>('first');
+
+  const baseId = useId();
+  const triggerId = `${baseId}-trigger`;
+  const popupId = `${baseId}-popup`;
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [position, setPosition] = useState<PositionState>({
+    side,
+    align,
+    arrowX: null,
+    arrowY: null,
+  });
+
+  // closeAll defaults to closing this menu; a parent's closeAll is injected for
+  // submenus. ownCloseAll is always created (hooks can't be conditional).
+  const ownCloseAll = useCallback(() => setOpen(false), [setOpen]);
+  const closeAll = closeAllProp ?? ownCloseAll;
+
+  // Pointer-anchor machinery (ContextMenu): always created but only wired into
+  // the context when pointerAnchored. The hook owns setOpen + pendingEdgeRef +
+  // pointRef, so it can build openAt/getAnchorRect itself.
+  const pointRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const getAnchorRect = useCallback(() => {
+    const { x, y } = pointRef.current;
+    return { width: 0, height: 0, x, y, top: y, left: x, right: x, bottom: y };
+  }, []);
+  const openAt = useCallback(
+    (x: number, y: number) => {
+      pointRef.current = { x, y };
+      pendingEdgeRef.current = 'first';
+      setOpen(true);
+    },
+    [setOpen]
+  );
+
+  const menuCtx = useMemo<MenuContextValue>(
+    () => ({
+      open,
+      setOpen,
+      closeAll,
+      dismissId: baseId,
+      parentDismissId,
+      anchorRef,
+      floatingRef,
+      popupRef,
+      arrowRef,
+      triggerId,
+      popupId,
+      activeId,
+      setActiveId,
+      pendingEdgeRef,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+      setPosition,
+      getAnchorRect: pointerAnchored ? getAnchorRect : undefined,
+      openAt: pointerAnchored ? openAt : undefined,
+    }),
+    [
+      open,
+      setOpen,
+      closeAll,
+      baseId,
+      parentDismissId,
+      activeId,
+      side,
+      align,
+      offset,
+      loop,
+      typeahead,
+      position,
+      pointerAnchored,
+      getAnchorRect,
+      openAt,
+    ]
+  );
+
+  return {
+    menuCtx,
+    open,
+    setOpen,
+    anchorRef,
+    floatingRef,
+    popupRef,
+    arrowRef,
+    pendingEdgeRef,
+    baseId,
+    triggerId,
+    popupId,
+    activeId,
+    setActiveId,
+    position,
+    setPosition,
+  };
+}


### PR DESCRIPTION
Second of the two structural dedups (the Positioner dedup, #83, was the first). Extracts the triplicated `MenuContextValue` setup + assembly from `MenuRoot`, `SubmenuRoot`, and `ContextMenuRoot` into one internal `useMenuCore` hook.

## What changed
- **New `packages/ui/src/menu/use-menu-core.ts`** owns `useControllableState`, the five refs, the ids, `activeId`/`position` state, the `closeAll` default, the ContextMenu pointer-anchor machinery (`pointRef`/`getAnchorRect`/`openAt`), and the assembled `MenuContextValue`. Returns `{ menuCtx, ...raw pieces }`. Direct unit test added (5 tests). Internal (not exported from `index.ts`).
- **`MenuRoot`** and **`ContextMenuRoot`** collapse to ~15-line wrappers; ContextMenu passes `pointerAnchored: true`, which moves its `openAt`/`getAnchorRect` into the hook (the hook owns the `setOpen`/`pendingEdgeRef` they close over, dissolving the ordering wrinkle).
- **`SubmenuRoot`** drops the shared setup + `menuCtx` assembly but keeps its submenu-only machinery (the hover open-timer and `submenuCtx`), sourcing the rest from the hook.

## Behavior
Pure dedup, behavior-preserving. `MenuContextValue` (in `menu/context.ts`) is unchanged. The existing menu/submenu/context-menu suites stay green.

## Verification
Full CI mirror green: build, format:check, typecheck, **1182 unit** (1177 + 5 new) + 4 integration, site build. Size config + `index.ts` untouched.

Note: this branch also carries `docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md` (a standing DX-review doc added this session, unrelated to the dedup, riding along). Spec/plan also included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)