### PR TITLE
refactor(server): single route matcher + shared resolver core

### DIFF
--- a/packages/server/src/__tests__/route-module-resolvers.test.ts
+++ b/packages/server/src/__tests__/route-module-resolvers.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import type { ServerRoute } from '@hono-preact/iso';
+import { makeRouteModuleResolvers } from '../route-module-resolvers.js';
+
+type TestMod = { tag?: string };
+
+function countingThunk(tag: string, calls: { n: number }) {
+  return () => {
+    calls.n++;
+    return Promise.resolve({ tag });
+  };
+}
+
+/** Strategy that composes the loaded tags outer-first into one array. */
+const tagStrategy = {
+  createExtra: () => new Map<string, string>(),
+  compose: (
+    route: ServerRoute,
+    ancestorMods: ReadonlyArray<TestMod>,
+    selfMod: TestMod,
+    extra: Map<string, string>
+  ) => {
+    const tags = [...ancestorMods, selfMod].map((m) => m.tag ?? '?');
+    extra.set(route.path, tags.join('+'));
+    return tags;
+  },
+};
+
+describe('makeRouteModuleResolvers', () => {
+  it('loads each distinct thunk exactly once per build (server + ancestor reuse)', async () => {
+    const calls = { n: 0 };
+    const layout = countingThunk('layout', calls);
+    const leaf = countingThunk('leaf', calls);
+    const routes: ServerRoute[] = [
+      { path: '/g', server: layout, ancestors: [] },
+      { path: '/g/leaf', server: leaf, ancestors: [layout] },
+    ];
+    const core = makeRouteModuleResolvers<
+      TestMod,
+      string[],
+      Map<string, string>
+    >(routes, {}, tagStrategy);
+    expect(await core.byPath('/g/leaf')).toEqual(['layout', 'leaf']);
+    expect(calls.n).toBe(2);
+  });
+
+  it('caches the build across calls when dev is false', async () => {
+    const calls = { n: 0 };
+    const routes: ServerRoute[] = [
+      { path: '/a', server: countingThunk('a', calls), ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<
+      TestMod,
+      string[],
+      Map<string, string>
+    >(routes, {}, tagStrategy);
+    await core.byPath('/a');
+    await core.byPath('/a');
+    await core.built();
+    expect(calls.n).toBe(1);
+  });
+
+  it('rebuilds on every call when dev is true', async () => {
+    const calls = { n: 0 };
+    const routes: ServerRoute[] = [
+      { path: '/a', server: countingThunk('a', calls), ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<
+      TestMod,
+      string[],
+      Map<string, string>
+    >(routes, { dev: true }, tagStrategy);
+    await core.byPath('/a');
+    await core.byPath('/a');
+    expect(calls.n).toBe(2);
+  });
+
+  it('does not cache a failed build: the next call retries and can succeed', async () => {
+    let failOnce = true;
+    const calls = { n: 0 };
+    const flaky = () => {
+      calls.n++;
+      if (failOnce) {
+        failOnce = false;
+        return Promise.reject(new Error('transient import error'));
+      }
+      return Promise.resolve({ tag: 'ok' });
+    };
+    const routes: ServerRoute[] = [
+      { path: '/a', server: flaky, ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<
+      TestMod,
+      string[],
+      Map<string, string>
+    >(routes, {}, tagStrategy);
+    await expect(core.byPath('/a')).rejects.toThrow('transient import error');
+    expect(await core.byPath('/a')).toEqual(['ok']);
+    expect(calls.n).toBe(2);
+  });
+
+  it('byPath resolves through findBestPattern and returns undefined on no match', async () => {
+    const calls = { n: 0 };
+    const routes: ServerRoute[] = [
+      { path: '/p/:id', server: countingThunk('param', calls), ancestors: [] },
+      { path: '/p/new', server: countingThunk('lit', calls), ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<
+      TestMod,
+      string[],
+      Map<string, string>
+    >(routes, {}, tagStrategy);
+    expect(await core.byPath('/p/new')).toEqual(['lit']);
+    expect(await core.byPath('/p/42')).toEqual(['param']);
+    expect(await core.byPath('/nope')).toBeUndefined();
+  });
+
+  it('built() exposes the byPathMap and the strategy-accumulated extra', async () => {
+    const calls = { n: 0 };
+    const layout = countingThunk('layout', calls);
+    const routes: ServerRoute[] = [
+      {
+        path: '/g/leaf',
+        server: countingThunk('leaf', calls),
+        ancestors: [layout],
+      },
+    ];
+    const core = makeRouteModuleResolvers<
+      TestMod,
+      string[],
+      Map<string, string>
+    >(routes, {}, tagStrategy);
+    const { byPathMap, extra } = await core.built();
+    expect(byPathMap.get('/g/leaf')).toEqual(['layout', 'leaf']);
+    expect(extra.get('/g/leaf')).toBe('layout+leaf');
+  });
+});

--- a/packages/server/src/__tests__/route-module-resolvers.test.ts
+++ b/packages/server/src/__tests__/route-module-resolvers.test.ts
@@ -115,6 +115,34 @@ describe('makeRouteModuleResolvers', () => {
     expect(await core.byPath('/nope')).toBeUndefined();
   });
 
+  it('concurrent first calls share one in-flight build', async () => {
+    const calls = { n: 0 };
+    let release!: (mod: TestMod) => void;
+    const gated = () => {
+      calls.n++;
+      return new Promise<TestMod>((resolve) => {
+        release = resolve;
+      });
+    };
+    const routes: ServerRoute[] = [
+      { path: '/a', server: gated, ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<
+      TestMod,
+      string[],
+      Map<string, string>
+    >(routes, {}, tagStrategy);
+    const first = core.byPath('/a');
+    const second = core.byPath('/a');
+    // Flush enough microtasks for build() to reach the gated thunk before
+    // we release it (the thunk is called inside an async Promise.all body).
+    await Promise.resolve();
+    release({ tag: 'a' });
+    expect(await first).toEqual(['a']);
+    expect(await second).toEqual(['a']);
+    expect(calls.n).toBe(1);
+  });
+
   it('built() exposes the byPathMap and the strategy-accumulated extra', async () => {
     const calls = { n: 0 };
     const layout = countingThunk('layout', calls);

--- a/packages/server/src/__tests__/route-pattern.test.ts
+++ b/packages/server/src/__tests__/route-pattern.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  urlPathMatchesPattern,
+  patternScore,
+  findBestPattern,
+} from '../route-pattern.js';
+
+describe('urlPathMatchesPattern', () => {
+  it('matches literal segments exactly', () => {
+    expect(urlPathMatchesPattern('/a/b', '/a/b')).toBe(true);
+    expect(urlPathMatchesPattern('/a/c', '/a/b')).toBe(false);
+  });
+
+  it('matches :param segments against any value', () => {
+    expect(urlPathMatchesPattern('/users/42', '/users/:id')).toBe(true);
+    expect(urlPathMatchesPattern('/users', '/users/:id')).toBe(false);
+  });
+
+  it('requires equal segment counts absent a wildcard', () => {
+    expect(urlPathMatchesPattern('/a/b/c', '/a/b')).toBe(false);
+    expect(urlPathMatchesPattern('/a', '/a/b')).toBe(false);
+  });
+
+  it('a trailing * matches any remainder including none', () => {
+    expect(urlPathMatchesPattern('/docs/a/b', '/docs/*')).toBe(true);
+    expect(urlPathMatchesPattern('/docs', '/docs/*')).toBe(true);
+  });
+
+  it('ignores leading/trailing slashes via segment comparison', () => {
+    expect(urlPathMatchesPattern('/a/b/', '/a/b')).toBe(true);
+    expect(urlPathMatchesPattern('a/b', '/a/b')).toBe(true);
+  });
+});
+
+describe('patternScore', () => {
+  it('scores literal=2, param=1, wildcard=0 per segment', () => {
+    expect(patternScore('/a/b')).toBe(4);
+    expect(patternScore('/a/:id')).toBe(3);
+    expect(patternScore('/a/*')).toBe(2);
+    expect(patternScore('/')).toBe(0);
+  });
+});
+
+describe('findBestPattern', () => {
+  it('returns null when nothing matches', () => {
+    expect(findBestPattern(['/a', '/b'], '/c')).toBeNull();
+  });
+
+  it('prefers higher specificity: literal beats param at the same depth', () => {
+    expect(
+      findBestPattern(
+        ['/admin/users/:id', '/admin/users/me'],
+        '/admin/users/me'
+      )
+    ).toBe('/admin/users/me');
+  });
+
+  it('prefers depth when scores tie', () => {
+    // Both match '/a/b/c' with score 2 ('/a/*' = 2+0; '/:a/:b/*' = 1+1+0);
+    // the deeper pattern wins regardless of iteration order.
+    expect(findBestPattern(['/a/*', '/:a/:b/*'], '/a/b/c')).toBe('/:a/:b/*');
+    expect(findBestPattern(['/:a/:b/*', '/a/*'], '/a/b/c')).toBe('/:a/:b/*');
+  });
+
+  it('keeps the first-seen pattern when score and depth both tie', () => {
+    expect(findBestPattern(['/x/:a', '/:x/a'], '/x/a')).toBe('/x/:a');
+    expect(findBestPattern(['/:x/a', '/x/:a'], '/x/a')).toBe('/:x/a');
+  });
+
+  it('accepts any iterable of patterns (Map keys)', () => {
+    const m = new Map([
+      ['/p/:id', 1],
+      ['/p/new', 2],
+    ]);
+    expect(findBestPattern(m.keys(), '/p/new')).toBe('/p/new');
+  });
+});

--- a/packages/server/src/__tests__/route-pattern.test.ts
+++ b/packages/server/src/__tests__/route-pattern.test.ts
@@ -30,6 +30,16 @@ describe('urlPathMatchesPattern', () => {
     expect(urlPathMatchesPattern('/a/b/', '/a/b')).toBe(true);
     expect(urlPathMatchesPattern('a/b', '/a/b')).toBe(true);
   });
+
+  it('a mid-pattern * matches the remainder; later segments are ignored', () => {
+    // Inherited characterization: the matcher returns true on the first *,
+    // wherever it appears. Generated route tables only emit trailing *.
+    expect(urlPathMatchesPattern('/a/x/c', '/a/*/b')).toBe(true);
+  });
+
+  it('treats the empty pattern like the root pattern', () => {
+    expect(urlPathMatchesPattern('/', '')).toBe(true);
+  });
 });
 
 describe('patternScore', () => {
@@ -73,5 +83,17 @@ describe('findBestPattern', () => {
       ['/p/new', 2],
     ]);
     expect(findBestPattern(m.keys(), '/p/new')).toBe('/p/new');
+  });
+
+  it('score is primary across different depths', () => {
+    // '/a/b' (score 4, depth 2) beats '/a/:x/*' (score 3, depth 3).
+    expect(findBestPattern(['/a/b', '/a/:x/*'], '/a/b')).toBe('/a/b');
+  });
+
+  it('the catch-all outranks the root pattern at the root URL', () => {
+    // Inherited characterization: '/' and '/*' both score 0 for '/', and
+    // the catch-all's depth 1 beats root's depth 0. Pinned so a future
+    // matcher rewrite cannot flip it silently.
+    expect(findBestPattern(['/', '/*'], '/')).toBe('/*');
   });
 });

--- a/packages/server/src/page-action-resolvers.ts
+++ b/packages/server/src/page-action-resolvers.ts
@@ -101,8 +101,8 @@ export function makePageActionResolvers(
       moduleKey: string,
       actionName: string
     ): Promise<ActionEntry | undefined> {
-      const { extra } = await core.built();
-      return extra.get(moduleKey)?.get(actionName);
+      const { extra: byModuleKeyMap } = await core.built();
+      return byModuleKeyMap.get(moduleKey)?.get(actionName);
     },
   };
 }

--- a/packages/server/src/page-action-resolvers.ts
+++ b/packages/server/src/page-action-resolvers.ts
@@ -1,4 +1,5 @@
 import type { ServerRoute } from '@hono-preact/iso';
+import { makeRouteModuleResolvers } from './route-module-resolvers.js';
 
 type ActionFn = (ctx: unknown, payload: unknown) => Promise<unknown>;
 
@@ -44,42 +45,14 @@ function extractActions(
   return out;
 }
 
-function segmentsOf(p: string): string[] {
-  return p.split('/').filter((s) => s !== '');
-}
-
-function urlPathMatchesPattern(urlPath: string, pattern: string): boolean {
-  const ps = segmentsOf(pattern);
-  const us = segmentsOf(urlPath);
-  for (let i = 0; i < ps.length; i++) {
-    const p = ps[i];
-    if (p === '*') return true;
-    if (i >= us.length) return false;
-    if (p.startsWith(':')) continue;
-    if (p !== us[i]) return false;
-  }
-  return ps.length === us.length;
-}
-
-function patternScore(pattern: string): number {
-  let score = 0;
-  for (const seg of segmentsOf(pattern)) {
-    if (seg === '*') score += 0;
-    else if (seg.startsWith(':')) score += 1;
-    else score += 2;
-  }
-  return score;
-}
-
 /**
  * Build action resolvers keyed by route path and by module key. Each
  * ServerRoute contributes its own serverActions and its ancestors' serverActions
  * to the merged map for that path. Ancestor entries are written first so that
  * a page-level action shadows a same-named layout action when names collide.
  *
- * Lazy semantics: the first call triggers loading all server modules. The result
- * is cached for the process lifetime (unless dev=true, which rebuilds on every
- * call so edits take effect without restarting the server).
+ * Build lifecycle (thunk dedup, evict-on-failure caching, dev rebuild)
+ * and URL-path matching live in `makeRouteModuleResolvers`.
  *
  * NOTE: framework-private. Intended consumer is the generated server entry and
  * pageActionHandler.
@@ -94,93 +67,42 @@ export function makePageActionResolvers(
     actionName: string
   ) => Promise<ActionEntry | undefined>;
 } {
-  const dev = options.dev ?? false;
-
-  type Built = {
-    byPathMap: Map<string, Map<string, ActionEntry>>;
-    byModuleKeyMap: Map<string, Map<string, ActionEntry>>;
-  };
-  let buildPromise: Promise<Built> | null = null;
-
-  const build = async (): Promise<Built> => {
-    // Load each distinct server thunk once; a thunk may appear as `server`
-    // on one route and as an `ancestor` on its children.
-    const thunkCache = new Map<() => Promise<unknown>, Promise<ServerModule>>();
-    const load = (thunk: () => Promise<unknown>): Promise<ServerModule> => {
-      let p = thunkCache.get(thunk);
-      if (!p) {
-        p = thunk().then((m) => m as ServerModule);
-        thunkCache.set(thunk, p);
-      }
-      return p;
-    };
-
-    const byPathMap = new Map<string, Map<string, ActionEntry>>();
-    const byModuleKeyMap = new Map<string, Map<string, ActionEntry>>();
-
-    await Promise.all(
-      serverRoutes.map(async (route) => {
-        const ancestorMods = await Promise.all(route.ancestors.map(load));
-        const selfMod = await load(route.server);
-
-        const merged = new Map<string, ActionEntry>();
-        // Write ancestors first (outer -> inner), then self. Later writes
-        // shadow earlier ones, so a page-level action wins over a layout
-        // action of the same name.
-        for (const mod of [...ancestorMods, selfMod]) {
-          for (const { name, entry } of extractActions(mod)) {
-            merged.set(name, entry);
-            let m = byModuleKeyMap.get(entry.moduleKey);
-            if (!m) {
-              m = new Map();
-              byModuleKeyMap.set(entry.moduleKey, m);
-            }
-            m.set(name, entry);
+  const core = makeRouteModuleResolvers<
+    ServerModule,
+    Map<string, ActionEntry>,
+    Map<string, Map<string, ActionEntry>>
+  >(serverRoutes, options, {
+    createExtra: () => new Map<string, Map<string, ActionEntry>>(),
+    compose: (_route, ancestorMods, selfMod, byModuleKeyMap) => {
+      const merged = new Map<string, ActionEntry>();
+      // Write ancestors first (outer -> inner), then self. Later writes
+      // shadow earlier ones, so a page-level action wins over a layout
+      // action of the same name.
+      for (const mod of [...ancestorMods, selfMod]) {
+        for (const { name, entry } of extractActions(mod)) {
+          merged.set(name, entry);
+          let m = byModuleKeyMap.get(entry.moduleKey);
+          if (!m) {
+            m = new Map();
+            byModuleKeyMap.set(entry.moduleKey, m);
           }
+          m.set(name, entry);
         }
-        byPathMap.set(route.path, merged);
-      })
-    );
-
-    return { byPathMap, byModuleKeyMap };
-  };
-
-  const get = (): Promise<Built> => {
-    if (dev) return build();
-    if (buildPromise) return buildPromise;
-    buildPromise = build().catch((err) => {
-      buildPromise = null;
-      return Promise.reject(err);
-    });
-    return buildPromise;
-  };
+      }
+      return merged;
+    },
+  });
 
   return {
     async byPath(path: string): Promise<Map<string, ActionEntry>> {
-      const { byPathMap } = await get();
-      let bestPattern: string | null = null;
-      let bestScore = -1;
-      let bestDepth = -1;
-      for (const pattern of byPathMap.keys()) {
-        if (!urlPathMatchesPattern(path, pattern)) continue;
-        const score = patternScore(pattern);
-        const depth = segmentsOf(pattern).length;
-        if (score > bestScore || (score === bestScore && depth > bestDepth)) {
-          bestPattern = pattern;
-          bestScore = score;
-          bestDepth = depth;
-        }
-      }
-      return bestPattern
-        ? (byPathMap.get(bestPattern) ?? new Map())
-        : new Map();
+      return (await core.byPath(path)) ?? new Map<string, ActionEntry>();
     },
     async byModuleKey(
       moduleKey: string,
       actionName: string
     ): Promise<ActionEntry | undefined> {
-      const { byModuleKeyMap } = await get();
-      return byModuleKeyMap.get(moduleKey)?.get(actionName);
+      const { extra } = await core.built();
+      return extra.get(moduleKey)?.get(actionName);
     },
   };
 }

--- a/packages/server/src/route-module-resolvers.ts
+++ b/packages/server/src/route-module-resolvers.ts
@@ -1,0 +1,106 @@
+import type { ServerRoute } from '@hono-preact/iso';
+import { findBestPattern } from './route-pattern.js';
+
+/**
+ * Shared core of the page-layer resolver factories (`makePageUseResolvers`
+ * and `makePageActionResolvers`). Owns the lazy build lifecycle and the
+ * URL-path lookup:
+ *
+ * - Loads every distinct server thunk exactly once per build. A given
+ *   thunk may appear as `server` on one ServerRoute and as an `ancestor`
+ *   on descendants; calling it just once keeps module-init side effects
+ *   (e.g. logging, registry insertion) idempotent.
+ * - Caches the built result for the process lifetime. A failed build is
+ *   not cached (the next call retries), so a transient import error does
+ *   not permanently poison the resolver. When `dev` is true the cache is
+ *   bypassed on every call so editing a `.server.*` file takes effect
+ *   without restarting the server.
+ * - `byPath` resolves a concrete URL path (params substituted) to the
+ *   most specific matching route pattern (see `findBestPattern`) and
+ *   returns that route's composed value, or undefined when no pattern
+ *   matches.
+ *
+ * The strategy owns everything route-shape-specific: how to compose one
+ * route's value from its ancestor modules plus its own module (ancestors
+ * arrive outermost-first, matching the middleware dispatcher's
+ * outer -> inner contract), and any side index it accumulates during the
+ * build (`extra`, e.g. a moduleKey reverse map).
+ */
+export function makeRouteModuleResolvers<TMod, TComposed, TExtra>(
+  serverRoutes: ReadonlyArray<ServerRoute>,
+  options: { dev?: boolean },
+  strategy: {
+    createExtra: () => TExtra;
+    compose: (
+      route: ServerRoute,
+      ancestorMods: ReadonlyArray<TMod>,
+      selfMod: TMod,
+      extra: TExtra
+    ) => TComposed;
+  }
+): {
+  byPath: (path: string) => Promise<TComposed | undefined>;
+  built: () => Promise<{ byPathMap: Map<string, TComposed>; extra: TExtra }>;
+} {
+  const dev = options.dev ?? false;
+
+  type Built = { byPathMap: Map<string, TComposed>; extra: TExtra };
+  let buildPromise: Promise<Built> | null = null;
+
+  const build = async (): Promise<Built> => {
+    const thunkCache = new Map<() => Promise<unknown>, Promise<TMod>>();
+    const load = (thunk: () => Promise<unknown>): Promise<TMod> => {
+      let p = thunkCache.get(thunk);
+      if (!p) {
+        // Structural read of a user-defined module's exports (a sanctioned
+        // cast boundary); the strategy narrows the fields it actually reads.
+        p = thunk().then((mod) => mod as TMod);
+        thunkCache.set(thunk, p);
+      }
+      return p;
+    };
+
+    const byPathMap = new Map<string, TComposed>();
+    const extra = strategy.createExtra();
+
+    await Promise.all(
+      serverRoutes.map(async (route) => {
+        const ancestorMods = await Promise.all(route.ancestors.map(load));
+        const selfMod = await load(route.server);
+        // Two ServerRoutes sharing the same path mean two `.server.*` files
+        // claim the same route, a route-table error. The route validator is
+        // the right place to surface that; here last write wins, matching
+        // the pre-consolidation factories.
+        byPathMap.set(
+          route.path,
+          strategy.compose(route, ancestorMods, selfMod, extra)
+        );
+      })
+    );
+
+    return { byPathMap, extra };
+  };
+
+  const built = (): Promise<Built> => {
+    if (dev) {
+      // In dev, always rebuild so edits to any `.server.*` file take
+      // effect on the next request without restarting the process.
+      return build();
+    }
+    if (buildPromise) return buildPromise;
+    buildPromise = build().catch((err) => {
+      buildPromise = null;
+      return Promise.reject(err);
+    });
+    return buildPromise;
+  };
+
+  return {
+    built,
+    async byPath(path: string) {
+      const { byPathMap } = await built();
+      const pattern = findBestPattern(byPathMap.keys(), path);
+      return pattern === null ? undefined : byPathMap.get(pattern);
+    },
+  };
+}

--- a/packages/server/src/route-module-resolvers.ts
+++ b/packages/server/src/route-module-resolvers.ts
@@ -28,7 +28,7 @@ import { findBestPattern } from './route-pattern.js';
  */
 export function makeRouteModuleResolvers<TMod, TComposed, TExtra>(
   serverRoutes: ReadonlyArray<ServerRoute>,
-  options: { dev?: boolean },
+  options: { dev?: boolean } = {},
   strategy: {
     createExtra: () => TExtra;
     compose: (
@@ -90,7 +90,7 @@ export function makeRouteModuleResolvers<TMod, TComposed, TExtra>(
     if (buildPromise) return buildPromise;
     buildPromise = build().catch((err) => {
       buildPromise = null;
-      return Promise.reject(err);
+      throw err;
     });
     return buildPromise;
   };

--- a/packages/server/src/route-pattern.ts
+++ b/packages/server/src/route-pattern.ts
@@ -6,7 +6,7 @@ function segmentsOf(path: string): string[] {
  * True when `urlPath` (the concrete URL the user navigated to, with all
  * params substituted) matches `pattern` exactly: same segment count, and
  * each pattern segment either equals the URL segment, is a `:param`, or is
- * a trailing `*`.
+ * a `*` (which matches the entire remainder; pattern segments after it are ignored).
  *
  * Used at lookup time. Callers resolve the URL to the most specific
  * pattern in their map via `findBestPattern`.
@@ -28,12 +28,12 @@ export function urlPathMatchesPattern(
 }
 
 /**
- * Score a route pattern for tiebreaker purposes when multiple patterns at
- * the same segment depth match the URL. Mirrors preact-iso's runtime
+ * Score a route pattern's specificity; findBestPattern uses this as the primary
+ * ranking when multiple patterns match the URL. Mirrors preact-iso's runtime
  * preference for literal segments: literal=2, param=1, wildcard=0. Within
  * the same score, `findBestPattern` falls back to depth, and within the
- * same depth, to iteration order. Pre-merged literal wins over
- * `/admin/users/:id` when the URL is `/admin/users/me`.
+ * same depth, to iteration order. A literal pattern such as /admin/users/me
+ * wins over `/admin/users/:id` when the URL is `/admin/users/me`.
  */
 export function patternScore(pattern: string): number {
   let score = 0;

--- a/packages/server/src/route-pattern.ts
+++ b/packages/server/src/route-pattern.ts
@@ -1,0 +1,75 @@
+function segmentsOf(path: string): string[] {
+  return path.split('/').filter((s) => s !== '');
+}
+
+/**
+ * True when `urlPath` (the concrete URL the user navigated to, with all
+ * params substituted) matches `pattern` exactly: same segment count, and
+ * each pattern segment either equals the URL segment, is a `:param`, or is
+ * a trailing `*`.
+ *
+ * Used at lookup time. Callers resolve the URL to the most specific
+ * pattern in their map via `findBestPattern`.
+ */
+export function urlPathMatchesPattern(
+  urlPath: string,
+  pattern: string
+): boolean {
+  const ps = segmentsOf(pattern);
+  const us = segmentsOf(urlPath);
+  for (let i = 0; i < ps.length; i++) {
+    const p = ps[i];
+    if (p === '*') return true;
+    if (i >= us.length) return false;
+    if (p.startsWith(':')) continue;
+    if (p !== us[i]) return false;
+  }
+  return ps.length === us.length;
+}
+
+/**
+ * Score a route pattern for tiebreaker purposes when multiple patterns at
+ * the same segment depth match the URL. Mirrors preact-iso's runtime
+ * preference for literal segments: literal=2, param=1, wildcard=0. Within
+ * the same score, `findBestPattern` falls back to depth, and within the
+ * same depth, to iteration order. Pre-merged literal wins over
+ * `/admin/users/:id` when the URL is `/admin/users/me`.
+ */
+export function patternScore(pattern: string): number {
+  let score = 0;
+  for (const seg of segmentsOf(pattern)) {
+    if (seg === '*') score += 0;
+    else if (seg.startsWith(':')) score += 1;
+    else score += 2;
+  }
+  return score;
+}
+
+/**
+ * Pick the best-matching pattern for a concrete URL path. Tiebreaker:
+ * (1) higher specificity score (literal=2, param=1, wildcard=0);
+ * (2) within the same score, more segments; (3) within the same depth,
+ * first in iteration order. Returns null when nothing matches.
+ *
+ * NOTE: O(patterns) linear scan. Fine for small apps; a precomputed trie
+ * or a request-keyed memo would help at scale.
+ */
+export function findBestPattern(
+  patterns: Iterable<string>,
+  urlPath: string
+): string | null {
+  let bestPattern: string | null = null;
+  let bestScore = -1;
+  let bestDepth = -1;
+  for (const pattern of patterns) {
+    if (!urlPathMatchesPattern(urlPath, pattern)) continue;
+    const score = patternScore(pattern);
+    const depth = segmentsOf(pattern).length;
+    if (score > bestScore || (score === bestScore && depth > bestDepth)) {
+      bestPattern = pattern;
+      bestScore = score;
+      bestDepth = depth;
+    }
+  }
+  return bestPattern;
+}

--- a/packages/server/src/route-server-modules.ts
+++ b/packages/server/src/route-server-modules.ts
@@ -98,8 +98,8 @@ export function makePageUseResolvers(
       return (await core.byPath(path)) ?? [];
     },
     async byModuleKey(key: string) {
-      const { byPathMap, extra } = await core.built();
-      const pattern = extra.get(key);
+      const { byPathMap, extra: patternByModuleKey } = await core.built();
+      const pattern = patternByModuleKey.get(key);
       return pattern ? (byPathMap.get(pattern) ?? []) : [];
     },
   };

--- a/packages/server/src/route-server-modules.ts
+++ b/packages/server/src/route-server-modules.ts
@@ -43,7 +43,7 @@ function pageUseFromMod(
  * pageActionHandler. The loader handler matches by the location's URL path;
  * the action handler matches by the action's owning module key. Both
  * lookups share one underlying composed map populated by loading every
- * routed `.server.*` module exactly once (then caching the result).
+ * routed `.server.*` module exactly once.
  *
  * Ancestor composition: each ServerRoute carries an explicit list of
  * ancestor server thunks captured during the route-tree walk. The

--- a/packages/server/src/route-server-modules.ts
+++ b/packages/server/src/route-server-modules.ts
@@ -1,4 +1,5 @@
 import type { RoutesManifest, ServerRoute } from '@hono-preact/iso';
+import { makeRouteModuleResolvers } from './route-module-resolvers.js';
 
 /**
  * Convert a RoutesManifest into the array of lazy server-module loaders
@@ -19,50 +20,6 @@ type PageUseModule = {
   __moduleKey?: unknown;
   pageUse?: unknown;
 };
-
-function segmentsOf(path: string): string[] {
-  return path.split('/').filter((s) => s !== '');
-}
-
-/**
- * True when `urlPath` (the concrete URL the user navigated to, with all
- * params substituted) matches `pattern` exactly: same segment count, and
- * each pattern segment either equals the URL segment, is a `:param`, or is
- * a trailing `*`.
- *
- * Used at lookup time. `byPath` resolves the URL to the most specific
- * pattern in the map and returns its already-composed pageUse.
- */
-function urlPathMatchesPattern(urlPath: string, pattern: string): boolean {
-  const ps = segmentsOf(pattern);
-  const us = segmentsOf(urlPath);
-  for (let i = 0; i < ps.length; i++) {
-    const p = ps[i];
-    if (p === '*') return true;
-    if (i >= us.length) return false;
-    if (p.startsWith(':')) continue;
-    if (p !== us[i]) return false;
-  }
-  return ps.length === us.length;
-}
-
-/**
- * Score a route pattern for tiebreaker purposes when multiple patterns at
- * the same segment depth match the URL. Mirrors preact-iso's runtime
- * preference for literal segments: literal=2, param=1, wildcard=0. Within
- * the same score, the caller falls back to depth, and within the same
- * depth, to the loaded order in `serverRoutes`. Pre-merged literal wins
- * over `/admin/users/:id` when the URL is `/admin/users/me`.
- */
-function patternScore(pattern: string): number {
-  let score = 0;
-  for (const seg of segmentsOf(pattern)) {
-    if (seg === '*') score += 0;
-    else if (seg.startsWith(':')) score += 1;
-    else score += 2;
-  }
-  return score;
-}
 
 function pageUseFromMod(
   mod: PageUseModule,
@@ -104,14 +61,8 @@ function pageUseFromMod(
  * the former. URL-prefix matching incorrectly conflates them and runs the
  * shared gate twice on every nested request.
  *
- * Lazy semantics: the first call to either resolver triggers the build of
- * all server modules listed in `serverRoutes`. Subsequent calls return
- * from the cached map. A failed build is not cached -- the next call
- * retries -- so a transient import error doesn't permanently poison the
- * resolver. Modules that don't export `pageUse` (the common case today)
- * contribute nothing to the composed arrays. When `dev` is true the cache
- * is bypassed on every call so editing a `.server.*` file's `pageUse`
- * takes effect without restarting the server.
+ * Build lifecycle (thunk dedup, evict-on-failure caching, dev rebuild)
+ * and URL-path matching live in `makeRouteModuleResolvers`.
  *
  * NOTE: framework-private. The only intended consumer outside tests is
  * the generated server entry. Reach for it at your own risk.
@@ -123,109 +74,33 @@ export function makePageUseResolvers(
   byPath: (path: string) => Promise<ReadonlyArray<unknown>>;
   byModuleKey: (key: string) => Promise<ReadonlyArray<unknown>>;
 } {
-  const dev = options.dev ?? false;
-
-  type Built = {
-    composedByPath: Map<string, ReadonlyArray<unknown>>;
-    patternByModuleKey: Map<string, string>;
-  };
-  let buildPromise: Promise<Built> | null = null;
-
-  const build = async (): Promise<Built> => {
-    // Load every distinct server thunk exactly once. A given thunk may
-    // appear as `server` on one ServerRoute and as an `ancestor` on
-    // descendants; calling it just once keeps module-init side effects
-    // (e.g. logging, registry insertion) idempotent.
-    const thunkCache = new Map<
-      () => Promise<unknown>,
-      Promise<PageUseModule>
-    >();
-    const load = (thunk: () => Promise<unknown>): Promise<PageUseModule> => {
-      let p = thunkCache.get(thunk);
-      if (!p) {
-        p = thunk().then((mod) => mod as PageUseModule);
-        thunkCache.set(thunk, p);
+  const core = makeRouteModuleResolvers<
+    PageUseModule,
+    ReadonlyArray<unknown>,
+    Map<string, string>
+  >(serverRoutes, options, {
+    createExtra: () => new Map<string, string>(),
+    compose: (route, ancestorMods, selfMod, patternByModuleKey) => {
+      const composed: unknown[] = [];
+      for (const mod of ancestorMods) {
+        composed.push(...pageUseFromMod(mod, route.path));
       }
-      return p;
-    };
-
-    const composedByPath = new Map<string, ReadonlyArray<unknown>>();
-    const patternByModuleKey = new Map<string, string>();
-
-    await Promise.all(
-      serverRoutes.map(async (route) => {
-        const ancestorMods = await Promise.all(
-          route.ancestors.map((t) => load(t))
-        );
-        const selfMod = await load(route.server);
-
-        const composed: unknown[] = [];
-        for (let i = 0; i < ancestorMods.length; i++) {
-          composed.push(...pageUseFromMod(ancestorMods[i], route.path));
-        }
-        composed.push(...pageUseFromMod(selfMod, route.path));
-
-        // Two ServerRoutes sharing the same path mean two `.server.*` files
-        // claim the same route -- a route-table error. The route validator
-        // is the right place to surface that; here we simply preserve the
-        // load order (last write wins for the composed map, which matches
-        // the previous behavior of `composedByPath.set(path, ...)`).
-        composedByPath.set(route.path, composed);
-
-        if (typeof selfMod.__moduleKey === 'string') {
-          patternByModuleKey.set(selfMod.__moduleKey, route.path);
-        }
-      })
-    );
-
-    return { composedByPath, patternByModuleKey };
-  };
-
-  const get = () => {
-    if (dev) {
-      // In dev, always rebuild so edits to `pageUse` in any .server.* file
-      // take effect on the next request without restarting the process.
-      return build();
-    }
-    if (buildPromise) return buildPromise;
-    buildPromise = build().catch((err) => {
-      buildPromise = null;
-      return Promise.reject(err);
-    });
-    return buildPromise;
-  };
+      composed.push(...pageUseFromMod(selfMod, route.path));
+      if (typeof selfMod.__moduleKey === 'string') {
+        patternByModuleKey.set(selfMod.__moduleKey, route.path);
+      }
+      return composed;
+    },
+  });
 
   return {
     async byPath(path: string) {
-      const { composedByPath } = await get();
-      // The handler receives the matched route's URL path (params
-      // substituted to literal values). Walk the composed map and pick the
-      // best-matching pattern. Tiebreaker: (1) higher specificity score
-      // (literal=2, param=1, wildcard=0); (2) within same score, longer
-      // path; (3) within same length, first inserted. Mirrors preact-iso's
-      // runtime preference for literal matches over parameterized siblings.
-      //
-      // NOTE: O(routes) linear scan. Fine for small apps; a precomputed
-      // trie or a request-keyed memo would help at scale.
-      let bestPattern: string | null = null;
-      let bestScore = -1;
-      let bestDepth = -1;
-      for (const pattern of composedByPath.keys()) {
-        if (!urlPathMatchesPattern(path, pattern)) continue;
-        const score = patternScore(pattern);
-        const depth = segmentsOf(pattern).length;
-        if (score > bestScore || (score === bestScore && depth > bestDepth)) {
-          bestPattern = pattern;
-          bestScore = score;
-          bestDepth = depth;
-        }
-      }
-      return bestPattern ? (composedByPath.get(bestPattern) ?? []) : [];
+      return (await core.byPath(path)) ?? [];
     },
     async byModuleKey(key: string) {
-      const { composedByPath, patternByModuleKey } = await get();
-      const pattern = patternByModuleKey.get(key);
-      return pattern ? (composedByPath.get(pattern) ?? []) : [];
+      const { byPathMap, extra } = await core.built();
+      const pattern = extra.get(key);
+      return pattern ? (byPathMap.get(pattern) ?? []) : [];
     },
   };
 }


### PR DESCRIPTION
PR 2 of 3 for Section A of the primitives DX review (spec: docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md, on local main).

## What

- **One route matcher.** The byte-identical `segmentsOf`/`urlPathMatchesPattern`/`patternScore` copies in `route-server-modules.ts` and `page-action-resolvers.ts` collapse into `route-pattern.ts`, plus `findBestPattern` encapsulating the scan-and-score loop both factories inlined. New direct tests pin the tiebreak ladder (score, then depth, then first-iterated) and the inherited edge quirks (mid-pattern `*`, catch-all-beats-root at `/`).
- **One resolver core.** `makeRouteModuleResolvers<TMod, TComposed, TExtra>` owns the per-build thunk cache, evict-on-failure build caching, dev rebuild gate, `Promise.all` ancestor walk, and `byPath` lookup. `makePageUseResolvers` and `makePageActionResolvers` are now ~100-line strategy wrappers holding only domain logic (pageUse concat + own-module key index vs action Map merge + per-entry key index), with their exact previous public signatures. New core tests cover thunk dedup, dev rebuild, failed-build retry, and concurrent first calls sharing one in-flight build, all previously tested only indirectly.

## Behavior

Zero intended change; all 143 pre-existing server tests pass unmodified, and the generated server entry's call sites are textually unaffected. One unreachable-in-practice delta found in review and accepted: a route with the empty-string path `''` (never emitted by the route table, which always produces `/`-prefixed paths) would now resolve via `byPath` instead of being dropped by the old truthiness check.

## Not in scope

No public-surface changes (the resolver factories stay on the public entry until Section B). PR 3 (shared cross-package constants module) follows.

## Verification

All six local CI-mirror steps pass: framework build, format:check, typecheck, test:coverage (1222 unit tests), test:integration, site build. Net -22 lines with the duplication single-sourced and directly unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)