### PR TITLE
Section B (PR B1): move server resolver factories to /internal/runtime

### DIFF
--- a/apps/example-node/vite.config.ts
+++ b/apps/example-node/vite.config.ts
@@ -10,12 +10,14 @@ export default defineConfig({
   resolve: {
     alias: [
       { find: 'hono-preact/internal', replacement: resolve(__dirname, '../../packages/hono-preact/src/internal.ts') },
+      { find: 'hono-preact/server/internal/runtime', replacement: resolve(__dirname, '../../packages/hono-preact/src/server-internal-runtime.ts') },
       { find: 'hono-preact/server', replacement: resolve(__dirname, '../../packages/hono-preact/src/server.ts') },
       { find: 'hono-preact/vite', replacement: resolve(__dirname, '../../packages/hono-preact/src/vite.ts') },
       { find: 'hono-preact/adapter-node', replacement: resolve(__dirname, '../../packages/hono-preact/src/adapter-node.ts') },
       { find: 'hono-preact', replacement: resolve(__dirname, '../../packages/hono-preact/src/index.ts') },
       { find: '@hono-preact/iso/internal', replacement: resolve(__dirname, '../../packages/iso/src/internal.ts') },
       { find: '@hono-preact/iso', replacement: resolve(__dirname, '../../packages/iso/src/index.ts') },
+      { find: '@hono-preact/server/internal/runtime', replacement: resolve(__dirname, '../../packages/server/src/internal-runtime.ts') },
       { find: '@hono-preact/server', replacement: resolve(__dirname, '../../packages/server/src/index.ts') },
     ],
   },

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -57,6 +57,10 @@ export default defineConfig((env) => ({
         replacement: resolve(__dirname, '../../packages/hono-preact/src/internal.ts'),
       },
       {
+        find: 'hono-preact/server/internal/runtime',
+        replacement: resolve(__dirname, '../../packages/hono-preact/src/server-internal-runtime.ts'),
+      },
+      {
         find: 'hono-preact/server',
         replacement: resolve(__dirname, '../../packages/hono-preact/src/server.ts'),
       },
@@ -81,6 +85,10 @@ export default defineConfig((env) => ({
       {
         find: '@hono-preact/iso',
         replacement: resolve(__dirname, '../../packages/iso/src/index.ts'),
+      },
+      {
+        find: '@hono-preact/server/internal/runtime',
+        replacement: resolve(__dirname, '../../packages/server/src/internal-runtime.ts'),
       },
       {
         find: '@hono-preact/server',

--- a/docs/superpowers/plans/2026-06-10-outcome-semantics-consolidation.md
+++ b/docs/superpowers/plans/2026-06-10-outcome-semantics-consolidation.md
@@ -1,0 +1,793 @@
+# Outcome Semantics Consolidation (PR 1 of Section A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One implementation of the `__outcome` wire format on the client (shared decoder for `Form` and `useAction`) and one server module for outcome-to-response translation, replacing four pasted translators and two divergent client parsers.
+
+**Architecture:** The decoder joins the encoder in `packages/iso/src/internal/action-envelope.ts`, returning a `DecodedEnvelope` discriminated union; `Form` and `useAction` become policy switches over it. On the server, `translateRootOutcome` and `translateOutcomeForLoader` move into a new `packages/server/src/outcome-translation.ts` alongside a shared `applyOutcomeHeaders` helper; the "render outcome is page-scope only" defense message becomes one exported constant in iso internal.
+
+**Tech Stack:** TypeScript, Preact, Hono, vitest (happy-dom for component tests). Test command: `pnpm exec vitest run <file>` from the package directory.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md`
+
+**Branch:** `feat/outcome-semantics-consolidation` (PR 1 of 3; PRs 2 and 3 get their own plans after this merges).
+
+**Behavior changes (deliberate, from the spec):**
+1. `Form` handles a `timeout` envelope as a real timeout error result (`Request timed out after <n>ms`) instead of the `Unexpected outcome: timeout` fallthrough.
+2. Truthy-primitive JSON bodies (e.g. `5`, `"x"`) now count as malformed in both consumers (Form reloads, useAction throws the malformed error). Today Form reloads only on falsy bodies and both treat truthy primitives as unknown outcomes. Pathological inputs; unified under "non-object body = malformed".
+
+Everything else, including all server status codes, response shapes, and error message strings, is behavior-preserving.
+
+**Two spec notes discovered during planning:**
+- The spec's "cross-origin redirect detection moves in as a shared helper" is already true: both consumers call `assignSafeRedirect` from `packages/iso/src/internal/safe-redirect.ts`. No work needed; the consumers keep calling it.
+- The spec's `rejectRenderOutcome()` helper lands as the `RENDER_PAGE_SCOPE_MESSAGE` constant instead: each channel's rejection response has a different shape (`c.text` vs `c.json` vs envelope body), so a shared function would need channel parameters for no gain. The constant is the single copy of the defense.
+
+---
+
+### Task 1: Envelope decoder in iso internal
+
+**Files:**
+- Modify: `packages/iso/src/internal/action-envelope.ts`
+- Modify: `packages/iso/src/internal.ts` (barrel: export the new message constant)
+- Test: `packages/iso/src/__tests__/action-envelope.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/iso/src/__tests__/action-envelope.test.ts` (it already imports `describe, expect, it` from vitest and tests `serializeActionOutcome`):
+
+```ts
+import {
+  decodeActionResponse,
+  RENDER_PAGE_SCOPE_MESSAGE,
+  serializeActionOutcome,
+} from '../internal/action-envelope.js';
+```
+
+(Merge with the file's existing import from the same module; keep one import statement.)
+
+```ts
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('decodeActionResponse', () => {
+  it('decodes success with its data', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'success', data: { id: 1 } })
+      )
+    ).toEqual({ kind: 'success', data: { id: 1 } });
+  });
+
+  it('decodes redirect with a string `to`', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'redirect', to: '/next', status: 302 })
+      )
+    ).toEqual({ kind: 'redirect', to: '/next' });
+  });
+
+  it('treats redirect without a string `to` as unknown', async () => {
+    expect(
+      await decodeActionResponse(jsonRes({ __outcome: 'redirect' }))
+    ).toEqual({ kind: 'unknown', outcome: 'redirect', message: undefined });
+  });
+
+  it('decodes deny, carrying status, message, and data', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes(
+          { __outcome: 'deny', status: 403, message: 'no', data: { x: 1 } },
+          403
+        )
+      )
+    ).toEqual({ kind: 'deny', status: 403, message: 'no', data: { x: 1 } });
+  });
+
+  it('falls back to the HTTP status and a derived message on a bare deny', async () => {
+    expect(
+      await decodeActionResponse(jsonRes({ __outcome: 'deny' }, 422))
+    ).toEqual({
+      kind: 'deny',
+      status: 422,
+      message: 'Request denied (422)',
+      data: undefined,
+    });
+  });
+
+  it('decodes error with a message fallback', async () => {
+    expect(await decodeActionResponse(jsonRes({ __outcome: 'error' }))).toEqual(
+      { kind: 'error', message: 'Action failed' }
+    );
+  });
+
+  it('decodes timeout with a numeric timeoutMs', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'timeout', timeoutMs: 5000 }, 504)
+      )
+    ).toEqual({ kind: 'timeout', timeoutMs: 5000 });
+  });
+
+  it('treats timeout without a numeric timeoutMs as unknown', async () => {
+    expect(
+      await decodeActionResponse(jsonRes({ __outcome: 'timeout' }, 504))
+    ).toEqual({ kind: 'unknown', outcome: 'timeout', message: undefined });
+  });
+
+  it('returns unknown for an unrecognized outcome, carrying the env message', async () => {
+    expect(
+      await decodeActionResponse(
+        jsonRes({ __outcome: 'whatever', message: 'm' })
+      )
+    ).toEqual({ kind: 'unknown', outcome: 'whatever', message: 'm' });
+  });
+
+  it('returns unknown for an envelope object without __outcome', async () => {
+    expect(await decodeActionResponse(jsonRes({}))).toEqual({
+      kind: 'unknown',
+      outcome: undefined,
+      message: undefined,
+    });
+  });
+
+  it('returns malformed for a non-JSON body, carrying the HTTP status', async () => {
+    const res = new Response('<!doctype html><p>oops</p>', { status: 200 });
+    expect(await decodeActionResponse(res)).toEqual({
+      kind: 'malformed',
+      httpStatus: 200,
+    });
+  });
+
+  it('returns malformed for a JSON null body', async () => {
+    expect(await decodeActionResponse(jsonRes(null, 500))).toEqual({
+      kind: 'malformed',
+      httpStatus: 500,
+    });
+  });
+
+  it('returns malformed for a primitive JSON body', async () => {
+    expect(await decodeActionResponse(jsonRes(5))).toEqual({
+      kind: 'malformed',
+      httpStatus: 200,
+    });
+  });
+});
+
+describe('RENDER_PAGE_SCOPE_MESSAGE', () => {
+  it('is the message serializeActionOutcome emits for a render outcome', () => {
+    const env = serializeActionOutcome({
+      kind: 'outcome',
+      outcome: {
+        __outcome: 'render',
+        Component: () => null,
+      },
+    });
+    expect(env.body).toEqual({
+      __outcome: 'error',
+      message: RENDER_PAGE_SCOPE_MESSAGE,
+    });
+    expect(env.status).toBe(500);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from `packages/iso`: `pnpm exec vitest run src/__tests__/action-envelope.test.ts`
+Expected: FAIL with `decodeActionResponse` / `RENDER_PAGE_SCOPE_MESSAGE` not exported.
+
+- [ ] **Step 3: Implement the decoder**
+
+In `packages/iso/src/internal/action-envelope.ts`, add after the existing type declarations:
+
+```ts
+/**
+ * The defense-in-depth message for `render` outcomes reaching a channel
+ * that cannot host them (actions, loaders, root middleware). One copy;
+ * the server translators import it from `@hono-preact/iso/internal`.
+ */
+export const RENDER_PAGE_SCOPE_MESSAGE = 'render outcome is page-scope only';
+
+/**
+ * The decoded client-side view of an action response. `unknown` is an
+ * envelope object with an unrecognized `__outcome` (consumers surface it
+ * as an error); `malformed` is a body that is not an envelope object at
+ * all (consumers own the policy: <Form> reloads as a PE fallback,
+ * useAction throws).
+ */
+export type DecodedEnvelope =
+  | { kind: 'success'; data: unknown }
+  | { kind: 'redirect'; to: string }
+  | { kind: 'deny'; status: number; message: string; data?: unknown }
+  | { kind: 'error'; message: string }
+  | { kind: 'timeout'; timeoutMs: number }
+  | {
+      kind: 'unknown';
+      outcome: string | undefined;
+      message: string | undefined;
+    }
+  | { kind: 'malformed'; httpStatus: number };
+
+export async function decodeActionResponse(
+  res: Response
+): Promise<DecodedEnvelope> {
+  let raw: unknown;
+  try {
+    raw = await res.json();
+  } catch {
+    return { kind: 'malformed', httpStatus: res.status };
+  }
+  if (raw === null || typeof raw !== 'object') {
+    return { kind: 'malformed', httpStatus: res.status };
+  }
+  // Parsing untrusted JSON is the sanctioned cast boundary; this is the one
+  // place the wire shape is asserted, so the consumers never cast.
+  const env = raw as {
+    __outcome?: unknown;
+    data?: unknown;
+    to?: unknown;
+    status?: unknown;
+    message?: unknown;
+    timeoutMs?: unknown;
+  };
+  switch (env.__outcome) {
+    case 'success':
+      return { kind: 'success', data: env.data };
+    case 'redirect':
+      if (typeof env.to === 'string') return { kind: 'redirect', to: env.to };
+      break;
+    case 'deny': {
+      const status = typeof env.status === 'number' ? env.status : res.status;
+      return {
+        kind: 'deny',
+        status,
+        message:
+          typeof env.message === 'string'
+            ? env.message
+            : `Request denied (${status})`,
+        data: env.data,
+      };
+    }
+    case 'error':
+      return {
+        kind: 'error',
+        message:
+          typeof env.message === 'string' ? env.message : 'Action failed',
+      };
+    case 'timeout':
+      if (typeof env.timeoutMs === 'number') {
+        return { kind: 'timeout', timeoutMs: env.timeoutMs };
+      }
+      break;
+  }
+  return {
+    kind: 'unknown',
+    outcome: typeof env.__outcome === 'string' ? env.__outcome : undefined,
+    message: typeof env.message === 'string' ? env.message : undefined,
+  };
+}
+```
+
+In the same file, replace the render-branch literal in `serializeActionOutcome`:
+
+```ts
+  // 'render' outcome is page-scope only; should never reach an action.
+  return {
+    body: { __outcome: 'error', message: RENDER_PAGE_SCOPE_MESSAGE },
+    status: 500,
+    headers: undefined,
+  };
+```
+
+In `packages/iso/src/internal.ts`, extend the existing export block from `./internal/action-envelope.js`:
+
+```ts
+export {
+  serializeActionOutcome,
+  decodeActionResponse,
+  RENDER_PAGE_SCOPE_MESSAGE,
+  type ActionEnvelope,
+  type ActionResolution,
+  type SerializedEnvelope,
+  type DecodedEnvelope,
+} from './internal/action-envelope.js';
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run from `packages/iso`: `pnpm exec vitest run src/__tests__/action-envelope.test.ts`
+Expected: PASS (all serialize + decode cases).
+
+Also run `pnpm exec vitest run src/__tests__/internal.test.ts` (the barrel-surface test); if it asserts an exact export list, add the three new names there.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/internal/action-envelope.ts packages/iso/src/internal.ts packages/iso/src/__tests__/action-envelope.test.ts packages/iso/src/__tests__/internal.test.ts
+git commit -m "feat(iso): add decodeActionResponse, the single envelope decoder
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Drop `internal.test.ts` from the add list if it needed no change.)
+
+---
+
+### Task 2: Form onto the decoder, with real timeout handling
+
+**Files:**
+- Modify: `packages/iso/src/form.tsx:68-173` (the `handleSubmit` callback)
+- Test: `packages/iso/src/__tests__/form.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the `describe('<Form>', ...)` block of `packages/iso/src/__tests__/form.test.tsx`:
+
+```ts
+  it('writes a timeout error result instead of an unknown-outcome error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ __outcome: 'timeout', timeoutMs: 5000 }), {
+        status: 504,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const stub = makeStub();
+    const { container } = render(
+      <Form action={stub}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    fireEvent.submit(container.querySelector('form')!);
+    await new Promise((r) => setTimeout(r, 0));
+    const stored = getLastActionResult({
+      __module: stub.__module,
+      __action: stub.__action,
+    });
+    expect(stored?.kind).toBe('error');
+    if (stored?.kind === 'error') {
+      expect(stored.message).toBe('Request timed out after 5000ms');
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('reloads the page on a malformed (non-envelope) body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<!doctype html><p>not an envelope</p>', { status: 200 })
+    );
+    const reloadSpy = vi
+      .spyOn(window.location, 'reload')
+      .mockImplementation(() => {});
+    const stub = makeStub();
+    const { container } = render(
+      <Form action={stub}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    fireEvent.submit(container.querySelector('form')!);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(
+      getLastActionResult({ __module: stub.__module, __action: stub.__action })
+    ).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+```
+
+Note: if happy-dom rejects spying on `window.location.reload` (non-configurable), replace the spy with `Object.defineProperty(window.location, 'reload', { value: vi.fn(), configurable: true })` style stubbing and restore it in a `finally`. Check what `getLastActionResult` returns for a never-set key (`undefined` vs `null`) and match the assertion; the deny test in this file shows the read pattern.
+
+- [ ] **Step 2: Run the tests to verify the timeout one fails**
+
+Run from `packages/iso`: `pnpm exec vitest run src/__tests__/form.test.tsx`
+Expected: the timeout test FAILS (message is `Unexpected outcome: timeout` today); the malformed test should already PASS (it pins existing behavior so the rewrite can't drop it).
+
+- [ ] **Step 3: Rewire handleSubmit onto the decoder**
+
+In `packages/iso/src/form.tsx`, add the import:
+
+```ts
+import { decodeActionResponse } from './internal/action-envelope.js';
+```
+
+Replace the body of the `try` block in `handleSubmit` (currently lines 90-159: the `fetch` call, the `env` parse/cast, and the outcome if-chain) with:
+
+```ts
+        const res = await fetch(target, {
+          method: 'POST',
+          body: fd,
+          headers: { Accept: 'application/json' },
+        });
+        const decoded = await decodeActionResponse(res);
+        switch (decoded.kind) {
+          case 'malformed':
+            // PE fallback policy: a non-envelope body means the POST landed
+            // somewhere that didn't speak the action protocol; reload so the
+            // server-rendered state wins.
+            handle?.revert();
+            if (typeof window !== 'undefined') window.location.reload();
+            return;
+          case 'redirect': {
+            const navigated = assignSafeRedirect(decoded.to);
+            if (navigated) {
+              handle?.settle();
+              return;
+            }
+            // Cross-origin: revert optimistic, surface as error result so
+            // useActionResult sees it.
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message: `Refused cross-origin redirect to ${decoded.to}`,
+              submittedPayload: payload,
+            });
+            return;
+          }
+          case 'success':
+            handle?.settle();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'success',
+              data: decoded.data,
+              submittedPayload: payload,
+            });
+            return;
+          case 'deny':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'deny',
+              status: decoded.status,
+              message: decoded.message,
+              data: decoded.data,
+              submittedPayload: payload,
+            });
+            return;
+          case 'error':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message: decoded.message,
+              submittedPayload: payload,
+            });
+            return;
+          case 'timeout':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message: `Request timed out after ${decoded.timeoutMs}ms`,
+              submittedPayload: payload,
+            });
+            return;
+          case 'unknown':
+            handle?.revert();
+            setLastActionResult(moduleKey, actionName, {
+              kind: 'error',
+              message:
+                decoded.message ??
+                `Unexpected outcome: ${decoded.outcome ?? 'unknown'}`,
+              submittedPayload: payload,
+            });
+            return;
+        }
+```
+
+The `catch`/`finally` blocks and everything before the `fetch` stay unchanged. The deny/error message fallbacks (`Request denied (...)`, `Action failed`) now come from the decoder, so they do not reappear here.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run from `packages/iso`: `pnpm exec vitest run src/__tests__/form.test.tsx src/__tests__/use-action-result.test.tsx src/__tests__/use-form-status.test.tsx src/__tests__/optimistic-action.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/form.tsx packages/iso/src/__tests__/form.test.tsx
+git commit -m "feat(iso): Form decodes via decodeActionResponse, handles timeout
+
+Form now reports a timeout envelope as 'Request timed out after Nms'
+instead of the unknown-outcome fallthrough. Reload-on-malformed stays
+as the explicit PE fallback policy.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: useAction onto the decoder (behavior-preserving)
+
+**Files:**
+- Modify: `packages/iso/src/action.ts:405-478` (the non-streaming "uniform envelope path" in `mutate`)
+- Test: existing `packages/iso/src/__tests__/action.test.tsx` and `packages/iso/src/__tests__/use-action-timeout.test.ts` (no new tests; staying green is the check)
+
+- [ ] **Step 1: Rewire the envelope branch**
+
+In `packages/iso/src/action.ts`, add to the existing import from `./internal/action-envelope.js` if present, otherwise add:
+
+```ts
+import { decodeActionResponse } from './internal/action-envelope.js';
+```
+
+Replace the `else` branch (the comment `// Uniform envelope path...` through the closing `else { throw new Error(\`Unknown action outcome: ...\`) }`) with:
+
+```ts
+        } else {
+          // Uniform envelope path. All non-streaming responses carry a JSON
+          // body shaped as { __outcome, ... } regardless of HTTP status.
+          const decoded = await decodeActionResponse(response);
+          if (decoded.kind === 'malformed') {
+            throw new Error(`Malformed envelope (HTTP ${decoded.httpStatus})`);
+          }
+          if (decoded.kind === 'success') {
+            const data = decoded.data as TResult;
+            setData(data);
+            invokeSuccess(data);
+            finalResult = data;
+            recordOutcome(currentStub.__module, currentStub.__action, {
+              kind: 'success',
+              data,
+              submittedPayload: payload,
+            });
+            outcomeRecorded = true;
+          } else if (decoded.kind === 'redirect') {
+            if (assignSafeRedirect(decoded.to)) {
+              // Navigation issued; this promise never settles.
+              return await new Promise<MutateResult<TResult>>(() => {});
+            }
+            // Cross-origin: surface as an error so the caller can handle it.
+            throw new Error(`Refused cross-origin redirect to ${decoded.to}`);
+          } else if (decoded.kind === 'deny') {
+            recordOutcome(currentStub.__module, currentStub.__action, {
+              kind: 'deny',
+              status: decoded.status,
+              message: decoded.message,
+              data: decoded.data,
+              submittedPayload: payload,
+            });
+            outcomeRecorded = true;
+            throw new Error(decoded.message);
+          } else if (decoded.kind === 'timeout') {
+            recordOutcome(currentStub.__module, currentStub.__action, {
+              kind: 'error',
+              message: `Request timed out after ${decoded.timeoutMs}ms`,
+              submittedPayload: payload,
+            });
+            outcomeRecorded = true;
+            throw new TimeoutError(decoded.timeoutMs);
+          } else if (decoded.kind === 'error') {
+            recordOutcome(currentStub.__module, currentStub.__action, {
+              kind: 'error',
+              message: decoded.message,
+              submittedPayload: payload,
+            });
+            outcomeRecorded = true;
+            throw new Error(decoded.message);
+          } else {
+            throw new Error(`Unknown action outcome: ${decoded.outcome}`);
+          }
+        }
+```
+
+Note the pre-existing `data as TResult` cast stays: it is the documented `useData() as T`-class seam, out of scope here. The `env` type literal and its `as typeof env` cast are deleted; the decoder owns the JSON-boundary cast now. The streaming branch above this code is untouched.
+
+- [ ] **Step 2: Run the action test suites**
+
+Run from `packages/iso`: `pnpm exec vitest run src/__tests__/action.test.tsx src/__tests__/use-action-timeout.test.ts src/__tests__/optimistic-action.test.tsx src/__tests__/optimistic-action-transition.test.ts`
+Expected: PASS unchanged. If a test asserted `Unknown action outcome: undefined` for a primitive-body response, it now sees `Malformed envelope (HTTP ...)`; per the spec that unification is accepted, update the assertion.
+
+- [ ] **Step 3: Run the full iso suite**
+
+Run from `packages/iso`: `pnpm exec vitest run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/iso/src/action.ts
+git commit -m "refactor(iso): useAction decodes via decodeActionResponse
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Server outcome-translation module
+
+**Files:**
+- Create: `packages/server/src/outcome-translation.ts`
+- Modify: `packages/server/src/render.tsx:52-73` (delete local `translateRootOutcome`, import it)
+- Modify: `packages/server/src/loaders-handler.ts:146-184` (delete local `translateOutcomeForLoader`, import it)
+- Modify: `packages/server/src/page-action-handler.ts:318-338` (use `applyOutcomeHeaders` for the two header loops)
+- Test: existing server suites (`render.test.tsx`, `render-honocontext.test.tsx`, `loaders-handler*.test.ts`, `page-action-handler.test.ts`); staying green is the check
+
+- [ ] **Step 1: Rebuild iso dist**
+
+The server package resolves `@hono-preact/iso/internal` through `dist/`, and Task 1 added `RENDER_PAGE_SCOPE_MESSAGE` there. From the repo root:
+
+```bash
+pnpm --filter '@hono-preact/iso' build
+```
+
+- [ ] **Step 2: Create the module**
+
+`packages/server/src/outcome-translation.ts`:
+
+```ts
+import type { Context } from 'hono';
+import type { Outcome } from '@hono-preact/iso';
+import { RENDER_PAGE_SCOPE_MESSAGE } from '@hono-preact/iso/internal';
+
+/** Apply an outcome's optional headers to the HTTP response. */
+export function applyOutcomeHeaders(
+  c: Context,
+  headers: Record<string, string> | undefined
+): void {
+  if (!headers) return;
+  for (const [k, v] of Object.entries(headers)) c.header(k, v);
+}
+
+// Outcome translation for the root chain dispatched around prerender. The
+// root layer (appConfig.use) only legitimately produces `redirect` or
+// `deny`; a `render` outcome is page-scope and must not flow through here.
+// Defense-in-depth: surface programmer error as a 500 rather than crash.
+export function translateRootOutcome(c: Context, outcome: Outcome): Response {
+  if (outcome.__outcome === 'redirect') {
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.redirect(outcome.to, outcome.status);
+  }
+  if (outcome.__outcome === 'deny') {
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.text(outcome.message ?? 'Forbidden', outcome.status);
+  }
+  return c.text(
+    `${RENDER_PAGE_SCOPE_MESSAGE} and cannot be issued by root middleware`,
+    500
+  );
+}
+
+export function translateOutcomeForLoader(
+  c: Context,
+  outcome: Outcome
+): Response {
+  if (outcome.__outcome === 'redirect') {
+    // Headers from the outcome ride the HTTP response via `c.header()`. They
+    // are deliberately NOT embedded in the JSON envelope: the client only
+    // reads `to` and calls `window.location.assign(to)`; any embedded
+    // headers would be dead bytes the client never inspects.
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.json(
+      {
+        __outcome: 'redirect',
+        to: outcome.to,
+        status: outcome.status,
+      },
+      200
+    );
+  }
+  if (outcome.__outcome === 'deny') {
+    applyOutcomeHeaders(c, outcome.headers);
+    return c.json(
+      { __outcome: 'deny', message: outcome.message },
+      outcome.status
+    );
+  }
+  if (outcome.__outcome === 'timeout') {
+    return c.json({ __outcome: 'timeout', timeoutMs: outcome.timeoutMs }, 504);
+  }
+  // render outcome should never reach the loader RPC; this is defense in depth.
+  return c.json(
+    {
+      __outcome: 'error',
+      message: RENDER_PAGE_SCOPE_MESSAGE,
+    },
+    500
+  );
+}
+```
+
+Do NOT export any of this from the server package index; it is package-internal (the public/internal boundary work is Section B).
+
+- [ ] **Step 3: Rewire the three call sites**
+
+In `packages/server/src/render.tsx`: delete the local `translateRootOutcome` function (lines 52-73, including its leading comment, which moved with it) and add to the imports:
+
+```ts
+import { translateRootOutcome } from './outcome-translation.js';
+```
+
+In `packages/server/src/loaders-handler.ts`: delete the local `translateOutcomeForLoader` (lines 146-184) and add:
+
+```ts
+import { translateOutcomeForLoader } from './outcome-translation.js';
+```
+
+In `packages/server/src/page-action-handler.ts`: add `import { applyOutcomeHeaders } from './outcome-translation.js';` and replace the two header loops:
+
+JSON path (currently `if (env.headers) { for ... c.header(k, v); }` around line 320):
+
+```ts
+      const env = serializeActionOutcome(resolution);
+      applyOutcomeHeaders(c, env.headers);
+      return c.json(env.body, env.status);
+```
+
+HTML/PE redirect path (currently `if (headers) { for ... }` around line 334):
+
+```ts
+      const { to, status, headers } = resolution.outcome;
+      applyOutcomeHeaders(c, headers);
+      return c.redirect(to, status);
+```
+
+- [ ] **Step 4: Run the server suites**
+
+Run from `packages/server`: `pnpm exec vitest run`
+Expected: PASS unchanged (the root 500 text and loader JSON bodies are byte-identical to before).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server/src/outcome-translation.ts packages/server/src/render.tsx packages/server/src/loaders-handler.ts packages/server/src/page-action-handler.ts
+git commit -m "refactor(server): consolidate outcome translation into one module
+
+translateRootOutcome and translateOutcomeForLoader move to
+outcome-translation.ts; the header-application loop and the
+render-is-page-scope defense message each have one copy now.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full verification (CI mirror)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the six CI steps in order, from the repo root**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+Expected: all six PASS. If `format:check` fails, run `pnpm format`, re-run `format:check`, and amend or commit the formatting as its own commit. Note: `test:integration` includes a scaffold test that needs network; if offline it can hang or flake, rerun when connected. Never pipe test output through `| tail` (it masks the exit code).
+
+- [ ] **Step 2: Commit any formatting fallout**
+
+```bash
+git add -A
+git commit -m "chore: pnpm format
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Skip if the tree is clean.)
+
+---
+
+### Task 6: PR
+
+- [ ] **Step 1: Push the branch and open the PR** (only after every Task 5 step passed and was personally observed)
+
+```bash
+git push -u origin feat/outcome-semantics-consolidation
+gh pr create --title "refactor(iso,server): single envelope codec + outcome-translation module" --body "$(cat <<'EOF'
+PR 1 of 3 for Section A of the primitives DX review (spec: docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md).
+
+- One client decoder: `decodeActionResponse` joins the encoder in iso's `action-envelope.ts`; `Form` and `useAction` are now policy switches over the decoded union.
+- Behavior change: `Form` reports `timeout` envelopes as a real timeout error result (was: unknown-outcome fallthrough). `Form` keeps reload-on-malformed as its explicit PE fallback.
+- One server translation module: `translateRootOutcome` / `translateOutcomeForLoader` / `applyOutcomeHeaders` in `outcome-translation.ts`; the "render outcome is page-scope only" defense message has one copy (`RENDER_PAGE_SCOPE_MESSAGE` in iso internal).
+- No public surface changes; all server status codes and response shapes unchanged.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Deep PR review**
+
+Per the project PR workflow, immediately run a deep review as the first post-open step, including replacement parity: enumerate every branch of the two deleted client parsers and the two moved server translators against the new code via the PR's deletion diff (do not trust the new code's comments).

--- a/docs/superpowers/plans/2026-06-10-server-resolver-consolidation.md
+++ b/docs/superpowers/plans/2026-06-10-server-resolver-consolidation.md
@@ -1,0 +1,768 @@
+# Server Resolver Consolidation (PR 2 of Section A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One route matcher and one resolver-factory core in the server package, replacing the byte-identical matcher copies and the structurally-twin factories in `route-server-modules.ts` and `page-action-resolvers.ts`.
+
+**Architecture:** Two new internal modules. `route-pattern.ts` holds `urlPathMatchesPattern`, `patternScore`, and a new `findBestPattern` that encapsulates the scan-and-score loop both factories inline today. `route-module-resolvers.ts` holds `makeRouteModuleResolvers<TMod, TComposed, TExtra>`, owning the per-build thunk cache, the dev-rebuild gate with evict-on-failure caching, the ancestor walk, and the `byPath` best-pattern lookup; a strategy object owns composition (pageUse array concat vs action Map merge) and any side index (`extra`). The two public factories become thin wrappers with their exact current signatures. ZERO behavior change; no public surface change.
+
+**Tech Stack:** TypeScript, vitest. Vitest config is repo-root-level: run tests FROM THE REPO ROOT, e.g. `pnpm exec vitest run packages/server/src/__tests__/route-pattern.test.ts` (running from inside a package dir finds no tests).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md` (PR 2 section)
+
+**Branch:** `feat/server-resolver-consolidation`
+
+**One deviation from the spec's wording:** the spec says the core owns "the moduleKey reverse map". The two factories' reverse maps have different shapes (`moduleKey -> pattern` vs `moduleKey -> actionName -> ActionEntry`) and different membership rules (pageUse indexes only the route's own module; actions index every contributing module), so one core-owned shape cannot serve both. The core instead provides the generic `extra` accumulator and each strategy builds its own index there. Same dedup outcome, honest about the asymmetry.
+
+**Known subtlety to preserve, not fix:** `byPathMap` insertion order arises inside a `Promise.all` over `serverRoutes`, so the "first inserted" tiebreak depends on async completion order exactly as it does today. The core must keep the same `Promise.all(serverRoutes.map(...))` shape. Do not serialize the loop.
+
+---
+
+### Task 1: route-pattern module
+
+**Files:**
+- Create: `packages/server/src/route-pattern.ts`
+- Test: `packages/server/src/__tests__/route-pattern.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/server/src/__tests__/route-pattern.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  urlPathMatchesPattern,
+  patternScore,
+  findBestPattern,
+} from '../route-pattern.js';
+
+describe('urlPathMatchesPattern', () => {
+  it('matches literal segments exactly', () => {
+    expect(urlPathMatchesPattern('/a/b', '/a/b')).toBe(true);
+    expect(urlPathMatchesPattern('/a/c', '/a/b')).toBe(false);
+  });
+
+  it('matches :param segments against any value', () => {
+    expect(urlPathMatchesPattern('/users/42', '/users/:id')).toBe(true);
+    expect(urlPathMatchesPattern('/users', '/users/:id')).toBe(false);
+  });
+
+  it('requires equal segment counts absent a wildcard', () => {
+    expect(urlPathMatchesPattern('/a/b/c', '/a/b')).toBe(false);
+    expect(urlPathMatchesPattern('/a', '/a/b')).toBe(false);
+  });
+
+  it('a trailing * matches any remainder including none', () => {
+    expect(urlPathMatchesPattern('/docs/a/b', '/docs/*')).toBe(true);
+    expect(urlPathMatchesPattern('/docs', '/docs/*')).toBe(true);
+  });
+
+  it('ignores leading/trailing slashes via segment comparison', () => {
+    expect(urlPathMatchesPattern('/a/b/', '/a/b')).toBe(true);
+    expect(urlPathMatchesPattern('a/b', '/a/b')).toBe(true);
+  });
+});
+
+describe('patternScore', () => {
+  it('scores literal=2, param=1, wildcard=0 per segment', () => {
+    expect(patternScore('/a/b')).toBe(4);
+    expect(patternScore('/a/:id')).toBe(3);
+    expect(patternScore('/a/*')).toBe(2);
+    expect(patternScore('/')).toBe(0);
+  });
+});
+
+describe('findBestPattern', () => {
+  it('returns null when nothing matches', () => {
+    expect(findBestPattern(['/a', '/b'], '/c')).toBeNull();
+  });
+
+  it('prefers higher specificity: literal beats param at the same depth', () => {
+    expect(
+      findBestPattern(['/admin/users/:id', '/admin/users/me'], '/admin/users/me')
+    ).toBe('/admin/users/me');
+  });
+
+  it('prefers depth when scores tie', () => {
+    // Both match '/a/b/c' with score 2 ('/a/*' = 2+0; '/:a/:b/*' = 1+1+0);
+    // the deeper pattern wins regardless of iteration order.
+    expect(findBestPattern(['/a/*', '/:a/:b/*'], '/a/b/c')).toBe('/:a/:b/*');
+    expect(findBestPattern(['/:a/:b/*', '/a/*'], '/a/b/c')).toBe('/:a/:b/*');
+  });
+
+  it('keeps the first-seen pattern when score and depth both tie', () => {
+    expect(findBestPattern(['/x/:a', '/:x/a'], '/x/a')).toBe('/x/:a');
+    expect(findBestPattern(['/:x/a', '/x/:a'], '/x/a')).toBe('/:x/a');
+  });
+
+  it('accepts any iterable of patterns (Map keys)', () => {
+    const m = new Map([
+      ['/p/:id', 1],
+      ['/p/new', 2],
+    ]);
+    expect(findBestPattern(m.keys(), '/p/new')).toBe('/p/new');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/route-pattern.test.ts`
+Expected: FAIL (module `../route-pattern.js` does not exist).
+
+- [ ] **Step 3: Create the module**
+
+Create `packages/server/src/route-pattern.ts`. The first three functions are EXACT moves of the byte-identical copies in `route-server-modules.ts:23-65` and `page-action-resolvers.ts:47-72` (doc comments taken from route-server-modules.ts, which has the richer ones); `findBestPattern` is the scan loop both factories inline today, lifted verbatim:
+
+```ts
+function segmentsOf(path: string): string[] {
+  return path.split('/').filter((s) => s !== '');
+}
+
+/**
+ * True when `urlPath` (the concrete URL the user navigated to, with all
+ * params substituted) matches `pattern` exactly: same segment count, and
+ * each pattern segment either equals the URL segment, is a `:param`, or is
+ * a trailing `*`.
+ *
+ * Used at lookup time. Callers resolve the URL to the most specific
+ * pattern in their map via `findBestPattern`.
+ */
+export function urlPathMatchesPattern(
+  urlPath: string,
+  pattern: string
+): boolean {
+  const ps = segmentsOf(pattern);
+  const us = segmentsOf(urlPath);
+  for (let i = 0; i < ps.length; i++) {
+    const p = ps[i];
+    if (p === '*') return true;
+    if (i >= us.length) return false;
+    if (p.startsWith(':')) continue;
+    if (p !== us[i]) return false;
+  }
+  return ps.length === us.length;
+}
+
+/**
+ * Score a route pattern for tiebreaker purposes when multiple patterns at
+ * the same segment depth match the URL. Mirrors preact-iso's runtime
+ * preference for literal segments: literal=2, param=1, wildcard=0. Within
+ * the same score, `findBestPattern` falls back to depth, and within the
+ * same depth, to iteration order. Pre-merged literal wins over
+ * `/admin/users/:id` when the URL is `/admin/users/me`.
+ */
+export function patternScore(pattern: string): number {
+  let score = 0;
+  for (const seg of segmentsOf(pattern)) {
+    if (seg === '*') score += 0;
+    else if (seg.startsWith(':')) score += 1;
+    else score += 2;
+  }
+  return score;
+}
+
+/**
+ * Pick the best-matching pattern for a concrete URL path. Tiebreaker:
+ * (1) higher specificity score (literal=2, param=1, wildcard=0);
+ * (2) within the same score, more segments; (3) within the same depth,
+ * first in iteration order. Returns null when nothing matches.
+ *
+ * NOTE: O(patterns) linear scan. Fine for small apps; a precomputed trie
+ * or a request-keyed memo would help at scale.
+ */
+export function findBestPattern(
+  patterns: Iterable<string>,
+  urlPath: string
+): string | null {
+  let bestPattern: string | null = null;
+  let bestScore = -1;
+  let bestDepth = -1;
+  for (const pattern of patterns) {
+    if (!urlPathMatchesPattern(urlPath, pattern)) continue;
+    const score = patternScore(pattern);
+    const depth = segmentsOf(pattern).length;
+    if (score > bestScore || (score === bestScore && depth > bestDepth)) {
+      bestPattern = pattern;
+      bestScore = score;
+      bestDepth = depth;
+    }
+  }
+  return bestPattern;
+}
+```
+
+`segmentsOf` stays module-private (no external consumer after this PR). Do NOT export this module from the server package index.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/route-pattern.test.ts`
+Expected: PASS (11 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server/src/route-pattern.ts packages/server/src/__tests__/route-pattern.test.ts
+git commit -m "feat(server): extract the single route-pattern matcher module
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: resolver core
+
+**Files:**
+- Create: `packages/server/src/route-module-resolvers.ts`
+- Test: `packages/server/src/__tests__/route-module-resolvers.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/server/src/__tests__/route-module-resolvers.test.ts`. The fixtures build `ServerRoute` objects directly (`{ path, server, ancestors }` is the whole type) and use a trivial strategy that records loads:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import type { ServerRoute } from '@hono-preact/iso';
+import { makeRouteModuleResolvers } from '../route-module-resolvers.js';
+
+type TestMod = { tag?: string };
+
+function countingThunk(tag: string, calls: { n: number }) {
+  return () => {
+    calls.n++;
+    return Promise.resolve({ tag });
+  };
+}
+
+/** Strategy that composes the loaded tags outer-first into one array. */
+const tagStrategy = {
+  createExtra: () => new Map<string, string>(),
+  compose: (
+    route: ServerRoute,
+    ancestorMods: ReadonlyArray<TestMod>,
+    selfMod: TestMod,
+    extra: Map<string, string>
+  ) => {
+    const tags = [...ancestorMods, selfMod].map((m) => m.tag ?? '?');
+    extra.set(route.path, tags.join('+'));
+    return tags;
+  },
+};
+
+describe('makeRouteModuleResolvers', () => {
+  it('loads each distinct thunk exactly once per build (server + ancestor reuse)', async () => {
+    const calls = { n: 0 };
+    const layout = countingThunk('layout', calls);
+    const leaf = countingThunk('leaf', calls);
+    const routes: ServerRoute[] = [
+      { path: '/g', server: layout, ancestors: [] },
+      { path: '/g/leaf', server: leaf, ancestors: [layout] },
+    ];
+    const core = makeRouteModuleResolvers<TestMod, string[], Map<string, string>>(
+      routes,
+      {},
+      tagStrategy
+    );
+    expect(await core.byPath('/g/leaf')).toEqual(['layout', 'leaf']);
+    expect(calls.n).toBe(2);
+  });
+
+  it('caches the build across calls when dev is false', async () => {
+    const calls = { n: 0 };
+    const routes: ServerRoute[] = [
+      { path: '/a', server: countingThunk('a', calls), ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<TestMod, string[], Map<string, string>>(
+      routes,
+      {},
+      tagStrategy
+    );
+    await core.byPath('/a');
+    await core.byPath('/a');
+    await core.built();
+    expect(calls.n).toBe(1);
+  });
+
+  it('rebuilds on every call when dev is true', async () => {
+    const calls = { n: 0 };
+    const routes: ServerRoute[] = [
+      { path: '/a', server: countingThunk('a', calls), ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<TestMod, string[], Map<string, string>>(
+      routes,
+      { dev: true },
+      tagStrategy
+    );
+    await core.byPath('/a');
+    await core.byPath('/a');
+    expect(calls.n).toBe(2);
+  });
+
+  it('does not cache a failed build: the next call retries and can succeed', async () => {
+    let failOnce = true;
+    const calls = { n: 0 };
+    const flaky = () => {
+      calls.n++;
+      if (failOnce) {
+        failOnce = false;
+        return Promise.reject(new Error('transient import error'));
+      }
+      return Promise.resolve({ tag: 'ok' });
+    };
+    const routes: ServerRoute[] = [
+      { path: '/a', server: flaky, ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<TestMod, string[], Map<string, string>>(
+      routes,
+      {},
+      tagStrategy
+    );
+    await expect(core.byPath('/a')).rejects.toThrow('transient import error');
+    expect(await core.byPath('/a')).toEqual(['ok']);
+    expect(calls.n).toBe(2);
+  });
+
+  it('byPath resolves through findBestPattern and returns undefined on no match', async () => {
+    const calls = { n: 0 };
+    const routes: ServerRoute[] = [
+      { path: '/p/:id', server: countingThunk('param', calls), ancestors: [] },
+      { path: '/p/new', server: countingThunk('lit', calls), ancestors: [] },
+    ];
+    const core = makeRouteModuleResolvers<TestMod, string[], Map<string, string>>(
+      routes,
+      {},
+      tagStrategy
+    );
+    expect(await core.byPath('/p/new')).toEqual(['lit']);
+    expect(await core.byPath('/p/42')).toEqual(['param']);
+    expect(await core.byPath('/nope')).toBeUndefined();
+  });
+
+  it('built() exposes the byPathMap and the strategy-accumulated extra', async () => {
+    const calls = { n: 0 };
+    const layout = countingThunk('layout', calls);
+    const routes: ServerRoute[] = [
+      { path: '/g/leaf', server: countingThunk('leaf', calls), ancestors: [layout] },
+    ];
+    const core = makeRouteModuleResolvers<TestMod, string[], Map<string, string>>(
+      routes,
+      {},
+      tagStrategy
+    );
+    const { byPathMap, extra } = await core.built();
+    expect(byPathMap.get('/g/leaf')).toEqual(['layout', 'leaf']);
+    expect(extra.get('/g/leaf')).toBe('layout+leaf');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/route-module-resolvers.test.ts`
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Create the module**
+
+Create `packages/server/src/route-module-resolvers.ts`:
+
+```ts
+import type { ServerRoute } from '@hono-preact/iso';
+import { findBestPattern } from './route-pattern.js';
+
+/**
+ * Shared core of the page-layer resolver factories (`makePageUseResolvers`
+ * and `makePageActionResolvers`). Owns the lazy build lifecycle and the
+ * URL-path lookup:
+ *
+ * - Loads every distinct server thunk exactly once per build. A given
+ *   thunk may appear as `server` on one ServerRoute and as an `ancestor`
+ *   on descendants; calling it just once keeps module-init side effects
+ *   (e.g. logging, registry insertion) idempotent.
+ * - Caches the built result for the process lifetime. A failed build is
+ *   not cached (the next call retries), so a transient import error does
+ *   not permanently poison the resolver. When `dev` is true the cache is
+ *   bypassed on every call so editing a `.server.*` file takes effect
+ *   without restarting the server.
+ * - `byPath` resolves a concrete URL path (params substituted) to the
+ *   most specific matching route pattern (see `findBestPattern`) and
+ *   returns that route's composed value, or undefined when no pattern
+ *   matches.
+ *
+ * The strategy owns everything route-shape-specific: how to compose one
+ * route's value from its ancestor modules plus its own module (ancestors
+ * arrive outermost-first, matching the middleware dispatcher's
+ * outer -> inner contract), and any side index it accumulates during the
+ * build (`extra`, e.g. a moduleKey reverse map).
+ */
+export function makeRouteModuleResolvers<TMod, TComposed, TExtra>(
+  serverRoutes: ReadonlyArray<ServerRoute>,
+  options: { dev?: boolean },
+  strategy: {
+    createExtra: () => TExtra;
+    compose: (
+      route: ServerRoute,
+      ancestorMods: ReadonlyArray<TMod>,
+      selfMod: TMod,
+      extra: TExtra
+    ) => TComposed;
+  }
+): {
+  byPath: (path: string) => Promise<TComposed | undefined>;
+  built: () => Promise<{ byPathMap: Map<string, TComposed>; extra: TExtra }>;
+} {
+  const dev = options.dev ?? false;
+
+  type Built = { byPathMap: Map<string, TComposed>; extra: TExtra };
+  let buildPromise: Promise<Built> | null = null;
+
+  const build = async (): Promise<Built> => {
+    const thunkCache = new Map<() => Promise<unknown>, Promise<TMod>>();
+    const load = (thunk: () => Promise<unknown>): Promise<TMod> => {
+      let p = thunkCache.get(thunk);
+      if (!p) {
+        // Structural read of a user-defined module's exports (a sanctioned
+        // cast boundary); the strategy narrows the fields it actually reads.
+        p = thunk().then((mod) => mod as TMod);
+        thunkCache.set(thunk, p);
+      }
+      return p;
+    };
+
+    const byPathMap = new Map<string, TComposed>();
+    const extra = strategy.createExtra();
+
+    await Promise.all(
+      serverRoutes.map(async (route) => {
+        const ancestorMods = await Promise.all(route.ancestors.map(load));
+        const selfMod = await load(route.server);
+        // Two ServerRoutes sharing the same path mean two `.server.*` files
+        // claim the same route, a route-table error. The route validator is
+        // the right place to surface that; here last write wins, matching
+        // the pre-consolidation factories.
+        byPathMap.set(
+          route.path,
+          strategy.compose(route, ancestorMods, selfMod, extra)
+        );
+      })
+    );
+
+    return { byPathMap, extra };
+  };
+
+  const built = (): Promise<Built> => {
+    if (dev) {
+      // In dev, always rebuild so edits to any `.server.*` file take
+      // effect on the next request without restarting the process.
+      return build();
+    }
+    if (buildPromise) return buildPromise;
+    buildPromise = build().catch((err) => {
+      buildPromise = null;
+      return Promise.reject(err);
+    });
+    return buildPromise;
+  };
+
+  return {
+    built,
+    async byPath(path: string) {
+      const { byPathMap } = await built();
+      const pattern = findBestPattern(byPathMap.keys(), path);
+      return pattern === null ? undefined : byPathMap.get(pattern);
+    },
+  };
+}
+```
+
+Do NOT export this module from the server package index.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/route-module-resolvers.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/server/src/route-module-resolvers.ts packages/server/src/__tests__/route-module-resolvers.test.ts
+git commit -m "feat(server): add makeRouteModuleResolvers, the shared resolver core
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: rewire makePageUseResolvers onto the core
+
+**Files:**
+- Modify: `packages/server/src/route-server-modules.ts`
+- Test: existing `packages/server/src/__tests__/route-server-modules.test.ts` (staying green is the check; no edits expected)
+
+- [ ] **Step 1: Rewrite the file**
+
+Replace the contents of `packages/server/src/route-server-modules.ts` below the `routeServerModules` function (keep lines 1-21 as they are: the import, `routeServerModules`, and the `PageUseModule` type). Delete `segmentsOf`, `urlPathMatchesPattern`, and `patternScore` (now in route-pattern.ts). Keep `pageUseFromMod` unchanged. Replace `makePageUseResolvers` with:
+
+```ts
+import { makeRouteModuleResolvers } from './route-module-resolvers.js';
+```
+
+(add to the imports at the top), and:
+
+```ts
+/**
+ * Build the two page-layer `use` resolvers wired into loadersHandler and
+ * pageActionHandler. The loader handler matches by the location's URL path;
+ * the action handler matches by the action's owning module key. Both
+ * lookups share one underlying composed map populated by loading every
+ * routed `.server.*` module exactly once (then caching the result).
+ *
+ * Ancestor composition: each ServerRoute carries an explicit list of
+ * ancestor server thunks captured during the route-tree walk. The
+ * resolver loads each ancestor's `pageUse` (if any) and concatenates them
+ * outer-first, with the route's own pageUse appended last. So a layout
+ * group's pageUse runs before each nested leaf's pageUse without the user
+ * having to repeat the import in every leaf .server.*. Order matches the
+ * middleware dispatcher's outer -> inner contract: app -> outermost
+ * layout -> ... -> leaf -> per-unit.
+ *
+ * Why route-tree ancestry (not URL-prefix ancestry): two routes can share
+ * a URL prefix without being parent/child in the tree. For example,
+ * `/demo/projects` and `/demo/projects/:projectId/issues/:issueId` are
+ * siblings of the `/demo` layout group; the latter is NOT a descendant of
+ * the former. URL-prefix matching incorrectly conflates them and runs the
+ * shared gate twice on every nested request.
+ *
+ * Build lifecycle (thunk dedup, evict-on-failure caching, dev rebuild)
+ * and URL-path matching live in `makeRouteModuleResolvers`.
+ *
+ * NOTE: framework-private. The only intended consumer outside tests is
+ * the generated server entry. Reach for it at your own risk.
+ */
+export function makePageUseResolvers(
+  serverRoutes: ReadonlyArray<ServerRoute>,
+  options: { dev?: boolean } = {}
+): {
+  byPath: (path: string) => Promise<ReadonlyArray<unknown>>;
+  byModuleKey: (key: string) => Promise<ReadonlyArray<unknown>>;
+} {
+  const core = makeRouteModuleResolvers<
+    PageUseModule,
+    ReadonlyArray<unknown>,
+    Map<string, string>
+  >(serverRoutes, options, {
+    createExtra: () => new Map<string, string>(),
+    compose: (route, ancestorMods, selfMod, patternByModuleKey) => {
+      const composed: unknown[] = [];
+      for (const mod of ancestorMods) {
+        composed.push(...pageUseFromMod(mod, route.path));
+      }
+      composed.push(...pageUseFromMod(selfMod, route.path));
+      if (typeof selfMod.__moduleKey === 'string') {
+        patternByModuleKey.set(selfMod.__moduleKey, route.path);
+      }
+      return composed;
+    },
+  });
+
+  return {
+    async byPath(path: string) {
+      return (await core.byPath(path)) ?? [];
+    },
+    async byModuleKey(key: string) {
+      const { byPathMap, extra } = await core.built();
+      const pattern = extra.get(key);
+      return pattern ? (byPathMap.get(pattern) ?? []) : [];
+    },
+  };
+}
+```
+
+Behavior notes the rewrite must hold (all verified by the existing test suite):
+- ancestors compose outer-first, self last (compose receives them in that order)
+- `byPath` returns `[]` when no pattern matches
+- `byModuleKey` returns `[]` for an unknown key
+- the moduleKey index uses the route's OWN module key only (ancestors do not register)
+
+- [ ] **Step 2: Run the existing suites**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/route-server-modules.test.ts packages/server/src/__tests__/loaders-handler.test.ts packages/server/src/__tests__/middleware-chain.test.ts`
+Expected: PASS unchanged.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter '@hono-preact/server' exec tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/server/src/route-server-modules.ts
+git commit -m "refactor(server): makePageUseResolvers onto the shared resolver core
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: rewire makePageActionResolvers onto the core
+
+**Files:**
+- Modify: `packages/server/src/page-action-resolvers.ts`
+- Test: existing `packages/server/src/__tests__/page-action-resolvers.test.ts` and `packages/server/src/__tests__/page-action-handler.test.ts` (staying green is the check)
+
+- [ ] **Step 1: Rewrite the file**
+
+In `packages/server/src/page-action-resolvers.ts`: keep the `ActionFn`/`ActionEntry`/`ServerModule` types and `extractActions` unchanged (lines 1-45). Delete `segmentsOf`, `urlPathMatchesPattern`, and `patternScore` (lines 47-72). Add the import:
+
+```ts
+import { makeRouteModuleResolvers } from './route-module-resolvers.js';
+```
+
+Replace `makePageActionResolvers` with:
+
+```ts
+/**
+ * Build action resolvers keyed by route path and by module key. Each
+ * ServerRoute contributes its own serverActions and its ancestors' serverActions
+ * to the merged map for that path. Ancestor entries are written first so that
+ * a page-level action shadows a same-named layout action when names collide.
+ *
+ * Build lifecycle (thunk dedup, evict-on-failure caching, dev rebuild)
+ * and URL-path matching live in `makeRouteModuleResolvers`.
+ *
+ * NOTE: framework-private. Intended consumer is the generated server entry and
+ * pageActionHandler.
+ */
+export function makePageActionResolvers(
+  serverRoutes: ReadonlyArray<ServerRoute>,
+  options: { dev?: boolean } = {}
+): {
+  byPath: (path: string) => Promise<Map<string, ActionEntry>>;
+  byModuleKey: (
+    moduleKey: string,
+    actionName: string
+  ) => Promise<ActionEntry | undefined>;
+} {
+  const core = makeRouteModuleResolvers<
+    ServerModule,
+    Map<string, ActionEntry>,
+    Map<string, Map<string, ActionEntry>>
+  >(serverRoutes, options, {
+    createExtra: () => new Map<string, Map<string, ActionEntry>>(),
+    compose: (route, ancestorMods, selfMod, byModuleKeyMap) => {
+      const merged = new Map<string, ActionEntry>();
+      // Write ancestors first (outer -> inner), then self. Later writes
+      // shadow earlier ones, so a page-level action wins over a layout
+      // action of the same name.
+      for (const mod of [...ancestorMods, selfMod]) {
+        for (const { name, entry } of extractActions(mod)) {
+          merged.set(name, entry);
+          let m = byModuleKeyMap.get(entry.moduleKey);
+          if (!m) {
+            m = new Map();
+            byModuleKeyMap.set(entry.moduleKey, m);
+          }
+          m.set(name, entry);
+        }
+      }
+      return merged;
+    },
+  });
+
+  return {
+    async byPath(path: string): Promise<Map<string, ActionEntry>> {
+      return (await core.byPath(path)) ?? new Map<string, ActionEntry>();
+    },
+    async byModuleKey(
+      moduleKey: string,
+      actionName: string
+    ): Promise<ActionEntry | undefined> {
+      const { extra } = await core.built();
+      return extra.get(moduleKey)?.get(actionName);
+    },
+  };
+}
+```
+
+Behavior notes the rewrite must hold:
+- ancestor actions register in the byModuleKey index too (unlike pageUse, every extracted entry registers under ITS OWN moduleKey)
+- `byPath` returns an empty Map when no pattern matches
+- same-name shadowing: self overwrites ancestor in the per-path merged Map
+
+- [ ] **Step 2: Run the existing suites**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/page-action-resolvers.test.ts packages/server/src/__tests__/page-action-handler.test.ts packages/server/src/__tests__/pe-form-no-js.integration.test.ts`
+Expected: PASS unchanged.
+
+- [ ] **Step 3: Full server suite + grep for stragglers**
+
+Run: `pnpm exec vitest run packages/server/src`
+Expected: PASS (143 pre-existing + 17 new from Tasks 1-2 = 160).
+
+Run: `rg -n "urlPathMatchesPattern|patternScore|segmentsOf" packages/server/src --glob '!__tests__' --glob '!route-pattern.ts'`
+Expected: no hits (the only definitions live in route-pattern.ts).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/server/src/page-action-resolvers.ts
+git commit -m "refactor(server): makePageActionResolvers onto the shared resolver core
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full verification (CI mirror)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the six CI steps in order, from the repo root**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+Expected: all six PASS. If `format:check` fails, run `pnpm format`, re-run, and commit the formatting. Never pipe test output through `| tail` in a way that masks the exit code.
+
+- [ ] **Step 2: Commit any formatting fallout**
+
+```bash
+git add -A
+git commit -m "chore: pnpm format
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Skip if clean.)
+
+---
+
+### Task 6: PR
+
+- [ ] **Step 1: Push and open the PR** (only after every Task 5 step passed)
+
+```bash
+git push -u origin feat/server-resolver-consolidation
+gh pr create --title "refactor(server): single route matcher + shared resolver core" --body "$(cat <<'EOF'
+PR 2 of 3 for Section A of the primitives DX review (spec: docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md).
+
+- One route matcher: the byte-identical `segmentsOf`/`urlPathMatchesPattern`/`patternScore` copies in route-server-modules.ts and page-action-resolvers.ts collapse into `route-pattern.ts`, plus `findBestPattern` encapsulating the scan-and-score loop both factories inlined.
+- One resolver core: `makeRouteModuleResolvers<TMod, TComposed, TExtra>` owns the thunk cache, evict-on-failure build caching, dev rebuild, ancestor walk, and byPath lookup; `makePageUseResolvers` and `makePageActionResolvers` are thin strategy wrappers with their exact previous signatures.
+- Zero behavior change; zero public-surface change (the boundary redraw is Section B). New direct tests for the matcher tiebreakers and the core's cache/dev/eviction semantics, which were previously tested only indirectly, twice.
+
+PR 3 (shared cross-package constants module) follows.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Deep PR review**
+
+Per the project PR workflow, immediately run a deep review as the first post-open step, including replacement parity: enumerate the behaviors of the two pre-PR factories from the deletion diff (thunk dedup scope, eviction, dev gate, tiebreak order, empty-result defaults, moduleKey index membership differences between the twins) and verify each in the new code.

--- a/docs/superpowers/plans/2026-06-11-contract-constants.md
+++ b/docs/superpowers/plans/2026-06-11-contract-constants.md
@@ -1,0 +1,467 @@
+# Shared Contract Constants (PR 3 of Section A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One shared constants module for the cross-package wire-contract literals (`/__loaders`, `static/client.js`, the virtual client id and its dev URL, `__moduleKey`, `__module`, `__action`), so cross-package agreement is structural instead of matching strings.
+
+**Architecture:** New `packages/iso/src/internal/contract.ts`, exported from the iso internal barrel. iso and server consumers import it directly; the vite package gains a `@hono-preact/iso` workspace dependency and interpolates the constants into its codegen template strings (generated output stays self-contained). The umbrella's `consolidate.mjs` already rewrites `@hono-preact/iso/internal` specifiers to relative paths inside `hono-preact/dist`, so the new vite-to-iso import survives consolidation unchanged.
+
+**Tech Stack:** TypeScript, vitest. Vitest config is repo-root-level: run tests FROM THE REPO ROOT (e.g. `pnpm exec vitest run packages/iso/src/__tests__/contract.test.ts`); running inside a package dir finds nothing.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md` (PR 3 section)
+
+**Branch:** `feat/contract-constants`
+
+**Three deviations from the spec's wording, decided during planning:**
+1. **The generated server-entry path stays in vite.** It is already single-sourced as `GENERATED_ENTRY_WRAPPER_RELATIVE` in `packages/vite/src/server-entry.ts:227-229`, and it is a vite build-time concept; moving it to iso would be a worse home. The spec's real requirement (the scaffolded `wrangler.jsonc` cannot drift from it) is met by a parity test in packages/vite that reads the template file across the monorepo.
+2. **`__moduleKey`/`__module`/`__action` keep literal syntax in typed positions.** TypeScript property declarations (`ActionStub.__module`) and dotted reads (`mod.__moduleKey`) cannot use a runtime constant without bracket-access contortions. The constants cover every VALUE position: FormData keys, `fd.get` calls, property-defining strings, and codegen template strings. The typed positions are pinned against the constants by the existing tests (a codegen string and a typed read that disagree fail the action/loader suites).
+3. **`/__actions` stays a literal** in vite's `RESERVED_PATHS`. It appears in exactly one package and is slated for removal by Section D (the dead reservation); promoting it to a shared constant would cement what we plan to delete.
+
+---
+
+### Task 1: contract module in iso internal
+
+**Files:**
+- Create: `packages/iso/src/internal/contract.ts`
+- Modify: `packages/iso/src/internal.ts` (barrel export)
+- Test: `packages/iso/src/__tests__/contract.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/iso/src/__tests__/contract.test.ts`. The exact-value assertions are deliberate: every constant is a wire contract, so an edit to any value must fail loudly here (changing one is a breaking change, not a refactor):
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  LOADERS_RPC_PATH,
+  CLIENT_ENTRY_FILE,
+  CLIENT_ENTRY_URL,
+  VIRTUAL_CLIENT_ID,
+  VIRTUAL_CLIENT_DEV_URL,
+  MODULE_KEY_EXPORT,
+  FORM_MODULE_FIELD,
+  FORM_ACTION_FIELD,
+} from '../internal/contract.js';
+
+describe('wire-contract constants', () => {
+  it('pins the exact wire values (changing any is a breaking change)', () => {
+    expect(LOADERS_RPC_PATH).toBe('/__loaders');
+    expect(CLIENT_ENTRY_FILE).toBe('static/client.js');
+    expect(VIRTUAL_CLIENT_ID).toBe('virtual:hono-preact/client');
+    expect(MODULE_KEY_EXPORT).toBe('__moduleKey');
+    expect(FORM_MODULE_FIELD).toBe('__module');
+    expect(FORM_ACTION_FIELD).toBe('__action');
+  });
+
+  it('derives the URL forms from their base constants', () => {
+    expect(CLIENT_ENTRY_URL).toBe(`/${CLIENT_ENTRY_FILE}`);
+    expect(VIRTUAL_CLIENT_DEV_URL).toBe(`/@id/__x00__${VIRTUAL_CLIENT_ID}`);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run packages/iso/src/__tests__/contract.test.ts`
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Create the module**
+
+Create `packages/iso/src/internal/contract.ts`:
+
+```ts
+// Cross-package wire-contract constants. Each constant documents every
+// consumer. Standing rule (primitives review, Section F): when a new
+// feature needs cross-package agreement on a path, field name, or
+// generated id, the value starts life here, not as matching string
+// literals. Typed property positions (e.g. `ActionStub.__module`,
+// `mod.__moduleKey` reads) keep literal syntax; these constants own every
+// value position (FormData keys, fetch URLs, codegen template strings).
+
+/**
+ * RPC endpoint for client loader fetches. Consumers: iso
+ * `internal/loader-fetch.ts` (the POST), vite `server-entry.ts` (the
+ * generated route registration and the reserved-path validation). The
+ * generated server entry mounts `loadersHandler` here.
+ */
+export const LOADERS_RPC_PATH = '/__loaders';
+
+/**
+ * Client bundle entry name and its URL form. Consumers: vite
+ * `hono-preact.ts` (rollup `entryFileNames`), iso `client-script.tsx`
+ * (the production script src). Must stay stable: it is the URL the SSR
+ * layer references.
+ */
+export const CLIENT_ENTRY_FILE = 'static/client.js';
+export const CLIENT_ENTRY_URL = `/${CLIENT_ENTRY_FILE}`;
+
+/**
+ * Virtual client-entry module id and its Vite dev-server URL. Consumers:
+ * vite `client-entry.ts` (resolveId), iso `client-script.tsx` (the dev
+ * script src). The URL form encodes Vite's `/@id/` route plus the
+ * `__x00__` escape of the `\0` resolved-id prefix.
+ */
+export const VIRTUAL_CLIENT_ID = 'virtual:hono-preact/client';
+export const VIRTUAL_CLIENT_DEV_URL = `/@id/__x00__${VIRTUAL_CLIENT_ID}`;
+
+/**
+ * Name of the module-key export the vite plugins generate into `.server.*`
+ * modules and thread into loader/action stubs. Consumers: vite
+ * `module-key-plugin.ts` and `server-only.ts` (codegen). iso and server
+ * read it as a typed property (`mod.__moduleKey`); the literal there is
+ * the same contract, kept in property syntax.
+ */
+export const MODULE_KEY_EXPORT = '__moduleKey';
+
+/**
+ * Form field names carrying the action identity in POSTs. Consumers: iso
+ * `form.tsx` (FormData set/skip, hidden inputs) and `action.ts` (stub
+ * property definition), server `page-action-handler.ts` (form reads and
+ * payload skip), vite `server-only.ts` (generated action stubs).
+ */
+export const FORM_MODULE_FIELD = '__module';
+export const FORM_ACTION_FIELD = '__action';
+```
+
+In `packages/iso/src/internal.ts`, add to Section 1 (the advanced/escape-hatch section, near the other plain-module exports), with a one-line comment:
+
+```ts
+// Cross-package wire-contract constants (paths, field names, generated ids).
+export {
+  LOADERS_RPC_PATH,
+  CLIENT_ENTRY_FILE,
+  CLIENT_ENTRY_URL,
+  VIRTUAL_CLIENT_ID,
+  VIRTUAL_CLIENT_DEV_URL,
+  MODULE_KEY_EXPORT,
+  FORM_MODULE_FIELD,
+  FORM_ACTION_FIELD,
+} from './internal/contract.js';
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run packages/iso/src/__tests__/contract.test.ts packages/iso/src/__tests__/internal.test.ts`
+Expected: PASS (contract 2 tests; if internal.test.ts asserts an exact barrel list, add the eight names there).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/iso/src/internal/contract.ts packages/iso/src/internal.ts packages/iso/src/__tests__/contract.test.ts
+git commit -m "feat(iso): add the cross-package wire-contract constants module
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Add internal.test.ts to the list if it needed the new names.)
+
+---
+
+### Task 2: iso consumers onto the contract
+
+**Files:**
+- Modify: `packages/iso/src/internal/loader-fetch.ts:31`
+- Modify: `packages/iso/src/client-script.tsx:4-6`
+- Modify: `packages/iso/src/form.tsx` (lines 43, 82-83, and the two hidden-input `name` attributes)
+- Modify: `packages/iso/src/action.ts` (the `attach('__module', ...)` / `attach('__action', ...)` value-position strings around lines 113-114)
+- Test: existing iso suites (staying green is the check; the values are unchanged so no assertion changes)
+
+- [ ] **Step 1: Rewire loader-fetch**
+
+In `packages/iso/src/internal/loader-fetch.ts`, add `import { LOADERS_RPC_PATH } from './contract.js';` and change the fetch call:
+
+```ts
+  const res = await fetch(LOADERS_RPC_PATH, {
+```
+
+(The rest of the call stays as-is.)
+
+- [ ] **Step 2: Rewire client-script**
+
+Replace the body of `packages/iso/src/client-script.tsx`'s src selection:
+
+```tsx
+import type { VNode } from 'preact';
+import {
+  CLIENT_ENTRY_URL,
+  VIRTUAL_CLIENT_DEV_URL,
+} from './internal/contract.js';
+
+export function ClientScript(): VNode {
+  const src = import.meta.env.PROD ? CLIENT_ENTRY_URL : VIRTUAL_CLIENT_DEV_URL;
+```
+
+(The comment block and the returned `<script>` element stay unchanged.)
+
+- [ ] **Step 3: Rewire form.tsx value positions**
+
+Add `import { FORM_MODULE_FIELD, FORM_ACTION_FIELD } from './internal/contract.js';` and replace exactly these value positions (the `action.__module` dotted reads at lines 61-62 stay):
+
+- Line 43: `if (key === FORM_MODULE_FIELD || key === FORM_ACTION_FIELD) continue;`
+- Lines 82-83: `fd.set(FORM_MODULE_FIELD, moduleKey); fd.set(FORM_ACTION_FIELD, actionName);`
+- The hidden inputs: `<input type="hidden" name={FORM_MODULE_FIELD} value={moduleKey} />` and `<input type="hidden" name={FORM_ACTION_FIELD} value={actionName} />`
+
+- [ ] **Step 4: Rewire action.ts value positions**
+
+Add `import { FORM_MODULE_FIELD, FORM_ACTION_FIELD } from './internal/contract.js';` and replace the two attachment lines at action.ts:113-114:
+
+```ts
+  if (opts?.__module !== undefined) attach(FORM_MODULE_FIELD, opts.__module);
+  if (opts?.__action !== undefined) attach(FORM_ACTION_FIELD, opts.__action);
+```
+
+(The `opts?.__module` dotted reads stay; only the string key passed to `attach` changes.) Then run `rg -n "'__module'|'__action'|\"__module\"|\"__action\"" packages/iso/src --glob '!__tests__'` and convert any remaining value-position hits the same way; typed property declarations and dotted reads are NOT hits for this grep and stay as they are.
+
+- [ ] **Step 5: Run the iso suite**
+
+Run: `pnpm exec vitest run packages/iso/src`
+Expected: PASS, same count as before this task (the constants carry identical values; in particular `client-script.test.tsx`'s literal URL assertions still pass).
+
+- [ ] **Step 6: Format and commit**
+
+`pnpm format`; `git status` shows only the four files. Then:
+
+```bash
+git add packages/iso/src/internal/loader-fetch.ts packages/iso/src/client-script.tsx packages/iso/src/form.tsx packages/iso/src/action.ts
+git commit -m "refactor(iso): consume the wire-contract constants
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: server consumer onto the contract
+
+**Files:**
+- Modify: `packages/server/src/page-action-handler.ts:148-159`
+- Test: existing server suites (staying green is the check)
+
+- [ ] **Step 1: Rebuild iso dist**
+
+The server package resolves `@hono-preact/iso/internal` through `dist/`:
+
+```bash
+pnpm --filter '@hono-preact/iso' build
+```
+
+- [ ] **Step 2: Rewire the form reads**
+
+In `packages/server/src/page-action-handler.ts`, extend the existing `@hono-preact/iso/internal` import with `FORM_MODULE_FIELD, FORM_ACTION_FIELD`, then replace the value positions around lines 148-159:
+
+```ts
+    const m = fd.get(FORM_MODULE_FIELD);
+    const a = fd.get(FORM_ACTION_FIELD);
+```
+
+the error message:
+
+```ts
+        error: `Form data must include ${FORM_MODULE_FIELD} and ${FORM_ACTION_FIELD} fields`,
+```
+
+and the payload skip:
+
+```ts
+      if (key === FORM_MODULE_FIELD || key === FORM_ACTION_FIELD) continue;
+```
+
+- [ ] **Step 3: Run the server suite, typecheck, format, commit**
+
+`pnpm exec vitest run packages/server/src` (expect 165 passing, unchanged), `pnpm --filter '@hono-preact/server' exec tsc --noEmit`, `pnpm format`. Then:
+
+```bash
+git add packages/server/src/page-action-handler.ts
+git commit -m "refactor(server): consume the form-field contract constants
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: vite consumers onto the contract + template parity test
+
+**Files:**
+- Modify: `packages/vite/package.json` (add dependency)
+- Modify: `packages/vite/src/server-entry.ts:61,95`
+- Modify: `packages/vite/src/hono-preact.ts:82` (entryFileNames)
+- Modify: `packages/vite/src/client-entry.ts:4`
+- Modify: `packages/vite/src/module-key-plugin.ts:35,39,84,99`
+- Modify: `packages/vite/src/server-only.ts:235,270`
+- Test: `packages/vite/src/__tests__/template-parity.test.ts` (new) + existing vite suites
+
+- [ ] **Step 1: Add the dependency**
+
+In `packages/vite/package.json`, add to `dependencies`:
+
+```json
+    "@hono-preact/iso": "workspace:*",
+```
+
+Then `pnpm install` from the worktree root (updates the lockfile; commit the lockfile change with this task).
+
+- [ ] **Step 2: Write the failing template-parity test**
+
+Create `packages/vite/src/__tests__/template-parity.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { GENERATED_ENTRY_WRAPPER_RELATIVE } from '../server-entry.js';
+
+const here = resolve(fileURLToPath(import.meta.url), '..');
+
+describe('scaffolder template parity', () => {
+  it("cloudflare wrangler.jsonc 'main' points at the generated entry wrapper", () => {
+    // The scaffolded template cannot import this constant, so this test is
+    // the drift guard between the plugin's generated-entry path and the
+    // wrangler config the scaffolder ships.
+    const wranglerPath = resolve(
+      here,
+      '../../../create-hono-preact/templates/cloudflare/wrangler.jsonc'
+    );
+    const raw = readFileSync(wranglerPath, 'utf8');
+    const main = /"main"\s*:\s*"([^"]+)"/.exec(raw)?.[1];
+    expect(main).toBe(GENERATED_ENTRY_WRAPPER_RELATIVE);
+  });
+});
+```
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/template-parity.test.ts`
+Expected: PASS already (the values agree today); this test exists to FAIL when either side drifts. Verify it runs and passes, then deliberately confirm it is wired to the real file (temporarily typo the regex if unsure, watch it fail, revert).
+
+- [ ] **Step 3: Rewire the vite sources**
+
+All five files add (or extend) the import:
+
+```ts
+import { LOADERS_RPC_PATH } from '@hono-preact/iso/internal';
+```
+
+(each file imports only the constants it uses).
+
+`packages/vite/src/server-entry.ts`:
+- Line 61 (codegen template string): `` `  .post('${LOADERS_RPC_PATH}', loadersHandler(serverModules, { dev, appConfig, resolvePageUse: pageUseResolvers.byPath }))\n` ``
+- Line 95: `const RESERVED_PATHS = new Set([LOADERS_RPC_PATH, '/__actions']);` (the `/__actions` literal stays; see plan-header deviation 3)
+
+`packages/vite/src/hono-preact.ts` (import `CLIENT_ENTRY_FILE`):
+- The client output config: `entryFileNames: CLIENT_ENTRY_FILE,` (chunk/asset name patterns stay literal)
+
+`packages/vite/src/client-entry.ts` (import `VIRTUAL_CLIENT_ID`):
+
+```ts
+export const VIRTUAL_CLIENT_ENTRY_ID = VIRTUAL_CLIENT_ID;
+```
+
+(The exported name `VIRTUAL_CLIENT_ENTRY_ID` stays; tests and the resolved-id derivation reference it.)
+
+`packages/vite/src/module-key-plugin.ts` (import `MODULE_KEY_EXPORT`):
+- Line 35, the already-transformed guard, built from the constant so it cannot drift:
+
+```ts
+      const alreadyKeyed = new RegExp(
+        `^\\s*export\\s+const\\s+${MODULE_KEY_EXPORT}\\s*=`,
+        'm'
+      );
+      if (alreadyKeyed.test(code)) return;
+```
+
+- Line 39: `` s.prepend(`export const ${MODULE_KEY_EXPORT} = ${JSON.stringify(key)};\n`); ``
+- Line 84: `` `, { ${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}${namePart} }` ``
+- Line 99: `` `${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}, ${namePart}` ``
+
+`packages/vite/src/server-only.ts` (import `MODULE_KEY_EXPORT, FORM_MODULE_FIELD, FORM_ACTION_FIELD`):
+- Line 235: `` `      ${MODULE_KEY_EXPORT}: ${JSON.stringify(moduleKey)},\n` ``
+- Line 270: `` `    const stub = { ${FORM_MODULE_FIELD}: ${JSON.stringify(moduleKey)}, ${FORM_ACTION_FIELD}: String(action) };\n` ``
+
+Preserve the surrounding template-string content byte-for-byte; the generated output must be identical to before (the vite test suites assert generated source text and will catch any whitespace drift).
+
+- [ ] **Step 4: Run the vite suite and typecheck**
+
+```bash
+pnpm exec vitest run packages/vite/src
+pnpm --filter '@hono-preact/vite' exec tsc --noEmit
+```
+
+Expected: PASS unchanged plus the new parity test (the generated-source assertions in `server-entry.test.ts`, `client-entry.test.ts`, `module-key-server-loaders.test.ts`, `server-only-plugin.test.ts`, and `path-key-parity.test.ts` pin that the interpolated output is byte-identical). The existing `path-key-parity.test.ts` needs no changes; with both codegen sites interpolating `MODULE_KEY_EXPORT` it now pins wire behavior over one shared spelling.
+
+- [ ] **Step 5: Verify the umbrella consolidation rewrites the new import**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+rg "@hono-preact/iso" packages/hono-preact/dist/vite/ || echo "CONSOLIDATION OK: no unrewritten specifiers"
+```
+
+Expected: `CONSOLIDATION OK` (consolidate.mjs's DIST_PATHS table already maps `@hono-preact/iso/internal`; this step proves it applied to the new imports).
+
+- [ ] **Step 6: Format and commit**
+
+`pnpm format`; `git status` shows the six vite files, the new test, package.json, and pnpm-lock.yaml. Then:
+
+```bash
+git add packages/vite/package.json pnpm-lock.yaml packages/vite/src/server-entry.ts packages/vite/src/hono-preact.ts packages/vite/src/client-entry.ts packages/vite/src/module-key-plugin.ts packages/vite/src/server-only.ts packages/vite/src/__tests__/template-parity.test.ts
+git commit -m "refactor(vite): interpolate wire-contract constants into codegen
+
+vite gains a build-time @hono-preact/iso dependency for the contract
+module; generated output is byte-identical. Adds the wrangler-template
+parity test guarding the generated-entry path.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full verification (CI mirror)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the six CI steps in order, from the repo root**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+Expected: all six PASS. If `format:check` fails, `pnpm format` and commit the fallout. Note: `test:integration` includes the network-dependent scaffold test.
+
+- [ ] **Step 2: Commit any formatting fallout**
+
+```bash
+git add -A && git commit -m "chore: pnpm format
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Skip if clean.)
+
+---
+
+### Task 6: PR
+
+- [ ] **Step 1: Push and open the PR** (only after every Task 5 step passed)
+
+```bash
+git push -u origin feat/contract-constants
+gh pr create --title "refactor: shared wire-contract constants module" --body "$(cat <<'EOF'
+PR 3 of 3 for Section A of the primitives DX review (spec: docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md). Closes out Section A.
+
+- New `packages/iso/src/internal/contract.ts`: one exported constant per cross-package literal (`/__loaders`, `static/client.js` + URL form, the virtual client id + derived dev URL, `__moduleKey`, `__module`, `__action`), each documenting every consumer. Exact values pinned by test; changing one is a breaking change and now fails loudly in one place.
+- iso, server, and vite consumers rewired onto the constants. vite gains a build-time `@hono-preact/iso` dependency; its codegen interpolates the constants, so generated output is byte-identical (pinned by the existing generated-source tests). The umbrella consolidation already rewrites the new import specifier (verified against the built dist).
+- New wrangler-template parity test in packages/vite guards the generated-entry path against scaffolder drift (the template cannot import the constant). The generated-entry path constant itself stays in vite where it already lives; `/__actions` stays a literal since Section D plans to delete it.
+- Standing rule adopted from the review (Section F): cross-package contracts start in this module, not as matching string literals.
+
+Zero behavior change; all values identical.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Deep PR review**
+
+Per the project PR workflow, immediately run a deep review as the first post-open step. Replacement-parity focus: for each constant, enumerate every pre-PR literal occurrence (from the deletion diff) and verify the constant landed at each value position with an identical value; confirm codegen output is byte-identical by reading the generated-source test expectations; confirm no typed-property position was clumsily converted to bracket access.

--- a/docs/superpowers/plans/2026-06-11-server-internal-boundary.md
+++ b/docs/superpowers/plans/2026-06-11-server-internal-boundary.md
@@ -1,0 +1,523 @@
+# Server internal boundary (Section B, PR B1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the framework-emitted server resolver factories off the public `@hono-preact/server` door onto a new `/internal/runtime` subpath, re-export `LoadersHandlerOptions` so the documented hand-wiring path can name its options type, and relocate `pickAccept` into a dedicated internal module.
+
+**Architecture:** Three stability tiers (public `.`, escape-hatch `/internal`, framework-emitted `/internal/runtime`). PR B1 implements the server half: the three factories (`routeServerModules`, `makePageUseResolvers`, `makePageActionResolvers`) become a framework-emitted tier on `@hono-preact/server/internal/runtime`, re-exposed through the umbrella as `hono-preact/server/internal/runtime`, which the generated server entry imports. `ActionEntry` stays public (it is in the public `pageActionHandler` options signature). No documented symbol moves, so there is zero user-facing breakage.
+
+**Tech Stack:** TypeScript, plain `tsc` builds, Vitest, pnpm workspaces, the umbrella `consolidate.mjs` dist-rewrite step.
+
+**Source spec:** `docs/superpowers/specs/2026-06-11-public-internal-boundary-design.md` (PR B1 section).
+
+**Conventions:**
+- Run a single test file with `pnpm exec vitest run <path>` from the repo root.
+- Never push without the six-step pre-push mirror in `CLAUDE.md` (Task 5 runs it).
+- Commit after each task; commit messages end with the `Co-Authored-By` trailer.
+
+---
+
+## File map
+
+- **Create** `packages/server/src/accept.ts` — the `Accept` type + `pickAccept` content negotiation helper, moved out of `page-action-handler.ts`.
+- **Create** `packages/server/src/__tests__/accept.test.ts` — the `pickAccept` unit tests, moved out of `page-action-handler.test.ts`.
+- **Create** `packages/server/src/internal-runtime.ts` — the framework-emitted door re-exporting the three factories.
+- **Create** `packages/server/src/__tests__/boundary.test.ts` — asserts the factory relocation and the `LoadersHandlerOptions` re-export.
+- **Create** `packages/hono-preact/src/server-internal-runtime.ts` — umbrella re-export of the server runtime door.
+- **Modify** `packages/server/src/page-action-handler.ts` — import `Accept`/`pickAccept` from `./accept.js`, delete the local definitions.
+- **Modify** `packages/server/src/__tests__/page-action-handler.test.ts` — drop the `pickAccept` import and its `describe` block.
+- **Modify** `packages/server/src/index.ts` — remove the three factory re-exports; add `LoadersHandlerOptions`.
+- **Modify** `packages/server/package.json` — add the `./internal/runtime` export.
+- **Modify** `packages/vite/src/server-entry.ts` — split the generated import so the factories come from `hono-preact/server/internal/runtime`.
+- **Modify** `packages/vite/src/__tests__/server-entry.test.ts` — update the expected generated-import string.
+- **Modify** `packages/hono-preact/package.json` — add the `./server/internal/runtime` export.
+- **Modify** `packages/hono-preact/scripts/consolidate.mjs` — add the `DIST_PATHS` rewrite entry.
+
+---
+
+## Task 1: Extract `pickAccept` into an internal `accept.ts` module
+
+**Files:**
+- Create: `packages/server/src/accept.ts`
+- Create: `packages/server/src/__tests__/accept.test.ts`
+- Modify: `packages/server/src/page-action-handler.ts` (remove `type Accept` at line 79 and `pickAccept` at lines 89-115; add an import)
+- Modify: `packages/server/src/__tests__/page-action-handler.test.ts` (remove the `pickAccept` import on line 4 and the `describe('pickAccept', …)` block at lines 317-357)
+
+- [ ] **Step 1: Write the moved unit test against the new module**
+
+Create `packages/server/src/__tests__/accept.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { pickAccept } from '../accept.js';
+
+describe('pickAccept', () => {
+  it('maps application/json to json', () => {
+    expect(pickAccept('application/json')).toBe('json');
+  });
+  it('maps text/event-stream to event-stream', () => {
+    expect(pickAccept('text/event-stream')).toBe('event-stream');
+  });
+  it('maps text/html to html', () => {
+    expect(pickAccept('text/html')).toBe('html');
+  });
+  it('maps */* to html', () => {
+    expect(pickAccept('*/*')).toBe('html');
+  });
+  it('defaults missing/empty Accept to html', () => {
+    expect(pickAccept(undefined)).toBe('html');
+    expect(pickAccept('')).toBe('html');
+  });
+  it('honors q-values when choosing the best candidate', () => {
+    expect(pickAccept('application/json, text/event-stream;q=0.9')).toBe(
+      'json'
+    );
+  });
+  it('breaks q-value ties by Accept order', () => {
+    expect(pickAccept('application/json, text/event-stream')).toBe('json');
+    expect(pickAccept('text/event-stream, application/json')).toBe(
+      'event-stream'
+    );
+  });
+  it('ignores unparseable q-values (defaults q to 1.0)', () => {
+    expect(pickAccept('application/json;q=invalid')).toBe('json');
+  });
+  it('ignores unsupported media types', () => {
+    expect(pickAccept('text/plain, application/json;q=0.5')).toBe('json');
+  });
+  it('treats q=0 as a real (lowest) preference, not exclusion', () => {
+    expect(pickAccept('application/json;q=0')).toBe('json');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/accept.test.ts`
+Expected: FAIL — `Failed to resolve import "../accept.js"` (module does not exist yet).
+
+- [ ] **Step 3: Create the `accept.ts` module**
+
+Create `packages/server/src/accept.ts` (verbatim move of the type + function from `page-action-handler.ts`):
+
+```ts
+export type Accept = 'html' | 'json' | 'event-stream';
+
+/**
+ * Content negotiation for action POSTs: chooses json (RPC), event-stream
+ * (streaming action), or html (progressive-enhancement form post) from the
+ * request's Accept header. Highest q-value wins; ties break by Accept order.
+ * `*\/*` and `text/html` map to html; unsupported media types are ignored.
+ * Unspecified quality defaults to 1.0; an empty/missing header defaults to html.
+ */
+export function pickAccept(header: string | undefined): Accept {
+  const h = header ?? '';
+  type Candidate = { type: Accept; q: number };
+  const candidates: Candidate[] = [];
+
+  for (const part of h.split(',')) {
+    const [mediaType, ...params] = part.trim().split(';');
+    const mt = (mediaType ?? '').trim().toLowerCase();
+    let q = 1.0;
+    for (const p of params) {
+      const kv = p.trim().split('=');
+      if (kv[0]?.trim() === 'q' && kv[1] !== undefined) {
+        const parsed = Number(kv[1].trim());
+        if (!Number.isNaN(parsed)) q = parsed;
+      }
+    }
+    if (mt === 'text/event-stream')
+      candidates.push({ type: 'event-stream', q });
+    else if (mt === 'application/json') candidates.push({ type: 'json', q });
+    else if (mt === 'text/html' || mt === '*/*')
+      candidates.push({ type: 'html', q });
+  }
+
+  if (candidates.length === 0) return 'html';
+  candidates.sort((a, b) => b.q - a.q);
+  return candidates[0]!.type;
+}
+```
+
+(Note: the `*\/*` in the doc comment above is an escaped block-comment terminator — write it as `*/*` in the actual file.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/accept.test.ts`
+Expected: PASS (11 assertions).
+
+- [ ] **Step 5: Point `page-action-handler.ts` at the new module and delete the local copies**
+
+In `packages/server/src/page-action-handler.ts`:
+- Delete `type Accept = 'html' | 'json' | 'event-stream';` (line 79) and the entire `export function pickAccept(...) { ... }` block (lines 89-115, including its doc comment).
+- Add to the import block at the top of the file (next to the other `./*.js` imports):
+
+```ts
+import { pickAccept, type Accept } from './accept.js';
+```
+
+(`pickAccept` is still called at the former line 193; `Accept` is used by `pickAccept`'s return site. The import covers both.)
+
+- [ ] **Step 6: Remove the moved test from `page-action-handler.test.ts`**
+
+In `packages/server/src/__tests__/page-action-handler.test.ts`:
+- Change line 4 from `import { pageActionHandler, pickAccept } from '../page-action-handler.js';` to `import { pageActionHandler } from '../page-action-handler.js';`
+- Delete the entire `describe('pickAccept', () => { ... });` block (lines 317-357).
+
+- [ ] **Step 7: Run the full server test suite**
+
+Run: `pnpm exec vitest run packages/server`
+Expected: PASS — `accept.test.ts` green, `page-action-handler.test.ts` green without the moved block, nothing else changed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/server/src/accept.ts \
+  packages/server/src/__tests__/accept.test.ts \
+  packages/server/src/page-action-handler.ts \
+  packages/server/src/__tests__/page-action-handler.test.ts
+git commit -m "refactor(server): extract pickAccept into internal accept module
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Server `/internal/runtime` door + relocate the factories, re-export `LoadersHandlerOptions`
+
+**Files:**
+- Create: `packages/server/src/internal-runtime.ts`
+- Create: `packages/server/src/__tests__/boundary.test.ts`
+- Modify: `packages/server/src/index.ts`
+- Modify: `packages/server/package.json`
+
+- [ ] **Step 1: Write the boundary test (value relocation + type re-export)**
+
+Create `packages/server/src/__tests__/boundary.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import * as publicEntry from '../index.js';
+import * as runtime from '../internal-runtime.js';
+// Type-surface check: this import + usage fails `tsc` if the re-export is
+// missing. Vitest strips types, so the real enforcement is `pnpm typecheck`.
+import type { LoadersHandlerOptions } from '../index.js';
+
+const _loadersHandlerOptions: LoadersHandlerOptions = {};
+void _loadersHandlerOptions;
+
+const FACTORIES = [
+  'routeServerModules',
+  'makePageUseResolvers',
+  'makePageActionResolvers',
+] as const;
+
+describe('server boundary', () => {
+  it('exposes the framework-emitted factories on /internal/runtime as functions', () => {
+    for (const name of FACTORIES) {
+      expect(typeof (runtime as Record<string, unknown>)[name]).toBe(
+        'function'
+      );
+    }
+  });
+
+  it('does not re-export the factories from the public entry', () => {
+    for (const name of FACTORIES) {
+      expect(name in publicEntry).toBe(false);
+    }
+  });
+
+  it('keeps the public handler surface available', () => {
+    expect(typeof publicEntry.renderPage).toBe('function');
+    expect(typeof publicEntry.loadersHandler).toBe('function');
+    expect(typeof publicEntry.pageActionHandler).toBe('function');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/server/src/__tests__/boundary.test.ts`
+Expected: FAIL — `Failed to resolve import "../internal-runtime.js"` (module missing). (After the module exists, the `does not re-export` assertion is what the index edit must satisfy.)
+
+- [ ] **Step 3: Create the framework-emitted door**
+
+Create `packages/server/src/internal-runtime.ts`:
+
+```ts
+// @hono-preact/server/internal/runtime — framework-emitted tier.
+//
+// These factories exist ONLY because the framework's generated server entry
+// imports and calls them (serverEntryPlugin). They are a private contract
+// between this version's vite plugins and this version's runtime; they have
+// no standalone user story. DO NOT IMPORT FROM USER CODE — this door is
+// undocumented and may change in any non-major release in lockstep with the
+// codegen that emits it.
+export {
+  routeServerModules,
+  makePageUseResolvers,
+} from './route-server-modules.js';
+export { makePageActionResolvers } from './page-action-resolvers.js';
+```
+
+- [ ] **Step 4: Remove the factories from the public index and add `LoadersHandlerOptions`**
+
+Replace the contents of `packages/server/src/index.ts` with:
+
+```ts
+export { HonoContext, useHonoContext } from './context.js';
+export { renderPage } from './render.js';
+export { loadersHandler, type LoadersHandlerOptions } from './loaders-handler.js';
+export { type ActionEntry } from './page-action-resolvers.js';
+export {
+  pageActionHandler,
+  type PageActionHandlerOptions,
+} from './page-action-handler.js';
+```
+
+(`ActionEntry` stays public because `PageActionHandlerOptions.resolverByPath` references it. The three factories are gone from this door; they live on `./internal-runtime.js`.)
+
+- [ ] **Step 5: Add the `./internal/runtime` export to the server package**
+
+In `packages/server/package.json`, change the `exports` block to:
+
+```json
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./internal/runtime": {
+      "types": "./dist/internal-runtime.d.ts",
+      "import": "./dist/internal-runtime.js"
+    }
+  },
+```
+
+- [ ] **Step 6: Run the boundary test and the full server suite**
+
+Run: `pnpm exec vitest run packages/server`
+Expected: PASS — `boundary.test.ts` green; resolver/handler tests unchanged (they import from their source modules, not the index).
+
+- [ ] **Step 7: Typecheck the server package (validates the `LoadersHandlerOptions` re-export)**
+
+Run: `pnpm --filter '@hono-preact/*' --filter hono-preact build && pnpm typecheck`
+Expected: PASS. (Build first so `dist/` is current — `typecheck` resolves cross-package types through `dist/`. The `_loadersHandlerOptions: LoadersHandlerOptions = {}` line in `boundary.test.ts` fails `tsc` if the type re-export is missing.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/server/src/internal-runtime.ts \
+  packages/server/src/__tests__/boundary.test.ts \
+  packages/server/src/index.ts \
+  packages/server/package.json
+git commit -m "refactor(server): move resolver factories to /internal/runtime, export LoadersHandlerOptions
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Update the generated server entry to import factories from the runtime door
+
+**Files:**
+- Modify: `packages/vite/src/__tests__/server-entry.test.ts` (the expected import string at line 101)
+- Modify: `packages/vite/src/server-entry.ts` (the codegen import block at lines 40-48)
+
+- [ ] **Step 1: Update the test's expected generated-import string**
+
+In `packages/vite/src/__tests__/server-entry.test.ts`, replace the single-block expectation (currently at line 101):
+
+```ts
+    expect(src).toContain(
+      `import {\n  loadersHandler,\n  pageActionHandler,\n  renderPage,\n} from 'hono-preact/server';`
+    );
+    expect(src).toContain(
+      `import {\n  makePageActionResolvers,\n  makePageUseResolvers,\n  routeServerModules,\n} from 'hono-preact/server/internal/runtime';`
+    );
+```
+
+(The other assertions in this file — `makePageUseResolvers(routes.serverRoutes, { dev })`, `makePageActionResolvers(routes.serverRoutes, { dev })`, the `loadersHandler(serverModules, …)` call, etc. — stay valid: only the import source changes, not the call sites.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts`
+Expected: FAIL — the generated source still emits the old single combined import from `hono-preact/server`.
+
+- [ ] **Step 3: Split the codegen import block**
+
+In `packages/vite/src/server-entry.ts`, replace this generated import (lines 40-48):
+
+```ts
+    `import {\n` +
+    `  loadersHandler,\n` +
+    `  makePageActionResolvers,\n` +
+    `  makePageUseResolvers,\n` +
+    `  pageActionHandler,\n` +
+    `  renderPage,\n` +
+    `  routeServerModules,\n` +
+    `} from 'hono-preact/server';\n` +
+```
+
+with:
+
+```ts
+    `import {\n` +
+    `  loadersHandler,\n` +
+    `  pageActionHandler,\n` +
+    `  renderPage,\n` +
+    `} from 'hono-preact/server';\n` +
+    `import {\n` +
+    `  makePageActionResolvers,\n` +
+    `  makePageUseResolvers,\n` +
+    `  routeServerModules,\n` +
+    `} from 'hono-preact/server/internal/runtime';\n` +
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full vite suite (catch any other codegen snapshot)**
+
+Run: `pnpm exec vitest run packages/vite`
+Expected: PASS — no other test asserts the old combined import (adapter/node-dev-server tests assert the entry-wrapper path, not the import block).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/vite/src/server-entry.ts \
+  packages/vite/src/__tests__/server-entry.test.ts
+git commit -m "feat(vite): import server resolver factories from /internal/runtime in generated entry
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Umbrella `hono-preact/server/internal/runtime` subpath
+
+**Files:**
+- Create: `packages/hono-preact/src/server-internal-runtime.ts`
+- Modify: `packages/hono-preact/package.json`
+- Modify: `packages/hono-preact/scripts/consolidate.mjs`
+
+- [ ] **Step 1: Create the umbrella re-export file**
+
+Create `packages/hono-preact/src/server-internal-runtime.ts`:
+
+```ts
+export * from '@hono-preact/server/internal/runtime';
+```
+
+- [ ] **Step 2: Add the umbrella export entry**
+
+In `packages/hono-preact/package.json`, add to the `exports` block (after the `./internal` entry):
+
+```json
+    "./server/internal/runtime": {
+      "types": "./dist/server-internal-runtime.d.ts",
+      "import": "./dist/server-internal-runtime.js"
+    }
+```
+
+(Add a comma after the previous `./internal` block so the JSON stays valid.)
+
+- [ ] **Step 3: Teach `consolidate.mjs` to recognize and rewrite the new specifier**
+
+`consolidate.mjs` rewrites a cross-package import only if (a) the specifier matches a hardcoded **regex alternation** and (b) it has a `DIST_PATHS` entry. Both must be updated, or the umbrella's `server-internal-runtime.js` keeps a bare `@hono-preact/server/internal/runtime` import that cannot resolve in a user's installed tarball.
+
+First, the `DIST_PATHS` map (around line 48) — add:
+
+```js
+  '@hono-preact/server/internal/runtime': 'server/internal-runtime.js',
+```
+
+Second, the matcher regex (line 101). Change its alternation group from:
+
+```js
+    /(['"])(@hono-preact\/(?:iso\/internal|iso\/page|iso|server|vite\/adapter-cloudflare|vite\/adapter-node|vite))(['"])/g,
+```
+
+to (note `server\/internal\/runtime` is listed **before** `server` so the longer specifier wins the ordered alternation):
+
+```js
+    /(['"])(@hono-preact\/(?:iso\/internal|iso\/page|iso|server\/internal\/runtime|server|vite\/adapter-cloudflare|vite\/adapter-node|vite))(['"])/g,
+```
+
+(The trailing `(['"])` already prevents `server` from matching the `@hono-preact/server` prefix inside the longer string, but listing longest-first is the defensive convention and matters for B2's `iso/internal/runtime` too.)
+
+- [ ] **Step 4: Build server + umbrella so the consolidated dist exists**
+
+Run: `pnpm --filter @hono-preact/server --filter hono-preact build`
+Expected: PASS, no errors.
+
+- [ ] **Step 5: Verify the consolidated dist resolves end-to-end**
+
+Run:
+
+```bash
+node --input-type=module -e "import('hono-preact/server/internal/runtime').then(m => { const ok = typeof m.makePageActionResolvers === 'function' && typeof m.makePageUseResolvers === 'function' && typeof m.routeServerModules === 'function'; if (!ok) { console.error('missing factory export', Object.keys(m)); process.exit(1); } console.log('resolved ok'); }).catch(e => { console.error(e); process.exit(1); });"
+```
+
+Expected: prints `resolved ok`. (This loads the umbrella's consolidated `dist/server-internal-runtime.js`, whose `@hono-preact/server/internal/runtime` import was rewritten by `consolidate.mjs` to the relative `./server/internal-runtime.js`. A failure here means the `DIST_PATHS` entry or the export map is wrong.)
+
+- [ ] **Step 6: Confirm the rewrite happened in the shipped file**
+
+Run: `grep -n "server/internal-runtime.js\|@hono-preact/server" packages/hono-preact/dist/server-internal-runtime.js`
+Expected: the import target is the relative `./server/internal-runtime.js`; no bare `@hono-preact/server/internal/runtime` specifier survives.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hono-preact/src/server-internal-runtime.ts \
+  packages/hono-preact/package.json \
+  packages/hono-preact/scripts/consolidate.mjs
+git commit -m "feat(hono-preact): expose server/internal/runtime umbrella subpath
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full pre-push verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the six-step CI mirror in order**
+
+Run each, expecting PASS before moving on (per `CLAUDE.md` "Pre-push verification"):
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+- [ ] **Step 2: If `format:check` fails, fix and amend**
+
+Run: `pnpm format` then re-run `pnpm format:check`. Stage the formatting changes into the most relevant task commit (or a `style:` commit) and re-run from Step 1.
+
+- [ ] **Step 3: Confirm the integration suite exercised the new path**
+
+`pnpm test:integration` builds a real app whose generated server entry now imports `hono-preact/server/internal/runtime`. A green integration run is the end-to-end proof that the umbrella subpath, the consolidate rewrite, and the codegen change all agree. (If the integration scaffold step hangs or flakes for network reasons offline, note it and re-run when online; do not push on an un-run integration suite.)
+
+---
+
+## Notes for the next PR (B2, iso)
+
+- B2 adds the iso `/internal/runtime` door (installers + loader stub + the whole `contract.ts` constants module), reduces `/internal` to escape-hatch-only with a rewritten header, removes the `getViewTransitionDirection` barrel leak, adds the codegen-invariant test, and folds in the minimal SSE comment.
+- B2 also touches the umbrella (`./internal/runtime` for iso, plus the iso half of `consolidate.mjs`'s `DIST_PATHS`). Plan B2 against the post-B1 `main` so the umbrella edits stack cleanly.
+- The breaking-change note (factories + barrel leak relocation) is recorded at the next release in the `vX-release-notes.md`, not as a rolling changelog (matching the repo's release pattern).
+
+---
+
+## Self-review
+
+- **Spec coverage (PR B1 section):** factories → `/internal/runtime` (Task 2), `LoadersHandlerOptions` re-export (Task 2), `pickAccept` de-surfaced (Task 1, via extraction), server-entry codegen + tests (Task 3), umbrella + `consolidate.mjs` (Task 4), `ActionEntry` stays public (Task 2 index keeps it). All present.
+- **Placeholder scan:** every code step shows the full code; commands have expected output. None pending.
+- **Type/name consistency:** `pickAccept`/`Accept` (Task 1) match the import in Task 1 Step 5; the three factory names are identical across Tasks 2, 3, 4 and the `FACTORIES` test array; the subpath string `hono-preact/server/internal/runtime` is identical in Tasks 3, 4, and 5.

--- a/docs/superpowers/plans/2026-06-11-server-internal-boundary.md
+++ b/docs/superpowers/plans/2026-06-11-server-internal-boundary.md
@@ -19,19 +19,19 @@
 
 ## File map
 
-- **Create** `packages/server/src/accept.ts` — the `Accept` type + `pickAccept` content negotiation helper, moved out of `page-action-handler.ts`.
-- **Create** `packages/server/src/__tests__/accept.test.ts` — the `pickAccept` unit tests, moved out of `page-action-handler.test.ts`.
-- **Create** `packages/server/src/internal-runtime.ts` — the framework-emitted door re-exporting the three factories.
-- **Create** `packages/server/src/__tests__/boundary.test.ts` — asserts the factory relocation and the `LoadersHandlerOptions` re-export.
-- **Create** `packages/hono-preact/src/server-internal-runtime.ts` — umbrella re-export of the server runtime door.
-- **Modify** `packages/server/src/page-action-handler.ts` — import `Accept`/`pickAccept` from `./accept.js`, delete the local definitions.
-- **Modify** `packages/server/src/__tests__/page-action-handler.test.ts` — drop the `pickAccept` import and its `describe` block.
-- **Modify** `packages/server/src/index.ts` — remove the three factory re-exports; add `LoadersHandlerOptions`.
-- **Modify** `packages/server/package.json` — add the `./internal/runtime` export.
-- **Modify** `packages/vite/src/server-entry.ts` — split the generated import so the factories come from `hono-preact/server/internal/runtime`.
-- **Modify** `packages/vite/src/__tests__/server-entry.test.ts` — update the expected generated-import string.
-- **Modify** `packages/hono-preact/package.json` — add the `./server/internal/runtime` export.
-- **Modify** `packages/hono-preact/scripts/consolidate.mjs` — add the `DIST_PATHS` rewrite entry.
+- **Create** `packages/server/src/accept.ts`, the `Accept` type + `pickAccept` content negotiation helper, moved out of `page-action-handler.ts`.
+- **Create** `packages/server/src/__tests__/accept.test.ts`, the `pickAccept` unit tests, moved out of `page-action-handler.test.ts`.
+- **Create** `packages/server/src/internal-runtime.ts`, the framework-emitted door re-exporting the three factories.
+- **Create** `packages/server/src/__tests__/boundary.test.ts`, asserts the factory relocation and the `LoadersHandlerOptions` re-export.
+- **Create** `packages/hono-preact/src/server-internal-runtime.ts`, umbrella re-export of the server runtime door.
+- **Modify** `packages/server/src/page-action-handler.ts`, import `Accept`/`pickAccept` from `./accept.js`, delete the local definitions.
+- **Modify** `packages/server/src/__tests__/page-action-handler.test.ts`, drop the `pickAccept` import and its `describe` block.
+- **Modify** `packages/server/src/index.ts`, remove the three factory re-exports; add `LoadersHandlerOptions`.
+- **Modify** `packages/server/package.json`, add the `./internal/runtime` export.
+- **Modify** `packages/vite/src/server-entry.ts`, split the generated import so the factories come from `hono-preact/server/internal/runtime`.
+- **Modify** `packages/vite/src/__tests__/server-entry.test.ts`, update the expected generated-import string.
+- **Modify** `packages/hono-preact/package.json`, add the `./server/internal/runtime` export.
+- **Modify** `packages/hono-preact/scripts/consolidate.mjs`, add the `DIST_PATHS` rewrite entry.
 
 ---
 
@@ -94,7 +94,7 @@ describe('pickAccept', () => {
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `pnpm exec vitest run packages/server/src/__tests__/accept.test.ts`
-Expected: FAIL — `Failed to resolve import "../accept.js"` (module does not exist yet).
+Expected: FAIL. `Failed to resolve import "../accept.js"` (module does not exist yet).
 
 - [ ] **Step 3: Create the `accept.ts` module**
 
@@ -139,7 +139,7 @@ export function pickAccept(header: string | undefined): Accept {
 }
 ```
 
-(Note: the `*\/*` in the doc comment above is an escaped block-comment terminator — write it as `*/*` in the actual file.)
+(Note: the `*\/*` in the doc comment above is an escaped block-comment terminator, write it as `*/*` in the actual file.)
 
 - [ ] **Step 4: Run the test to verify it passes**
 
@@ -167,7 +167,7 @@ In `packages/server/src/__tests__/page-action-handler.test.ts`:
 - [ ] **Step 7: Run the full server test suite**
 
 Run: `pnpm exec vitest run packages/server`
-Expected: PASS — `accept.test.ts` green, `page-action-handler.test.ts` green without the moved block, nothing else changed.
+Expected: PASS. `accept.test.ts` green, `page-action-handler.test.ts` green without the moved block, nothing else changed.
 
 - [ ] **Step 8: Commit**
 
@@ -238,19 +238,19 @@ describe('server boundary', () => {
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `pnpm exec vitest run packages/server/src/__tests__/boundary.test.ts`
-Expected: FAIL — `Failed to resolve import "../internal-runtime.js"` (module missing). (After the module exists, the `does not re-export` assertion is what the index edit must satisfy.)
+Expected: FAIL. `Failed to resolve import "../internal-runtime.js"` (module missing). (After the module exists, the `does not re-export` assertion is what the index edit must satisfy.)
 
 - [ ] **Step 3: Create the framework-emitted door**
 
 Create `packages/server/src/internal-runtime.ts`:
 
 ```ts
-// @hono-preact/server/internal/runtime — framework-emitted tier.
+// @hono-preact/server/internal/runtime, framework-emitted tier.
 //
 // These factories exist ONLY because the framework's generated server entry
 // imports and calls them (serverEntryPlugin). They are a private contract
 // between this version's vite plugins and this version's runtime; they have
-// no standalone user story. DO NOT IMPORT FROM USER CODE — this door is
+// no standalone user story. DO NOT IMPORT FROM USER CODE, this door is
 // undocumented and may change in any non-major release in lockstep with the
 // codegen that emits it.
 export {
@@ -297,12 +297,12 @@ In `packages/server/package.json`, change the `exports` block to:
 - [ ] **Step 6: Run the boundary test and the full server suite**
 
 Run: `pnpm exec vitest run packages/server`
-Expected: PASS — `boundary.test.ts` green; resolver/handler tests unchanged (they import from their source modules, not the index).
+Expected: PASS. `boundary.test.ts` green; resolver/handler tests unchanged (they import from their source modules, not the index).
 
 - [ ] **Step 7: Typecheck the server package (validates the `LoadersHandlerOptions` re-export)**
 
 Run: `pnpm --filter '@hono-preact/*' --filter hono-preact build && pnpm typecheck`
-Expected: PASS. (Build first so `dist/` is current — `typecheck` resolves cross-package types through `dist/`. The `_loadersHandlerOptions: LoadersHandlerOptions = {}` line in `boundary.test.ts` fails `tsc` if the type re-export is missing.)
+Expected: PASS. (Build first so `dist/` is current, `typecheck` resolves cross-package types through `dist/`. The `_loadersHandlerOptions: LoadersHandlerOptions = {}` line in `boundary.test.ts` fails `tsc` if the type re-export is missing.)
 
 - [ ] **Step 8: Commit**
 
@@ -337,12 +337,12 @@ In `packages/vite/src/__tests__/server-entry.test.ts`, replace the single-block 
     );
 ```
 
-(The other assertions in this file — `makePageUseResolvers(routes.serverRoutes, { dev })`, `makePageActionResolvers(routes.serverRoutes, { dev })`, the `loadersHandler(serverModules, …)` call, etc. — stay valid: only the import source changes, not the call sites.)
+(The other assertions in this file, `makePageUseResolvers(routes.serverRoutes, { dev })`, `makePageActionResolvers(routes.serverRoutes, { dev })`, the `loadersHandler(serverModules, …)` call, etc., stay valid: only the import source changes, not the call sites.)
 
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `pnpm exec vitest run packages/vite/src/__tests__/server-entry.test.ts`
-Expected: FAIL — the generated source still emits the old single combined import from `hono-preact/server`.
+Expected: FAIL. the generated source still emits the old single combined import from `hono-preact/server`.
 
 - [ ] **Step 3: Split the codegen import block**
 
@@ -382,7 +382,7 @@ Expected: PASS.
 - [ ] **Step 5: Run the full vite suite (catch any other codegen snapshot)**
 
 Run: `pnpm exec vitest run packages/vite`
-Expected: PASS — no other test asserts the old combined import (adapter/node-dev-server tests assert the entry-wrapper path, not the import block).
+Expected: PASS. no other test asserts the old combined import (adapter/node-dev-server tests assert the entry-wrapper path, not the import block).
 
 - [ ] **Step 6: Commit**
 
@@ -428,7 +428,7 @@ In `packages/hono-preact/package.json`, add to the `exports` block (after the `.
 
 `consolidate.mjs` rewrites a cross-package import only if (a) the specifier matches a hardcoded **regex alternation** and (b) it has a `DIST_PATHS` entry. Both must be updated, or the umbrella's `server-internal-runtime.js` keeps a bare `@hono-preact/server/internal/runtime` import that cannot resolve in a user's installed tarball.
 
-First, the `DIST_PATHS` map (around line 48) — add:
+First, the `DIST_PATHS` map (around line 48), add:
 
 ```js
   '@hono-preact/server/internal/runtime': 'server/internal-runtime.js',

--- a/docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-10-semantics-consolidation-design.md
@@ -1,0 +1,111 @@
+# Semantics consolidation (Section A of the primitives DX review)
+
+**Date:** 2026-06-10
+**Status:** Approved design, pre-implementation
+**Source:** Section A of `docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md`
+**Goal:** The same semantics should have one implementation. Five duplication clusters collapse into shared modules across three PRs, with one deliberate behavior change (Form timeout handling) and otherwise byte-level behavior preservation.
+
+## Scope decisions (locked with user)
+
+1. **Three PRs by theme.** PR 1: outcome semantics (client envelope codec + server outcome translation). PR 2: server resolvers (route matcher + resolver-factory twins). PR 3: shared constants module. Release pressure is explicitly zero; no release work in scope.
+2. **Unify accidental divergences, keep deliberate ones.** Form learns real timeout handling (behavior change, effectively a bug fix). Form keeps `window.location.reload()` on malformed bodies as an explicit progressive-enhancement policy. All server status codes and response shapes are unchanged.
+3. **No public-surface changes.** `makePageUseResolvers` / `makePageActionResolvers` keep their exact signatures. Boundary redrawing is Section B work, not this.
+
+## PR 1: Outcome semantics
+
+### Client envelope codec (one decoder)
+
+`packages/iso/src/internal/action-envelope.ts` already owns the `ActionEnvelope` wire type and the encoder `serializeActionOutcome`. It gains the decoder so the whole wire format lives in one file:
+
+- `decodeActionResponse(res: Response): Promise<DecodedEnvelope>` parses the JSON body and validates the `__outcome` discriminant. Returns a discriminated union with kinds `success | redirect | deny | error | timeout | unknown | malformed`. `malformed` covers non-JSON and non-envelope bodies; `unknown` carries an unrecognized `__outcome` string (the two are distinct because both consumers treat them differently today). The decoder never throws for body-shape problems, the consumer decides.
+- Cross-origin redirect detection (currently duplicated in both call sites) moves in as a shared helper.
+
+Consumers become policy switches over `DecodedEnvelope`:
+
+- `useAction` (`packages/iso/src/action.ts:405-478` today): behavior unchanged. `timeout` throws `TimeoutError(timeoutMs)`; `malformed` throws a parse error; unknown outcomes throw.
+- `Form` (`packages/iso/src/form.tsx:95-159` today): `timeout` becomes a timeout-flavored error result with a message derived from `timeoutMs`, replacing today's `Unexpected outcome: timeout` fallthrough (the one behavior change). `malformed` keeps `window.location.reload()`, written as an explicit, commented PE-fallback policy.
+
+### Server outcome translation (one module, four channels)
+
+New `packages/server/src/outcome-translation.ts`. The four translation sites stay four channels because they genuinely produce different output (root HTML response, loader JSON, action envelope, action HTML/PE), but they are built from shared pieces in one file:
+
+- Outcome-to-status mapping and redirect/deny shaping helpers.
+- A single `rejectRenderOutcome()` helper owning the one copy of the "render outcome is page-scope only" defense, today pasted into three files (`render.tsx:70`, `loaders-handler.ts:180`, `action-envelope.ts:65`).
+- `translateRootOutcome` (from `render.tsx:56-73`) and `translateOutcomeForLoader` (from `loaders-handler.ts:146-183`) move here.
+- `page-action-handler.ts`'s HTML/PE branch (lines 318-390 today) calls the shared pieces in place.
+- `serializeActionOutcome` stays in iso (the wire type's home) but delegates render rejection to the shared message constant.
+
+### PR 1 tests
+
+- Decoder unit tests: every outcome kind, malformed bodies (non-JSON, null, missing discriminant), cross-origin redirect.
+- Existing Form/useAction tests stay green except the Form timeout case, updated to assert the new timeout error result.
+- A test pinning the single render-rejection defense message.
+
+## PR 2: Server resolvers
+
+### One route matcher
+
+New `packages/server/src/route-pattern.ts` holding the single copy of `segmentsOf`, `urlPathMatchesPattern`, and `patternScore`. The two existing copies (`route-server-modules.ts:23-65`, `page-action-resolvers.ts:47-72`) are byte-identical, so this is a pure move. The module also gains `findBestPattern(patterns, urlPath)` encapsulating the scan-and-score loop both factories inline today (specificity, then depth, then insertion order).
+
+Deriving the matcher from preact-iso directly is not possible (preact-iso does not export its matcher); one well-tested mirror with the existing "mirrors preact-iso's literal-segment preference" comment is the practical ceiling.
+
+### Merge the resolver-factory twins
+
+New internal core `makeRouteModuleResolvers<T>` owning everything `makePageUseResolvers` (`route-server-modules.ts:119-231`) and `makePageActionResolvers` (`page-action-resolvers.ts:87-186`) share verbatim:
+
+- Thunk cache with error recovery (failed loads evict so dev can retry).
+- Dev-rebuild gating (`dev: true` bypasses cache per call).
+- Outer-to-inner ancestor walk.
+- `byPath` best-pattern scan via `findBestPattern`.
+- ModuleKey reverse map.
+
+Parameterized by a small strategy object: extract the payload from a loaded module (`pageUse` array vs `serverActions` via `extractActions`) and merge ancestor payloads (array concat vs Map with same-name shadowing). The two public factories become thin wrappers with their exact current signatures and return types.
+
+### PR 2 tests
+
+- The duplicated matcher coverage folds into one `route-pattern` test file.
+- Direct core tests for cache-eviction-on-error and dev-rebuild (today tested only indirectly, twice).
+- Existing resolver tests stay green unchanged; that is the behavior-preservation check.
+
+## PR 3: Shared constants module
+
+### Location
+
+`packages/iso/src/internal/contract.ts`. iso is the bottom of the dependency graph; server already depends on it. vite gains a `@hono-preact/iso` workspace dependency: a new edge, but build-time only, importing only constants from a `sideEffects: false` package. A separate `@hono-preact/contract` package was considered and rejected as permanent release surface for a file of strings. Placing it in iso's internal tier lines up with Section B's planned split of `/internal` into a stable framework-emitted tier. `server-exports-contract.ts` stays in vite (all consumers are vite-side).
+
+### Contents
+
+One exported constant per literal, each with a doc comment naming every consumer:
+
+- `/__loaders` (iso `internal/loader-fetch.ts`, vite `server-entry.ts` codegen, server `loaders-handler` mount docs).
+- `static/client.js` and the URL form `/static/client.js` (vite `hono-preact.ts:82` entryFileNames, iso `client-script.tsx:5`).
+- The virtual client id `virtual:hono-preact/client` and its dev-server URL `/@id/__x00__virtual:hono-preact/client`, with the URL derived from the id by a small helper rather than hand-encoded.
+- `__moduleKey`, `__module`, `__action` field names (iso form/action, server page-action-handler, vite module-key plugin).
+- The generated server-entry path (vite plugin constant).
+
+vite's codegen interpolates constants into generated output; generated files stay self-contained and do not import the contract at runtime.
+
+### Unimportable consumers
+
+- The scaffolded `wrangler.jsonc` template cannot import TypeScript: create-hono-preact gets a parity test asserting the template's entry path equals the constant.
+- The existing `__moduleKey` parity test simplifies to pinning wire behavior, since both sides now import the same constant.
+
+### PR 3 tests
+
+The parity tests above; otherwise mechanical substitution verified by the whole suite staying green.
+
+## Error handling
+
+- Decoder: body-shape problems are data (`malformed` / `unknown`), not throws; consumers own the failure policy. `unknown` keeps today's per-consumer behavior: Form produces an `Unexpected outcome: <value>` error result, useAction throws. `malformed` keeps Form's reload and useAction's parse-error throw.
+- Resolver core: preserves the existing evict-on-failure cache semantics exactly; a load error still propagates to the caller after eviction.
+- Translation module: unknown outcomes still produce the existing 500 responses per channel.
+
+## Out of scope
+
+- Moving resolver factories off the public `/server` entry, iso barrel re-export cleanup, `/internal` tier split (Section B).
+- The six site-discovered primitives (Section C), vestigial-export trims (Section D), UI dedups (Section E).
+- Any release work.
+
+## Execution order
+
+PR 1, then PR 2, then PR 3, each through the standard flow: implementation plan, build, the six-step local CI mirror, PR, deep review. PR 3 touches files PRs 1 and 2 create or move, so it goes last to avoid rebase churn.

--- a/docs/superpowers/specs/2026-06-11-public-internal-boundary-design.md
+++ b/docs/superpowers/specs/2026-06-11-public-internal-boundary-design.md
@@ -113,8 +113,8 @@ Zero documented-API breakage: no symbol with a docs page changes location. The o
 
 ## PR decomposition
 
-- **PR B1 — server:** factories → `/internal/runtime`, re-export `LoadersHandlerOptions`, de-export `pickAccept`, server-entry codegen update + tests. Self-contained within the server + vite packages.
-- **PR B2 — iso:** new `/internal/runtime` door (installers + stub + contract module), `/internal` reduced to escape-hatch + header rewrite + SSE comment, barrel leak fix, client-entry/server-only/plugin codegen + the invariant test + leak-test fixtures.
+- **PR B1 (server):** factories → `/internal/runtime`, re-export `LoadersHandlerOptions`, de-export `pickAccept`, server-entry codegen update + tests. Self-contained within the server + vite packages.
+- **PR B2 (iso):** new `/internal/runtime` door (installers + stub + contract module), `/internal` reduced to escape-hatch + header rewrite + SSE comment, barrel leak fix, client-entry/server-only/plugin codegen + the invariant test + leak-test fixtures.
 
 Both PRs touch the umbrella (`package.json` exports + `consolidate.mjs` + the two re-export files); the umbrella changes naturally split by which sub-package each subpath points at, so each PR carries its own umbrella half. Order is flexible (the two doors are independent), but landing B1 first keeps the smaller, lower-risk change ahead of the iso churn.
 

--- a/docs/superpowers/specs/2026-06-11-public-internal-boundary-design.md
+++ b/docs/superpowers/specs/2026-06-11-public-internal-boundary-design.md
@@ -1,0 +1,125 @@
+# Public/internal boundary, framework spine (Section B of the primitives DX review)
+
+**Date:** 2026-06-11
+**Status:** Approved design, pre-implementation
+**Source:** Section B of `docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md`
+**Goal:** Redraw the public/internal boundary deliberately before v1 freezes it by accident. Establish a three-tier stability model with structurally distinct doors, then apply it to the iso and server packages. No documented public symbol moves, so there is zero user-facing breakage; only JSDoc-private imports relocate.
+
+## Scope decisions (locked with user)
+
+1. **Framework spine only.** This spec covers the iso/server tier model, the boundary rule, server factory relocation, iso barrel leak fixes, and the SSE-codec question. The **ui boundary inversion** (promote `usePositioner`/`useListboxSelection`, demote the micro-helpers, export contexts so a custom part can read `activeId`) is deferred to its own follow-on spec; it is ui-ergonomics work that overlaps Section E and is a different kind of change.
+2. **Boundary rule = intent + docs page.** Public means *intended for users AND has a docs page* (a live demo is not required; the live-demo gap stays a Section F "dogfood-or-delete" concern, separate from this structural work). Escape-hatch means *exported but explicitly unstable, "read the source."* Framework-emitted means *pure plumbing with no user composition story.*
+3. **Separate subpath for the framework-emitted tier (Approach A).** A real door, not a naming convention or a manifest. The `__$..._hpiso` ugly-name convention is retained as defense-in-depth on the symbols that already have it.
+4. **Door name follows the existing convention.** The one private door we already ship is `/internal`, so the framework-emitted tier nests under it as **`/internal/runtime`**. `/internal` remains the escape-hatch door. The server package gets `/internal/runtime` with no bare `/internal` (it has no escape-hatch tier), which is correct, not an inconsistency.
+5. **SSE stays minimal.** The review's premise ("encoder `sseGeneratorResponse` is public") is false today: the encoder is package-private and the decoder `readSSE` is consumed internally via source import, with its only door presence an undogfooded escape-hatch export. No new server door, no encoder export. See §5.
+
+## The tier model
+
+Three tiers, each a distinct stability contract behind a distinct door:
+
+| Tier | Stability contract | iso door | server door |
+|---|---|---|---|
+| **Public** | semver-stable, supported, documented | `.` (barrel) | `.` |
+| **Escape-hatch** | exported, may change in any minor, "read the source" | `/internal` | (none) |
+| **Framework-emitted** | co-versioned private plumbing; users never import | `/internal/runtime` | `/internal/runtime` |
+
+**Membership rule for the framework-emitted tier** (the enforceable invariant): a symbol belongs on `/internal/runtime` only if it is *pure plumbing with no user composition story*, concretely one of:
+
+- a symbol the framework's codegen **emits** into generated user code (the client-entry installers, the server-only loader stub, the server-entry resolver factories), or
+- the cross-package **wire-contract constants** module (`internal/contract.ts`), consumed by our own vite plugins at build time and by iso/server source at runtime.
+
+Everything else currently on iso `/internal` stays escape-hatch, **even when the server package imports it** (e.g. `HonoRequestContext`, `RENDER_PAGE_SCOPE_MESSAGE`, the `fan*` helpers). The server package is co-versioned framework code and is allowed to consume the escape-hatch tier; cross-package internal use does not promote a symbol to tier 3. Tier 3 is reserved for symbols with no coherent advanced-user story at all.
+
+## PR B1: server boundary
+
+`packages/server/src/index.ts` today exports, undifferentiated: `HonoContext`, `useHonoContext`, `renderPage`, `loadersHandler`, `routeServerModules`, `makePageUseResolvers`, `makePageActionResolvers`, `pageActionHandler`, `ActionEntry`, `PageActionHandlerOptions`.
+
+**Public `.` (after):** `HonoContext`, `useHonoContext`, `renderPage`, `loadersHandler`, `pageActionHandler`, `ActionEntry`, `PageActionHandlerOptions`, and a **newly added re-export of `LoadersHandlerOptions`** (from `loaders-handler.ts:104`). This closes the documented custom-wiring gap: today a hand-rolled handler can call `loadersHandler` but cannot name its own options type.
+
+**New `/internal/runtime` door:** `routeServerModules`, `makePageUseResolvers`, `makePageActionResolvers`. These exist only because the generated server entry imports and calls them; they have no standalone user story. Note the three relocating symbols are all *values* (functions); no type moves, so no public signature is left referencing a now-private type. In particular **`ActionEntry` stays public** even though it is defined next to `makePageActionResolvers`, because `PageActionHandlerOptions.resolverByPath` (`(path: string) => Promise<Map<string, ActionEntry>>`) is part of the public `pageActionHandler` options surface; a hand-wired handler must be able to name it.
+
+- New file `packages/server/src/internal-runtime.ts` re-exporting the three factories from their source modules (`route-server-modules.ts`, `page-action-resolvers.ts`), with a tier-3 header (see §6).
+- `package.json` adds `"./internal/runtime": { "types": "./dist/internal-runtime.d.ts", "import": "./dist/internal-runtime.js" }`.
+
+**`pickAccept`** (`page-action-handler.ts:89`) loses its `export` keyword. It is already unreachable from any package door; its lone consumer is a unit test that imports the source module directly. Module-private is the honest state.
+
+**Codegen + tests:**
+- `packages/vite/src/server-entry.ts` changes its generated import from `hono-preact/server` to `hono-preact/server/internal/runtime` for the three factories (the public `loadersHandler`/`renderPage`/`pageActionHandler` imports stay on `hono-preact/server`). Update `server-entry.test.ts` expected output strings accordingly.
+- New `LoadersHandlerOptions` re-export gets a one-line type-surface assertion in the server package's public-API test (or a `tsd`-style check if one exists).
+
+## PR B2: iso boundary
+
+### New `/internal/runtime` door
+
+New file `packages/iso/src/internal-runtime.ts`, exporting exactly the plumbing tier:
+
+- **Installers** (codegen-emitted by the client-entry): `installHistoryShim`, `installNavTransitionScheduler`, `installStreamRegistry`.
+- **Loader stub** (codegen-emitted by server-only): `__$createLoaderStub_hpiso`.
+- **Wire-contract constants** (the whole `internal/contract.ts` module): `LOADERS_RPC_PATH`, `CLIENT_ENTRY_FILE`, `CLIENT_ENTRY_URL`, `VIRTUAL_CLIENT_ID`, `VIRTUAL_CLIENT_DEV_URL`, `MODULE_KEY_EXPORT`, `LOADER_NAME_OPTION`, `FORM_MODULE_FIELD`, `FORM_ACTION_FIELD`.
+
+`package.json` adds `"./internal/runtime"`. Relies on iso's existing `sideEffects: false` so a vite plugin importing one constant does not drag installer runtime code into the build graph.
+
+### `/internal` becomes escape-hatch-only
+
+`packages/iso/src/internal.ts` loses the symbols listed above. Everything else stays (the compose-by-hand escape hatches: `Loader`, `Envelope`, `RouteBoundary`, `OptimisticOverlay`, the action-envelope codec, contexts, request-scope helpers, `PageMiddlewareHost`, `dispatchServer`/`dispatchClient`, `partitionUse`, the `fan*` helpers, `useRender`, `mergeRefs`, `readSSE`, etc.). Specifically note:
+
+- The `history-shim` re-export splits: `installHistoryShim` moves to `/internal/runtime`; `getNavDirection` stays on `/internal` (it has a user-facing "get nav direction" story and is reachable there already).
+- The file header is rewritten: the obsolete in-file "Section 1 / Section 2" comment split is removed (the split is now a real subpath), and the stability disclaimer becomes honestly *unstable*, no longer hedged by also covering plumbing the framework's own emitted code requires.
+
+### Barrel leak fixes (`packages/iso/src/index.ts`)
+
+- **Remove** the `export { getNavDirection as getViewTransitionDirection } from './internal/history-shim.js'` re-export (`index.ts:147`). It is an undocumented barrel rename of an internal symbol. It remains reachable as `getNavDirection` on `/internal`. (Full deletion of the symbol is a Section D call and is out of scope here.)
+- **`ViewTransitionEvent`** already lives correctly as a *type-only* export on the barrel (`index.ts:134`, part of the public `useViewTransitionLifecycle` callback signature) and as a *value* on `/internal` (`internal.ts:75`). This split is intentional and stays; the design only documents the rationale in a comment so it is not "fixed" into a leak later.
+
+### Codegen + plugin imports
+
+- `packages/vite/src/client-entry.ts`: generated import of the three installers changes from `hono-preact/internal` to `hono-preact/internal/runtime`. Its own build-time `VIRTUAL_CLIENT_ID` import changes from `@hono-preact/iso/internal` to `@hono-preact/iso/internal/runtime`.
+- `packages/vite/src/server-only.ts`: generated `__$createLoaderStub_hpiso` import changes from `hono-preact/internal` to `hono-preact/internal/runtime`; its build-time constant imports (`MODULE_KEY_EXPORT`, `LOADER_NAME_OPTION`, `FORM_MODULE_FIELD`, `FORM_ACTION_FIELD`) change to `@hono-preact/iso/internal/runtime`.
+- `packages/vite/src/hono-preact.ts` (`CLIENT_ENTRY_FILE`), `server-entry.ts` (`LOADERS_RPC_PATH`), `module-key-plugin.ts` (`MODULE_KEY_EXPORT`, `LOADER_NAME_OPTION`): build-time constant imports change to `@hono-preact/iso/internal/runtime`.
+- Update `client-entry.test.ts` and the `__tests__/fixtures/leak-test/vite.config.ts` alias fixtures to the new specifiers.
+
+### The invariant test
+
+A new test asserts the `/internal/runtime` door cannot drift from what the framework actually emits:
+
+1. Its non-constant exports == the set of symbols the codegen emits (the installers + the loader stub), derived from the same generated-string sources the existing codegen tests check.
+2. Its constant exports == the public exports of `internal/contract.ts` (the whole wire-contract module, re-exported as a unit).
+
+## Umbrella package (`hono-preact`)
+
+The umbrella ships a self-contained tarball; `scripts/consolidate.mjs` copies each sub-package's `dist/` in and rewrites `@hono-preact/*` import specifiers to file-relative paths using its `DIST_PATHS` map. Three coordinated changes:
+
+1. **New re-export files:** `src/internal-runtime.ts` (`export * from '@hono-preact/iso/internal/runtime'`) and `src/server-internal-runtime.ts` (`export * from '@hono-preact/server/internal/runtime'`).
+2. **`package.json` exports:** add `"./internal/runtime"` → `dist/internal-runtime.js` and `"./server/internal/runtime"` → `dist/server-internal-runtime.js`. `"./internal"` stays mapped to the iso escape-hatch door.
+3. **`consolidate.mjs` `DIST_PATHS`** gains `'@hono-preact/iso/internal/runtime': 'iso/internal-runtime.js'` and `'@hono-preact/server/internal/runtime': 'server/internal-runtime.js'`. This is the easy-to-miss step: without it, the vite plugins' build-time constant imports (rewritten in the shipped dist) and the umbrella re-export files fail to resolve in a user's installed environment.
+
+Codegen emits umbrella specifiers (`hono-preact/internal/runtime`, `hono-preact/server/internal/runtime`) because user apps depend on `hono-preact`, not the workspace-private sub-packages. The vite plugins' own source uses workspace specifiers (`@hono-preact/iso/internal/runtime`), which `consolidate.mjs` rewrites at publish time.
+
+## SSE codec (§5): minimal touch
+
+Facts established during design:
+- `sseGeneratorResponse` (encoder) is **package-private** in `packages/server/src/sse.ts`; its only consumers are `loaders-handler.ts` and `page-action-handler.ts`. It is on no door.
+- `readSSE` (decoder) is consumed **internally via source import** by `action.ts` and `internal/loader-fetch.ts`; its only *door* presence is the escape-hatch export on iso `/internal`, dogfooded nowhere.
+
+So the "codec split across stability tiers" problem is largely illusory. The minimal, correct action:
+- Keep `readSSE` as the one blessed escape-hatch on iso `/internal`, grouped under a clear "SSE codec (decoder)" header.
+- Add a short comment recording that the encoder and the SSE wire format are intentionally framework-internal (package-private), so a future contributor does not "promote" the encoder for false symmetry.
+
+No new server escape-hatch door, no encoder export. This folds into PR B2 (it only touches iso `/internal`'s header), so there is no separate B3.
+
+## Breaking-change posture
+
+Zero documented-API breakage: no symbol with a docs page changes location. The only relocations are JSDoc-private imports (`routeServerModules`/`makePageUseResolvers`/`makePageActionResolvers` off the public `/server` door; `getViewTransitionDirection` off the iso barrel; the iso installers/stub/constants from `/internal` to `/internal/runtime`). Anyone who reached past the JSDoc-private notes loses those import paths; that is exactly the pre-v1 cleanup this section exists to do. Lands in the next minor with a changelog note. Release pressure is zero and no release work is in scope.
+
+## PR decomposition
+
+- **PR B1 — server:** factories → `/internal/runtime`, re-export `LoadersHandlerOptions`, de-export `pickAccept`, server-entry codegen update + tests. Self-contained within the server + vite packages.
+- **PR B2 — iso:** new `/internal/runtime` door (installers + stub + contract module), `/internal` reduced to escape-hatch + header rewrite + SSE comment, barrel leak fix, client-entry/server-only/plugin codegen + the invariant test + leak-test fixtures.
+
+Both PRs touch the umbrella (`package.json` exports + `consolidate.mjs` + the two re-export files); the umbrella changes naturally split by which sub-package each subpath points at, so each PR carries its own umbrella half. Order is flexible (the two doors are independent), but landing B1 first keeps the smaller, lower-risk change ahead of the iso churn.
+
+## Out of scope (deferred to follow-on specs)
+
+- **ui boundary inversion** (Section B's ui bullet): promote `usePositioner` + `useListboxSelection` to a supported tier, demote the micro-helpers (`getItems`, `wrapNext`, `matchTypeahead`, `OPTION_SELECTOR`), export or wrap contexts so a from-scratch custom part can read `activeId`. Its own spec.
+- **Section D trims** that brush against this work (`getViewTransitionDirection` full deletion, mutable `env` export, `loaderUse`/`actionUse`).
+- The **Section F live-demo gap** for legitimately-public-but-undemoed API (`createCache`, timeouts, `Persist`, `useRouteMatch`, etc.). This spec keeps them public; dogfooding them is separate.

--- a/packages/hono-preact/__tests__/exports.test.ts
+++ b/packages/hono-preact/__tests__/exports.test.ts
@@ -74,10 +74,13 @@ describe('hono-preact/server export', () => {
     expect(typeof m.renderPage).toBe('function');
     expect(typeof m.loadersHandler).toBe('function');
     expect(typeof m.pageActionHandler).toBe('function');
-    expect(typeof m.routeServerModules).toBe('function');
-    expect(typeof m.makePageUseResolvers).toBe('function');
-    // Server exports added by Spec C
-    expect(typeof m.makePageActionResolvers).toBe('function');
+  });
+
+  it('no longer surfaces the framework-emitted resolver factories (moved to /internal/runtime)', async () => {
+    const m = await import('hono-preact/server');
+    expect('routeServerModules' in m).toBe(false);
+    expect('makePageUseResolvers' in m).toBe(false);
+    expect('makePageActionResolvers' in m).toBe(false);
   });
 });
 

--- a/packages/hono-preact/package.json
+++ b/packages/hono-preact/package.json
@@ -59,6 +59,10 @@
     "./internal": {
       "types": "./dist/internal.d.ts",
       "import": "./dist/internal.js"
+    },
+    "./server/internal/runtime": {
+      "types": "./dist/server-internal-runtime.d.ts",
+      "import": "./dist/server-internal-runtime.js"
     }
   },
   "scripts": {

--- a/packages/hono-preact/scripts/consolidate.mjs
+++ b/packages/hono-preact/scripts/consolidate.mjs
@@ -49,6 +49,7 @@ const DIST_PATHS = {
   '@hono-preact/iso/internal': 'iso/internal.js',
   '@hono-preact/iso/page': 'iso/page-only.js',
   '@hono-preact/iso': 'iso/index.js',
+  '@hono-preact/server/internal/runtime': 'server/internal-runtime.js',
   '@hono-preact/server': 'server/index.js',
   '@hono-preact/vite': 'vite/index.js',
   '@hono-preact/vite/adapter-cloudflare': 'vite/adapter-cloudflare.js',
@@ -98,7 +99,7 @@ async function rewriteImports(filePath) {
   const isTypeFile = filePath.endsWith('.d.ts');
 
   let rewritten = original.replace(
-    /(['"])(@hono-preact\/(?:iso\/internal|iso\/page|iso|server|vite\/adapter-cloudflare|vite\/adapter-node|vite))(['"])/g,
+    /(['"])(@hono-preact\/(?:iso\/internal|iso\/page|iso|server\/internal\/runtime|server|vite\/adapter-cloudflare|vite\/adapter-node|vite))(['"])/g,
     (match, q1, source, q2) => {
       const distRel = DIST_PATHS[source];
       if (!distRel) return match;

--- a/packages/hono-preact/src/server-internal-runtime.ts
+++ b/packages/hono-preact/src/server-internal-runtime.ts
@@ -1,0 +1,1 @@
+export * from '@hono-preact/server/internal/runtime';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./internal/runtime": {
+      "types": "./dist/internal-runtime.d.ts",
+      "import": "./dist/internal-runtime.js"
     }
   },
   "scripts": {

--- a/packages/server/src/__tests__/accept.test.ts
+++ b/packages/server/src/__tests__/accept.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { pickAccept } from '../accept.js';
+
+describe('pickAccept', () => {
+  it('maps application/json to json', () => {
+    expect(pickAccept('application/json')).toBe('json');
+  });
+  it('maps text/event-stream to event-stream', () => {
+    expect(pickAccept('text/event-stream')).toBe('event-stream');
+  });
+  it('maps text/html to html', () => {
+    expect(pickAccept('text/html')).toBe('html');
+  });
+  it('maps */* to html', () => {
+    expect(pickAccept('*/*')).toBe('html');
+  });
+  it('defaults missing/empty Accept to html', () => {
+    expect(pickAccept(undefined)).toBe('html');
+    expect(pickAccept('')).toBe('html');
+  });
+  it('honors q-values when choosing the best candidate', () => {
+    expect(pickAccept('application/json, text/event-stream;q=0.9')).toBe(
+      'json'
+    );
+  });
+  it('breaks q-value ties by Accept order', () => {
+    expect(pickAccept('application/json, text/event-stream')).toBe('json');
+    expect(pickAccept('text/event-stream, application/json')).toBe(
+      'event-stream'
+    );
+  });
+  it('ignores unparseable q-values (defaults q to 1.0)', () => {
+    expect(pickAccept('application/json;q=invalid')).toBe('json');
+  });
+  it('ignores unsupported media types', () => {
+    expect(pickAccept('text/plain, application/json;q=0.5')).toBe('json');
+  });
+  it('treats q=0 as a real (lowest) preference, not exclusion', () => {
+    expect(pickAccept('application/json;q=0')).toBe('json');
+  });
+});

--- a/packages/server/src/__tests__/boundary.test.ts
+++ b/packages/server/src/__tests__/boundary.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import * as publicEntry from '../index.js';
+import * as runtime from '../internal-runtime.js';
+// Type-surface check: this import + usage fails `tsc` if the re-export is
+// missing. Vitest strips types, so the real enforcement is `pnpm typecheck`.
+import type { LoadersHandlerOptions } from '../index.js';
+
+const _loadersHandlerOptions: LoadersHandlerOptions = {};
+void _loadersHandlerOptions;
+
+const FACTORIES = [
+  'routeServerModules',
+  'makePageUseResolvers',
+  'makePageActionResolvers',
+] as const;
+
+describe('server boundary', () => {
+  it('exposes the framework-emitted factories on /internal/runtime as functions', () => {
+    for (const name of FACTORIES) {
+      expect(typeof (runtime as Record<string, unknown>)[name]).toBe(
+        'function'
+      );
+    }
+  });
+
+  it('does not re-export the factories from the public entry', () => {
+    for (const name of FACTORIES) {
+      expect(name in publicEntry).toBe(false);
+    }
+  });
+
+  it('keeps the public handler surface available', () => {
+    expect(typeof publicEntry.renderPage).toBe('function');
+    expect(typeof publicEntry.loadersHandler).toBe('function');
+    expect(typeof publicEntry.pageActionHandler).toBe('function');
+  });
+});

--- a/packages/server/src/__tests__/page-action-handler.test.ts
+++ b/packages/server/src/__tests__/page-action-handler.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { h } from 'preact';
 import { Hono } from 'hono';
-import { pageActionHandler, pickAccept } from '../page-action-handler.js';
+import { pageActionHandler } from '../page-action-handler.js';
 import { deny, redirect, defineAction, isTimeout } from '@hono-preact/iso';
 
 function buildHandler(
@@ -311,47 +311,5 @@ describe('pageActionHandler timeouts', () => {
     await post({ module: 'pages/timed', action: 'create', payload: {} });
     expect(observedReason).toBeInstanceOf(DOMException);
     expect((observedReason as DOMException).name).toBe('TimeoutError');
-  });
-});
-
-describe('pickAccept', () => {
-  it('returns json when only application/json is requested', () => {
-    expect(pickAccept('application/json')).toBe('json');
-  });
-  it('returns event-stream when only text/event-stream is requested', () => {
-    expect(pickAccept('text/event-stream')).toBe('event-stream');
-  });
-  it('returns html when only text/html is requested', () => {
-    expect(pickAccept('text/html')).toBe('html');
-  });
-  it('returns html when */* is requested', () => {
-    expect(pickAccept('*/*')).toBe('html');
-  });
-  it('returns html when no header is given', () => {
-    expect(pickAccept(undefined)).toBe('html');
-    expect(pickAccept('')).toBe('html');
-  });
-  it('prefers higher-q candidate in mixed Accept', () => {
-    // The JS-on default header sent by useAction.
-    expect(pickAccept('application/json, text/event-stream;q=0.9')).toBe(
-      'json'
-    );
-  });
-  it('breaks ties on first occurrence (stable sort)', () => {
-    expect(pickAccept('application/json, text/event-stream')).toBe('json');
-    expect(pickAccept('text/event-stream, application/json')).toBe(
-      'event-stream'
-    );
-  });
-  it('handles malformed q values gracefully (defaults to 1.0)', () => {
-    expect(pickAccept('application/json;q=invalid')).toBe('json');
-  });
-  it('ignores unknown media types', () => {
-    expect(pickAccept('text/plain, application/json;q=0.5')).toBe('json');
-  });
-  it('respects q=0 by deprioritizing (still picks if it is the only candidate)', () => {
-    // q=0 technically means "not acceptable" per RFC 9110, but our parser is lenient.
-    // The function returns the highest-q; q=0 wins over no candidates.
-    expect(pickAccept('application/json;q=0')).toBe('json');
   });
 });

--- a/packages/server/src/__tests__/pe-form-no-js.integration.test.ts
+++ b/packages/server/src/__tests__/pe-form-no-js.integration.test.ts
@@ -2,11 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { h } from 'preact';
 import { Hono } from 'hono';
 import { LocationProvider } from 'preact-iso';
-import {
-  pageActionHandler,
-  makePageActionResolvers,
-  renderPage,
-} from '../index.js';
+import { pageActionHandler, renderPage } from '../index.js';
+import { makePageActionResolvers } from '../internal-runtime.js';
 import { deny, useActionResult, type ServerRoute } from '@hono-preact/iso';
 
 function Page() {

--- a/packages/server/src/accept.ts
+++ b/packages/server/src/accept.ts
@@ -1,0 +1,36 @@
+export type Accept = 'html' | 'json' | 'event-stream';
+
+/**
+ * Content negotiation for action POSTs: chooses json (RPC), event-stream
+ * (streaming action), or html (progressive-enhancement form post) from the
+ * request's Accept header. Highest q-value wins; ties break by Accept order.
+ * Wildcards and text/html map to html; unsupported media types are ignored.
+ * Unspecified quality defaults to 1.0; an empty/missing header defaults to html.
+ */
+export function pickAccept(header: string | undefined): Accept {
+  const h = header ?? '';
+  type Candidate = { type: Accept; q: number };
+  const candidates: Candidate[] = [];
+
+  for (const part of h.split(',')) {
+    const [mediaType, ...params] = part.trim().split(';');
+    const mt = (mediaType ?? '').trim().toLowerCase();
+    let q = 1.0;
+    for (const p of params) {
+      const kv = p.trim().split('=');
+      if (kv[0]?.trim() === 'q' && kv[1] !== undefined) {
+        const parsed = Number(kv[1].trim());
+        if (!Number.isNaN(parsed)) q = parsed;
+      }
+    }
+    if (mt === 'text/event-stream')
+      candidates.push({ type: 'event-stream', q });
+    else if (mt === 'application/json') candidates.push({ type: 'json', q });
+    else if (mt === 'text/html' || mt === '*/*')
+      candidates.push({ type: 'html', q });
+  }
+
+  if (candidates.length === 0) return 'html';
+  candidates.sort((a, b) => b.q - a.q);
+  return candidates[0]!.type;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,9 @@
 export { HonoContext, useHonoContext } from './context.js';
 export { renderPage } from './render.js';
-export { loadersHandler, type LoadersHandlerOptions } from './loaders-handler.js';
+export {
+  loadersHandler,
+  type LoadersHandlerOptions,
+} from './loaders-handler.js';
 export { type ActionEntry } from './page-action-resolvers.js';
 export {
   pageActionHandler,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,14 +1,7 @@
 export { HonoContext, useHonoContext } from './context.js';
 export { renderPage } from './render.js';
-export { loadersHandler } from './loaders-handler.js';
-export {
-  routeServerModules,
-  makePageUseResolvers,
-} from './route-server-modules.js';
-export {
-  makePageActionResolvers,
-  type ActionEntry,
-} from './page-action-resolvers.js';
+export { loadersHandler, type LoadersHandlerOptions } from './loaders-handler.js';
+export { type ActionEntry } from './page-action-resolvers.js';
 export {
   pageActionHandler,
   type PageActionHandlerOptions,

--- a/packages/server/src/internal-runtime.ts
+++ b/packages/server/src/internal-runtime.ts
@@ -1,0 +1,13 @@
+// @hono-preact/server/internal/runtime: framework-emitted tier.
+//
+// These factories exist ONLY because the framework's generated server entry
+// imports and calls them (serverEntryPlugin). They are a private contract
+// between this version's vite plugins and this version's runtime; they have
+// no standalone user story. DO NOT IMPORT FROM USER CODE; this door is
+// undocumented and may change in any non-major release in lockstep with the
+// codegen that emits it.
+export {
+  routeServerModules,
+  makePageUseResolvers,
+} from './route-server-modules.js';
+export { makePageActionResolvers } from './page-action-resolvers.js';

--- a/packages/server/src/page-action-handler.ts
+++ b/packages/server/src/page-action-handler.ts
@@ -25,6 +25,7 @@ import {
   isAsyncGenerator,
 } from './sse.js';
 import type { ActionEntry } from './page-action-resolvers.js';
+import { pickAccept, type Accept } from './accept.js';
 import type { VNode } from 'preact';
 
 export interface PageActionHandlerOptions {
@@ -74,44 +75,6 @@ export interface PageActionHandlerOptions {
    * 500; this is a side channel only.
    */
   onError?: (err: unknown, ctx: { module: string; action: string }) => void;
-}
-
-type Accept = 'html' | 'json' | 'event-stream';
-
-/**
- * Parse the Accept header and return the highest-priority recognized type.
- * Follows RFC 9110 quality values (;q=0.9 etc) so that
- * "application/json, text/event-stream;q=0.9" correctly resolves to 'json',
- * not 'event-stream'. Unspecified quality defaults to 1.0.
- *
- * Internal: exported for unit testing only; not part of the public API.
- */
-export function pickAccept(header: string | undefined): Accept {
-  const h = header ?? '';
-  type Candidate = { type: Accept; q: number };
-  const candidates: Candidate[] = [];
-
-  for (const part of h.split(',')) {
-    const [mediaType, ...params] = part.trim().split(';');
-    const mt = (mediaType ?? '').trim().toLowerCase();
-    let q = 1.0;
-    for (const p of params) {
-      const kv = p.trim().split('=');
-      if (kv[0]?.trim() === 'q' && kv[1] !== undefined) {
-        const parsed = Number(kv[1].trim());
-        if (!Number.isNaN(parsed)) q = parsed;
-      }
-    }
-    if (mt === 'text/event-stream')
-      candidates.push({ type: 'event-stream', q });
-    else if (mt === 'application/json') candidates.push({ type: 'json', q });
-    else if (mt === 'text/html' || mt === '*/*')
-      candidates.push({ type: 'html', q });
-  }
-
-  if (candidates.length === 0) return 'html';
-  candidates.sort((a, b) => b.q - a.q);
-  return candidates[0]!.type;
 }
 
 async function parseBody(

--- a/packages/server/src/page-action-handler.ts
+++ b/packages/server/src/page-action-handler.ts
@@ -25,7 +25,7 @@ import {
   isAsyncGenerator,
 } from './sse.js';
 import type { ActionEntry } from './page-action-resolvers.js';
-import { pickAccept, type Accept } from './accept.js';
+import { pickAccept } from './accept.js';
 import type { VNode } from 'preact';
 
 export interface PageActionHandlerOptions {

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -98,7 +98,10 @@ describe('generateCoreAppModule', () => {
     expect(src).toContain(`import { Hono } from 'hono';`);
     expect(src).toContain(`import { Routes, env } from 'hono-preact';`);
     expect(src).toContain(
-      `import {\n  loadersHandler,\n  makePageActionResolvers,\n  makePageUseResolvers,\n  pageActionHandler,\n  renderPage,\n  routeServerModules,\n} from 'hono-preact/server';`
+      `import {\n  loadersHandler,\n  pageActionHandler,\n  renderPage,\n} from 'hono-preact/server';`
+    );
+    expect(src).toContain(
+      `import {\n  makePageActionResolvers,\n  makePageUseResolvers,\n  routeServerModules,\n} from 'hono-preact/server/internal/runtime';`
     );
 
     // User imports (absolute paths)

--- a/packages/vite/src/server-entry.ts
+++ b/packages/vite/src/server-entry.ts
@@ -40,12 +40,14 @@ export function generateCoreAppModule(
     `import { Routes, env } from 'hono-preact';\n` +
     `import {\n` +
     `  loadersHandler,\n` +
-    `  makePageActionResolvers,\n` +
-    `  makePageUseResolvers,\n` +
     `  pageActionHandler,\n` +
     `  renderPage,\n` +
-    `  routeServerModules,\n` +
     `} from 'hono-preact/server';\n` +
+    `import {\n` +
+    `  makePageActionResolvers,\n` +
+    `  makePageUseResolvers,\n` +
+    `  routeServerModules,\n` +
+    `} from 'hono-preact/server/internal/runtime';\n` +
     `import Layout from '${layoutAbsPath}';\n` +
     `import routes from '${routesAbsPath}';\n` +
     apiImport +


### PR DESCRIPTION
## Summary

First PR of **Section B** (redraw the public/internal boundary before v1). Framework-spine, server half. Spec: `docs/superpowers/specs/2026-06-11-public-internal-boundary-design.md`; plan: `docs/superpowers/plans/2026-06-11-server-internal-boundary.md`.

- Move the three framework-private resolver factories (`routeServerModules`, `makePageUseResolvers`, `makePageActionResolvers`) off the public `hono-preact/server` door onto a new framework-emitted subpath **`hono-preact/server/internal/runtime`**. They exist only because the generated server entry imports them.
- Re-export **`LoadersHandlerOptions`** from the public server door (closes the documented hand-wiring gap where a custom handler could call `loadersHandler` but not name its options type). `ActionEntry` stays public (referenced by the public `PageActionHandlerOptions.resolverByPath` signature).
- Extract `pickAccept` into a focused internal `accept.ts` module (pure move, byte-identical logic).
- Wire it end to end: the generated server entry now splits its import; the umbrella exposes the subpath (`package.json` exports + `consolidate.mjs` `DIST_PATHS` and regex-alternation, longest-first); the dogfood-app dev configs get the deeper alias ahead of the shorter `hono-preact/server` one so it isn't prefix-shadowed.

**Zero user-facing public-API breakage**: no symbol with a docs page changes location. End users resolve the new subpath via the umbrella exports map; only the monorepo's source-alias dev setup needed the extra alias.

## Test plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck` (validates the `LoadersHandlerOptions` re-export via a type-surface assertion)
- [x] `pnpm test` (1229 passed) including new boundary-lock tests (`packages/server/src/__tests__/boundary.test.ts`, updated `packages/hono-preact/__tests__/exports.test.ts`)
- [x] `pnpm test:integration` (4 passed) builds a real app whose generated server entry imports `hono-preact/server/internal/runtime`, proving end-to-end resolution through the shipped tarball
- [x] `pnpm --filter site build`

## Notes

- Deep PR review (replacement parity + cross-cutting concerns per CLAUDE.md) was run before opening: public server-door symbol set loses only the three factories and gains only `LoadersHandlerOptions`; `pickAccept` is a verified pure move; no middleware/auth/observability path is touched.
- PR B2 (the iso half: `/internal/runtime` for installers + loader stub + contract constants, `/internal` reduced to escape-hatch, barrel leak fix, SSE comment) will be planned against post-merge `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)