### PR TITLE
refactor(iso,server): single envelope codec + outcome-translation module

### DIFF
--- a/packages/iso/src/__tests__/action-envelope.test.ts
+++ b/packages/iso/src/__tests__/action-envelope.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  decodeActionResponse,
+  RENDER_PAGE_SCOPE_MESSAGE,
   serializeActionOutcome,
   type ActionEnvelope,
 } from '../internal/action-envelope.js';
@@ -77,5 +79,133 @@ describe('serializeActionOutcome', () => {
       }),
     });
     expect(env.headers).toEqual({ 'WWW-Authenticate': 'Bearer' });
+  });
+});
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('decodeActionResponse', () => {
+  it('decodes success with its data', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'success', data: { id: 1 } })
+      )
+    ).toEqual({ kind: 'success', data: { id: 1 } });
+  });
+
+  it('decodes redirect with a string `to`', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'redirect', to: '/next', status: 302 })
+      )
+    ).toEqual({ kind: 'redirect', to: '/next' });
+  });
+
+  it('treats redirect without a string `to` as unknown', async () => {
+    expect(
+      await decodeActionResponse(jsonRes({ __outcome: 'redirect' }))
+    ).toEqual({ kind: 'unknown', outcome: 'redirect', message: undefined });
+  });
+
+  it('decodes deny, carrying status, message, and data', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes(
+          { __outcome: 'deny', status: 403, message: 'no', data: { x: 1 } },
+          403
+        )
+      )
+    ).toEqual({ kind: 'deny', status: 403, message: 'no', data: { x: 1 } });
+  });
+
+  it('falls back to the HTTP status and a derived message on a bare deny', async () => {
+    expect(
+      await decodeActionResponse(jsonRes({ __outcome: 'deny' }, 422))
+    ).toEqual({
+      kind: 'deny',
+      status: 422,
+      message: 'Request denied (422)',
+      data: undefined,
+    });
+  });
+
+  it('decodes error with a message fallback', async () => {
+    expect(await decodeActionResponse(jsonRes({ __outcome: 'error' }))).toEqual(
+      { kind: 'error', message: 'Action failed' }
+    );
+  });
+
+  it('decodes timeout with a numeric timeoutMs', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'timeout', timeoutMs: 5000 }, 504)
+      )
+    ).toEqual({ kind: 'timeout', timeoutMs: 5000 });
+  });
+
+  it('treats timeout without a numeric timeoutMs as unknown', async () => {
+    expect(
+      await decodeActionResponse(jsonRes({ __outcome: 'timeout' }, 504))
+    ).toEqual({ kind: 'unknown', outcome: 'timeout', message: undefined });
+  });
+
+  it('returns unknown for an unrecognized outcome, carrying the env message', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'whatever', message: 'm' })
+      )
+    ).toEqual({ kind: 'unknown', outcome: 'whatever', message: 'm' });
+  });
+
+  it('returns unknown for an envelope object without __outcome', async () => {
+    expect(await decodeActionResponse(jsonRes({}))).toEqual({
+      kind: 'unknown',
+      outcome: undefined,
+      message: undefined,
+    });
+  });
+
+  it('returns malformed for a non-JSON body, carrying the HTTP status', async () => {
+    const res = new Response('<!doctype html><p>oops</p>', { status: 200 });
+    expect(await decodeActionResponse(res)).toEqual({
+      kind: 'malformed',
+      httpStatus: 200,
+    });
+  });
+
+  it('returns malformed for a JSON null body', async () => {
+    expect(await decodeActionResponse(jsonRes(null, 500))).toEqual({
+      kind: 'malformed',
+      httpStatus: 500,
+    });
+  });
+
+  it('returns malformed for a primitive JSON body', async () => {
+    expect(await decodeActionResponse(jsonRes(5))).toEqual({
+      kind: 'malformed',
+      httpStatus: 200,
+    });
+  });
+});
+
+describe('RENDER_PAGE_SCOPE_MESSAGE', () => {
+  it('is the message serializeActionOutcome emits for a render outcome', () => {
+    const env = serializeActionOutcome({
+      kind: 'outcome',
+      outcome: {
+        __outcome: 'render',
+        Component: () => null,
+      },
+    });
+    expect(env.body).toEqual({
+      __outcome: 'error',
+      message: RENDER_PAGE_SCOPE_MESSAGE,
+    });
+    expect(env.status).toBe(500);
   });
 });

