### PR TITLE
Prefetch on intent (Section C #3): usePrefetch hook

### DIFF
--- a/apps/site/src/components/demo/IssueRow.tsx
+++ b/apps/site/src/components/demo/IssueRow.tsx
@@ -1,21 +1,16 @@
-import { prefetch, ViewTransitionName } from 'hono-preact';
+import { usePrefetch, ViewTransitionName } from 'hono-preact';
 import type { FunctionComponent } from 'preact';
-import { useCallback } from 'preact/hooks';
 import type { Issue } from '../../demo/data.js';
 import { serverLoaders } from '../../pages/demo/issue.server.js';
 
 type Props = { issue: Issue; projectSlug: string };
-
-const ISSUE_ROUTE = '/demo/projects/:projectId/issues/:issueId';
 
 const IssueRow: FunctionComponent<Props> = ({ issue, projectSlug }) => {
   const href = `/demo/projects/${projectSlug}/issues/${issue.id}`;
 
   // Prefetch the issue page's primary loader on hover/focus. The comments
   // loader streams and the activity loader is small; both stay on-demand.
-  const onPrefetch = useCallback(() => {
-    void prefetch(serverLoaders.issue, { url: href, route: ISSUE_ROUTE });
-  }, [href]);
+  const prefetchIssue = usePrefetch(href, serverLoaders.issue);
 
   return (
     <li class="border p-3 flex items-baseline justify-between">
@@ -25,8 +20,8 @@ const IssueRow: FunctionComponent<Props> = ({ issue, projectSlug }) => {
         render={
           <a
             href={href}
-            onMouseEnter={onPrefetch}
-            onFocus={onPrefetch}
+            onMouseEnter={prefetchIssue}
+            onFocus={prefetchIssue}
             class="font-medium underline"
           />
         }

--- a/apps/site/src/pages/docs/link-prefetch.mdx
+++ b/apps/site/src/pages/docs/link-prefetch.mdx
@@ -52,6 +52,30 @@ Add `data-no-prefetch` to the links that lead to those routes, or refactor them 
 
 The emitted script is a normal `<script>` element and is subject to your `Content-Security-Policy`. Apps with strict CSPs that don't allow inline scripts will see the speculation script blocked by the browser. The framework does not currently plumb a CSP nonce. If your app needs Speculation Rules under strict CSP, file an issue describing the use case.
 
+## Prefetch on intent
+
+`usePrefetch(href, loaders)` returns a callback that prefetches a link's loader
+data, resolving the target route's params from the route table for you (no
+copied route pattern). Bind it to whatever events express intent, hover and
+focus, touch, an `IntersectionObserver`, a long-press:
+
+```tsx
+import { usePrefetch } from 'hono-preact';
+import { serverLoaders } from '../pages/issue.server.js';
+
+function IssueLink({ href }: { href: string }) {
+  const prefetchIssue = usePrefetch(href, serverLoaders.issue);
+  return (
+    <a href={href} onMouseEnter={prefetchIssue} onFocus={prefetchIssue}>
+      Open issue
+    </a>
+  );
+}
+```
+
+Pass one loader or an array. A warm cache makes repeat fires free, so binding to
+several events is fine.
+
 ## See also
 
 - [Middleware](/docs/middleware): `defineApp` accepts other options beyond `speculation`, including `use` for middleware composition.

--- a/docs/superpowers/plans/2026-06-12-use-prefetch.md
+++ b/docs/superpowers/plans/2026-06-12-use-prefetch.md
@@ -1,0 +1,392 @@
+# Prefetch on intent: usePrefetch (Section C #3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `usePrefetch(href, refs)`, which resolves `href` to its route params from the route manifest and returns a trigger to prefetch the named loader(s); migrate `IssueRow` off its hand-copied route pattern and manual prefetch wiring.
+
+**Architecture:** A new internal `RouteManifestContext` carries the flat route list (`routes.flat`); `Routes` provides it. `usePrefetch` reads it, matches `href` against the patterns (cast-free via `matchPath`), and calls the existing `prefetch(ref, { location })`. Returns a bare `() => void` the consumer binds to any event. No global singleton; `prefetch()` is unchanged.
+
+**Tech Stack:** TypeScript, preact, preact-iso, Vitest + `@testing-library/preact` (happy-dom).
+
+**Source spec:** `docs/superpowers/specs/2026-06-12-use-prefetch-design.md`.
+
+**Conventions:**
+- Run a single test file with `pnpm exec vitest run <path>` from the repo root.
+- No em-dashes in code/comments/commit messages.
+- Run `pnpm format` before the pre-push step (`.mdx` is checked too).
+- Commit after each task; messages end with the `Co-Authored-By: Claude Opus 4.8 (1M context)` trailer.
+
+## File map
+
+- **Create** `packages/iso/src/internal/route-manifest.ts`: the `RouteManifestContext`.
+- **Create** `packages/iso/src/use-prefetch.ts`: the hook.
+- **Create** `packages/iso/src/__tests__/use-prefetch.test.tsx`: hook tests.
+- **Modify** `packages/iso/src/index.ts`: export `usePrefetch`.
+- **Modify** `packages/iso/src/define-routes.tsx`: `Routes` provides the context.
+- **Modify** `packages/iso/src/__tests__/define-routes.test.tsx`: context-provider test.
+- **Modify** `apps/site/src/components/demo/IssueRow.tsx`: use `usePrefetch`.
+- **Modify** `apps/site/src/pages/docs/link-prefetch.mdx`: a "Prefetch on intent" note.
+
+---
+
+## Task 1: The `usePrefetch` hook + manifest context
+
+**Files:**
+- Create: `packages/iso/src/internal/route-manifest.ts`
+- Create: `packages/iso/src/use-prefetch.ts`
+- Create: `packages/iso/src/__tests__/use-prefetch.test.tsx`
+- Modify: `packages/iso/src/index.ts`
+
+- [ ] **Step 1: Write the hook tests.** Create `packages/iso/src/__tests__/use-prefetch.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { RouteManifestContext } from '../internal/route-manifest.js';
+import { usePrefetch } from '../use-prefetch.js';
+import { defineLoader } from '../define-loader.js';
+import type { FlatRoute } from '../define-routes.js';
+import type { LoaderRef } from '../define-loader.js';
+
+const prefetchSpy = vi.fn();
+vi.mock('../prefetch.js', () => ({
+  prefetch: (...args: unknown[]) => prefetchSpy(...args),
+}));
+
+beforeEach(() => prefetchSpy.mockClear());
+afterEach(cleanup);
+
+const FLAT: ReadonlyArray<FlatRoute> = [
+  {
+    path: '/demo/projects/:projectId/issues/:issueId',
+    component: () => null,
+    key: 'k1',
+  },
+];
+
+const ref = defineLoader(async () => ({ ok: true }), { __moduleKey: 'pf' });
+
+function Harness({
+  href,
+  refs,
+}: {
+  href: string;
+  refs: LoaderRef<unknown> | ReadonlyArray<LoaderRef<unknown>>;
+}) {
+  const prefetch = usePrefetch(href, refs);
+  return <button onClick={prefetch}>go</button>;
+}
+
+function renderIn(href: string, refs: LoaderRef<unknown>) {
+  return render(
+    <RouteManifestContext.Provider value={FLAT}>
+      <Harness href={href} refs={refs} />
+    </RouteManifestContext.Provider>
+  );
+}
+
+describe('usePrefetch', () => {
+  it('resolves params from the manifest and prefetches the loader', () => {
+    const { getByRole } = renderIn('/demo/projects/p1/issues/i1', ref);
+    fireEvent.click(getByRole('button'));
+    expect(prefetchSpy).toHaveBeenCalledWith(ref, {
+      location: {
+        path: '/demo/projects/p1/issues/i1',
+        pathParams: { projectId: 'p1', issueId: 'i1' },
+        searchParams: {},
+      },
+    });
+  });
+
+  it('is a no-op when no manifest route matches', () => {
+    const { getByRole } = renderIn('/nope', ref);
+    fireEvent.click(getByRole('button'));
+    expect(prefetchSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run it; expect FAIL** (cannot resolve `../internal/route-manifest.js` / `../use-prefetch.js`). `pnpm exec vitest run packages/iso/src/__tests__/use-prefetch.test.tsx`
+
+- [ ] **Step 3: Create the context.** Create `packages/iso/src/internal/route-manifest.ts`:
+
+```ts
+import { createContext } from 'preact';
+import type { FlatRoute } from '../define-routes.js';
+
+/**
+ * The flat route list (patterns) of the active app, provided by `Routes`.
+ * `usePrefetch` reads it to resolve an href to its route params. Internal.
+ */
+export const RouteManifestContext = createContext<ReadonlyArray<FlatRoute>>([]);
+```
+
+- [ ] **Step 4: Create the hook.** Create `packages/iso/src/use-prefetch.ts`:
+
+```ts
+import { useCallback, useContext } from 'preact/hooks';
+import type { RouteHook } from 'preact-iso';
+import type { LoaderRef } from './define-loader.js';
+import { prefetch } from './prefetch.js';
+import { matchPath } from './route-active.js';
+import { RouteManifestContext } from './internal/route-manifest.js';
+
+function parseHref(href: string): {
+  path: string;
+  searchParams: Record<string, string>;
+} {
+  const parsed = new URL(href, 'http://_');
+  let path = parsed.pathname;
+  if (path.length > 1 && path.endsWith('/')) path = path.slice(0, -1);
+  const searchParams: Record<string, string> = {};
+  parsed.searchParams.forEach((value, key) => {
+    searchParams[key] = value;
+  });
+  return { path, searchParams };
+}
+
+// Specificity for picking among overlapping matches (a `:param`/`*` catch-all
+// can match the same href as a literal leaf). Literal segments rank highest,
+// then `:param`, then `*`; the most specific route is the one the router lands
+// on, so its params are the ones the target loader reads.
+function specificity(pattern: string): number {
+  let score = 0;
+  for (const seg of pattern.split('/')) {
+    if (seg === '') continue;
+    if (seg.includes('*')) score += 1;
+    else if (seg.startsWith(':')) score += 2;
+    else score += 3;
+  }
+  return score;
+}
+
+/**
+ * Returns a callback that prefetches `refs` for the route `href` points at.
+ * Bind it to any intent event (hover, focus, touch, pointerenter, an
+ * IntersectionObserver). The route's params are resolved from the manifest, so
+ * callers do not repeat the route pattern. A warm cache makes repeat calls a
+ * no-op (see `prefetch`).
+ */
+export function usePrefetch(
+  href: string,
+  refs: LoaderRef<unknown> | ReadonlyArray<LoaderRef<unknown>>
+): () => void {
+  const flat = useContext(RouteManifestContext);
+  return useCallback(() => {
+    const { path, searchParams } = parseHref(href);
+    let bestParams: Record<string, string> | null = null;
+    let bestScore = -1;
+    for (const route of flat) {
+      const params = matchPath(path, route.path, true);
+      if (!params) continue;
+      const score = specificity(route.path);
+      if (score > bestScore) {
+        bestScore = score;
+        bestParams = params;
+      }
+    }
+    if (!bestParams) return; // off-manifest or outside Routes: best-effort no-op
+    const location: RouteHook = { path, pathParams: bestParams, searchParams };
+    const list = Array.isArray(refs) ? refs : [refs];
+    for (const ref of list) void prefetch(ref, { location });
+  }, [href, refs, flat]);
+}
+```
+
+(No cast: `prefetch.ts`'s own `buildLocation` already constructs and returns exactly `{ path, searchParams, pathParams }` typed `RouteHook` with no cast, so the object literal is assignable, the extra `RouteHook` fields are optional. If `tsc` unexpectedly complains here, re-check that `bestParams`/`searchParams` are typed `Record<string, string>` rather than widened.)
+
+- [ ] **Step 5: Add the barrel export.** In `packages/iso/src/index.ts`, in the `// Utilities.` section near `export { prefetch } from './prefetch.js';`, add:
+```ts
+export { usePrefetch } from './use-prefetch.js';
+```
+
+- [ ] **Step 6: Run the test; expect PASS** (2 tests). `pnpm exec vitest run packages/iso/src/__tests__/use-prefetch.test.tsx`
+
+- [ ] **Step 7: Build + typecheck.** `pnpm --filter @hono-preact/iso build && pnpm typecheck`
+Expected: PASS. (If a `Cannot find module '@hono-preact/...'` unrelated error appears, run `pnpm install` and retry.)
+
+- [ ] **Step 8: Commit.**
+```bash
+git add packages/iso/src/internal/route-manifest.ts \
+  packages/iso/src/use-prefetch.ts \
+  packages/iso/src/__tests__/use-prefetch.test.tsx \
+  packages/iso/src/index.ts
+git commit -m "feat(iso): usePrefetch hook (resolve href params from the manifest, prefetch on intent)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `Routes` provides the manifest context
+
+**Files:**
+- Modify: `packages/iso/src/define-routes.tsx`
+- Modify: `packages/iso/src/__tests__/define-routes.test.tsx`
+
+- [ ] **Step 1: Write the provider test.** Append to `packages/iso/src/__tests__/define-routes.test.tsx`, inside the existing `describe('<Routes>', ...)` block. It uses the same harness pattern the file already uses (`history.replaceState` + `LocationProvider` + lazy `view`). Add `useContext` to the `preact/hooks` import (the file already imports `useState`), and `RouteManifestContext` from `../internal/route-manifest.js`, and `FlatRoute` to the `../define-routes.js` type import:
+
+```tsx
+  it('provides the route manifest via RouteManifestContext', async () => {
+    let seen: ReadonlyArray<FlatRoute> | null = null;
+    const Probe = () => {
+      seen = useContext(RouteManifestContext);
+      return h('div', { 'data-testid': 'probe' }, 'ok');
+    };
+    const manifest = defineRoutes([
+      { path: '/ctx', view: () => Promise.resolve({ default: Probe }) },
+    ]);
+    history.replaceState(null, '', '/ctx');
+    const { findByTestId } = render(
+      h(LocationProvider, null, h(Routes, { routes: manifest })) as VNode
+    );
+    await findByTestId('probe');
+    expect(seen).toBe(manifest.flat);
+  });
+```
+
+- [ ] **Step 2: Run it; expect FAIL** (`seen` is the empty default array, not `manifest.flat`, because `Routes` does not provide the context yet). `pnpm exec vitest run packages/iso/src/__tests__/define-routes.test.tsx`
+
+- [ ] **Step 3: Wire the provider into `Routes`.** In `packages/iso/src/define-routes.tsx`:
+  - Add `import { RouteManifestContext } from './internal/route-manifest.js';`
+  - Wrap the `Routes` component's returned `Router` element in the provider. The current `Routes` returns `h(asRouteComponent(Router), { onLoadStart, onLoadEnd }, ...routes.flat.map(...))`. Change it to wrap that whole `h(...)` in `h(RouteManifestContext.Provider, { value: routes.flat }, <the existing Router element>)`:
+```tsx
+export const Routes: ComponentType<RoutesProps> = ({ routes }) => {
+  return h(
+    RouteManifestContext.Provider,
+    { value: routes.flat },
+    h(
+      asRouteComponent(Router),
+      {
+        onLoadStart: __noteLoadStart,
+        onLoadEnd: __noteLoadEnd,
+      },
+      ...routes.flat.map((r) =>
+        h(Route, {
+          key: r.key,
+          path: r.path,
+          component: asRouteComponent(r.component),
+        })
+      )
+    )
+  );
+};
+```
+
+- [ ] **Step 4: Run the test; expect PASS.** `pnpm exec vitest run packages/iso/src/__tests__/define-routes.test.tsx` (the new test plus all existing `<Routes>` tests stay green).
+
+- [ ] **Step 5: Build + typecheck.** `pnpm --filter @hono-preact/iso build && pnpm typecheck` -> expect PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/iso/src/define-routes.tsx packages/iso/src/__tests__/define-routes.test.tsx
+git commit -m "feat(iso): Routes provides the flat route manifest via context (for usePrefetch)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Migrate `IssueRow`
+
+**Files:**
+- Modify: `apps/site/src/components/demo/IssueRow.tsx`
+
+- [ ] **Step 1: Read `apps/site/src/components/demo/IssueRow.tsx`.** It declares `const ISSUE_ROUTE = '/demo/projects/:projectId/issues/:issueId';`, a `useCallback` `onPrefetch` that calls `prefetch(serverLoaders.issue, { url: href, route: ISSUE_ROUTE })`, and binds `onMouseEnter={onPrefetch} onFocus={onPrefetch}` on the anchor inside the `ViewTransitionName` render.
+
+- [ ] **Step 2: Switch to `usePrefetch`.**
+  - In the `hono-preact` import, replace `prefetch` with `usePrefetch` (keep `ViewTransitionName`). Remove the `useCallback` import if it becomes unused.
+  - Delete the `const ISSUE_ROUTE = ...;` line.
+  - Replace the `onPrefetch` `useCallback` with: `const prefetchIssue = usePrefetch(href, serverLoaders.issue);`
+  - Change the anchor's handlers from `onMouseEnter={onPrefetch} onFocus={onPrefetch}` to `onMouseEnter={prefetchIssue} onFocus={prefetchIssue}`.
+
+- [ ] **Step 3: Typecheck + build the framework + site.** Run:
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build && pnpm typecheck && pnpm --filter site build
+```
+Expected: PASS. (Build the framework first so the site resolves `usePrefetch` through `dist/`. A failure on an unused `useCallback`/`prefetch` import means Step 2 missed removing one.)
+
+- [ ] **Step 4: Commit.**
+```bash
+git add apps/site/src/components/demo/IssueRow.tsx
+git commit -m "refactor(site): IssueRow uses usePrefetch (drops copied route pattern + manual prefetch wiring)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Document `usePrefetch`
+
+**Files:**
+- Modify: `apps/site/src/pages/docs/link-prefetch.mdx`
+
+- [ ] **Step 1: Add a "Prefetch on intent" section.** Read `apps/site/src/pages/docs/link-prefetch.mdx` to find a sensible insertion point (after the section describing the manual `prefetch()` on a link, or at the end of a usage section). Insert:
+
+````md
+## Prefetch on intent
+
+`usePrefetch(href, loaders)` returns a callback that prefetches a link's loader
+data, resolving the target route's params from the route table for you (no
+copied route pattern). Bind it to whatever events express intent, hover and
+focus, touch, an `IntersectionObserver`, a long-press:
+
+```tsx
+import { usePrefetch } from 'hono-preact';
+import { serverLoaders } from '../pages/issue.server.js';
+
+function IssueLink({ href }: { href: string }) {
+  const prefetchIssue = usePrefetch(href, serverLoaders.issue);
+  return (
+    <a href={href} onMouseEnter={prefetchIssue} onFocus={prefetchIssue}>
+      Open issue
+    </a>
+  );
+}
+```
+
+Pass one loader or an array. A warm cache makes repeat fires free, so binding to
+several events is fine.
+````
+
+- [ ] **Step 2: Verify docs parse + parity + prettier.** Run:
+- `pnpm exec vitest run apps/site/src/pages/docs/__tests__` -> expect PASS (no page added).
+- `pnpm --filter site build` -> expect PASS.
+- `pnpm exec prettier --check apps/site/src/pages/docs/link-prefetch.mdx`; if flagged, `pnpm exec prettier --write` it and re-check.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add apps/site/src/pages/docs/link-prefetch.mdx
+git commit -m "docs: document usePrefetch for prefetch-on-intent
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full pre-push verification
+
+**Files:** none.
+
+- [ ] **Step 1: Run the six-step CI mirror in order, each expecting PASS:**
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+- [ ] **Step 2: If `format:check` fails,** `pnpm format`, restage into the relevant commit or a `style:` commit, and re-run from Step 1.
+
+- [ ] **Step 3: Flake note.** If `measure-client-size` times out under load, re-run it in isolation (`pnpm exec vitest run scripts/__tests__/measure-client-size.test.mjs`) before treating it as real.
+
+---
+
+## Self-review
+
+- **Spec coverage:** the `usePrefetch` hook returning a bare trigger (Task 1), the internal `RouteManifestContext` provided by `Routes` (Tasks 1 + 2), href->params resolution via `matchPath` + specificity (Task 1), the `IssueRow` migration (Task 3), docs (Task 4). `prefetch()` unchanged; NavLink deferred (correctly absent). All present.
+- **Placeholder scan:** every code step has full code; the one cast (`as RouteHook`) is annotated with the existing-precedent rationale and a "drop if tsc accepts" instruction. No placeholders.
+- **Type/name consistency:** `usePrefetch(href, refs)` and `RouteManifestContext` are identical across the hook, its test, the barrel, the Routes wiring, the provider test, and the migration; the resolved `location` shape (`{ path, pathParams, searchParams }`) matches the `prefetch` test's assertion and `prefetch.ts`'s own `buildLocation`.

--- a/docs/superpowers/specs/2026-06-12-use-prefetch-design.md
+++ b/docs/superpowers/specs/2026-06-12-use-prefetch-design.md
@@ -1,0 +1,83 @@
+# Prefetch on intent: `usePrefetch` (Section C, primitive 3) design
+
+**Date:** 2026-06-12
+**Status:** Approved design, pre-implementation
+**Source:** Section C (primitive 3, "prefetch-on-intent in `NavLink`") of `docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md`. Third of the six site-discovered primitives.
+**Goal:** Kill the two real smells in the site's hand-rolled prefetch link: a copied route-pattern string and hand-wired intent handlers. Ship a `usePrefetch(href, refs)` hook that resolves `href` to its route params from the route manifest and returns a trigger to bind to any event; migrate `IssueRow` onto it.
+
+## Scope decisions (locked with user)
+
+1. **Minimal framework sliver (not the full NavLink primitive).** The only genuinely framework-shaped part is resolving an `href` to the target route's params, which needs the route table (framework-owned). The rest (event wiring, calling `prefetch`) is thin. So this ships the small piece that earns its keep, not an opinionated NavLink prefetch prop.
+2. **A hook reading a context, NOT a global singleton.** `prefetch()` is a plain async function and cannot read context, so making `prefetch()` itself resolve the manifest would require a module-level manifest registry, i.e. another global singleton (declined for primitive #2 for the same reason). Instead a `usePrefetch` hook reads an internal route-manifest context provided by `Routes`. `prefetch()` is unchanged.
+3. **A single trigger function, bound to any event by the consumer.** `usePrefetch` returns `() => void`, not a fixed `{ onMouseEnter, onFocus }`. Which events express "intent" is the consumer's policy (hover/focus, touch, pointerenter, IntersectionObserver, long-press), not the framework's. `() => void` is assignable to any event handler.
+4. **The user names the loader ref(s).** A lazy route's loaders are not on the client until you navigate, so they cannot be auto-discovered on hover; and the site deliberately prefetches only the primary loader. So `refs` is required, not auto-resolved.
+5. **NavLink integration deferred.** Once `usePrefetch` exists, a `<NavLink prefetch={refs}>` prop is a trivial later increment. Out of scope here.
+
+## API
+
+Exported from the iso barrel (`packages/iso/src/index.ts`):
+
+```ts
+export function usePrefetch(
+  href: string,
+  refs: LoaderRef<unknown> | ReadonlyArray<LoaderRef<unknown>>
+): () => void;
+```
+
+`usePrefetch` returns a stable callback. When called, it resolves `href` to the target route's location (params) from the manifest and prefetches each named loader for that location. Bind the callback to whatever events you want:
+
+```tsx
+const prefetchIssue = usePrefetch(href, serverLoaders.issue);
+<a href={href} onMouseEnter={prefetchIssue} onFocus={prefetchIssue} />;
+```
+
+`prefetch()` already no-ops on a warm cache (its `serializeLocationForCache` check), so binding to multiple events or a repeatedly-firing one is free; no debounce or policy is baked in.
+
+## Internal route-manifest context
+
+New internal `RouteManifestContext` (e.g. `packages/iso/src/internal/route-manifest.tsx`) carrying the flat route list:
+
+```ts
+export const RouteManifestContext = createContext<ReadonlyArray<FlatRoute>>([]);
+```
+
+`Routes` (`define-routes.tsx`) wraps its rendered `Router` in `RouteManifestContext.Provider value={routes.flat}` so any descendant (every page is one) can read the patterns. The context is internal (not a public export); only `usePrefetch` reads it. `FlatRoute.path` is the route pattern (e.g. `/demo/projects/:projectId/issues/:issueId`).
+
+## `href` -> params resolution
+
+`usePrefetch` reads `RouteManifestContext`, parses `href` to a path + searchParams (reusing the URL parsing already in `prefetch.ts`'s `buildLocation`), and finds the best-matching route among the flat patterns:
+
+- Match each `FlatRoute.path` against the href path with preact-iso's `exec` (the same matcher `route-active.ts` uses).
+- Among matches, pick the most specific (the route the router would land on): prefer literal segments over `:param` over `*`, then more segments. A small specificity comparator in the hook's module; the common case is a single match, so this is a tiebreak for catch-all overlaps.
+- Build the location as `{ path, pathParams: <matched params>, searchParams }` and pass it to `prefetch(ref, { location })` for each ref.
+- If no route matches (e.g. used outside `Routes`, or an off-manifest href), the trigger is a no-op (prefetch is best-effort; never throw from an intent handler).
+
+This is exactly the "copied route pattern" the site hand-maintained, now derived from the one source of truth.
+
+## Dogfood migration
+
+`apps/site/src/components/demo/IssueRow.tsx` (the only consumer): remove `const ISSUE_ROUTE = '/demo/projects/:projectId/issues/:issueId';`, the `useCallback` `onPrefetch` (which called `prefetch(serverLoaders.issue, { url: href, route: ISSUE_ROUTE })`), and the `prefetch`/`useCallback` imports if now unused. Add `const prefetchIssue = usePrefetch(href, serverLoaders.issue);` and keep the existing `onMouseEnter={prefetchIssue} onFocus={prefetchIssue}` bindings on the anchor inside the `ViewTransitionName` render. Behavior is unchanged (still prefetches only the primary `issue` loader on hover/focus); the route-pattern copy and the prefetch plumbing are gone.
+
+## Docs
+
+A short "Prefetch on intent" section on `apps/site/src/pages/docs/link-prefetch.mdx` (the existing prefetch docs page) showing `usePrefetch(href, refs)` and that the returned callback binds to any event. No new page. Follow the `add-docs-page` conventions for the added section.
+
+## Tests
+
+New `packages/iso/src/__tests__/use-prefetch.test.tsx`:
+- The returned trigger, when called, calls `prefetch` with the loader ref and a location whose `pathParams` were resolved from the manifest pattern (render the harness inside a `RouteManifestContext.Provider` with a `:id`-style pattern; spy on `prefetch` by mocking `../prefetch.js`, or assert the loader's cache was populated for the resolved key). Verify the params come from the manifest, not from a hand-passed pattern.
+- An href that matches no manifest pattern makes the trigger a no-op (no `prefetch` call, no throw).
+- Repeated calls dedupe via the existing warm-cache check (a second call with a warm cache issues no new fetch). This may be covered by `prefetch`'s own tests; assert at least that calling the trigger twice does not double-fetch when the cache is warm.
+
+Mock `../prefetch.js`'s `prefetch` to a spy (the cleanest way to assert the resolved location), mirroring how `page.test.tsx` mocks a dependency. A `RouteManifestContext.Provider` supplies the patterns.
+
+## Breaking changes
+
+None. `usePrefetch` is an additive export; `prefetch()` is unchanged; `Routes` gains an internal context provider (no surface change). The site migration is behavior-preserving.
+
+## Out of scope (deferred)
+
+- `NavLink` `prefetch` prop (a later increment once `usePrefetch` exists).
+- Prefetch policy (hover delay, Save-Data / slow-connection opt-out, touch heuristics): deliberately left to the consumer's choice of events.
+- Auto-discovering a route's loaders (not feasible client-side pre-navigation).
+- The remaining Section C primitives (#4 typed params, #5 single-source guards, #6 content-glob).

--- a/packages/iso/src/__tests__/define-routes.test.tsx
+++ b/packages/iso/src/__tests__/define-routes.test.tsx
@@ -2,15 +2,17 @@
 import { describe, it, expect } from 'vitest';
 import type { ComponentType, VNode } from 'preact';
 import { h } from 'preact';
-import { useState } from 'preact/hooks';
+import { useState, useContext } from 'preact/hooks';
 import { fireEvent, render, waitFor } from '@testing-library/preact';
 import { LocationProvider, Router } from 'preact-iso';
 import {
   defineRoutes,
   Routes,
+  type FlatRoute,
   type LayoutProps,
   type ViewProps,
 } from '../define-routes.js';
+import { RouteManifestContext } from '../internal/route-manifest.js';
 
 const noopView = () => Promise.resolve({ default: () => null });
 const noopLayout = () =>
@@ -441,13 +443,33 @@ describe('<Routes>', () => {
     const result = (
       Routes as unknown as (props: { routes: typeof m }) => VNode
     )({ routes: m });
-    expect(result.type).toBe(Router);
-    const props = result.props as {
+    // Routes wraps the Router in a RouteManifestContext.Provider; the Router
+    // is the Provider's sole child.
+    const routerVNode = (result.props as { children: VNode }).children;
+    expect(routerVNode.type).toBe(Router);
+    const props = routerVNode.props as {
       onLoadStart?: unknown;
       onLoadEnd?: unknown;
     };
     expect(typeof props.onLoadStart).toBe('function');
     expect(typeof props.onLoadEnd).toBe('function');
+  });
+
+  it('provides the route manifest via RouteManifestContext', async () => {
+    let seen: ReadonlyArray<FlatRoute> | null = null;
+    const Probe = () => {
+      seen = useContext(RouteManifestContext);
+      return h('div', { 'data-testid': 'probe' }, 'ok');
+    };
+    const manifest = defineRoutes([
+      { path: '/ctx', view: () => Promise.resolve({ default: Probe }) },
+    ]);
+    history.replaceState(null, '', '/ctx');
+    const { findByTestId } = render(
+      h(LocationProvider, null, h(Routes, { routes: manifest })) as VNode
+    );
+    await findByTestId('probe');
+    expect(seen).toBe(manifest.flat);
   });
 });
 

--- a/packages/iso/src/__tests__/define-routes.test.tsx
+++ b/packages/iso/src/__tests__/define-routes.test.tsx
@@ -8,8 +8,8 @@ import { LocationProvider, Router } from 'preact-iso';
 import {
   defineRoutes,
   Routes,
-  type FlatRoute,
   type LayoutProps,
+  type ServerRoute,
   type ViewProps,
 } from '../define-routes.js';
 import { RouteManifestContext } from '../internal/route-manifest.js';
@@ -456,20 +456,24 @@ describe('<Routes>', () => {
   });
 
   it('provides the route manifest via RouteManifestContext', async () => {
-    let seen: ReadonlyArray<FlatRoute> | null = null;
+    let seen: ReadonlyArray<ServerRoute> | null = null;
     const Probe = () => {
       seen = useContext(RouteManifestContext);
       return h('div', { 'data-testid': 'probe' }, 'ok');
     };
     const manifest = defineRoutes([
-      { path: '/ctx', view: () => Promise.resolve({ default: Probe }) },
+      {
+        path: '/ctx',
+        view: () => Promise.resolve({ default: Probe }),
+        server: () => Promise.resolve({}),
+      },
     ]);
     history.replaceState(null, '', '/ctx');
     const { findByTestId } = render(
       h(LocationProvider, null, h(Routes, { routes: manifest })) as VNode
     );
     await findByTestId('probe');
-    expect(seen).toBe(manifest.flat);
+    expect(seen).toBe(manifest.serverRoutes);
   });
 });
 

--- a/packages/iso/src/__tests__/use-prefetch.test.tsx
+++ b/packages/iso/src/__tests__/use-prefetch.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/preact';
+import { RouteManifestContext } from '../internal/route-manifest.js';
+import { usePrefetch } from '../use-prefetch.js';
+import { defineLoader } from '../define-loader.js';
+import type { FlatRoute } from '../define-routes.js';
+import type { LoaderRef } from '../define-loader.js';
+
+const prefetchSpy = vi.fn();
+vi.mock('../prefetch.js', () => ({
+  prefetch: (...args: unknown[]) => prefetchSpy(...args),
+}));
+
+beforeEach(() => prefetchSpy.mockClear());
+afterEach(cleanup);
+
+const FLAT: ReadonlyArray<FlatRoute> = [
+  {
+    path: '/demo/projects/:projectId/issues/:issueId',
+    component: () => null,
+    key: 'k1',
+  },
+];
+
+const ref = defineLoader(async () => ({ ok: true }), { __moduleKey: 'pf' });
+
+function Harness({
+  href,
+  refs,
+}: {
+  href: string;
+  refs: LoaderRef<unknown> | ReadonlyArray<LoaderRef<unknown>>;
+}) {
+  const prefetch = usePrefetch(href, refs);
+  return <button onClick={prefetch}>go</button>;
+}
+
+function renderIn(href: string, refs: LoaderRef<unknown>) {
+  return render(
+    <RouteManifestContext.Provider value={FLAT}>
+      <Harness href={href} refs={refs} />
+    </RouteManifestContext.Provider>
+  );
+}
+
+describe('usePrefetch', () => {
+  it('resolves params from the manifest and prefetches the loader', () => {
+    const { getByRole } = renderIn('/demo/projects/p1/issues/i1', ref);
+    fireEvent.click(getByRole('button'));
+    expect(prefetchSpy).toHaveBeenCalledWith(ref, {
+      location: {
+        path: '/demo/projects/p1/issues/i1',
+        pathParams: { projectId: 'p1', issueId: 'i1' },
+        searchParams: {},
+      },
+    });
+  });
+
+  it('is a no-op when no manifest route matches', () => {
+    const { getByRole } = renderIn('/nope', ref);
+    fireEvent.click(getByRole('button'));
+    expect(prefetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/iso/src/__tests__/use-prefetch.test.tsx
+++ b/packages/iso/src/__tests__/use-prefetch.test.tsx
@@ -4,7 +4,7 @@ import { render, cleanup, fireEvent } from '@testing-library/preact';
 import { RouteManifestContext } from '../internal/route-manifest.js';
 import { usePrefetch } from '../use-prefetch.js';
 import { defineLoader } from '../define-loader.js';
-import type { FlatRoute } from '../define-routes.js';
+import { defineRoutes } from '../define-routes.js';
 import type { LoaderRef } from '../define-loader.js';
 
 const prefetchSpy = vi.fn();
@@ -15,13 +15,25 @@ vi.mock('../prefetch.js', () => ({
 beforeEach(() => prefetchSpy.mockClear());
 afterEach(cleanup);
 
-const FLAT: ReadonlyArray<FlatRoute> = [
+// Build the manifest the way an app does: a layout group with a nested leaf
+// that has a server module. The leaf pattern lives in `serverRoutes`, NOT in
+// `flat` (flat only has the group `/demo` and `/demo/*`).
+const manifest = defineRoutes([
   {
-    path: '/demo/projects/:projectId/issues/:issueId',
-    component: () => null,
-    key: 'k1',
+    path: '/demo',
+    layout: () =>
+      Promise.resolve({
+        default: ({ children }: { children: unknown }) => children as never,
+      }),
+    children: [
+      {
+        path: 'projects/:projectId/issues/:issueId',
+        view: () => Promise.resolve({ default: () => null }),
+        server: () => Promise.resolve({}),
+      },
+    ],
   },
-];
+]);
 
 const ref = defineLoader(async () => ({ ok: true }), { __moduleKey: 'pf' });
 
@@ -38,14 +50,14 @@ function Harness({
 
 function renderIn(href: string, refs: LoaderRef<unknown>) {
   return render(
-    <RouteManifestContext.Provider value={FLAT}>
+    <RouteManifestContext.Provider value={manifest.serverRoutes}>
       <Harness href={href} refs={refs} />
     </RouteManifestContext.Provider>
   );
 }
 
 describe('usePrefetch', () => {
-  it('resolves params from the manifest and prefetches the loader', () => {
+  it('resolves nested-leaf params from the manifest and prefetches the loader', () => {
     const { getByRole } = renderIn('/demo/projects/p1/issues/i1', ref);
     fireEvent.click(getByRole('button'));
     expect(prefetchSpy).toHaveBeenCalledWith(ref, {

--- a/packages/iso/src/define-routes.tsx
+++ b/packages/iso/src/define-routes.tsx
@@ -8,6 +8,7 @@ import type {
 import { lazy, Route, Router, useLocation } from 'preact-iso';
 import type { RouteHook } from 'preact-iso';
 import { RouteLocationsProvider } from './internal/route-locations.js';
+import { RouteManifestContext } from './internal/route-manifest.js';
 import { __noteLoadEnd, __noteLoadStart } from './internal/route-change.js';
 
 function wrapWithRouteLocations(
@@ -469,17 +470,21 @@ export type RoutesProps = {
 
 export const Routes: ComponentType<RoutesProps> = ({ routes }) => {
   return h(
-    asRouteComponent(Router),
-    {
-      onLoadStart: __noteLoadStart,
-      onLoadEnd: __noteLoadEnd,
-    },
-    ...routes.flat.map((r) =>
-      h(Route, {
-        key: r.key,
-        path: r.path,
-        component: asRouteComponent(r.component),
-      })
+    RouteManifestContext.Provider,
+    { value: routes.flat },
+    h(
+      asRouteComponent(Router),
+      {
+        onLoadStart: __noteLoadStart,
+        onLoadEnd: __noteLoadEnd,
+      },
+      ...routes.flat.map((r) =>
+        h(Route, {
+          key: r.key,
+          path: r.path,
+          component: asRouteComponent(r.component),
+        })
+      )
     )
   );
 };

--- a/packages/iso/src/define-routes.tsx
+++ b/packages/iso/src/define-routes.tsx
@@ -471,7 +471,7 @@ export type RoutesProps = {
 export const Routes: ComponentType<RoutesProps> = ({ routes }) => {
   return h(
     RouteManifestContext.Provider,
-    { value: routes.flat },
+    { value: routes.serverRoutes },
     h(
       asRouteComponent(Router),
       {

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -117,6 +117,7 @@ export type {
 
 // Utilities.
 export { prefetch } from './prefetch.js';
+export { usePrefetch } from './use-prefetch.js';
 export { isBrowser, env } from './is-browser.js';
 
 // Client entry primitives (item 4 of v0.1).

--- a/packages/iso/src/internal/route-manifest.ts
+++ b/packages/iso/src/internal/route-manifest.ts
@@ -1,8 +1,13 @@
 import { createContext } from 'preact';
-import type { FlatRoute } from '../define-routes.js';
+import type { ServerRoute } from '../define-routes.js';
 
 /**
- * The flat route list (patterns) of the active app, provided by `Routes`.
- * `usePrefetch` reads it to resolve an href to its route params. Internal.
+ * The server-bearing routes of the active app (each with its absolute leaf
+ * `path`), provided by `Routes`. `usePrefetch` matches an href against these
+ * patterns to resolve params. Uses serverRoutes, not the flat route list,
+ * because a layout group's nested leaf patterns appear only in serverRoutes.
+ * Internal.
  */
-export const RouteManifestContext = createContext<ReadonlyArray<FlatRoute>>([]);
+export const RouteManifestContext = createContext<ReadonlyArray<ServerRoute>>(
+  []
+);

--- a/packages/iso/src/internal/route-manifest.ts
+++ b/packages/iso/src/internal/route-manifest.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'preact';
+import type { FlatRoute } from '../define-routes.js';
+
+/**
+ * The flat route list (patterns) of the active app, provided by `Routes`.
+ * `usePrefetch` reads it to resolve an href to its route params. Internal.
+ */
+export const RouteManifestContext = createContext<ReadonlyArray<FlatRoute>>([]);

--- a/packages/iso/src/use-prefetch.ts
+++ b/packages/iso/src/use-prefetch.ts
@@ -21,8 +21,8 @@ function parseHref(href: string): {
 
 // Specificity for picking among overlapping matches (a `:param`/`*` catch-all
 // can match the same href as a literal leaf). Literal segments rank highest,
-// then `:param`, then `*`; the most specific route is the one the router lands
-// on, so its params are the ones the target loader reads.
+// then `:param`, then `*`; the most specific server route is the one the
+// router lands on, so its params are the ones the target loader reads.
 function specificity(pattern: string): number {
   let score = 0;
   for (const seg of pattern.split('/')) {
@@ -45,12 +45,12 @@ export function usePrefetch(
   href: string,
   refs: LoaderRef<unknown> | ReadonlyArray<LoaderRef<unknown>>
 ): () => void {
-  const flat = useContext(RouteManifestContext);
+  const routes = useContext(RouteManifestContext);
   return useCallback(() => {
     const { path, searchParams } = parseHref(href);
     let bestParams: Record<string, string> | null = null;
     let bestScore = -1;
-    for (const route of flat) {
+    for (const route of routes) {
       const params = matchPath(path, route.path, true);
       if (!params) continue;
       const score = specificity(route.path);
@@ -63,5 +63,5 @@ export function usePrefetch(
     const location: RouteHook = { path, pathParams: bestParams, searchParams };
     const list = Array.isArray(refs) ? refs : [refs];
     for (const ref of list) void prefetch(ref, { location });
-  }, [href, refs, flat]);
+  }, [href, refs, routes]);
 }

--- a/packages/iso/src/use-prefetch.ts
+++ b/packages/iso/src/use-prefetch.ts
@@ -1,0 +1,67 @@
+import { useCallback, useContext } from 'preact/hooks';
+import type { RouteHook } from 'preact-iso';
+import type { LoaderRef } from './define-loader.js';
+import { prefetch } from './prefetch.js';
+import { matchPath } from './route-active.js';
+import { RouteManifestContext } from './internal/route-manifest.js';
+
+function parseHref(href: string): {
+  path: string;
+  searchParams: Record<string, string>;
+} {
+  const parsed = new URL(href, 'http://_');
+  let path = parsed.pathname;
+  if (path.length > 1 && path.endsWith('/')) path = path.slice(0, -1);
+  const searchParams: Record<string, string> = {};
+  parsed.searchParams.forEach((value, key) => {
+    searchParams[key] = value;
+  });
+  return { path, searchParams };
+}
+
+// Specificity for picking among overlapping matches (a `:param`/`*` catch-all
+// can match the same href as a literal leaf). Literal segments rank highest,
+// then `:param`, then `*`; the most specific route is the one the router lands
+// on, so its params are the ones the target loader reads.
+function specificity(pattern: string): number {
+  let score = 0;
+  for (const seg of pattern.split('/')) {
+    if (seg === '') continue;
+    if (seg.includes('*')) score += 1;
+    else if (seg.startsWith(':')) score += 2;
+    else score += 3;
+  }
+  return score;
+}
+
+/**
+ * Returns a callback that prefetches `refs` for the route `href` points at.
+ * Bind it to any intent event (hover, focus, touch, pointerenter, an
+ * IntersectionObserver). The route's params are resolved from the manifest, so
+ * callers do not repeat the route pattern. A warm cache makes repeat calls a
+ * no-op (see `prefetch`).
+ */
+export function usePrefetch(
+  href: string,
+  refs: LoaderRef<unknown> | ReadonlyArray<LoaderRef<unknown>>
+): () => void {
+  const flat = useContext(RouteManifestContext);
+  return useCallback(() => {
+    const { path, searchParams } = parseHref(href);
+    let bestParams: Record<string, string> | null = null;
+    let bestScore = -1;
+    for (const route of flat) {
+      const params = matchPath(path, route.path, true);
+      if (!params) continue;
+      const score = specificity(route.path);
+      if (score > bestScore) {
+        bestScore = score;
+        bestParams = params;
+      }
+    }
+    if (!bestParams) return; // off-manifest or outside Routes: best-effort no-op
+    const location: RouteHook = { path, pathParams: bestParams, searchParams };
+    const list = Array.isArray(refs) ? refs : [refs];
+    for (const ref of list) void prefetch(ref, { location });
+  }, [href, refs, flat]);
+}


### PR DESCRIPTION
## Summary

Third of the six Section C site-discovered primitives, scoped to the minimal framework-shaped sliver after discussion: the only part that genuinely needs the framework is resolving an `href` to its route params (which needs the route table). Spec: `docs/superpowers/specs/2026-06-12-use-prefetch-design.md`; plan: `docs/superpowers/plans/2026-06-12-use-prefetch.md`.

- **`usePrefetch(href, loaders)` hook** returns a bare `() => void` trigger. On call it resolves `href` to the target route's params from the manifest (so callers stop copying route-pattern strings) and prefetches the named loader(s) via the existing `prefetch()`. The consumer binds the trigger to whatever event expresses intent (hover/focus, touch, pointerenter, an `IntersectionObserver`) - no baked-in policy. Pass one loader or an array; a warm cache makes repeat fires free.
- **Internal `RouteManifestContext`** (provided by `Routes`) carries the route patterns. `prefetch()` is unchanged; no global singleton.
- **Dogfood:** `IssueRow` drops the copied `ISSUE_ROUTE` pattern and the manual `useCallback`+`prefetch` wiring, keeping its existing `onMouseEnter`/`onFocus` bindings.

Deferred (per the design): a `<NavLink prefetch>` prop (trivial later increment), prefetch policy, and auto-discovering a lazy route's loaders (not possible client-side pre-navigation).

## Test plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1256 passed) including `usePrefetch` resolving a nested layout-group leaf's params from a real `defineRoutes` manifest, and `Routes` providing the manifest context
- [x] `pnpm test:integration` (4 passed)
- [x] `pnpm --filter site build`

## Notes

- Deep review caught a real defect during development: resolving against `routes.flat` was wrong, because a layout group's nested leaf patterns live only in `routes.serverRoutes` (flat has just the group + `/*`). Matching an href under a layout group landed on the `/*` catch-all with empty params, silently breaking the prefetch for the entire demo. Fixed to resolve against `serverRoutes` (absolute leaf paths) and verified end-to-end against the real route nesting (`/demo/projects/:projectId/issues/:issueId` resolves `/demo/projects/p1/issues/i1` to `{projectId, issueId}`). The regression test now builds the manifest via `defineRoutes` with a layout group rather than a hand-rolled flat array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)