### PR TITLE
Form lifecycle (Section C #1): onSuccess/onError/invalidate/reset + shared useInvalidate

### DIFF
--- a/apps/site/src/pages/demo/issue.tsx
+++ b/apps/site/src/pages/demo/issue.tsx
@@ -158,7 +158,12 @@ const CommentsSection: FunctionComponent<{
     <section class="space-y-3">
       <h3 class="font-semibold">Comments</h3>
       <CommentList comments={addComment.value} />
-      <Form action={addComment} reset invalidate={[commentsLoader]} class="space-y-2">
+      <Form
+        action={addComment}
+        reset
+        invalidate={[commentsLoader]}
+        class="space-y-2"
+      >
         <input type="hidden" name="issueId" value={issueId} />
         <textarea
           name="body"

--- a/apps/site/src/pages/demo/issue.tsx
+++ b/apps/site/src/pages/demo/issue.tsx
@@ -3,11 +3,10 @@ import {
   Form,
   useFormStatus,
   useOptimisticAction,
-  useActionResult,
   ViewTransitionName,
 } from 'hono-preact';
 import type { FunctionComponent } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import { useTitle } from 'hoofd/preact';
 import { serverLoaders, serverActions } from './issue.server.js';
 import { serverLoaders as projectIssuesLoaders } from './project-issues.server.js';
@@ -132,9 +131,6 @@ const CommentsSection: FunctionComponent<{
   comments: CommentData[];
   issueId: string;
 }> = ({ comments, issueId }) => {
-  const [formKey, setFormKey] = useState(0);
-  const result = useActionResult(serverActions.addComment);
-
   // Drive the optimistic list AND the form submit from the SAME action object.
   // Passing it to <Form> is what makes <Form> call addOptimistic on submit, so
   // the new comment paints immediately; a bare `serverActions.addComment` stub
@@ -158,18 +154,11 @@ const CommentsSection: FunctionComponent<{
   });
   const { pending } = useFormStatus(serverActions.addComment);
 
-  useEffect(() => {
-    if (result?.kind === 'success') {
-      setFormKey((k) => k + 1);
-      commentsLoader.invalidate();
-    }
-  }, [result]);
-
   return (
     <section class="space-y-3">
       <h3 class="font-semibold">Comments</h3>
       <CommentList comments={addComment.value} />
-      <Form key={formKey} action={addComment} class="space-y-2">
+      <Form action={addComment} reset invalidate={[commentsLoader]} class="space-y-2">
         <input type="hidden" name="issueId" value={issueId} />
         <textarea
           name="body"

--- a/apps/site/src/pages/demo/project-issues.tsx
+++ b/apps/site/src/pages/demo/project-issues.tsx
@@ -1,6 +1,6 @@
-import { definePage, Form, useFormStatus, useActionResult } from 'hono-preact';
+import { definePage, Form, useFormStatus } from 'hono-preact';
 import type { FunctionComponent } from 'preact';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
 import { serverLoaders, serverActions } from './project-issues.server.js';
 import { requireSession } from '../../demo/guard.js';
 import IssueRow from '../../components/demo/IssueRow.js';
@@ -11,15 +11,6 @@ const ProjectIssuesPage: FunctionComponent = () => {
   const data = issuesLoader.useData();
   const [showForm, setShowForm] = useState(false);
   const { pending: creating } = useFormStatus(serverActions.createIssue);
-  const result = useActionResult(serverActions.createIssue);
-  const lastSeenSuccess = useRef<unknown>(null);
-
-  useEffect(() => {
-    if (result?.kind === 'success' && result !== lastSeenSuccess.current) {
-      lastSeenSuccess.current = result;
-      setShowForm(false);
-    }
-  }, [result]);
 
   if (!data) return <p>Unknown project.</p>;
   const { project, issues } = data;
@@ -38,7 +29,7 @@ const ProjectIssuesPage: FunctionComponent = () => {
       </div>
 
       {showForm && (
-        <Form action={serverActions.createIssue} class="border p-3 space-y-2">
+        <Form action={serverActions.createIssue} onSuccess={() => setShowForm(false)} class="border p-3 space-y-2">
           <input type="hidden" name="projectId" value={project.id} />
           <input
             name="title"

--- a/apps/site/src/pages/demo/project-issues.tsx
+++ b/apps/site/src/pages/demo/project-issues.tsx
@@ -29,7 +29,11 @@ const ProjectIssuesPage: FunctionComponent = () => {
       </div>
 
       {showForm && (
-        <Form action={serverActions.createIssue} onSuccess={() => setShowForm(false)} class="border p-3 space-y-2">
+        <Form
+          action={serverActions.createIssue}
+          onSuccess={() => setShowForm(false)}
+          class="border p-3 space-y-2"
+        >
           <input type="hidden" name="projectId" value={project.id} />
           <input
             name="title"

--- a/apps/site/src/pages/docs/actions.mdx
+++ b/apps/site/src/pages/docs/actions.mdx
@@ -97,6 +97,34 @@ defineAction<{ title: string; tags: string[]; photos: File[] }, ...>
 
 String values are passed as strings; coerce them in the action body if you need numbers or booleans. File inputs are handled automatically; see [File uploads](#file-uploads).
 
+### Form lifecycle
+
+`<Form>` accepts optional callbacks that fire after a submission resolves, plus
+declarative cache invalidation and form reset:
+
+| Prop         | Type                             | Notes                                                                                                                                             |
+| ------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onSuccess`  | `(data, { reset }) => void`      | Fires on a successful action. `reset()` clears the form; `reset(names)` clears specific fields.                                                   |
+| `onError`    | `(err: Error) => void`           | Fires on an error, timeout, or unknown outcome. A `deny` is not an error; read it via `useActionResult`.                                          |
+| `invalidate` | `'auto' \| false \| LoaderRef[]` | Same semantics as `useAction`'s `invalidate`: `'auto'` re-runs the active loader; an array clears each (and re-runs the active loader if listed). |
+| `reset`      | `boolean`                        | Reset the form to its defaults after a successful submit.                                                                                         |
+
+```tsx
+<Form
+  action={serverActions.createIssue}
+  reset
+  invalidate="auto"
+  onSuccess={() => setShowForm(false)}
+>
+  <input name="title" />
+  <button type="submit">Create</button>
+</Form>
+```
+
+`reset` calls the form's native reset (restoring uncontrolled fields to their
+defaults and firing a `reset` event). Controlled custom fields can subscribe to
+that event to reset themselves.
+
 ## Progressive enhancement (PE): forms without JS
 
 `<Form action={stub}>` works without JavaScript. On a no-JS page load the form submits as a standard HTML POST to the page URL. The server runs the action, then re-renders the page. Inside the rendered page, `useActionResult(stub?)` returns the outcome of that action call so you can show validation errors or a success message without requiring JavaScript.

--- a/docs/superpowers/plans/2026-06-12-form-lifecycle.md
+++ b/docs/superpowers/plans/2026-06-12-form-lifecycle.md
@@ -1,0 +1,493 @@
+# Form lifecycle (Section C #1, PR 1: iso) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `Form` the success lifecycle (`onSuccess`/`onError`/`invalidate`/`reset`) it currently lacks, sharing `useAction`'s invalidation implementation via a new `useInvalidate()` hook, and delete the two site workarounds that hand-roll the missing behavior.
+
+**Architecture:** Extract `useAction`'s inline `invalidate` logic into `useInvalidate()` (one implementation, two consumers), then add four optional props to `Form` that wire into the existing `handleSubmit` outcome switch (additive: the `setLastActionResult` / optimistic behavior is unchanged). `reset` builds on native `formEl.reset()` (which fires the standard `reset` event ui components will later subscribe to in PR 2).
+
+**Tech Stack:** TypeScript, preact, Vitest + `@testing-library/preact` (happy-dom), plain `tsc` builds.
+
+**Source spec:** `docs/superpowers/specs/2026-06-12-form-lifecycle-design.md` (Part A + Part C). PR 2 (the ui `Select`/`Combobox` reset participation, Part B) is planned separately against post-PR1 `main`.
+
+**Conventions:**
+- Run a single test file with `pnpm exec vitest run <path>` from the repo root.
+- No em-dashes in code/comments/commit messages.
+- Commit after each task; messages end with the `Co-Authored-By: Claude Opus 4.8 (1M context)` trailer.
+
+## File map
+
+- **Create** `packages/iso/src/use-invalidate.ts`: the shared invalidation hook.
+- **Create** `packages/iso/src/__tests__/use-invalidate.test.tsx`: its unit tests.
+- **Modify** `packages/iso/src/action.ts`: refactor `useAction` onto `useInvalidate`.
+- **Modify** `packages/iso/src/form.tsx`: the four new props + per-outcome wiring + the `resetFormFields` helper.
+- **Modify** `packages/iso/src/__tests__/form.test.tsx`: lifecycle tests.
+- **Modify** `apps/site/src/pages/demo/project-issues.tsx` + `apps/site/src/pages/demo/issue.tsx`: delete the workarounds.
+- **Modify** `apps/site/src/pages/docs/actions.mdx`: document the lifecycle props.
+
+---
+
+## Task 1: Extract `useInvalidate()` and refactor `useAction` onto it
+
+**Files:**
+- Create: `packages/iso/src/use-invalidate.ts`
+- Create: `packages/iso/src/__tests__/use-invalidate.test.tsx`
+- Modify: `packages/iso/src/action.ts`
+
+- [ ] **Step 1: Write the hook's unit tests.** Create `packages/iso/src/__tests__/use-invalidate.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/preact';
+import { useInvalidate, type InvalidateInput } from '../use-invalidate.js';
+import { ReloadContext } from '../reload-context.js';
+import { ActiveLoaderIdContext } from '../internal/contexts.js';
+import { defineLoader } from '../define-loader.js';
+
+afterEach(cleanup);
+
+function Harness({ input }: { input: InvalidateInput }) {
+  const apply = useInvalidate();
+  return <button onClick={() => apply(input)}>go</button>;
+}
+
+function click() {
+  document.querySelector('button')!.click();
+}
+
+describe('useInvalidate', () => {
+  it('calls reload() for "auto"', async () => {
+    const reload = vi.fn();
+    render(
+      <ReloadContext.Provider value={{ reload, reloading: false }}>
+        <Harness input="auto" />
+      </ReloadContext.Provider>
+    );
+    await act(async () => click());
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing for false', async () => {
+    const reload = vi.fn();
+    render(
+      <ReloadContext.Provider value={{ reload, reloading: false }}>
+        <Harness input={false} />
+      </ReloadContext.Provider>
+    );
+    await act(async () => click());
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('invalidates each ref in an array and reloads when the active loader is included', async () => {
+    const active = defineLoader(async () => ({ value: 1 }), {
+      __moduleKey: 'inv-active',
+    });
+    const other = defineLoader(async () => ({ value: 2 }), {
+      __moduleKey: 'inv-other',
+    });
+    const invActive = vi.spyOn(active, 'invalidate');
+    const invOther = vi.spyOn(other, 'invalidate');
+    const reload = vi.fn();
+    render(
+      <ActiveLoaderIdContext.Provider value={active.__id}>
+        <ReloadContext.Provider value={{ reload, reloading: false }}>
+          <Harness input={[active, other]} />
+        </ReloadContext.Provider>
+      </ActiveLoaderIdContext.Provider>
+    );
+    await act(async () => click());
+    expect(invActive).toHaveBeenCalled();
+    expect(invOther).toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('invalidates refs without reloading when none is the active loader', async () => {
+    const other = defineLoader(async () => ({ value: 2 }), {
+      __moduleKey: 'inv-only-other',
+    });
+    const invOther = vi.spyOn(other, 'invalidate');
+    const reload = vi.fn();
+    render(
+      <ActiveLoaderIdContext.Provider value={null}>
+        <ReloadContext.Provider value={{ reload, reloading: false }}>
+          <Harness input={[other]} />
+        </ReloadContext.Provider>
+      </ActiveLoaderIdContext.Provider>
+    );
+    await act(async () => click());
+    expect(invOther).toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it; expect FAIL** (cannot resolve `../use-invalidate.js`). `pnpm exec vitest run packages/iso/src/__tests__/use-invalidate.test.tsx`
+
+- [ ] **Step 3: Create the hook.** Create `packages/iso/src/use-invalidate.ts`:
+
+```ts
+import { useCallback, useContext } from 'preact/hooks';
+import { ReloadContext } from './reload-context.js';
+import { ActiveLoaderIdContext } from './internal/contexts.js';
+import type { LoaderRef } from './define-loader.js';
+
+/** How to update loader caches after an action commits. Same vocabulary as
+ * `useAction`'s `invalidate` option: `'auto'` re-runs the active page's loader;
+ * an array calls `.invalidate()` on each `LoaderRef` (and re-runs the active
+ * loader if it is in the list); `false`/undefined does nothing. */
+export type InvalidateInput =
+  | 'auto'
+  | false
+  | ReadonlyArray<LoaderRef<unknown>>;
+
+/**
+ * Reads the enclosing `ReloadContext` + `ActiveLoaderIdContext` and returns a
+ * stable apply function shared by `useAction` and `<Form>`. Must be called at
+ * the top level of a component/hook (it uses `useContext`).
+ */
+export function useInvalidate(): (invalidate: InvalidateInput | undefined) => void {
+  const reloadCtx = useContext(ReloadContext);
+  const activeLoaderId = useContext(ActiveLoaderIdContext);
+  return useCallback(
+    (invalidate) => {
+      if (invalidate === 'auto') {
+        reloadCtx?.reload();
+      } else if (Array.isArray(invalidate)) {
+        let invalidatedActive = false;
+        for (const ref of invalidate) {
+          ref.invalidate();
+          if (activeLoaderId && ref.__id === activeLoaderId) {
+            invalidatedActive = true;
+          }
+        }
+        // If the user's list includes the active page's loader, re-run it so
+        // the visible <Loader> picks up fresh data. Other refs just clear their
+        // caches; those pages refetch on their next mount.
+        if (invalidatedActive) {
+          reloadCtx?.reload();
+        }
+      }
+    },
+    [reloadCtx, activeLoaderId]
+  );
+}
+```
+
+- [ ] **Step 4: Run the test; expect PASS.** `pnpm exec vitest run packages/iso/src/__tests__/use-invalidate.test.tsx`
+
+- [ ] **Step 5: Refactor `useAction` onto the hook.** In `packages/iso/src/action.ts`:
+  - Add the import: `import { useInvalidate } from './use-invalidate.js';`
+  - Remove the two now-unused context reads (currently lines 230-231): `const reloadCtx = useContext(ReloadContext);` and `const activeLoaderId = useContext(ActiveLoaderIdContext);`. Replace them with: `const applyInvalidate = useInvalidate();`
+  - Replace the inline invalidate block (currently lines 472-487, the `if (currentOptions?.invalidate === 'auto') { ... } else if (Array.isArray(...)) { ... }`) with a single line: `applyInvalidate(currentOptions?.invalidate);`
+  - Remove the now-unused imports `ReloadContext` (from `./reload-context.js`) and `ActiveLoaderIdContext` (from `./internal/contexts.js`) IF nothing else in the file uses them. Verify with `grep -n "ReloadContext\|ActiveLoaderIdContext" packages/iso/src/action.ts` after the edit; if the only remaining references are the (now-removed) import lines, delete those imports. Keep `useContext` in the `preact/hooks` import only if still used elsewhere; otherwise drop it.
+
+- [ ] **Step 6: Run the action tests (refactor parity) + the new hook test.** `pnpm exec vitest run packages/iso/src/__tests__/action.test.tsx packages/iso/src/__tests__/use-invalidate.test.tsx`
+Expected: PASS. The three existing `useAction` invalidate tests (`'auto'`, `false`, active-loader-in-array) are the parity check that the extraction preserved behavior.
+
+- [ ] **Step 7: Build + typecheck.** `pnpm --filter @hono-preact/iso build && pnpm typecheck`
+Expected: PASS. (If a `Cannot find module '@hono-preact/...'` unrelated error appears, run `pnpm install` and retry.)
+
+- [ ] **Step 8: Commit.**
+```bash
+git add packages/iso/src/use-invalidate.ts \
+  packages/iso/src/__tests__/use-invalidate.test.tsx \
+  packages/iso/src/action.ts
+git commit -m "refactor(iso): extract useInvalidate hook; useAction shares it
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add the `Form` lifecycle props
+
+**Files:**
+- Modify: `packages/iso/src/form.tsx`
+- Modify: `packages/iso/src/__tests__/form.test.tsx`
+
+- [ ] **Step 1: Write the lifecycle tests.** Append to `packages/iso/src/__tests__/form.test.tsx` (inside the existing top-level `describe`, after the existing tests). These assume the file's existing `makeStub()` helper and `@testing-library/preact` `render`/`fireEvent`. Add a small fetch stub per test:
+
+```tsx
+  it('calls onSuccess with the action data on a success outcome', async () => {
+    const stub = makeStub();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ __outcome: 'success', data: { id: 7 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const onSuccess = vi.fn();
+    const { getByRole } = render(
+      <Form action={stub} onSuccess={onSuccess}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    await act(async () => {
+      fireEvent.submit(getByRole('button').closest('form')!);
+    });
+    expect(onSuccess).toHaveBeenCalledWith({ id: 7 }, expect.objectContaining({
+      reset: expect.any(Function),
+    }));
+  });
+
+  it('calls onError on an error outcome and not on deny', async () => {
+    const stub = makeStub();
+    const onError = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ __outcome: 'error', message: 'boom' }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+    );
+    const { getByRole } = render(
+      <Form action={stub} onError={onError}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    await act(async () => {
+      fireEvent.submit(getByRole('button').closest('form')!);
+    });
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('boom');
+  });
+
+  it('resets the form after success when reset is set', async () => {
+    const stub = makeStub();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ __outcome: 'success', data: { id: 1 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { getByRole } = render(
+      <Form action={stub} reset>
+        <input name="text" defaultValue="" />
+        <button type="submit">go</button>
+      </Form>
+    );
+    const input = getByRole('textbox') as HTMLInputElement;
+    input.value = 'typed';
+    await act(async () => {
+      fireEvent.submit(getByRole('button').closest('form')!);
+    });
+    expect(input.value).toBe('');
+  });
+```
+
+Add `act` to the existing `@testing-library/preact` import (it currently imports `render, fireEvent, cleanup`; `fireEvent` and `vi` are already imported).
+
+- [ ] **Step 2: Run them; expect FAIL** (the props do not exist yet, so onSuccess/onError are never called and `reset` does nothing). `pnpm exec vitest run packages/iso/src/__tests__/form.test.tsx`
+
+- [ ] **Step 3: Add the props + the reset helper to `form.tsx`.** Three edits:
+
+  (a) Add imports near the top:
+```ts
+import type { LoaderRef } from './define-loader.js';
+import { useInvalidate } from './use-invalidate.js';
+```
+and add `useRef` to the existing `preact/hooks` import.
+
+  (b) Add a module-level helper above the `Form` function:
+```ts
+function resetFormFields(formEl: HTMLFormElement, fields?: string[]): void {
+  if (!fields) {
+    formEl.reset();
+    return;
+  }
+  for (const name of fields) {
+    const el = formEl.elements.namedItem(name);
+    const nodes =
+      el instanceof RadioNodeList ? Array.from(el) : el ? [el] : [];
+    for (const node of nodes) {
+      if (node instanceof HTMLInputElement) {
+        if (node.type === 'checkbox' || node.type === 'radio')
+          node.checked = node.defaultChecked;
+        else node.value = node.defaultValue;
+      } else if (node instanceof HTMLTextAreaElement) {
+        node.value = node.defaultValue;
+      } else if (node instanceof HTMLSelectElement) {
+        for (const opt of Array.from(node.options))
+          opt.selected = opt.defaultSelected;
+      }
+    }
+  }
+}
+```
+
+  (c) Extend `FormProps` and wire the component. Change the `FormProps` type to add the four props:
+```ts
+export type FormProps<TPayload, TResult> = Omit<
+  JSX.HTMLAttributes<HTMLFormElement>,
+  'action' | 'method' | 'onSubmit' | 'enctype'
+> & {
+  action: FormActionInput<TPayload, TResult>;
+  children?: ComponentChildren;
+  onSuccess?: (
+    data: TResult,
+    helpers: { reset: (fields?: string[]) => void }
+  ) => void;
+  onError?: (err: Error) => void;
+  invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
+  reset?: boolean;
+};
+```
+Then in the component: destructure `onSuccess, onError, invalidate, reset` from props (so they are not spread onto the `<form>` via `...rest`), add `const applyInvalidate = useInvalidate();`, and keep the handlers in a ref so `handleSubmit`'s identity does not churn:
+```ts
+export function Form<TPayload, TResult>({
+  action,
+  children,
+  onSuccess,
+  onError,
+  invalidate,
+  reset,
+  ...rest
+}: FormProps<TPayload, TResult>) {
+  const [pending, setPending] = useState(false);
+  const moduleKey = action.__module;
+  const actionName = action.__action;
+  const applyInvalidate = useInvalidate();
+  const lifecycle = useRef({ onSuccess, onError, invalidate, reset });
+  lifecycle.current = { onSuccess, onError, invalidate, reset };
+  // ...existing `optimistic` useMemo unchanged...
+```
+Inside `handleSubmit`, capture the form element once (it already does: `const formEl = e.currentTarget as HTMLFormElement;`) and add `const resetForm = (fields?: string[]) => resetFormFields(formEl, fields);`. Then extend the outcome switch:
+- `case 'success':` after the existing `handle?.settle();` and `setLastActionResult(... 'success' ...)`, add:
+```ts
+            lifecycle.current.onSuccess?.(decoded.data, { reset: resetForm });
+            applyInvalidate(lifecycle.current.invalidate);
+            if (lifecycle.current.reset) resetForm();
+```
+- `case 'error':` after its `setLastActionResult`, add `lifecycle.current.onError?.(new Error(decoded.message));`
+- `case 'timeout':` after its `setLastActionResult`, add `lifecycle.current.onError?.(new Error(\`Request timed out after ${decoded.timeoutMs}ms\`));`
+- `case 'unknown':` after its `setLastActionResult`, add `lifecycle.current.onError?.(new Error(decoded.message ?? \`Unexpected outcome: ${decoded.outcome ?? 'unknown'}\`));`
+- Leave `case 'deny'`, `case 'redirect'`, `case 'malformed'` unchanged.
+- In the `catch (err)` block, after the existing `setLastActionResult(... 'error' ...)`, add `lifecycle.current.onError?.(err instanceof Error ? err : new Error(String(err)));`
+
+Finally add `applyInvalidate` to `handleSubmit`'s dependency array (currently `[moduleKey, actionName, optimistic]` becomes `[moduleKey, actionName, optimistic, applyInvalidate]`).
+
+- [ ] **Step 4: Run the Form tests; expect PASS.** `pnpm exec vitest run packages/iso/src/__tests__/form.test.tsx`
+
+- [ ] **Step 5: Build + typecheck.** `pnpm --filter @hono-preact/iso build && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/iso/src/form.tsx packages/iso/src/__tests__/form.test.tsx
+git commit -m "feat(iso): Form onSuccess/onError/invalidate/reset lifecycle props
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Delete the two site workarounds (dogfood proof)
+
+**Files:**
+- Modify: `apps/site/src/pages/demo/project-issues.tsx`
+- Modify: `apps/site/src/pages/demo/issue.tsx`
+
+- [ ] **Step 1: Migrate `project-issues.tsx`.** Remove the `lastSeenSuccess` ref and the `useEffect` that watches `result` (lines ~14-22): delete `const lastSeenSuccess = useRef<unknown>(null);` and the entire `useEffect(() => { if (result?.kind === 'success' ...) { ...setShowForm(false); } }, [result]);`. Find the `<Form action={serverActions.createIssue} ...>` in the JSX and add `onSuccess={() => setShowForm(false)}`. Remove the now-unused `result`/`useActionResult`/`useRef`/`useEffect` bindings if nothing else in the file references them (check each: `grep -n "result\|useActionResult\|useRef\|useEffect" apps/site/src/pages/demo/project-issues.tsx`).
+
+- [ ] **Step 2: Migrate `issue.tsx`.** In `CommentsSection`, remove `const [formKey, setFormKey] = useState(0);` and the `useEffect(() => { if (result?.kind === 'success') { setFormKey((k) => k + 1); commentsLoader.invalidate(); } }, [result]);`. Find the comment `<Form action={addComment} key={formKey} ...>` (the form driven by `addComment`): remove the `key={formKey}` prop and add `reset invalidate={[commentsLoader]}`. Keep the `addComment` (the `useOptimisticAction` result) passed as the `action` prop unchanged. Remove the now-unused `result`/`useActionResult`/`useEffect`/`useState` bindings if nothing else uses them (check with grep as above; `useState` may still be used elsewhere in the file).
+
+- [ ] **Step 2.5: Verify no orphan imports.** For each file, confirm `pnpm typecheck` (Step 4) will not fail on an unused import; remove any import that is now unreferenced (e.g. `useEffect`, `useRef`, `useActionResult` if they were only for the deleted code).
+
+- [ ] **Step 3: Typecheck + build the site.** `pnpm --filter '@hono-preact/*' --filter hono-preact build && pnpm typecheck && pnpm --filter site build`
+Expected: PASS. (Build the framework first so the site resolves the new `Form` props through `dist/`.)
+
+- [ ] **Step 4: Commit.**
+```bash
+git add apps/site/src/pages/demo/project-issues.tsx apps/site/src/pages/demo/issue.tsx
+git commit -m "refactor(site): replace hand-rolled Form success effects with onSuccess/reset/invalidate
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Document the Form lifecycle props
+
+**Files:**
+- Modify: `apps/site/src/pages/docs/actions.mdx`
+
+- [ ] **Step 1: Add a lifecycle subsection to the `<Form>` documentation.** In `apps/site/src/pages/docs/actions.mdx`, after the existing `### FormData serialization` area (or right after the paragraph describing `<Form>` accepting HTML attributes around line 88), add a `### Form lifecycle` section with a props table and a short example:
+
+````md
+### Form lifecycle
+
+`<Form>` accepts optional callbacks that fire after a submission resolves, plus
+declarative cache invalidation and form reset:
+
+| Prop         | Type                                                              | Notes                                                                                              |
+| ------------ | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `onSuccess`  | `(data, { reset }) => void`                                       | Fires on a successful action. `reset()` clears the form; `reset(names)` clears specific fields.     |
+| `onError`    | `(err: Error) => void`                                           | Fires on an error, timeout, or unknown outcome. A `deny` is not an error; read it via `useActionResult`. |
+| `invalidate` | `'auto' \| false \| LoaderRef[]`                                  | Same semantics as `useAction`'s `invalidate`: `'auto'` re-runs the active loader; an array clears each (and re-runs the active loader if listed). |
+| `reset`      | `boolean`                                                        | Reset the form to its defaults after a successful submit.                                           |
+
+```tsx
+<Form
+  action={serverActions.createIssue}
+  reset
+  invalidate="auto"
+  onSuccess={() => setShowForm(false)}
+>
+  <input name="title" />
+  <button type="submit">Create</button>
+</Form>
+```
+
+`reset` calls the form's native reset (restoring uncontrolled fields to their
+defaults and firing a `reset` event). Controlled custom fields can subscribe to
+that event to reset themselves.
+````
+
+- [ ] **Step 2: Verify the docs build + parity.** `pnpm exec vitest run apps/site/src/pages/docs/__tests__` (still green; no page added) and that the MDX parses via `pnpm --filter site build`.
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add apps/site/src/pages/docs/actions.mdx
+git commit -m "docs: document Form lifecycle props
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full pre-push verification
+
+**Files:** none.
+
+- [ ] **Step 1: Run the six-step CI mirror in order, each expecting PASS:**
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+- [ ] **Step 2: If `format:check` fails,** `pnpm format`, restage into the relevant commit or a `style:` commit, and re-run from Step 1.
+
+- [ ] **Step 3: Flake note.** If `measure-client-size` times out under load, re-run it in isolation before treating it as real (`pnpm exec vitest run scripts/__tests__/measure-client-size.test.mjs`).
+
+---
+
+## Self-review
+
+- **Spec coverage (Part A + C):** `useInvalidate` extraction + `useAction` refactor (Task 1), the four `Form` props + per-outcome wiring including the `reset(fields?)` helper and the deny-stays-structured rule (Task 2), site migration of both workarounds (Task 3), docs (Task 4). Part B (ui) is a separate PR/plan, correctly out of scope. `useInvalidate` stays internal (not added to the barrel), per the spec.
+- **Placeholder scan:** every code step has full code; the site-migration steps reference exact files and grep checks rather than vague "remove the effect." No placeholders.
+- **Type/name consistency:** `useInvalidate`/`InvalidateInput` names match across Task 1's hook, its test, and Task 2's `Form` import; the four prop names (`onSuccess`/`onError`/`invalidate`/`reset`) are identical across `FormProps`, the wiring, the tests, and the docs table; `resetFormFields`/`resetForm` are consistently named; the `onError` message strings match the `setLastActionResult` messages they mirror.

--- a/docs/superpowers/specs/2026-06-12-form-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-12-form-lifecycle-design.md
@@ -1,0 +1,90 @@
+# Form lifecycle primitive (Section C, primitive 1) design
+
+**Date:** 2026-06-12
+**Status:** Approved design, pre-implementation
+**Source:** Section C (primitive 1, "Form success lifecycle") of `docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md`. First of the six site-discovered primitives.
+**Goal:** Give `Form` the success lifecycle the site hand-rolls twice. `Form` gains `onSuccess`/`onError`/`invalidate`/`reset`, mirroring `useAction`'s existing vocabulary and sharing its invalidation implementation, and the ui `Select`/`Combobox` learn to reset on a form reset. Deletes both site workarounds.
+
+## Scope decisions (locked with user)
+
+1. **`Form` matches `useAction`'s lifecycle, plus `reset`.** `onSuccess`/`onError`/`invalidate` use the same names and the same `invalidate` semantics as `useAction`; `reset` is form-specific. `onMutate`/snapshot threading does NOT apply to `Form` (it gets optimistic via the branded `action` prop).
+2. **One invalidation implementation.** The `'auto' | false | LoaderRef[]` logic currently inlined in `useAction` (action.ts:472-487) is extracted into a shared `useInvalidate()` hook; both `useAction` and `Form` call it. This is the review's "one vocabulary, one implementation" point.
+3. **`deny` stays a structured result.** `onError` fires only for `error`/`timeout`/`unknown`. `deny` continues to flow to `useActionResult` as a structured outcome (status/message/data) for inline display.
+4. **`reset` supports both a declarative prop and an imperative helper.** `reset?: boolean` (auto-reset on success) and a `reset()` helper passed to `onSuccess`, which also accepts field names to reset a subset of native controls.
+5. **Custom-field reset uses the native `reset` event, and the ui components opt in.** A full reset calls `formEl.reset()`, which fires the standard cancelable `reset` event; the ui `Select`/`Combobox` listen for it and reset to their `defaultValue`. This spans two packages (Part A iso, Part B ui) but no cross-package code dependency: the ui side keys off the native event, so it works under any form. Builds on the platform, not a bespoke Form-field protocol.
+6. **Two PRs.** PR 1 (iso): Form lifecycle + `useInvalidate` + `useAction` refactor + site migration + docs. PR 2 (ui): `Select`/`Combobox` form-reset participation + docs. PR 2 is independent (native reset events), so it can land before or after PR 1.
+
+## Part A (PR 1), iso: `Form` lifecycle + shared invalidation
+
+### A1. Extract `useInvalidate()`
+
+`useAction` today reads `ReloadContext` (`reloadCtx.reload()`) and `ActiveLoaderIdContext` (`activeLoaderId`) and, at action-commit time, runs (action.ts:472-487):
+- `'auto'` → `reloadCtx?.reload()`.
+- array → `ref.invalidate()` for each; if any ref's `__id === activeLoaderId`, also `reloadCtx?.reload()`.
+- `false`/absent → nothing.
+
+New `useInvalidate()` (its own module, e.g. `packages/iso/src/use-invalidate.ts`) reads both contexts and returns a stable `apply(invalidate: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>) => void` containing that exact logic. `useAction` is refactored to `const applyInvalidate = useInvalidate()` and calls `applyInvalidate(currentOptions.invalidate)` where it currently inlines lines 472-487. Behavior is unchanged (the existing `useAction` invalidate tests are the parity check). `useInvalidate` is not exported from the public barrel in this PR (it is an internal shared core; `Form`/`useAction` consume it within iso). Exporting it publicly is a separate decision (it would need a docs page).
+
+### A2. `Form` API additions
+
+`FormProps<TPayload, TResult>` (form.tsx:25) gains:
+
+```ts
+onSuccess?: (data: TResult, helpers: { reset: (fields?: string[]) => void }) => void;
+onError?: (err: Error) => void;
+invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
+reset?: boolean;
+```
+
+The four are destructured in the component and the callbacks are kept in refs (read at submit time) so changing handler identity does not need to re-create `handleSubmit`. `Form` calls `const applyInvalidate = useInvalidate()` at the top.
+
+A `resetForm(fields?: string[])` closure over the submit's `formEl`:
+- no args → `formEl.reset()` (full native reset; restores uncontrolled controls to defaults and fires the cancelable `reset` event).
+- with names → for each name, restore that named control to its default (`input.value = input.defaultValue` / `input.checked = input.defaultChecked`; `select.selectedIndex` per `option.defaultSelected`; `textarea.value = textarea.defaultValue`), via `formEl.elements.namedItem(name)`. No event (partial reset has no platform signal).
+
+Per-outcome wiring inside `handleSubmit` (additive; the existing `setLastActionResult`/optimistic settle/revert behavior is unchanged):
+- **`success`**: after `handle?.settle()` + `setLastActionResult(... 'success' ...)`, call `onSuccess?.(decoded.data, { reset: resetForm })`, then `applyInvalidate(invalidate)`, then if `reset === true` call `resetForm()`.
+- **`error` / `timeout` / `unknown`**: after the existing `setLastActionResult(... 'error' ...)`, call `onError?.(new Error(message))` (the same message string the result already carries).
+- **`deny`**: unchanged (structured result only, no callback).
+- **`redirect`** (navigates) and **`malformed`** (reloads): unchanged, no callbacks.
+- **catch block** (network/throw): call `onError?.(err as Error)` alongside the existing error result.
+
+### A3. Site migration (PR 1)
+
+- `apps/site/src/pages/demo/project-issues.tsx`: remove `lastSeenSuccess` ref + the success `useEffect`; pass `onSuccess={() => setShowForm(false)}` to `<Form>`. Drop the now-unused `useActionResult`/`useRef` imports if nothing else uses them.
+- `apps/site/src/pages/demo/issue.tsx`: remove `formKey` state + the success `useEffect`; change the comment `<Form>` to `<Form reset invalidate={[commentsLoader]} ...>` and drop the `key={formKey}` remount. Keep the optimistic wiring (the branded `action` prop) intact.
+
+## Part B (PR 2), ui: `Select`/`Combobox` form-reset participation
+
+Both roots already use `useControllableState({ value, defaultValue: defaultValue ?? empty, onChange })` (select.tsx:77, combobox.tsx:93), so `setValue` works controlled or uncontrolled and `defaultValue` is the natural reset target (mirroring native: a native control resets to its `defaultValue`).
+
+Add to each root (a small internal effect, e.g. a shared `useFormReset(ref, onReset)` helper in ui):
+- On mount, resolve the enclosing form via a ref on the root/trigger element: `el.closest('form')`. If none, do nothing.
+- Add a `reset` listener on that form. On the event, if `!event.defaultPrevented`, call `setValue(defaultValue ?? empty)`. Combobox additionally resets `inputValue` to `defaultInputValue ?? ''`.
+- Remove the listener on unmount / when the form ref changes.
+
+This makes a `Select`/`Combobox` reset to its default on any form reset (our `<Form reset>`, a native reset button, etc.), the same way native fields do. No dependency on iso.
+
+## Docs
+
+- **PR 1:** the actions / `Form` docs gain the four lifecycle props (a `Form` props table). If `/docs/optimistic-ui` shows the success-effect pattern, update it to the new props. Follow the `add-docs-page` skill conventions; no new page is strictly required if `Form` is documented on an existing page, but a props table is.
+- **PR 2:** a short "Form reset" note on the Select and Combobox pages (resets to `defaultValue` on form reset; respects `preventDefault`).
+
+## Tests
+
+- **PR 1:**
+  - `useInvalidate` units: `'auto'` calls `reload`; `false`/absent does nothing; array calls each `ref.invalidate()`; array including the active loader also calls `reload`.
+  - `useAction` existing invalidate tests stay green (refactor parity).
+  - `Form`: `onSuccess` fires with `decoded.data` on success; `onError` fires (with the right message) on an error outcome and NOT on `deny`; `invalidate` is applied; `reset` prop clears an uncontrolled field after success; the `reset` helper resets named fields.
+- **PR 2:**
+  - `Select`/`Combobox`: dispatching a `reset` event on the enclosing form resets the value to `defaultValue` (uncontrolled) and fires `onValueChange(defaultValue)` (controlled); a `preventDefault`ed reset does not reset; Combobox also clears its input text.
+
+## Breaking changes
+
+None. All `Form` additions are optional props; the existing result-store behavior is untouched. The `useAction` change is an internal refactor with identical behavior. The ui change is additive (new event listener). Recorded in the next release notes only as new features.
+
+## Out of scope (deferred)
+
+- Exporting `useInvalidate` as a public primitive (it stays an internal shared core; promote later with a docs page if a consumer wants it).
+- A bespoke Form-field reset registration protocol (the native `reset` event covers custom-field participation).
+- The other five Section C primitives (each its own spec).

--- a/packages/iso/src/__tests__/form.test.tsx
+++ b/packages/iso/src/__tests__/form.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { render, fireEvent, cleanup, act, waitFor } from '@testing-library/preact';
+import {
+  render,
+  fireEvent,
+  cleanup,
+  act,
+  waitFor,
+} from '@testing-library/preact';
 import { Form } from '../form.js';
 import type { ActionStub } from '../action.js';
 import {
@@ -244,10 +250,13 @@ describe('<Form>', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ __outcome: 'success', data: { id: 7 } }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        new Response(
+          JSON.stringify({ __outcome: 'success', data: { id: 7 } }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
       )
     );
     const onSuccess = vi.fn();
@@ -297,10 +306,13 @@ describe('<Form>', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ __outcome: 'success', data: { id: 1 } }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        new Response(
+          JSON.stringify({ __outcome: 'success', data: { id: 1 } }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
       )
     );
     const { getByRole } = render(

--- a/packages/iso/src/__tests__/form.test.tsx
+++ b/packages/iso/src/__tests__/form.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { render, fireEvent, cleanup, act, waitFor } from '@testing-library/preact';
 import { Form } from '../form.js';
 import type { ActionStub } from '../action.js';
 import {
@@ -237,5 +237,83 @@ describe('<Form>', () => {
     expect(
       getLastActionResult({ __module: stub.__module, __action: stub.__action })
     ).toBeNull();
+  });
+
+  it('calls onSuccess with the action data on a success outcome', async () => {
+    const stub = makeStub();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ __outcome: 'success', data: { id: 7 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const onSuccess = vi.fn();
+    const { getByRole } = render(
+      <Form action={stub} onSuccess={onSuccess}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    await act(async () => {
+      fireEvent.submit(getByRole('button').closest('form')!);
+    });
+    await waitFor(() =>
+      expect(onSuccess).toHaveBeenCalledWith(
+        { id: 7 },
+        expect.objectContaining({ reset: expect.any(Function) })
+      )
+    );
+  });
+
+  it('calls onError on an error outcome and not on deny', async () => {
+    const stub = makeStub();
+    const onError = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ __outcome: 'error', message: 'boom' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { getByRole } = render(
+      <Form action={stub} onError={onError}>
+        <button type="submit">go</button>
+      </Form>
+    );
+    await act(async () => {
+      fireEvent.submit(getByRole('button').closest('form')!);
+    });
+    await waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('boom');
+  });
+
+  it('resets the form after success when reset is set', async () => {
+    const stub = makeStub();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ __outcome: 'success', data: { id: 1 } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    const { getByRole } = render(
+      <Form action={stub} reset>
+        <input name="text" defaultValue="" />
+        <button type="submit">go</button>
+      </Form>
+    );
+    const input = getByRole('textbox') as HTMLInputElement;
+    input.value = 'typed';
+    await act(async () => {
+      fireEvent.submit(getByRole('button').closest('form')!);
+    });
+    await waitFor(() => expect(input.value).toBe(''));
   });
 });

--- a/packages/iso/src/__tests__/use-invalidate.test.tsx
+++ b/packages/iso/src/__tests__/use-invalidate.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/preact';
+import { useInvalidate, type InvalidateInput } from '../use-invalidate.js';
+import { ReloadContext } from '../reload-context.js';
+import { ActiveLoaderIdContext } from '../internal/contexts.js';
+import { defineLoader } from '../define-loader.js';
+
+afterEach(cleanup);
+
+function Harness({ input }: { input: InvalidateInput }) {
+  const apply = useInvalidate();
+  return <button onClick={() => apply(input)}>go</button>;
+}
+
+function click() {
+  document.querySelector('button')!.click();
+}
+
+describe('useInvalidate', () => {
+  it('calls reload() for "auto"', async () => {
+    const reload = vi.fn();
+    render(
+      <ReloadContext.Provider value={{ reload, reloading: false }}>
+        <Harness input="auto" />
+      </ReloadContext.Provider>
+    );
+    await act(async () => click());
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing for false', async () => {
+    const reload = vi.fn();
+    render(
+      <ReloadContext.Provider value={{ reload, reloading: false }}>
+        <Harness input={false} />
+      </ReloadContext.Provider>
+    );
+    await act(async () => click());
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('invalidates each ref in an array and reloads when the active loader is included', async () => {
+    const active = defineLoader(async () => ({ value: 1 }), {
+      __moduleKey: 'inv-active',
+    });
+    const other = defineLoader(async () => ({ value: 2 }), {
+      __moduleKey: 'inv-other',
+    });
+    const invActive = vi.spyOn(active, 'invalidate');
+    const invOther = vi.spyOn(other, 'invalidate');
+    const reload = vi.fn();
+    render(
+      <ActiveLoaderIdContext.Provider value={active.__id}>
+        <ReloadContext.Provider value={{ reload, reloading: false }}>
+          <Harness input={[active, other]} />
+        </ReloadContext.Provider>
+      </ActiveLoaderIdContext.Provider>
+    );
+    await act(async () => click());
+    expect(invActive).toHaveBeenCalled();
+    expect(invOther).toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('invalidates refs without reloading when none is the active loader', async () => {
+    const other = defineLoader(async () => ({ value: 2 }), {
+      __moduleKey: 'inv-only-other',
+    });
+    const invOther = vi.spyOn(other, 'invalidate');
+    const reload = vi.fn();
+    render(
+      <ActiveLoaderIdContext.Provider value={null}>
+        <ReloadContext.Provider value={{ reload, reloading: false }}>
+          <Harness input={[other]} />
+        </ReloadContext.Provider>
+      </ActiveLoaderIdContext.Provider>
+    );
+    await act(async () => click());
+    expect(invOther).toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -1,8 +1,7 @@
-import { useCallback, useContext, useRef, useState } from 'preact/hooks';
+import { useCallback, useRef, useState } from 'preact/hooks';
 import type { Context } from 'hono';
-import { ReloadContext } from './reload-context.js';
-import { ActiveLoaderIdContext } from './internal/contexts.js';
 import type { LoaderRef } from './define-loader.js';
+import { useInvalidate } from './use-invalidate.js';
 import type { ActionUse } from './internal/use-types.js';
 import { beginSubmit, endSubmit } from './internal/form-submit-store.js';
 import { assignSafeRedirect } from './internal/safe-redirect.js';
@@ -227,8 +226,7 @@ export function useAction<
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [data, setData] = useState<TResult | null>(null);
-  const reloadCtx = useContext(ReloadContext);
-  const activeLoaderId = useContext(ActiveLoaderIdContext);
+  const applyInvalidate = useInvalidate();
 
   const stubRef = useRef(stub);
   stubRef.current = stub;
@@ -469,24 +467,7 @@ export function useAction<
           }
         }
 
-        if (currentOptions?.invalidate === 'auto') {
-          reloadCtx?.reload();
-        } else if (Array.isArray(currentOptions?.invalidate)) {
-          let invalidatedActive = false;
-          for (const ref of currentOptions.invalidate) {
-            ref.invalidate();
-            if (activeLoaderId && ref.__id === activeLoaderId) {
-              invalidatedActive = true;
-            }
-          }
-          // If the user's invalidate list includes the active page's loader,
-          // also re-run that loader so the visible <Loader> picks up fresh
-          // data. Other refs (sibling pages) just clear their caches; those
-          // pages will refetch on their next mount.
-          if (invalidatedActive) {
-            reloadCtx?.reload();
-          }
-        }
+        applyInvalidate(currentOptions?.invalidate);
       } catch (err) {
         const e = err instanceof Error ? err : new Error(String(err));
         // Write to the store only for unclassified errors (network failures,

--- a/packages/iso/src/form.tsx
+++ b/packages/iso/src/form.tsx
@@ -46,8 +46,7 @@ function resetFormFields(formEl: HTMLFormElement, fields?: string[]): void {
   }
   for (const name of fields) {
     const el = formEl.elements.namedItem(name);
-    const nodes =
-      el instanceof RadioNodeList ? Array.from(el) : el ? [el] : [];
+    const nodes = el instanceof RadioNodeList ? Array.from(el) : el ? [el] : [];
     for (const node of nodes) {
       if (node instanceof HTMLInputElement) {
         if (node.type === 'checkbox' || node.type === 'radio')
@@ -167,7 +166,9 @@ export function Form<TPayload, TResult>({
               data: decoded.data,
               submittedPayload: payload,
             });
-            lifecycle.current.onSuccess?.(decoded.data as TResult, { reset: resetForm });
+            lifecycle.current.onSuccess?.(decoded.data as TResult, {
+              reset: resetForm,
+            });
             applyInvalidate(lifecycle.current.invalidate);
             if (lifecycle.current.reset) resetForm();
             return;

--- a/packages/iso/src/form.tsx
+++ b/packages/iso/src/form.tsx
@@ -1,5 +1,5 @@
 import type { JSX, ComponentChildren } from 'preact';
-import { useState, useCallback, useMemo } from 'preact/hooks';
+import { useState, useCallback, useMemo, useRef } from 'preact/hooks';
 import type { ActionStub } from './action.js';
 import {
   OPTIMISTIC_BRAND,
@@ -11,6 +11,8 @@ import { FORM_MODULE_FIELD, FORM_ACTION_FIELD } from './internal/contract.js';
 import { setLastActionResult } from './internal/action-result-store.js';
 import { assignSafeRedirect } from './internal/safe-redirect.js';
 import { decodeActionResponse } from './internal/action-envelope.js';
+import type { LoaderRef } from './define-loader.js';
+import { useInvalidate } from './use-invalidate.js';
 
 /**
  * The `action` prop accepts either a plain action stub or the branded value
@@ -28,7 +30,38 @@ export type FormProps<TPayload, TResult> = Omit<
 > & {
   action: FormActionInput<TPayload, TResult>;
   children?: ComponentChildren;
+  onSuccess?: (
+    data: TResult,
+    helpers: { reset: (fields?: string[]) => void }
+  ) => void;
+  onError?: (err: Error) => void;
+  invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
+  reset?: boolean;
 };
+
+function resetFormFields(formEl: HTMLFormElement, fields?: string[]): void {
+  if (!fields) {
+    formEl.reset();
+    return;
+  }
+  for (const name of fields) {
+    const el = formEl.elements.namedItem(name);
+    const nodes =
+      el instanceof RadioNodeList ? Array.from(el) : el ? [el] : [];
+    for (const node of nodes) {
+      if (node instanceof HTMLInputElement) {
+        if (node.type === 'checkbox' || node.type === 'radio')
+          node.checked = node.defaultChecked;
+        else node.value = node.defaultValue;
+      } else if (node instanceof HTMLTextAreaElement) {
+        node.value = node.defaultValue;
+      } else if (node instanceof HTMLSelectElement) {
+        for (const opt of Array.from(node.options))
+          opt.selected = opt.defaultSelected;
+      }
+    }
+  }
+}
 
 function hasOptimisticBrand<TPayload, TResult>(
   action: FormActionInput<TPayload, TResult>
@@ -56,11 +89,18 @@ function collectFormData(
 export function Form<TPayload, TResult>({
   action,
   children,
+  onSuccess,
+  onError,
+  invalidate,
+  reset,
   ...rest
 }: FormProps<TPayload, TResult>) {
   const [pending, setPending] = useState(false);
   const moduleKey = action.__module;
   const actionName = action.__action;
+  const applyInvalidate = useInvalidate();
+  const lifecycle = useRef({ onSuccess, onError, invalidate, reset });
+  lifecycle.current = { onSuccess, onError, invalidate, reset };
 
   const optimistic = useMemo(
     () => (hasOptimisticBrand(action) ? action[OPTIMISTIC_BRAND] : undefined),
@@ -71,6 +111,7 @@ export function Form<TPayload, TResult>({
     async (e: Event) => {
       e.preventDefault();
       const formEl = e.currentTarget as HTMLFormElement;
+      const resetForm = (fields?: string[]) => resetFormFields(formEl, fields);
       const target =
         typeof window !== 'undefined'
           ? window.location.pathname + window.location.search
@@ -126,6 +167,9 @@ export function Form<TPayload, TResult>({
               data: decoded.data,
               submittedPayload: payload,
             });
+            lifecycle.current.onSuccess?.(decoded.data as TResult, { reset: resetForm });
+            applyInvalidate(lifecycle.current.invalidate);
+            if (lifecycle.current.reset) resetForm();
             return;
           case 'deny':
             handle?.revert();
@@ -144,6 +188,7 @@ export function Form<TPayload, TResult>({
               message: decoded.message,
               submittedPayload: payload,
             });
+            lifecycle.current.onError?.(new Error(decoded.message));
             return;
           case 'timeout':
             handle?.revert();
@@ -152,6 +197,9 @@ export function Form<TPayload, TResult>({
               message: `Request timed out after ${decoded.timeoutMs}ms`,
               submittedPayload: payload,
             });
+            lifecycle.current.onError?.(
+              new Error(`Request timed out after ${decoded.timeoutMs}ms`)
+            );
             return;
           case 'unknown':
             handle?.revert();
@@ -162,6 +210,12 @@ export function Form<TPayload, TResult>({
                 `Unexpected outcome: ${decoded.outcome ?? 'unknown'}`,
               submittedPayload: payload,
             });
+            lifecycle.current.onError?.(
+              new Error(
+                decoded.message ??
+                  `Unexpected outcome: ${decoded.outcome ?? 'unknown'}`
+              )
+            );
             return;
           default:
             decoded satisfies never;
@@ -173,12 +227,15 @@ export function Form<TPayload, TResult>({
           message: err instanceof Error ? err.message : String(err),
           submittedPayload: payload,
         });
+        lifecycle.current.onError?.(
+          err instanceof Error ? err : new Error(String(err))
+        );
       } finally {
         setPending(false);
         endSubmit(moduleKey, actionName);
       }
     },
-    [moduleKey, actionName, optimistic]
+    [moduleKey, actionName, optimistic, applyInvalidate]
   );
 
   return (

--- a/packages/iso/src/use-invalidate.ts
+++ b/packages/iso/src/use-invalidate.ts
@@ -1,0 +1,47 @@
+import { useCallback, useContext } from 'preact/hooks';
+import { ReloadContext } from './reload-context.js';
+import { ActiveLoaderIdContext } from './internal/contexts.js';
+import type { LoaderRef } from './define-loader.js';
+
+/** How to update loader caches after an action commits. Same vocabulary as
+ * `useAction`'s `invalidate` option: `'auto'` re-runs the active page's loader;
+ * an array calls `.invalidate()` on each `LoaderRef` (and re-runs the active
+ * loader if it is in the list); `false`/undefined does nothing. */
+export type InvalidateInput =
+  | 'auto'
+  | false
+  | ReadonlyArray<LoaderRef<unknown>>;
+
+/**
+ * Reads the enclosing `ReloadContext` + `ActiveLoaderIdContext` and returns a
+ * stable apply function shared by `useAction` and `<Form>`. Must be called at
+ * the top level of a component/hook (it uses `useContext`).
+ */
+export function useInvalidate(): (
+  invalidate: InvalidateInput | undefined
+) => void {
+  const reloadCtx = useContext(ReloadContext);
+  const activeLoaderId = useContext(ActiveLoaderIdContext);
+  return useCallback(
+    (invalidate) => {
+      if (invalidate === 'auto') {
+        reloadCtx?.reload();
+      } else if (Array.isArray(invalidate)) {
+        let invalidatedActive = false;
+        for (const ref of invalidate) {
+          ref.invalidate();
+          if (activeLoaderId && ref.__id === activeLoaderId) {
+            invalidatedActive = true;
+          }
+        }
+        // If the user's list includes the active page's loader, re-run it so
+        // the visible <Loader> picks up fresh data. Other refs just clear their
+        // caches; those pages refetch on their next mount.
+        if (invalidatedActive) {
+          reloadCtx?.reload();
+        }
+      }
+    },
+    [reloadCtx, activeLoaderId]
+  );
+}


### PR DESCRIPTION
## Summary

First of the six Section C site-discovered primitives. `Form` had no success lifecycle, so the site hand-rolled it twice (`useActionResult` + `useEffect` dedup). This gives `Form` the same vocabulary `useAction` already has, sharing one implementation. Spec: `docs/superpowers/specs/2026-06-12-form-lifecycle-design.md`; plan: `docs/superpowers/plans/2026-06-12-form-lifecycle.md`. This is **PR 1 (iso)**; PR 2 (ui Select/Combobox form-reset participation) is planned separately.

- **`useInvalidate()` hook (new, internal):** extracts `useAction`'s inline `'auto' | false | LoaderRef[]` invalidation logic; `useAction` refactored onto it (behavior-preserving, the existing invalidate tests are the parity oracle). One implementation, two consumers.
- **`Form` gains four optional props:** `onSuccess(data, { reset })`, `onError(err)`, `invalidate`, `reset`. Wired additively into the existing `handleSubmit` outcome switch:
  - `onSuccess` fires on `success` (with the action data); then `invalidate` applies; then `reset` if set.
  - `onError` fires on `error`/`timeout`/`unknown` and the catch block, with messages matching `setLastActionResult`. `deny` stays a structured result (read via `useActionResult`), not an error.
  - `reset?: boolean` (auto-reset on success) plus a `reset(fields?)` helper passed to `onSuccess` (full native `formEl.reset()`, or named-field reset). A full reset fires the standard `reset` event, which PR 2's ui components will subscribe to.
- **Dogfood proof:** both site workarounds deleted (net −20 lines): `project-issues.tsx` → `onSuccess`; `issue.tsx` → `reset invalidate={[commentsLoader]}` (the `formKey`-remount + manual `useEffect` both gone, optimistic wiring preserved).

No breaking changes (all additive optional props; the `useAction` change is an internal refactor with identical behavior).

## Test plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1243 passed) including new `useInvalidate` units, the `useAction` invalidate parity tests, and new `Form` lifecycle tests (onSuccess/onError/reset)
- [x] `pnpm test:integration` (4 passed)
- [x] `pnpm --filter site build`

## Notes

- Deep review ran before opening: the invalidation extraction is bit-for-bit identical to the old inline logic; the `onError` outcome matrix matches the spec exactly; the site migration preserves behavior. One conscious edge (pre-existing, unchanged): a refused cross-origin redirect surfaces to `useActionResult` but not to a `Form onError` handler.
- `useInvalidate` is kept internal (not on the barrel); promotable later with a docs page if a consumer wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)