--- a/packages/iso/src/__tests__/action-envelope.test.ts
+++ b/packages/iso/src/__tests__/action-envelope.test.ts
@@ -170,6 +170,16 @@ describe('decodeActionResponse', () => {
     });
   });
 
+  it('treats a JSON array body as unknown, not malformed', async () => {
+    // typeof [] === 'object' passes the envelope-object gate on purpose:
+    // both pre-consolidation parsers treated arrays like an empty object.
+    expect(await decodeActionResponse(jsonRes([1, 2]))).toEqual({
+      kind: 'unknown',
+      outcome: undefined,
+      message: undefined,
+    });
+  });
+
   it('returns malformed for a non-JSON body, carrying the HTTP status', async () => {
     const res = new Response('<!doctype html><p>oops</p>', { status: 200 });
     expect(await decodeActionResponse(res)).toEqual({

--- a/packages/iso/src/__tests__/action.test.tsx
+++ b/packages/iso/src/__tests__/action.test.tsx
@@ -733,6 +733,29 @@ describe('useAction — outcome envelope decoding', () => {
       expect(mutateResult!.error.message).toBe('Upload forbidden');
     }
   });
+
+  it('surfaces a non-envelope body as a malformed-envelope error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('<!doctype html><p>bad gateway</p>', { status: 502 })
+        )
+    );
+
+    const { result } = renderHook(() => useAction(stub));
+    let mutateResult: Awaited<ReturnType<typeof result.current.mutate>>;
+    await act(async () => {
+      mutateResult = await result.current.mutate({ title: 'Dune' });
+    });
+    expect(mutateResult!.ok).toBe(false);
+    if (!mutateResult!.ok) {
+      expect(mutateResult!.error.message).toMatch(
+        /Malformed envelope \(HTTP 502\)/
+      );
+    }
+  });
 });
 
 describe('useAction — streaming (onChunk)', () => {

--- a/packages/iso/src/__tests__/form.test.tsx
+++ b/packages/iso/src/__tests__/form.test.tsx
@@ -34,6 +34,7 @@ function makeStub(): ActionStub<{ text: string }, { id: number }, never> {
 afterEach(() => {
   cleanup();
   clearLastActionResult('pages/test.server', 'submit');
+  vi.restoreAllMocks();
 });
 
 describe('<Form>', () => {
@@ -99,7 +100,6 @@ describe('<Form>', () => {
     expect((init as RequestInit).body).toBeInstanceOf(FormData);
     const headers = new Headers((init as RequestInit).headers);
     expect(headers.get('Accept')).toMatch(/application\/json/);
-    fetchMock.mockRestore();
   });
 
   it('sends action identity from props even when hydrated hidden inputs are stale', async () => {
@@ -137,7 +137,6 @@ describe('<Form>', () => {
     const body = (init as RequestInit).body as FormData;
     expect(body.get('__module')).toBe('pages/test.server');
     expect(body.get('__action')).toBe('submit');
-    fetchMock.mockRestore();
   });
 
   it('writes deny outcome to the client store on JS-on path', async () => {
@@ -170,7 +169,6 @@ describe('<Form>', () => {
       expect(stored.status).toBe(422);
       expect(stored.message).toBe('bad');
     }
-    vi.restoreAllMocks();
   });
 
   it('writes success outcome to the client store', async () => {
@@ -193,7 +191,6 @@ describe('<Form>', () => {
       __action: stub.__action,
     });
     expect(stored?.kind).toBe('success');
-    vi.restoreAllMocks();
   });
 
   it('writes a timeout error result instead of an unknown-outcome error', async () => {
@@ -219,7 +216,6 @@ describe('<Form>', () => {
     if (stored?.kind === 'error') {
       expect(stored.message).toBe('Request timed out after 5000ms');
     }
-    vi.restoreAllMocks();
   });
 
   it('reloads the page on a malformed (non-envelope) body', async () => {
@@ -241,6 +237,5 @@ describe('<Form>', () => {
     expect(
       getLastActionResult({ __module: stub.__module, __action: stub.__action })
     ).toBeNull();
-    vi.restoreAllMocks();
   });
 });

--- a/packages/iso/src/__tests__/form.test.tsx
+++ b/packages/iso/src/__tests__/form.test.tsx
@@ -195,4 +195,52 @@ describe('<Form>', () => {
     expect(stored?.kind).toBe('success');
     vi.restoreAllMocks();
   });
+
+  it('writes a timeout error result instead of an unknown-outcome error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ __outcome: 'timeout', timeoutMs: 5000 }), {
+        status: 504,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const stub = makeStub();
+    const { container } = render(
+      <Form action={stub}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    fireEvent.submit(container.querySelector('form')!);
+    await new Promise((r) => setTimeout(r, 0));
+    const stored = getLastActionResult({
+      __module: stub.__module,
+      __action: stub.__action,
+    });
+    expect(stored?.kind).toBe('error');
+    if (stored?.kind === 'error') {
+      expect(stored.message).toBe('Request timed out after 5000ms');
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('reloads the page on a malformed (non-envelope) body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<!doctype html><p>not an envelope</p>', { status: 200 })
+    );
+    const reloadSpy = vi
+      .spyOn(window.location, 'reload')
+      .mockImplementation(() => {});
+    const stub = makeStub();
+    const { container } = render(
+      <Form action={stub}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    fireEvent.submit(container.querySelector('form')!);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(
+      getLastActionResult({ __module: stub.__module, __action: stub.__action })
+    ).toBeNull();
+    vi.restoreAllMocks();
+  });
 });

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -454,8 +454,11 @@ export function useAction<
             });
             outcomeRecorded = true;
             throw new Error(decoded.message);
-          } else {
+          } else if (decoded.kind === 'unknown') {
             throw new Error(`Unknown action outcome: ${decoded.outcome}`);
+          } else {
+            decoded satisfies never;
+            throw new Error('Unreachable: unhandled decoded envelope kind');
           }
         }
 

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -10,6 +10,7 @@ import {
   setLastActionResult,
   type StoredActionResult,
 } from './internal/action-result-store.js';
+import { decodeActionResponse } from './internal/action-envelope.js';
 
 export type ActionStub<TPayload, TResult, TChunk = never> = {
   readonly __module: string;
@@ -405,21 +406,12 @@ export function useAction<
         } else {
           // Uniform envelope path. All non-streaming responses carry a JSON
           // body shaped as { __outcome, ... } regardless of HTTP status.
-          let env: {
-            __outcome?: string;
-            data?: unknown;
-            to?: string;
-            status?: number;
-            message?: string;
-            timeoutMs?: number;
-          };
-          try {
-            env = (await response.json()) as typeof env;
-          } catch {
-            throw new Error(`Malformed envelope (HTTP ${response.status})`);
+          const decoded = await decodeActionResponse(response);
+          if (decoded.kind === 'malformed') {
+            throw new Error(`Malformed envelope (HTTP ${decoded.httpStatus})`);
           }
-          if (env.__outcome === 'success') {
-            const data = env.data as TResult;
+          if (decoded.kind === 'success') {
+            const data = decoded.data as TResult;
             setData(data);
             invokeSuccess(data);
             finalResult = data;
@@ -429,51 +421,41 @@ export function useAction<
               submittedPayload: payload,
             });
             outcomeRecorded = true;
-          } else if (
-            env.__outcome === 'redirect' &&
-            typeof env.to === 'string'
-          ) {
-            if (assignSafeRedirect(env.to)) {
+          } else if (decoded.kind === 'redirect') {
+            if (assignSafeRedirect(decoded.to)) {
               // Navigation issued; this promise never settles.
               return await new Promise<MutateResult<TResult>>(() => {});
             }
             // Cross-origin: surface as an error so the caller can handle it.
-            throw new Error(`Refused cross-origin redirect to ${env.to}`);
-          } else if (env.__outcome === 'deny') {
-            const msg =
-              env.message ??
-              `Request denied (${env.status ?? response.status})`;
+            throw new Error(`Refused cross-origin redirect to ${decoded.to}`);
+          } else if (decoded.kind === 'deny') {
             recordOutcome(currentStub.__module, currentStub.__action, {
               kind: 'deny',
-              status: env.status ?? response.status,
-              message: msg,
-              data: env.data,
+              status: decoded.status,
+              message: decoded.message,
+              data: decoded.data,
               submittedPayload: payload,
             });
             outcomeRecorded = true;
-            throw new Error(msg);
-          } else if (
-            env.__outcome === 'timeout' &&
-            typeof env.timeoutMs === 'number'
-          ) {
+            throw new Error(decoded.message);
+          } else if (decoded.kind === 'timeout') {
             recordOutcome(currentStub.__module, currentStub.__action, {
               kind: 'error',
-              message: `Request timed out after ${env.timeoutMs}ms`,
+              message: `Request timed out after ${decoded.timeoutMs}ms`,
               submittedPayload: payload,
             });
             outcomeRecorded = true;
-            throw new TimeoutError(env.timeoutMs);
-          } else if (env.__outcome === 'error') {
-            const msg = env.message ?? 'Action failed';
+            throw new TimeoutError(decoded.timeoutMs);
+          } else if (decoded.kind === 'error') {
             recordOutcome(currentStub.__module, currentStub.__action, {
               kind: 'error',
-              message: msg,
+              message: decoded.message,
               submittedPayload: payload,
             });
             outcomeRecorded = true;
-            throw new Error(msg);
+            throw new Error(decoded.message);
           } else {
-            throw new Error(`Unknown action outcome: ${env.__outcome}`);
+            throw new Error(`Unknown action outcome: ${decoded.outcome}`);
           }
         }
 

--- a/packages/iso/src/form.tsx
+++ b/packages/iso/src/form.tsx
@@ -162,6 +162,8 @@ export function Form<TPayload, TResult>({
               submittedPayload: payload,
             });
             return;
+          default:
+            decoded satisfies never;
         }
       } catch (err) {
         handle?.revert();

--- a/packages/iso/src/form.tsx
+++ b/packages/iso/src/form.tsx
@@ -9,6 +9,7 @@ import type { OptimisticHandle } from './optimistic.js';
 import { beginSubmit, endSubmit } from './internal/form-submit-store.js';
 import { setLastActionResult } from './internal/action-result-store.js';
 import { assignSafeRedirect } from './internal/safe-redirect.js';
+import { decodeActionResponse } from './internal/action-envelope.js';
 
 /**
  * The `action` prop accepts either a plain action stub or the branded value
@@ -92,71 +93,76 @@ export function Form<TPayload, TResult>({
           body: fd,
           headers: { Accept: 'application/json' },
         });
-        const env = (await res.json().catch(() => null)) as {
-          __outcome?: string;
-          to?: string;
-          message?: string;
-          data?: unknown;
-          status?: number;
-        } | null;
-        if (!env) {
-          handle?.revert();
-          if (typeof window !== 'undefined') window.location.reload();
-          return;
-        }
-        if (env.__outcome === 'redirect' && typeof env.to === 'string') {
-          const navigated = assignSafeRedirect(env.to);
-          if (navigated) {
-            handle?.settle();
+        const decoded = await decodeActionResponse(res);
+        switch (decoded.kind) {
+          case 'malformed':
+            // PE fallback policy: a non-envelope body means the POST landed
+            // somewhere that didn't speak the action protocol; reload so the
+            // server-rendered state wins.
+            handle?.revert();
+            if (typeof window !== 'undefined') window.location.reload();
+            return;
+          case 'redirect': {
+            const navigated = assignSafeRedirect(decoded.to);
+            if (navigated) {
+              handle?.settle();
+              return;
+            }
+            // Cross-origin: revert optimistic, surface as error result so
+            // useActionResult sees it.
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message: `Refused cross-origin redirect to ${decoded.to}`,
+              submittedPayload: payload,
+            });
             return;
           }
-          // Cross-origin: revert optimistic, surface as error result so useActionResult sees it.
-          handle?.revert();
-          setLastActionResult(moduleKey, actionName, {
-            kind: 'error',
-            message: `Refused cross-origin redirect to ${env.to}`,
-            submittedPayload: payload,
-          });
-          return;
+          case 'success':
+            handle?.settle();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'success',
+              data: decoded.data,
+              submittedPayload: payload,
+            });
+            return;
+          case 'deny':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'deny',
+              status: decoded.status,
+              message: decoded.message,
+              data: decoded.data,
+              submittedPayload: payload,
+            });
+            return;
+          case 'error':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message: decoded.message,
+              submittedPayload: payload,
+            });
+            return;
+          case 'timeout':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message: `Request timed out after ${decoded.timeoutMs}ms`,
+              submittedPayload: payload,
+            });
+            return;
+          case 'unknown':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message:
+                decoded.message ??
+                `Unexpected outcome: ${decoded.outcome ?? 'unknown'}`,
+              submittedPayload: payload,
+            });
+            return;
         }
-        if (env.__outcome === 'success') {
-          handle?.settle();
-          setLastActionResult(moduleKey, actionName, {
-            kind: 'success',
-            data: env.data,
-            submittedPayload: payload,
-          });
-          return;
-        }
-        if (env.__outcome === 'deny') {
-          handle?.revert();
-          setLastActionResult(moduleKey, actionName, {
-            kind: 'deny',
-            status: env.status ?? res.status,
-            message:
-              env.message ?? `Request denied (${env.status ?? res.status})`,
-            data: env.data,
-            submittedPayload: payload,
-          });
-          return;
-        }
-        if (env.__outcome === 'error') {
-          handle?.revert();
-          setLastActionResult(moduleKey, actionName, {
-            kind: 'error',
-            message: env.message ?? 'Action failed',
-            submittedPayload: payload,
-          });
-          return;
-        }
-        // Unknown outcome (e.g. 'timeout'): treat as error.
-        handle?.revert();
-        setLastActionResult(moduleKey, actionName, {
-          kind: 'error',
-          message:
-            env.message ?? `Unexpected outcome: ${env.__outcome ?? 'unknown'}`,
-          submittedPayload: payload,
-        });
       } catch (err) {
         handle?.revert();
         setLastActionResult(moduleKey, actionName, {

--- a/packages/iso/src/internal.ts
+++ b/packages/iso/src/internal.ts
@@ -33,9 +33,12 @@ export { OptimisticOverlay } from './internal/optimistic-overlay.js';
 
 export {
   serializeActionOutcome,
+  decodeActionResponse,
+  RENDER_PAGE_SCOPE_MESSAGE,
   type ActionEnvelope,
   type ActionResolution,
   type SerializedEnvelope,
+  type DecodedEnvelope,
 } from './internal/action-envelope.js';
 
 export { LoaderIdContext, LoaderDataContext } from './internal/contexts.js';

--- a/packages/iso/src/internal/action-envelope.ts
+++ b/packages/iso/src/internal/action-envelope.ts
@@ -19,6 +19,92 @@ export type SerializedEnvelope = {
   headers: Record<string, string> | undefined;
 };
 
+/**
+ * The defense-in-depth message for `render` outcomes reaching a channel
+ * that cannot host them (actions, loaders, root middleware). One copy;
+ * the server translators import it from `@hono-preact/iso/internal`.
+ */
+export const RENDER_PAGE_SCOPE_MESSAGE = 'render outcome is page-scope only';
+
+/**
+ * The decoded client-side view of an action response. `unknown` is an
+ * envelope object with an unrecognized `__outcome` (consumers surface it
+ * as an error); `malformed` is a body that is not an envelope object at
+ * all (consumers own the policy: <Form> reloads as a PE fallback,
+ * useAction throws).
+ */
+export type DecodedEnvelope =
+  | { kind: 'success'; data: unknown }
+  | { kind: 'redirect'; to: string }
+  | { kind: 'deny'; status: number; message: string; data?: unknown }
+  | { kind: 'error'; message: string }
+  | { kind: 'timeout'; timeoutMs: number }
+  | {
+      kind: 'unknown';
+      outcome: string | undefined;
+      message: string | undefined;
+    }
+  | { kind: 'malformed'; httpStatus: number };
+
+export async function decodeActionResponse(
+  res: Response
+): Promise<DecodedEnvelope> {
+  let raw: unknown;
+  try {
+    raw = await res.json();
+  } catch {
+    return { kind: 'malformed', httpStatus: res.status };
+  }
+  if (raw === null || typeof raw !== 'object') {
+    return { kind: 'malformed', httpStatus: res.status };
+  }
+  // Parsing untrusted JSON is the sanctioned cast boundary; this is the one
+  // place the wire shape is asserted, so the consumers never cast.
+  const env = raw as {
+    __outcome?: unknown;
+    data?: unknown;
+    to?: unknown;
+    status?: unknown;
+    message?: unknown;
+    timeoutMs?: unknown;
+  };
+  switch (env.__outcome) {
+    case 'success':
+      return { kind: 'success', data: env.data };
+    case 'redirect':
+      if (typeof env.to === 'string') return { kind: 'redirect', to: env.to };
+      break;
+    case 'deny': {
+      const status = typeof env.status === 'number' ? env.status : res.status;
+      return {
+        kind: 'deny',
+        status,
+        message:
+          typeof env.message === 'string'
+            ? env.message
+            : `Request denied (${status})`,
+        data: env.data,
+      };
+    }
+    case 'error':
+      return {
+        kind: 'error',
+        message:
+          typeof env.message === 'string' ? env.message : 'Action failed',
+      };
+    case 'timeout':
+      if (typeof env.timeoutMs === 'number') {
+        return { kind: 'timeout', timeoutMs: env.timeoutMs };
+      }
+      break;
+  }
+  return {
+    kind: 'unknown',
+    outcome: typeof env.__outcome === 'string' ? env.__outcome : undefined,
+    message: typeof env.message === 'string' ? env.message : undefined,
+  };
+}
+
 export function serializeActionOutcome(
   resolution: ActionResolution
 ): SerializedEnvelope {
@@ -62,7 +148,7 @@ export function serializeActionOutcome(
   }
   // 'render' outcome is page-scope only; should never reach an action.
   return {
-    body: { __outcome: 'error', message: 'render outcome is page-scope only' },
+    body: { __outcome: 'error', message: RENDER_PAGE_SCOPE_MESSAGE },
     status: 500,
     headers: undefined,
   };

--- a/packages/iso/src/internal/action-envelope.ts
+++ b/packages/iso/src/internal/action-envelope.ts
@@ -21,8 +21,9 @@ export type SerializedEnvelope = {
 
 /**
  * The defense-in-depth message for `render` outcomes reaching a channel
- * that cannot host them (actions, loaders, root middleware). One copy;
- * the server translators import it from `@hono-preact/iso/internal`.
+ * that cannot host them. Used verbatim by the action envelope and the
+ * loader RPC; root middleware composes a longer variant on top of it
+ * (see the server package's outcome translation).
  */
 export const RENDER_PAGE_SCOPE_MESSAGE = 'render outcome is page-scope only';
 

--- a/packages/server/src/__tests__/render.test.tsx
+++ b/packages/server/src/__tests__/render.test.tsx
@@ -137,7 +137,7 @@ describe('renderPage', () => {
 
   // B7 defensive 500: render() outcomes are page-scope only. If an
   // app-level middleware leaks one through to translateRootOutcome, the
-  // third branch in render.tsx should return 500 rather than crash.
+  // third branch in translateRootOutcome (outcome-translation.ts) should return 500 rather than crash.
   it('returns 500 when an app-level middleware throws a render outcome', async () => {
     const Alt = () => (
       <html>

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -3,7 +3,6 @@ import {
   isOutcome,
   timeoutOutcome,
   type AppConfig,
-  type Outcome,
   type ServerMiddleware,
   type ServerLoaderCtx,
   type Middleware,
@@ -14,6 +13,7 @@ import {
   dispatchServer,
   partitionUse,
 } from '@hono-preact/iso/internal';
+import { translateOutcomeForLoader } from './outcome-translation.js';
 import {
   sseGeneratorResponse,
   sseReadableStreamResponse,
@@ -141,46 +141,6 @@ export interface LoadersHandlerOptions {
    * a deadline).
    */
   defaultTimeoutMs?: number | false;
-}
-
-function translateOutcomeForLoader(c: Context, outcome: Outcome): Response {
-  if (outcome.__outcome === 'redirect') {
-    // Headers from the outcome ride the HTTP response via `c.header()`. They
-    // are deliberately NOT embedded in the JSON envelope: the client only
-    // reads `to` and calls `window.location.assign(to)`; any embedded
-    // headers would be dead bytes the client never inspects.
-    if (outcome.headers) {
-      for (const [k, v] of Object.entries(outcome.headers)) c.header(k, v);
-    }
-    return c.json(
-      {
-        __outcome: 'redirect',
-        to: outcome.to,
-        status: outcome.status,
-      },
-      200
-    );
-  }
-  if (outcome.__outcome === 'deny') {
-    if (outcome.headers) {
-      for (const [k, v] of Object.entries(outcome.headers)) c.header(k, v);
-    }
-    return c.json(
-      { __outcome: 'deny', message: outcome.message },
-      outcome.status
-    );
-  }
-  if (outcome.__outcome === 'timeout') {
-    return c.json({ __outcome: 'timeout', timeoutMs: outcome.timeoutMs }, 504);
-  }
-  // render outcome should never reach the loader RPC; this is defense in depth.
-  return c.json(
-    {
-      __outcome: 'error',
-      message: 'render outcome is page-scope only',
-    },
-    500
-  );
 }
 
 export function loadersHandler(

--- a/packages/server/src/outcome-translation.ts
+++ b/packages/server/src/outcome-translation.ts
@@ -1,3 +1,9 @@
+// Outcome -> HTTP response translation for the root middleware chain and the
+// loader RPC. Action outcomes are translated elsewhere: serializeActionOutcome
+// (iso internal) builds the JSON envelope, and pageActionHandler keeps its
+// HTML/PE translation inline because it is entangled with page re-rendering
+// and the request-scope action-result slot.
+
 import type { Context } from 'hono';
 import type { Outcome } from '@hono-preact/iso';
 import { RENDER_PAGE_SCOPE_MESSAGE } from '@hono-preact/iso/internal';
@@ -11,10 +17,12 @@ export function applyOutcomeHeaders(
   for (const [k, v] of Object.entries(headers)) c.header(k, v);
 }
 
-// Outcome translation for the root chain dispatched around prerender. The
-// root layer (appConfig.use) only legitimately produces `redirect` or
-// `deny`; a `render` outcome is page-scope and must not flow through here.
-// Defense-in-depth: surface programmer error as a 500 rather than crash.
+/**
+ * Outcome translation for the root chain dispatched around prerender. The
+ * root layer (appConfig.use) only legitimately produces `redirect` or
+ * `deny`; a `render` outcome is page-scope and must not flow through here.
+ * Defense-in-depth: surface programmer error as a 500 rather than crash.
+ */
 export function translateRootOutcome(c: Context, outcome: Outcome): Response {
   if (outcome.__outcome === 'redirect') {
     applyOutcomeHeaders(c, outcome.headers);
@@ -30,6 +38,10 @@ export function translateRootOutcome(c: Context, outcome: Outcome): Response {
   );
 }
 
+/**
+ * Translate a middleware/loader outcome into the loader RPC's JSON envelope
+ * response.
+ */
 export function translateOutcomeForLoader(
   c: Context,
   outcome: Outcome

--- a/packages/server/src/outcome-translation.ts
+++ b/packages/server/src/outcome-translation.ts
@@ -1,0 +1,70 @@
+import type { Context } from 'hono';
+import type { Outcome } from '@hono-preact/iso';
+import { RENDER_PAGE_SCOPE_MESSAGE } from '@hono-preact/iso/internal';
+
+/** Apply an outcome's optional headers to the HTTP response. */
+export function applyOutcomeHeaders(
+  c: Context,
+  headers: Record<string, string> | undefined
+): void {
+  if (!headers) return;
+  for (const [k, v] of Object.entries(headers)) c.header(k, v);
+}
+
+// Outcome translation for the root chain dispatched around prerender. The
+// root layer (appConfig.use) only legitimately produces `redirect` or
+// `deny`; a `render` outcome is page-scope and must not flow through here.
+// Defense-in-depth: surface programmer error as a 500 rather than crash.
+export function translateRootOutcome(c: Context, outcome: Outcome): Response {
+  if (outcome.__outcome === 'redirect') {
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.redirect(outcome.to, outcome.status);
+  }
+  if (outcome.__outcome === 'deny') {
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.text(outcome.message ?? 'Forbidden', outcome.status);
+  }
+  return c.text(
+    `${RENDER_PAGE_SCOPE_MESSAGE} and cannot be issued by root middleware`,
+    500
+  );
+}
+
+export function translateOutcomeForLoader(
+  c: Context,
+  outcome: Outcome
+): Response {
+  if (outcome.__outcome === 'redirect') {
+    // Headers from the outcome ride the HTTP response via `c.header()`. They
+    // are deliberately NOT embedded in the JSON envelope: the client only
+    // reads `to` and calls `window.location.assign(to)`; any embedded
+    // headers would be dead bytes the client never inspects.
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.json(
+      {
+        __outcome: 'redirect',
+        to: outcome.to,
+        status: outcome.status,
+      },
+      200
+    );
+  }
+  if (outcome.__outcome === 'deny') {
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.json(
+      { __outcome: 'deny', message: outcome.message },
+      outcome.status
+    );
+  }
+  if (outcome.__outcome === 'timeout') {
+    return c.json({ __outcome: 'timeout', timeoutMs: outcome.timeoutMs }, 504);
+  }
+  // render outcome should never reach the loader RPC; this is defense in depth.
+  return c.json(
+    {
+      __outcome: 'error',
+      message: RENDER_PAGE_SCOPE_MESSAGE,
+    },
+    500
+  );
+}

--- a/packages/server/src/page-action-handler.ts
+++ b/packages/server/src/page-action-handler.ts
@@ -16,6 +16,7 @@ import {
   serializeActionOutcome,
   type ActionResolution,
 } from '@hono-preact/iso/internal';
+import { applyOutcomeHeaders } from './outcome-translation.js';
 import {
   sseGeneratorResponse,
   sseReadableStreamResponse,
@@ -317,9 +318,7 @@ export function pageActionHandler(
     // JSON path: serialize the resolution into the uniform envelope.
     if (accept === 'json') {
       const env = serializeActionOutcome(resolution);
-      if (env.headers) {
-        for (const [k, v] of Object.entries(env.headers)) c.header(k, v);
-      }
+      applyOutcomeHeaders(c, env.headers);
       return c.json(env.body, env.status);
     }
 
@@ -331,9 +330,7 @@ export function pageActionHandler(
       resolution.outcome.__outcome === 'redirect'
     ) {
       const { to, status, headers } = resolution.outcome;
-      if (headers) {
-        for (const [k, v] of Object.entries(headers)) c.header(k, v);
-      }
+      applyOutcomeHeaders(c, headers);
       return c.redirect(to, status);
     }
 

--- a/packages/server/src/render.tsx
+++ b/packages/server/src/render.tsx
@@ -24,6 +24,7 @@ import {
 } from '@hono-preact/iso/internal';
 import type { ServerLoaderStream } from '@hono-preact/iso/internal';
 import { speculationRulesTag } from './speculation-rules.js';
+import { translateRootOutcome } from './outcome-translation.js';
 
 function escapeHtml(str: string): string {
   return str
@@ -47,29 +48,6 @@ function toAttrs(obj: Record<string, string | undefined>): string {
     .filter(([, v]) => v != null)
     .map(([k, v]) => `${k}="${escapeHtml(String(v))}"`)
     .join(' ');
-}
-
-// Outcome translation for the root chain dispatched around prerender. The
-// root layer (appConfig.use) only legitimately produces `redirect` or
-// `deny`; a `render` outcome is page-scope and must not flow through here.
-// Defense-in-depth: surface programmer error as a 500 rather than crash.
-function translateRootOutcome(c: Context, outcome: Outcome): Response {
-  if (outcome.__outcome === 'redirect') {
-    if (outcome.headers) {
-      for (const [k, v] of Object.entries(outcome.headers)) c.header(k, v);
-    }
-    return c.redirect(outcome.to, outcome.status);
-  }
-  if (outcome.__outcome === 'deny') {
-    if (outcome.headers) {
-      for (const [k, v] of Object.entries(outcome.headers)) c.header(k, v);
-    }
-    return c.text(outcome.message ?? 'Forbidden', outcome.status);
-  }
-  return c.text(
-    'render outcome is page-scope only and cannot be issued by root middleware',
-    500
-  );
 }
 
 function buildActionResultContext(): ActionResultContextValue {


### PR DESCRIPTION
PR 1 of 3 for Section A of the primitives DX review (spec: docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md, on local main).

## What

- **One client decoder.** `decodeActionResponse` + `DecodedEnvelope` join the encoder in iso's `internal/action-envelope.ts`, so the whole `__outcome` wire format lives in one file. `Form` and `useAction` are now policy switches over the decoded union; the deny/error message fallbacks live in the decoder instead of being duplicated in both consumers.
- **One server translation module.** `translateRootOutcome` and `translateOutcomeForLoader` moved verbatim into `packages/server/src/outcome-translation.ts` alongside a shared `applyOutcomeHeaders`; the "render outcome is page-scope only" defense message has one copy (`RENDER_PAGE_SCOPE_MESSAGE` in iso internal, composed with a suffix for the root-middleware variant).

## Behavior changes (deliberate, per spec)

1. `Form` reports a `timeout` envelope as a real timeout error result (`Request timed out after Nms`) instead of the `Unexpected outcome: timeout` fallthrough.
2. Non-object JSON bodies now uniformly classify as malformed: `Form` reloads (previously only falsy bodies reloaded; truthy primitives errored), and `useAction` throws `Malformed envelope (HTTP n)` (previously `Unknown action outcome: undefined`, or a raw TypeError for JSON `null`).

Everything else is behavior-preserving: all server status codes, JSON shapes, header application, and message strings are byte-identical (verified branch-by-branch against the deleted code).

## Not in scope

No public surface changes (the boundary redraw is Section B); route matcher + resolver twins are PR 2; the shared constants module is PR 3.

## Verification

All six local CI-mirror steps pass: framework build, format:check, typecheck, test:coverage (644 unit tests), test:integration, site build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)