### PR TITLE
feat: typed route params (useParams + defineLoader routeId)

### DIFF
--- a/apps/site/src/pages/demo/issue.server.ts
+++ b/apps/site/src/pages/demo/issue.server.ts
@@ -1,4 +1,9 @@
-import { defineAction, defineLoader, type LoaderCtx } from 'hono-preact';
+import {
+  defineAction,
+  defineLoader,
+  type LoaderCtx,
+  type RouteParams,
+} from 'hono-preact';
 import {
   activityForProject,
   addComment,
@@ -16,6 +21,9 @@ import { currentUser } from '../../demo/session.js';
 import { requireSession } from '../../demo/guard.js';
 import { assertCanClose } from './issue-guards.js';
 
+const ISSUE_ROUTE = '/demo/projects/:projectId/issues/:issueId';
+type IssueParams = RouteParams<typeof ISSUE_ROUTE>;
+
 export const pageUse = requireSession;
 
 type WithAuthor<T extends { authorId: string }> = T & { author: User | null };
@@ -25,7 +33,7 @@ const withAuthor = <T extends { authorId: string }>(x: T): WithAuthor<T> => ({
 });
 
 const issueLoader = async (
-  ctx: LoaderCtx
+  ctx: LoaderCtx<IssueParams>
 ): Promise<WithAuthor<Issue> | null> => {
   const id = ctx.location.pathParams.issueId;
   if (!id) return null;
@@ -34,7 +42,7 @@ const issueLoader = async (
 };
 
 const commentsLoader = async function* (
-  ctx: LoaderCtx
+  ctx: LoaderCtx<IssueParams>
 ): AsyncGenerator<WithAuthor<Comment>[]> {
   const id = ctx.location.pathParams.issueId;
   if (!id) {
@@ -55,7 +63,9 @@ const commentsLoader = async function* (
   if (cumulative.length === 0) yield [];
 };
 
-const activityLoader = async (ctx: LoaderCtx): Promise<ActivityItem[]> => {
+const activityLoader = async (
+  ctx: LoaderCtx<IssueParams>
+): Promise<ActivityItem[]> => {
   const issueId = ctx.location.pathParams.issueId;
   const issue = issueId ? getIssue(issueId) : null;
   if (!issue) return [];
@@ -63,9 +73,9 @@ const activityLoader = async (ctx: LoaderCtx): Promise<ActivityItem[]> => {
 };
 
 export const serverLoaders = {
-  issue: defineLoader(issueLoader),
-  comments: defineLoader(commentsLoader),
-  activity: defineLoader(activityLoader),
+  issue: defineLoader(ISSUE_ROUTE, issueLoader),
+  comments: defineLoader(ISSUE_ROUTE, commentsLoader),
+  activity: defineLoader(ISSUE_ROUTE, activityLoader),
 };
 
 export const serverActions = {

--- a/apps/site/src/pages/demo/issue.server.ts
+++ b/apps/site/src/pages/demo/issue.server.ts
@@ -1,9 +1,4 @@
-import {
-  defineAction,
-  defineLoader,
-  type LoaderCtx,
-  type RouteParams,
-} from 'hono-preact';
+import { defineAction, serverRoute } from 'hono-preact';
 import {
   activityForProject,
   addComment,
@@ -21,8 +16,9 @@ import { currentUser } from '../../demo/session.js';
 import { requireSession } from '../../demo/guard.js';
 import { assertCanClose } from './issue-guards.js';
 
-const ISSUE_ROUTE = '/demo/projects/:projectId/issues/:issueId';
-type IssueParams = RouteParams<typeof ISSUE_ROUTE>;
+// Bind this server module to its route once; `route.loader(fn)` then types
+// `ctx.location.pathParams` (issueId/projectId) from the route's pattern.
+const route = serverRoute('/demo/projects/:projectId/issues/:issueId');
 
 export const pageUse = requireSession;
 
@@ -32,50 +28,45 @@ const withAuthor = <T extends { authorId: string }>(x: T): WithAuthor<T> => ({
   author: getUser(x.authorId),
 });
 
-const issueLoader = async (
-  ctx: LoaderCtx<IssueParams>
-): Promise<WithAuthor<Issue> | null> => {
-  const id = ctx.location.pathParams.issueId;
-  if (!id) return null;
-  const issue = getIssue(id);
-  return issue ? withAuthor(issue) : null;
-};
-
-const commentsLoader = async function* (
-  ctx: LoaderCtx<IssueParams>
-): AsyncGenerator<WithAuthor<Comment>[]> {
-  const id = ctx.location.pathParams.issueId;
-  if (!id) {
-    yield [];
-    return;
-  }
-  const all = listComments(id).map(withAuthor);
-  // Demo throttle: trickle comments one at a time. Removes any feeling of
-  // "wait for the whole loader" and is the visible proof of streaming.
-  const cumulative: WithAuthor<Comment>[] = [];
-  for (const c of all) {
-    if (ctx.signal.aborted) return;
-    cumulative.push(c);
-    yield cumulative;
-    await new Promise((r) => setTimeout(r, 300));
-  }
-  // Final yield to flush state when there are zero comments.
-  if (cumulative.length === 0) yield [];
-};
-
-const activityLoader = async (
-  ctx: LoaderCtx<IssueParams>
-): Promise<ActivityItem[]> => {
-  const issueId = ctx.location.pathParams.issueId;
-  const issue = issueId ? getIssue(issueId) : null;
-  if (!issue) return [];
-  return activityForProject(issue.projectId, 10);
-};
-
 export const serverLoaders = {
-  issue: defineLoader(ISSUE_ROUTE, issueLoader),
-  comments: defineLoader(ISSUE_ROUTE, commentsLoader),
-  activity: defineLoader(ISSUE_ROUTE, activityLoader),
+  issue: route.loader(
+    async ({ location }): Promise<WithAuthor<Issue> | null> => {
+      const id = location.pathParams.issueId;
+      if (!id) return null;
+      const issue = getIssue(id);
+      return issue ? withAuthor(issue) : null;
+    }
+  ),
+
+  comments: route.loader(async function* ({
+    location,
+    signal,
+  }): AsyncGenerator<WithAuthor<Comment>[]> {
+    const id = location.pathParams.issueId;
+    if (!id) {
+      yield [];
+      return;
+    }
+    const all = listComments(id).map(withAuthor);
+    // Demo throttle: trickle comments one at a time. Removes any feeling of
+    // "wait for the whole loader" and is the visible proof of streaming.
+    const cumulative: WithAuthor<Comment>[] = [];
+    for (const c of all) {
+      if (signal.aborted) return;
+      cumulative.push(c);
+      yield cumulative;
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    // Final yield to flush state when there are zero comments.
+    if (cumulative.length === 0) yield [];
+  }),
+
+  activity: route.loader(async ({ location }): Promise<ActivityItem[]> => {
+    const issueId = location.pathParams.issueId;
+    const issue = issueId ? getIssue(issueId) : null;
+    if (!issue) return [];
+    return activityForProject(issue.projectId, 10);
+  }),
 };
 
 export const serverActions = {

--- a/apps/site/src/pages/demo/project-layout.tsx
+++ b/apps/site/src/pages/demo/project-layout.tsx
@@ -1,10 +1,9 @@
 import type { LayoutProps } from 'hono-preact';
-import { useRoute, useRouteChange, ViewTransitionName } from 'hono-preact';
+import { useParams, useRouteChange, ViewTransitionName } from 'hono-preact';
 import { useTitle } from 'hoofd/preact';
 
 export default function ProjectLayout({ children }: LayoutProps) {
-  const route = useRoute();
-  const slug = (route.pathParams as { projectId?: string }).projectId ?? '';
+  const { projectId: slug } = useParams('/demo/projects/:projectId');
 
   useTitle(`${slug.toUpperCase()} · demo`);
   useRouteChange(() => {

--- a/apps/site/src/pages/docs/layouts.mdx
+++ b/apps/site/src/pages/docs/layouts.mdx
@@ -63,6 +63,46 @@ export default function MoviesLayout({ children }: LayoutProps) {
 
 `children` is the matched descendant tree. The framework injects it.
 
+## Typed route params
+
+`pathParams` is `Record<string, string>` by default, so reading `route.pathParams.id` is unchecked. Register your route tree once and `useParams` returns params typed from the route's own pattern, with the route id validated against your real routes.
+
+Register in `routes.ts`, next to `defineRoutes`. Give the tree its own `as const` binding and register against `typeof routeTree`:
+
+```ts
+import { defineRoutes, type RoutePaths } from 'hono-preact';
+
+const routeTree = [
+  {
+    path: '/movies',
+    layout: () => import('./pages/movies-layout.js'),
+    children: [{ path: ':id', view: () => import('./pages/movie.js') }],
+  },
+] as const;
+
+export default defineRoutes(routeTree);
+
+declare module 'hono-preact' {
+  interface RegisteredRoutes {
+    paths: RoutePaths<typeof routeTree>;
+  }
+}
+```
+
+Then name the route you are on; the params are inferred from its pattern:
+
+```tsx
+import { useParams } from 'hono-preact';
+
+export default function Movie() {
+  // id is typed `string`; an unknown or misspelled route id is a type error.
+  const { id } = useParams('/movies/:id');
+  return <h1>{id}</h1>;
+}
+```
+
+Register against `typeof routeTree` (the tree array), not `typeof routes` (the manifest `defineRoutes` returns). The manifest form creates a type cycle. Before you register, `useParams` still works: it accepts any string and projects that pattern's params.
+
 ## URL composition rules
 
 | Rule                                                     | Why                                                                         |

--- a/apps/site/src/pages/docs/loaders.mdx
+++ b/apps/site/src/pages/docs/loaders.mdx
@@ -126,6 +126,20 @@ export const serverLoaders = {
 };
 ```
 
+### Typed loader params
+
+Pass the route id as the first argument and `ctx.location.pathParams` is typed from the route's pattern instead of `Record<string, string>` (requires the one-time [route registration](/docs/layouts#typed-route-params)):
+
+```ts
+export const serverLoaders = {
+  // location.pathParams.id is typed `string`
+  default: defineLoader('/movies/:id', async ({ location }) => {
+    const movie = await getMovie(location.pathParams.id);
+    return { movie };
+  }),
+};
+```
+
 ### The loader context
 
 Every loader is called with a single context argument with the same three fields, regardless of whether it returns a value or streams:

--- a/apps/site/src/pages/docs/loaders.mdx
+++ b/apps/site/src/pages/docs/loaders.mdx
@@ -128,16 +128,30 @@ export const serverLoaders = {
 
 ### Typed loader params
 
-Pass the route id as the first argument and `ctx.location.pathParams` is typed from the route's pattern instead of `Record<string, string>` (requires the one-time [route registration](/docs/layouts#typed-route-params)):
+After the one-time [route registration](/docs/layouts#typed-route-params), bind a server module to its route with `serverRoute`. `route.loader(fn)` types `ctx.location.pathParams` from the route's pattern (no annotation needed), and the route id autocompletes against your registered routes:
 
 ```ts
+import { serverRoute } from 'hono-preact';
+
+const route = serverRoute('/movies/:id');
+
 export const serverLoaders = {
   // location.pathParams.id is typed `string`
-  default: defineLoader('/movies/:id', async ({ location }) => {
+  default: route.loader(async ({ location }) => {
     const movie = await getMovie(location.pathParams.id);
     return { movie };
   }),
 };
+```
+
+`serverRoute` names the route once for the whole module, the common one-module-one-route case. For a route-agnostic or shared-across-routes loader, use `defineLoader` directly: `defineLoader(routeId, fn)` types params the same way, while `defineLoader(fn)` leaves `pathParams` as `Record<string, string>`.
+
+```ts
+// lower-level: route id per loader, or omit it for untyped params
+default: defineLoader('/movies/:id', async ({ location }) => {
+  const movie = await getMovie(location.pathParams.id);
+  return { movie };
+}),
 ```
 
 ### The loader context

--- a/apps/site/src/routes.ts
+++ b/apps/site/src/routes.ts
@@ -1,4 +1,4 @@
-import { defineRoutes } from 'hono-preact';
+import { defineRoutes, type RoutePaths } from 'hono-preact';
 // Registers the global `docs` view-transition type rule (enter/leave/within
 // /docs). Side-effect import: the generated client entry imports this module,
 // so the subscriber is installed once at startup.
@@ -6,7 +6,12 @@ import './docs-transition.js';
 
 const docsView = () => import('./components/DocsRoute.js');
 
-export default defineRoutes([
+// The tree is its own `as const` binding (not just inlined into defineRoutes)
+// so the route registration below can reference `typeof routeTree`. Registering
+// against the manifest (`typeof routes`) would form a type cycle: the manifest
+// is built by `defineRoutes` (a hono-preact value) and the module augmentation
+// is evaluated while resolving it. The tree is a plain literal, so it is safe.
+const routeTree = [
   { path: '/', view: () => import('./pages/home.js') },
   { path: '/docs', view: docsView },
   { path: '/docs/*', view: docsView },
@@ -47,4 +52,12 @@ export default defineRoutes([
     path: '*',
     view: () => import('./pages/not-found.js'),
   },
-]);
+] as const;
+
+export default defineRoutes(routeTree);
+
+declare module 'hono-preact' {
+  interface RegisteredRoutes {
+    paths: RoutePaths<typeof routeTree>;
+  }
+}

--- a/apps/site/src/typed-route-params.assert.ts
+++ b/apps/site/src/typed-route-params.assert.ts
@@ -1,0 +1,48 @@
+// Compile-time assertions for the typed-route-params engine, exercised against
+// the real site route tree. Not imported anywhere; `pnpm typecheck` is the
+// oracle. If the type engine or the route registration regresses, tsc fails.
+import { useParams } from 'hono-preact';
+import type { RoutePaths, RouteParams } from 'hono-preact';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+// RoutePaths over the manifest produced by the site's defineRoutes call.
+type SiteManifest = typeof import('./routes.js').default;
+type SitePaths = RoutePaths<SiteManifest>;
+
+// All checks collected into one exported tuple so `noUnusedLocals` does not flag
+// them; each `Expect<...>` still fails compilation if its condition is not true.
+export type _TypedRouteParamAssertions = [
+  // The deep layout-group leaf is present (the `flat`-omission gotcha).
+  Expect<
+    '/demo/projects/:projectId/issues/:issueId' extends SitePaths ? true : false
+  >,
+  // The layout id is present.
+  Expect<'/demo/projects/:projectId' extends SitePaths ? true : false>,
+  // Param extraction: multi, single, none.
+  Expect<
+    Equal<
+      RouteParams<'/demo/projects/:projectId/issues/:issueId'>,
+      { projectId: string } & { issueId: string }
+    >
+  >,
+  Expect<
+    Equal<RouteParams<'/demo/projects/:projectId'>, { projectId: string }>
+  >,
+  Expect<Equal<RouteParams<'/demo/login'>, {}>>,
+  // A bogus route id is NOT in the computed union.
+  Expect<'/not/a/route' extends SitePaths ? false : true>,
+];
+
+// End-to-end: the `declare module` registration actually CONSTRAINS useParams
+// (proves the augmentation reached the iso-internal registry, not the `string`
+// fallback). If registration ever stops reaching iso, the @ts-expect-error
+// below becomes unused and `pnpm typecheck` fails here.
+export function useRegistrationReachesIso() {
+  // @ts-expect-error '/not/a/route' is not a registered route id
+  return useParams('/not/a/route');
+}

--- a/docs/superpowers/plans/2026-06-12-typed-route-params.md
+++ b/docs/superpowers/plans/2026-06-12-typed-route-params.md
@@ -1,0 +1,874 @@
+# Typed route params (Section C #4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the framework full, validated route-param inference (TanStack-style): the user names a route once, the name is checked against the real route table, and params are derived from the pattern. Ship `useParams(routeId)`, a `defineLoader(routeId, fn)` overload, and a type-only registry; migrate the two site cast/stringly sites.
+
+**Architecture:** A ~45-line recursive template-literal type engine (`AbsolutePaths` walks the route tree exactly as the runtime joins paths; `RouteParams` extracts `:param` names) plus a registry interface users augment with one `declare module 'hono-preact'` block. `defineRoutes` becomes `defineRoutes<const T>` returning a `RoutesManifest<T>` carrying a phantom tree type. The loader half adds a `defineLoader(routeId, fn)` overload and the matching Vite codegen so `__moduleKey` is still threaded through the new arity. No new dependency; no codegen of source.
+
+**Tech Stack:** TypeScript 6.0.3 (workspace `pnpm -r exec tsc`), preact, preact-iso, `@babel/parser` + MagicString (Vite plugin), Vitest + `@testing-library/preact` (happy-dom).
+
+**Source spec:** `docs/superpowers/specs/2026-06-12-typed-route-params-design.md`.
+
+**Conventions:**
+- Run a single iso/ui test file with `pnpm exec vitest run <path>` from the repo root; the vite plugin suite with `pnpm --filter @hono-preact/vite test` (or `pnpm exec vitest run packages/vite/...`).
+- No em-dashes in code/comments/commit messages.
+- Run `pnpm format` before the pre-push step (`.mdx` and `.ts` are checked).
+- Commit after each task; messages end with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- The iso package's `tsconfig.json` EXCLUDES `src/**/__tests__/**` from typecheck, so type-level assertions there are NOT CI-covered. The CI oracle for exact type shapes is a pure-type file in `apps/site/src/` (typechecked by `pnpm typecheck`, emits nothing). Runtime behavior is tested with Vitest in iso.
+
+## Note on the registry mechanism (verified)
+
+A spike confirmed that `declare module 'hono-preact' { interface RegisteredRoutes { paths: ... } }` merges into the interface that `@hono-preact/iso` declares and re-exports (augmentation through a `export type` re-export reaches the original interface). So `RegisteredPaths`, computed in iso, sees the user's augmentation. The site dogfood (Task 6) is the end-to-end confirmation: if the cross-package `.d.ts` boundary ever behaved differently, `useParams('/typo')` would stop erroring and the assertions file (Task 6) would fail. If that ever happens, the fallback is a global `interface HonoPreactRegisteredRoutes` augmented via `declare global`; not expected to be needed.
+
+## File map
+
+- **Create** `packages/iso/src/internal/typed-routes.ts`: the type engine (`AbsolutePaths`, `RouteParams`, `RegisteredRoutes`, `RegisteredPaths`, `RoutePaths`).
+- **Modify** `packages/iso/src/define-routes.tsx`: `RouteDef.children` readonly; `RoutesManifest<T>` phantom; `defineRoutes<const T>`.
+- **Create** `packages/iso/src/use-params.ts` + `packages/iso/src/__tests__/use-params.test.tsx`.
+- **Modify** `packages/iso/src/define-loader.ts`: generic `LoaderCtx<TParams>` / `Loader<T, TParams>`; `defineLoader(routeId, fn)` overload + impl normalization.
+- **Create** `packages/iso/src/__tests__/define-loader-route-id.test.ts`.
+- **Modify** `packages/iso/src/index.ts`: export `useParams`, `RouteParams`, `RoutePaths`, `RegisteredRoutes`.
+- **Modify** `packages/vite/src/server-loaders-parser.ts`: opts position shifts to `arguments[2]` for the route-id form.
+- **Modify** `packages/vite/src/module-key-plugin.ts`: thread `__moduleKey`/`__loaderName` into the route-id form.
+- **Modify** `packages/vite/src/__tests__/module-key-plugin.test.ts` and `server-loaders-parser.test.ts`: flip/extend the route-id cases.
+- **Modify** `apps/site/src/routes.ts`: name the manifest + `declare module 'hono-preact'` registration.
+- **Modify** `apps/site/src/pages/demo/project-layout.tsx`: `useParams`.
+- **Modify** `apps/site/src/pages/demo/issue.server.ts`: `defineLoader(routeId, fn)`.
+- **Create** `apps/site/src/typed-route-params.assert.ts`: compile-time exact-shape assertions (CI oracle).
+- **Modify** `apps/site/src/pages/docs/layouts.mdx` and `loaders.mdx`: docs.
+
+---
+
+## Task 1: Reshape `define-routes.tsx` for `const` inference
+
+**Files:**
+- Modify: `packages/iso/src/define-routes.tsx`
+
+- [ ] **Step 1: Widen `RouteDef.children` to readonly.** In `packages/iso/src/define-routes.tsx`, change the `RouteDef` type's `children` field:
+```ts
+  children?: readonly RouteDef[];
+```
+(was `children?: RouteDef[];`). Every internal consumer already takes `ReadonlyArray<RouteDef>`, so nothing else changes here.
+
+- [ ] **Step 2: Make `RoutesManifest` generic with a phantom tree.** Replace the `RoutesManifest` type declaration with:
+```ts
+export type RoutesManifest<
+  T extends readonly RouteDef[] = readonly RouteDef[],
+> = {
+  tree: ReadonlyArray<RouteDef>;
+  flat: ReadonlyArray<FlatRoute>;
+  serverImports: ReadonlyArray<LazyServerImport>;
+  /**
+   * Path-keyed view of every server module in the tree. (existing doc comment
+   * unchanged -- keep it.)
+   */
+  serverRoutes: ReadonlyArray<ServerRoute>;
+  /**
+   * Phantom: carries the literal route-tree type so `RoutePaths<typeof routes>`
+   * can extract the route-pattern union for typed params. Never assigned at
+   * runtime; the `?` keeps the `defineRoutes` return object unchanged.
+   */
+  readonly __tree?: T;
+};
+```
+Keep the existing JSDoc on `serverRoutes`. The default type parameter means the four existing `RoutesManifest` references (no type args) resolve unchanged.
+
+- [ ] **Step 3: Make `defineRoutes` preserve the literal tree.** Change the signature:
+```ts
+export function defineRoutes<const T extends readonly RouteDef[]>(
+  tree: T
+): RoutesManifest<T> {
+  validate(tree);
+  const viewCache = new Map<unknown, ComponentType<ViewProps>>();
+  const keyCache = new Map<ComponentType<ViewProps>, string>();
+  return {
+    tree,
+    flat: flattenTree(tree, viewCache, keyCache),
+    serverImports: collectServerImports(tree),
+    serverRoutes: collectServerRoutes(tree),
+  };
+}
+```
+The `const` type parameter infers literal route paths without the caller writing `as const`; the body is otherwise unchanged. The returned object omits `__tree` (optional); the `RoutesManifest<T>` annotation is what carries `T` into `typeof routes`.
+
+- [ ] **Step 4: Build + typecheck iso, and run the existing route tests.** Run:
+```bash
+pnpm --filter @hono-preact/iso build && pnpm typecheck && pnpm exec vitest run packages/iso/src/__tests__/define-routes.test.tsx
+```
+Expected: PASS. (If `pnpm typecheck` reports an error in `packages/server/src/route-server-modules.ts` or the example apps about `RoutesManifest`, it means the default type param was dropped; re-check Step 2. If a `Cannot find module '@hono-preact/...'` error appears, run `pnpm install` and retry.)
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/iso/src/define-routes.tsx
+git commit -m "refactor(iso): defineRoutes preserves literal tree for typed params
+
+RouteDef.children is now readonly and RoutesManifest carries a phantom
+tree type so a const-inferred tree's route patterns can be derived at
+the type level. Backward-compatible via the default type parameter.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: The type engine (`internal/typed-routes.ts`)
+
+**Files:**
+- Create: `packages/iso/src/internal/typed-routes.ts`
+- Modify: `packages/iso/src/index.ts`
+
+- [ ] **Step 1: Create the type engine.** Create `packages/iso/src/internal/typed-routes.ts`:
+```ts
+import type { RouteDef } from '../define-routes.js';
+
+// Absolute-path extraction. Mirrors the runtime join in define-routes.tsx:
+//   here = parent === '' ? path : (path === '' ? parent : `${parent}/${path}`)
+// and the `/`-root reset (a layout/grouping at `/` joins children from '').
+type Here<Parent extends string, Path extends string> = Parent extends ''
+  ? Path
+  : Path extends ''
+    ? Parent
+    : `${Parent}/${Path}`;
+
+type NextParent<H extends string> = H extends '/' ? '' : H;
+
+type NodePaths<R extends RouteDef, Parent extends string> = Here<
+  Parent,
+  R['path']
+> extends infer H
+  ? H extends string
+    ?
+        | (R extends { view: unknown } ? H : never)
+        | (R extends { layout: unknown } ? H : never)
+        | (R extends { children: infer C }
+            ? C extends readonly RouteDef[]
+              ? AbsolutePaths<C, NextParent<H>>
+              : never
+            : never)
+    : never
+  : never;
+
+/**
+ * The union of absolute route patterns for every view/layout node in a route
+ * tree (the ids a consumer can legitimately name). Walks layout-group nesting,
+ * which `RoutesManifest.flat` omits.
+ */
+export type AbsolutePaths<
+  T extends readonly RouteDef[],
+  Parent extends string = '',
+> = T extends readonly [infer Head, ...infer Tail]
+  ? Head extends RouteDef
+    ? Tail extends readonly RouteDef[]
+      ? NodePaths<Head, Parent> | AbsolutePaths<Tail, Parent>
+      : never
+    : never
+  : never;
+
+// Param extraction. Handles required `:id`, optional `:id?`, and the preact-iso
+// modifier suffixes `*` / `+`. A pattern with no `:param` yields `{}`.
+type ParamKey<Seg extends string> = Seg extends `${infer Name}?`
+  ? { optional: true; name: Name }
+  : Seg extends `${infer Name}*`
+    ? { optional: true; name: Name }
+    : Seg extends `${infer Name}+`
+      ? { optional: false; name: Name }
+      : { optional: false; name: Seg };
+
+type ParamFrom<Seg extends string> =
+  ParamKey<Seg> extends { optional: infer O; name: infer N extends string }
+    ? O extends true
+      ? { [K in N]?: string }
+      : { [K in N]: string }
+    : never;
+
+/** Extract the path-params object type from an absolute route pattern. */
+export type RouteParams<Path extends string> =
+  Path extends `${string}:${infer Param}/${infer Rest}`
+    ? ParamFrom<Param> & RouteParams<`/${Rest}`>
+    : Path extends `${string}:${infer Param}`
+      ? ParamFrom<Param>
+      : {};
+
+/**
+ * Augment this interface to register your app's routes for typed params:
+ *
+ * ```ts
+ * declare module 'hono-preact' {
+ *   interface RegisteredRoutes {
+ *     paths: RoutePaths<typeof routes>;
+ *   }
+ * }
+ * ```
+ *
+ * Until registered, `RegisteredPaths` falls back to `string` (the param hooks
+ * still work; they just accept any string and project its param shape).
+ */
+export interface RegisteredRoutes {
+  // augmented by users
+}
+
+export type RegisteredPaths = RegisteredRoutes extends {
+  paths: infer P extends string;
+}
+  ? P
+  : string;
+
+/** The route-pattern union of a manifest produced by `defineRoutes`. */
+export type RoutePaths<M> = M extends {
+  __tree?: infer T extends readonly RouteDef[];
+}
+  ? AbsolutePaths<T>
+  : never;
+```
+
+- [ ] **Step 2: Re-export the public types from the barrel.** In `packages/iso/src/index.ts`, in the "Declarative route tree" block (right after the `export type { RouteDef, RoutesManifest, ... } from './define-routes.js';` block, before "Server bindings"), add:
+```ts
+// Typed route params.
+export type {
+  RouteParams,
+  RoutePaths,
+  RegisteredRoutes,
+} from './internal/typed-routes.js';
+```
+(`RegisteredPaths` and `AbsolutePaths` stay internal; `useParams`/`defineLoader` import them directly from the internal module. `RegisteredRoutes` MUST be on the barrel so `declare module 'hono-preact'` can target it.)
+
+- [ ] **Step 3: Build + typecheck.** Run:
+```bash
+pnpm --filter @hono-preact/iso build && pnpm typecheck
+```
+Expected: PASS. (The types have no runtime; this just confirms they compile and the barrel re-export resolves. If a Section B boundary test about barrel exports later fails in the pre-push step, it is because these three new public types need allow-listing; handle it there.)
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/iso/src/internal/typed-routes.ts packages/iso/src/index.ts
+git commit -m "feat(iso): route-param type engine + RegisteredRoutes registry
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: The `useParams` hook
+
+**Files:**
+- Create: `packages/iso/src/use-params.ts`
+- Create: `packages/iso/src/__tests__/use-params.test.tsx`
+- Modify: `packages/iso/src/index.ts`
+
+- [ ] **Step 1: Write the failing test.** Create `packages/iso/src/__tests__/use-params.test.tsx`:
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { useParams } from '../use-params.js';
+
+const mockRoute = { path: '/demo/projects/p1', searchParams: {}, pathParams: {} as Record<string, string> };
+vi.mock('preact-iso', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useRoute: () => mockRoute };
+});
+
+afterEach(cleanup);
+
+function Harness({ onParams }: { onParams: (p: unknown) => void }) {
+  const params = useParams('/demo/projects/:projectId');
+  onParams(params);
+  return null;
+}
+
+describe('useParams', () => {
+  it('returns the live route pathParams for the named route', () => {
+    mockRoute.pathParams = { projectId: 'p1' };
+    let seen: unknown;
+    render(<Harness onParams={(p) => (seen = p)} />);
+    expect(seen).toEqual({ projectId: 'p1' });
+  });
+});
+```
+
+- [ ] **Step 2: Run it; expect FAIL** (cannot resolve `../use-params.js`).
+```bash
+pnpm exec vitest run packages/iso/src/__tests__/use-params.test.tsx
+```
+
+- [ ] **Step 3: Create the hook.** Create `packages/iso/src/use-params.ts`:
+```ts
+import { useRoute } from 'preact-iso';
+import type { RegisteredPaths, RouteParams } from './internal/typed-routes.js';
+
+/**
+ * Typed route params for the named route. `route` is a type-level selector that
+ * names which route's param shape to project; the live param values come from
+ * the active route match. Constrain to the registered route union once an app
+ * adds the `declare module 'hono-preact'` registration; until then any string
+ * is accepted and its param shape projected.
+ *
+ * ```tsx
+ * const { projectId } = useParams('/demo/projects/:projectId');
+ * ```
+ */
+export function useParams<P extends RegisteredPaths>(route: P): RouteParams<P> {
+  void route; // type-level only; the live params come from the route match.
+  // The structural read off Record<string, string> is the one sanctioned cast
+  // boundary: the runtime value lacks the literal that `route` names.
+  return useRoute().pathParams as RouteParams<P>;
+}
+```
+
+- [ ] **Step 4: Add the barrel export.** In `packages/iso/src/index.ts`, in the `// Hooks.` section (after the `export { useNavigate, ... }` line), add:
+```ts
+export { useParams } from './use-params.js';
+```
+
+- [ ] **Step 5: Run the test; expect PASS.**
+```bash
+pnpm exec vitest run packages/iso/src/__tests__/use-params.test.tsx
+```
+
+- [ ] **Step 6: Build + typecheck.**
+```bash
+pnpm --filter @hono-preact/iso build && pnpm typecheck
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add packages/iso/src/use-params.ts packages/iso/src/__tests__/use-params.test.tsx packages/iso/src/index.ts
+git commit -m "feat(iso): useParams hook for typed route params
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: The `defineLoader(routeId, fn)` overload (iso)
+
+**Files:**
+- Modify: `packages/iso/src/define-loader.ts`
+- Create: `packages/iso/src/__tests__/define-loader-route-id.test.ts`
+
+- [ ] **Step 1: Make `LoaderCtx` / `Loader` generic over params.** In `packages/iso/src/define-loader.ts`, replace the `LoaderCtx` and `Loader` declarations:
+```ts
+export type LoaderCtx<TParams = Record<string, string>> = {
+  c: Context;
+  location: Omit<RouteHook, 'pathParams'> & { pathParams: TParams };
+  signal: AbortSignal;
+};
+
+export type Loader<T, TParams = Record<string, string>> =
+  | ((ctx: LoaderCtx<TParams>) => Promise<T>)
+  | ((ctx: LoaderCtx<TParams>) => Promise<ReadableStream<T>>)
+  | ((ctx: LoaderCtx<TParams>) => AsyncGenerator<T, void, unknown>);
+```
+The defaults keep every existing `LoaderCtx` / `Loader<T>` usage identical (`pathParams: Record<string, string>`). `LoaderRef<T>.fn` stays `Loader<T>` (defaulted params); no change needed there.
+
+- [ ] **Step 2: Add the imports.** At the top of `define-loader.ts`, add to the existing type import from the internal types:
+```ts
+import type { RegisteredPaths, RouteParams } from './internal/typed-routes.js';
+```
+
+- [ ] **Step 3: Add the overload declarations + normalize the impl.** Replace the single `export function defineLoader<T>(fn, opts?)` signature + body opening with overloads and a normalizing implementation signature:
+```ts
+export function defineLoader<T>(
+  fn: Loader<T>,
+  opts?: DefineLoaderOpts<T>
+): LoaderRef<T>;
+export function defineLoader<RouteId extends RegisteredPaths, T>(
+  route: RouteId,
+  fn: Loader<T, RouteParams<RouteId>>,
+  opts?: DefineLoaderOpts<T>
+): LoaderRef<T>;
+export function defineLoader(
+  fnOrRoute: Loader<unknown> | string,
+  fnOrOpts?: Loader<unknown> | DefineLoaderOpts<unknown>,
+  maybeOpts?: DefineLoaderOpts<unknown>
+): LoaderRef<unknown> {
+  // Normalize the two overload forms. The route id is type-level only (it
+  // selects the param shape for the loader fn); it is not stored on the ref
+  // and does not affect cache/`params` behavior.
+  const isRouteForm = typeof fnOrRoute === 'string';
+  const fn = (isRouteForm ? fnOrOpts : fnOrRoute) as Loader<unknown>;
+  const opts = (
+    isRouteForm ? maybeOpts : fnOrOpts
+  ) as DefineLoaderOpts<unknown> | undefined;
+
+  validateTimeoutMs(opts?.timeoutMs, 'defineLoader');
+  // ... rest of the existing body UNCHANGED (it already reads `fn` and `opts`).
+}
+```
+The rest of the function body (from `const idKey = ...` through `return ref;`) is unchanged; it already references `fn` and `opts`, which now come from the normalization above. The two `as` casts are the standard overload-implementation widening (the public overloads guarantee the real shapes), not a user-facing reshape.
+
+- [ ] **Step 4: Write the test.** Create `packages/iso/src/__tests__/define-loader-route-id.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { defineLoader, type LoaderCtx } from '../define-loader.js';
+
+describe('defineLoader(routeId, fn) overload', () => {
+  it('returns a LoaderRef behaviorally identical to defineLoader(fn)', () => {
+    const fn = async (_ctx: LoaderCtx<{ id: string }>) => ({ ok: true });
+    const ref = defineLoader('/things/:id', fn);
+    expect(typeof ref.__id).toBe('symbol');
+    expect(ref.fn).toBe(fn);
+    expect(ref.params).toEqual([]);
+    expect(typeof ref.invalidate).toBe('function');
+  });
+
+  it('threads opts through the third argument', () => {
+    const fn = async (_ctx: LoaderCtx<{ id: string }>) => ({ ok: true });
+    const ref = defineLoader('/things/:id', fn, { params: ['q'] });
+    expect(ref.params).toEqual(['q']);
+  });
+
+  it('still supports the fn-first form', () => {
+    const fn = async () => ({ ok: true });
+    const ref = defineLoader(fn, { params: '*' });
+    expect(ref.fn).toBe(fn);
+    expect(ref.params).toBe('*');
+  });
+});
+```
+
+- [ ] **Step 5: Run the test; expect PASS.**
+```bash
+pnpm exec vitest run packages/iso/src/__tests__/define-loader-route-id.test.ts
+```
+
+- [ ] **Step 6: Build + typecheck.**
+```bash
+pnpm --filter @hono-preact/iso build && pnpm typecheck
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add packages/iso/src/define-loader.ts packages/iso/src/__tests__/define-loader-route-id.test.ts
+git commit -m "feat(iso): defineLoader(routeId, fn) overload for typed loader params
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Vite codegen for the route-id loader form
+
+**Files:**
+- Modify: `packages/vite/src/server-loaders-parser.ts`
+- Modify: `packages/vite/src/module-key-plugin.ts`
+- Modify: `packages/vite/src/__tests__/server-loaders-parser.test.ts`
+- Modify: `packages/vite/src/__tests__/module-key-plugin.test.ts`
+
+- [ ] **Step 1: Update the parser to find opts at the shifted position.** In `packages/vite/src/server-loaders-parser.ts`, inside `parseServerLoaders`, replace the opts-extraction block (currently reading `call.arguments[1]`):
+```ts
+        // The route-id overload `defineLoader('/r/:id', fn, opts?)` shifts the
+        // opts object to the third argument; the fn-first form keeps it second.
+        const isRouteForm = call.arguments[0]?.type === 'StringLiteral';
+        const optsCandidate = isRouteForm
+          ? call.arguments[2]
+          : call.arguments[1];
+        const optsArg =
+          optsCandidate?.type === 'ObjectExpression'
+            ? (optsCandidate as ObjectExpression)
+            : null;
+
+        entries.push({ name: prop.key.name, call, optsArg });
+```
+(Replaces the old `const secondArg = call.arguments[1]; const optsArg = ...; entries.push(...)`.) This also fixes `server-only.ts`'s `readParamsOpt(entry.optsArg)` for the route-id form, since it reads `entry.optsArg`.
+
+- [ ] **Step 2: Update the parser test.** In `packages/vite/src/__tests__/server-loaders-parser.test.ts`, add a route-id case to the `describe` that covers `optsArg` (right after the "non-ObjectExpression second arg has optsArg === null" test, before the closing `});` of that describe):
+```ts
+  it('reads opts from the third arg for the route-id form', () => {
+    const program = parseProgram(`
+      export const serverLoaders = {
+        x: defineLoader('/things/:id', async () => ({}), { params: ['q'] }),
+      };
+    `);
+    const [entry] = parseServerLoaders(program);
+    expect(entry.optsArg?.type).toBe('ObjectExpression');
+  });
+
+  it('route-id form with no opts has optsArg === null', () => {
+    const program = parseProgram(`
+      export const serverLoaders = {
+        x: defineLoader('/things/:id', async () => ({})),
+      };
+    `);
+    const [entry] = parseServerLoaders(program);
+    expect(entry.optsArg).toBeNull();
+  });
+```
+
+- [ ] **Step 3: Run the parser test; expect PASS.**
+```bash
+pnpm exec vitest run packages/vite/src/__tests__/server-loaders-parser.test.ts
+```
+
+- [ ] **Step 4: Teach the module-key plugin the route-id form.** In `packages/vite/src/module-key-plugin.ts`, replace the body of `visitCallWithName` (from the `if (node.arguments.length === 0 ...)` guard through the end of the function) with route-id-aware logic:
+```ts
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'defineLoader'
+        ) {
+          return;
+        }
+        const args = node.arguments;
+        if (args.length === 0) return;
+
+        const namePartAfter = loaderName
+          ? `, ${LOADER_NAME_OPTION}: ${JSON.stringify(loaderName)}`
+          : '';
+        const namePartBefore = loaderName
+          ? `${LOADER_NAME_OPTION}: ${JSON.stringify(loaderName)}, `
+          : '';
+        const appendOptsAfter = (afterEnd: number) =>
+          s.appendRight(
+            afterEnd,
+            `, { ${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}${namePartAfter} }`
+          );
+        const mergeInto = (opts: typeof args[number]) => {
+          if (opts.type !== 'ObjectExpression') return;
+          const insertAt = opts.properties[0]?.start ?? opts.start! + 1;
+          s.appendRight(
+            insertAt,
+            `${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}, ${namePartBefore}`
+          );
+        };
+
+        const isRouteForm = args[0].type === 'StringLiteral';
+        if (isRouteForm) {
+          // defineLoader('/r/:id', fn) | defineLoader('/r/:id', fn, opts)
+          if (args.length < 2 || args.length > 3) return;
+          if (args.length === 2) {
+            const fnEnd = args[1].end;
+            if (fnEnd == null) return;
+            appendOptsAfter(fnEnd);
+          } else {
+            mergeInto(args[2]);
+          }
+          return;
+        }
+
+        // fn-first form: defineLoader(fn) | defineLoader(fn, opts)
+        if (args.length > 2) return;
+        if (args.length === 1) {
+          const fnEnd = args[0].end;
+          if (fnEnd == null) return;
+          appendOptsAfter(fnEnd);
+          return;
+        }
+        mergeInto(args[1]);
+```
+This preserves the existing fn-first behavior and adds the route-id branch (2-arg appends opts after the fn; 3-arg merges into the existing opts object).
+
+- [ ] **Step 5: Update the module-key plugin tests.** In `packages/vite/src/__tests__/module-key-plugin.test.ts`, REPLACE the test titled `'leaves an existing two-arg defineLoader call unchanged'` (the one passing `defineLoader('movies', async () => ({}))`) with route-id-form expectations:
+```ts
+  it('threads __moduleKey into the route-id form (two args)', () => {
+    const plugin = makePlugin();
+    const code = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `export const loader = defineLoader('/movies/:id', async () => ({}));`,
+    ].join('\n');
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toContain(
+      `defineLoader('/movies/:id', async () => ({}), { __moduleKey: "src/pages/movies" })`
+    );
+  });
+
+  it('merges __moduleKey into the route-id form opts (three args)', () => {
+    const plugin = makePlugin();
+    const code = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `export const loader = defineLoader('/movies/:id', async () => ({}), { params: ['q'] });`,
+    ].join('\n');
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toContain('__moduleKey: "src/pages/movies"');
+    expect(result?.code).toContain(`params: ['q']`);
+  });
+```
+
+- [ ] **Step 6: Run the module-key plugin test; expect PASS.**
+```bash
+pnpm exec vitest run packages/vite/src/__tests__/module-key-plugin.test.ts
+```
+
+- [ ] **Step 7: Run the full vite plugin suite** to catch any server-only / validation regression from the parser change:
+```bash
+pnpm --filter @hono-preact/vite test
+```
+Expected: PASS. (If `server-only-plugin.test.ts` or `server-loader-validation-plugin.test.ts` fails, inspect whether it asserts a behavior the parser change altered; the parser change only shifts WHERE opts is read for string-first calls, so any failure indicates a fixture using a string-first form that previously had no opts detected. Add a route-id fixture if needed, but do not loosen validation.)
+
+- [ ] **Step 8: Build vite + typecheck.**
+```bash
+pnpm --filter @hono-preact/vite build && pnpm typecheck
+```
+Expected: PASS.
+
+- [ ] **Step 9: Commit.**
+```bash
+git add packages/vite/src/server-loaders-parser.ts packages/vite/src/module-key-plugin.ts \
+  packages/vite/src/__tests__/server-loaders-parser.test.ts \
+  packages/vite/src/__tests__/module-key-plugin.test.ts
+git commit -m "feat(vite): thread __moduleKey through defineLoader(routeId, fn)
+
+The route-id loader overload puts a string first and may take a third
+opts arg; the module-key plugin now injects the key into that arity and
+the serverLoaders parser reads opts from the shifted position.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Site dogfood + the CI type-shape oracle
+
+**Files:**
+- Modify: `apps/site/src/routes.ts`
+- Modify: `apps/site/src/pages/demo/project-layout.tsx`
+- Modify: `apps/site/src/pages/demo/issue.server.ts`
+- Create: `apps/site/src/typed-route-params.assert.ts`
+
+- [ ] **Step 1: Register the routes.** In `apps/site/src/routes.ts`, name the manifest and add the registration block. Change the default export from `export default defineRoutes([...])` to a named const, and import `RoutePaths`:
+```ts
+import { defineRoutes, type RoutePaths } from 'hono-preact';
+```
+At the bottom, replace `export default defineRoutes([` ... `]);` so the array is assigned to a const that is both exported and referenced by the registration:
+```ts
+const routes = defineRoutes([
+  // ... the existing tree, unchanged ...
+]);
+
+export default routes;
+
+declare module 'hono-preact' {
+  interface RegisteredRoutes {
+    paths: RoutePaths<typeof routes>;
+  }
+}
+```
+(Keep the existing `docsView` const and the `./docs-transition.js` side-effect import.)
+
+- [ ] **Step 2: Migrate `project-layout.tsx` to `useParams`.** In `apps/site/src/pages/demo/project-layout.tsx`:
+  - Change the import line `import { useRoute, useRouteChange, ViewTransitionName } from 'hono-preact';` to drop `useRoute` and add `useParams`:
+```ts
+import { useParams, useRouteChange, ViewTransitionName } from 'hono-preact';
+```
+  - Replace the two lines:
+```ts
+  const route = useRoute();
+  const slug = (route.pathParams as { projectId?: string }).projectId ?? '';
+```
+with:
+```ts
+  const { projectId: slug } = useParams('/demo/projects/:projectId');
+```
+(`slug` is now a typed non-optional `string`; the rest of the component is unchanged.)
+
+- [ ] **Step 3: Migrate `issue.server.ts` loaders to the route-id form.** In `apps/site/src/pages/demo/issue.server.ts`:
+  - Add `RouteParams` to the `hono-preact` import:
+```ts
+import {
+  defineAction,
+  defineLoader,
+  type LoaderCtx,
+  type RouteParams,
+} from 'hono-preact';
+```
+  - Below the imports (before `type WithAuthor`), add a single shared route-id const + param alias:
+```ts
+const ISSUE_ROUTE = '/demo/projects/:projectId/issues/:issueId';
+type IssueParams = RouteParams<typeof ISSUE_ROUTE>;
+```
+  - Change each loader's `ctx: LoaderCtx` annotation to `ctx: LoaderCtx<IssueParams>` (three loaders: `issueLoader`, `commentsLoader`, `activityLoader`). The bodies are unchanged; `ctx.location.pathParams.issueId` / `.projectId` are now typed `string`.
+  - Change the `serverLoaders` object to pass the route id first:
+```ts
+export const serverLoaders = {
+  issue: defineLoader(ISSUE_ROUTE, issueLoader),
+  comments: defineLoader(ISSUE_ROUTE, commentsLoader),
+  activity: defineLoader(ISSUE_ROUTE, activityLoader),
+};
+```
+(`serverActions` are unchanged.)
+
+- [ ] **Step 4: Create the type-shape oracle.** Create `apps/site/src/typed-route-params.assert.ts` (a compile-time-only file; never imported, emits nothing, but typechecked by `pnpm typecheck`):
+```ts
+// Compile-time assertions for the typed-route-params engine, exercised against
+// the real site route tree. Not imported anywhere; `pnpm typecheck` is the
+// oracle. If the type engine or the route registration regresses, tsc fails.
+import type { RoutePaths, RouteParams } from 'hono-preact';
+import type routes from './routes.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+type SitePaths = RoutePaths<typeof routes>;
+
+// The deep layout-group leaf is present (the `flat`-omission gotcha).
+type _LeafPresent = Expect<
+  '/demo/projects/:projectId/issues/:issueId' extends SitePaths ? true : false
+>;
+// The layout id is present.
+type _LayoutPresent = Expect<
+  '/demo/projects/:projectId' extends SitePaths ? true : false
+>;
+
+// Param extraction: multi, single, none.
+type _Multi = Expect<
+  Equal<
+    RouteParams<'/demo/projects/:projectId/issues/:issueId'>,
+    { projectId: string } & { issueId: string }
+  >
+>;
+type _Single = Expect<
+  Equal<RouteParams<'/demo/projects/:projectId'>, { projectId: string }>
+>;
+type _None = Expect<Equal<RouteParams<'/demo/login'>, {}>>;
+
+// A bogus route id is NOT in the union (registration actually constrains).
+type _Bogus = Expect<'/not/a/route' extends SitePaths ? false : true>;
+```
+
+- [ ] **Step 5: Build the framework, then typecheck + build the site.** Run (framework first so the site resolves the new exports through `dist/`):
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build && pnpm typecheck && pnpm --filter site build
+```
+Expected: PASS. (If `pnpm typecheck` fails inside `typed-route-params.assert.ts`, the type engine or registration is wrong: read the failing assertion. If `useParams('/demo/projects/:projectId')` reports the arg is not assignable to `RegisteredPaths`, the `declare module` augmentation did not reach iso, see the registry note at the top; the fallback is a global interface.)
+
+- [ ] **Step 6: Run the site docs/page tests + the demo integration** to confirm no behavior change:
+```bash
+pnpm exec vitest run apps/site/src/pages/docs/__tests__
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+```bash
+git add apps/site/src/routes.ts apps/site/src/pages/demo/project-layout.tsx \
+  apps/site/src/pages/demo/issue.server.ts apps/site/src/typed-route-params.assert.ts
+git commit -m "refactor(site): adopt typed route params (useParams + defineLoader routeId)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Docs
+
+**Files:**
+- Modify: `apps/site/src/pages/docs/layouts.mdx`
+- Modify: `apps/site/src/pages/docs/loaders.mdx`
+
+- [ ] **Step 1: Document `useParams` on `layouts.mdx`.** Read `apps/site/src/pages/docs/layouts.mdx` and find the spot just after it introduces dynamic segments / `pathParams.id` (around line 35). Add a `## Typed route params` section (follow the `add-docs-page` template conventions: prose, a code example, a short API note). Use this content:
+````md
+## Typed route params
+
+Register your route tree once and `useParams` gives you typed params for any
+route, validated against the real routes. Add this next to your `defineRoutes`
+call (e.g. in `routes.ts`):
+
+```ts
+import { defineRoutes, type RoutePaths } from 'hono-preact';
+
+const routes = defineRoutes([
+  /* ... */
+]);
+export default routes;
+
+declare module 'hono-preact' {
+  interface RegisteredRoutes {
+    paths: RoutePaths<typeof routes>;
+  }
+}
+```
+
+Then name the route you are on; the params are inferred from its pattern:
+
+```tsx
+import { useParams } from 'hono-preact';
+
+function ProjectLayout() {
+  // projectId is typed `string`; a typo'd or unknown route id is a type error.
+  const { projectId } = useParams('/projects/:projectId');
+  return <h1>{projectId}</h1>;
+}
+```
+
+Before you register the routes, `useParams` still works: it accepts any string
+and returns that pattern's param shape.
+````
+Read the page first to match its heading style and the `CodeTabs`/import conventions used by neighboring sections; if the page uses `import` blocks for components, mirror that.
+
+- [ ] **Step 2: Document the loader form on `loaders.mdx`.** Read `apps/site/src/pages/docs/loaders.mdx`, find the "Example: detail page (using route params)" section (around line 112) that documents `location.pathParams`. Add a short note + example right after that section showing the typed form:
+````md
+### Typed loader params
+
+Pass the route id as the first argument to `defineLoader` and `ctx.location.pathParams`
+is typed from the route's pattern (requires the one-time route registration shown
+in [Layouts](/docs/layouts#typed-route-params)):
+
+```ts
+export const serverLoaders = {
+  // location.pathParams.id is typed `string`
+  default: defineLoader('/movies/:id', async ({ location }) => {
+    return getMovie(location.pathParams.id);
+  }),
+};
+```
+````
+Match the page's existing fence/`CodeTabs` style.
+
+- [ ] **Step 3: Verify docs parse + parity + prettier.** Run:
+```bash
+pnpm exec vitest run apps/site/src/pages/docs/__tests__
+pnpm --filter site build
+pnpm exec prettier --check apps/site/src/pages/docs/layouts.mdx apps/site/src/pages/docs/loaders.mdx
+```
+Expected: PASS. (If prettier flags either file, `pnpm exec prettier --write` it and re-check. The docs-template-check PostToolUse hook is a soft warn; address any template gap it reports.)
+
+- [ ] **Step 4: Commit.**
+```bash
+git add apps/site/src/pages/docs/layouts.mdx apps/site/src/pages/docs/loaders.mdx
+git commit -m "docs: typed route params (useParams + defineLoader routeId)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Full pre-push verification
+
+**Files:** none.
+
+- [ ] **Step 1: Run the six-step CI mirror in order, each expecting PASS:**
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+- [ ] **Step 2: If `format:check` fails,** run `pnpm format`, restage into the relevant commit or a `style:` commit, and re-run from Step 1.
+
+- [ ] **Step 3: Boundary-export check.** If a Section B public/internal boundary test fails because `RouteParams` / `RoutePaths` / `RegisteredRoutes` are newly on the main barrel, add them to that test's allow-list (they are intended public API). Do not remove the exports.
+
+- [ ] **Step 4: Flake note.** If `measure-client-size` times out under load, re-run it in isolation (`pnpm exec vitest run scripts/__tests__/measure-client-size.test.mjs`) before treating it as real. The client-size sticky comment may move by a few bytes (a new hook export); that is expected.
+
+---
+
+## Self-review
+
+- **Spec coverage:** type engine (Task 2), the `defineRoutes`/`RouteDef` reshapes (Task 1), `useParams` (Task 3), the `defineLoader(routeId, fn)` overload (Task 4) and its Vite codegen + flipped tests (Task 5), the registration + both site migrations + the CI type oracle (Task 6), docs on `layouts.mdx` + `loaders.mdx` (Task 7), full pre-push (Task 8). The deferred items (dev-mode wrong-route guard, auto-derived cache params, search-param typing, file-based routing) are correctly absent.
+- **Placeholder scan:** every code step has full code; the two `as` casts (overload-impl normalization in Task 4, the structural pathParams read in Task 3) are the spec's single sanctioned boundary, justified in comments. No TODO/TBD.
+- **Type/name consistency:** `RouteParams` / `RoutePaths` / `RegisteredRoutes` / `RegisteredPaths` / `AbsolutePaths` are spelled identically across Tasks 2, 3, 4, 6; `__tree` matches between `RoutesManifest` (Task 1) and `RoutePaths` (Task 2); `LoaderCtx<TParams>` matches between the iso change (Task 4) and the site annotation (Task 6); the `defineLoader` overload's `(route, fn, opts?)` arity matches the plugin's 2-arg/3-arg handling (Task 5) and the parser's shifted opts position (Task 5).
+- **Codegen parity:** the predecessor behavior (string-first `defineLoader` skipped, no `__moduleKey`) is intentionally replaced by injection; the two tests asserting the old skip are flipped (Task 5, Step 5) and the parser's `optsArg` consumer (`server-only.ts`) is covered by the central parser fix (Task 5, Step 1).

--- a/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
+++ b/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
@@ -1,0 +1,243 @@
+# Typed route params (Section C, primitive 4) design
+
+**Date:** 2026-06-12
+**Status:** Approved design, pre-implementation
+**Source:** Section C (primitive 4, "typed route params") of `docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md`. Fourth of the six site-discovered primitives.
+**Goal:** Kill the stringly-typed `pathParams` access the site hand-maintains: the real `(route.pathParams as { projectId?: string })` cast in `demo/project-layout.tsx` and the unchecked `ctx.location.pathParams.issueId` in `demo/issue.server.ts`. Give the framework full param inference in the TanStack style: the user names a route once, that name is validated against the actual route table, and the params are derived from the route's pattern. No codegen, no runtime registry.
+
+## Scope decisions (locked with user)
+
+1. **Full inference, validated typed-routing (option 1), via a type-only registry (mechanism A).** The user names the route once per consumer (`useParams('/demo/projects/:projectId')`); that string is constrained to the union of real route patterns; the param object is derived from the named pattern. No file-based routing (loaders/components are decoupled from the route table by thunks, so types cannot flow definition->use automatically), and no codegen step (the type machinery is ~45 self-contained lines of template-literal types). This is the realistic ceiling for inference in a manifest-based router.
+2. **No new dependency, no TypeScript upgrade.** The workspace already runs `typescript@6.0.3` (an earlier "4.9.4" reading was a stray global Homebrew `tsc` shadowing the workspace binary; `pnpm -r exec tsc`, which `pnpm typecheck` uses, resolves the local 6.0.3). `const` type parameters and recursive template-literal types are native. A spike (`AbsolutePaths` + `RouteParams` + registry fallback, typechecked under `tsc@6.0.3 --strict`) confirmed every assertion. No helper lib (`type-fest`, a codegen router) earns its keep here.
+3. **Loaders are covered via a `defineLoader(routeId, fn)` overload** (user's choice). The route id comes first so TypeScript can use it to contextually type `ctx` in the loader fn (a later argument cannot constrain an earlier one, which is why an opts-bag `{ route }` cannot type `ctx`). This drags in the Vite codegen (see PR 2) because the plugin currently treats a string-first `defineLoader` as an invalid form and skips it.
+4. **Graceful degradation before registration.** With no `declare module` augmentation, `RegisteredPaths` falls back to `string`, so `useParams`/`defineLoader(routeId, ...)` still compile and return the param shape for whatever literal is passed. Registration only adds validation of the route id against the real table.
+5. **Ship as two PRs.** PR 1 (iso-only) lands the shared type machinery + `useParams` + the `project-layout.tsx` migration. PR 2 (iso + vite) lands the `defineLoader` overload + the codegen changes + the `issue.server.ts` migration. This mirrors the primitive #1 split (#91 iso / #92 ui), keeps each PR focused and reviewable, and isolates the codegen risk in PR 2.
+
+## The type machinery (internal `packages/iso/src/internal/typed-routes.ts`)
+
+Proven by the spike. Mirrors the runtime path-join rules in `define-routes.tsx` exactly (`here = parent === '' ? path : (path === '' ? parent : ` + "`${parent}/${path}`" + `)` and the `/`-root reset).
+
+```ts
+import type { RouteDef } from '../define-routes.js';
+
+// Absolute-path extraction --------------------------------------------------
+type Here<Parent extends string, Path extends string> = Parent extends ''
+  ? Path
+  : Path extends ''
+    ? Parent
+    : `${Parent}/${Path}`;
+
+type NextParent<H extends string> = H extends '/' ? '' : H;
+
+type NodePaths<R extends RouteDef, Parent extends string> = Here<
+  Parent,
+  R['path']
+> extends infer H
+  ? H extends string
+    ?
+        | (R extends { view: unknown } ? H : never)
+        | (R extends { layout: unknown } ? H : never)
+        | (R extends { children: infer C }
+            ? C extends readonly RouteDef[]
+              ? AbsolutePaths<C, NextParent<H>>
+              : never
+            : never)
+    : never
+  : never;
+
+export type AbsolutePaths<
+  T extends readonly RouteDef[],
+  Parent extends string = '',
+> = T extends readonly [infer Head, ...infer Tail]
+  ? Head extends RouteDef
+    ? Tail extends readonly RouteDef[]
+      ? NodePaths<Head, Parent> | AbsolutePaths<Tail, Parent>
+      : never
+    : never
+  : never;
+
+// Param extraction ----------------------------------------------------------
+type ParamKey<Seg extends string> = Seg extends `${infer Name}?`
+  ? { optional: true; name: Name }
+  : Seg extends `${infer Name}*`
+    ? { optional: true; name: Name }
+    : Seg extends `${infer Name}+`
+      ? { optional: false; name: Name }
+      : { optional: false; name: Seg };
+
+type ParamFrom<Seg extends string> =
+  ParamKey<Seg> extends { optional: infer O; name: infer N extends string }
+    ? O extends true
+      ? { [K in N]?: string }
+      : { [K in N]: string }
+    : never;
+
+export type RouteParams<Path extends string> =
+  Path extends `${string}:${infer Param}/${infer Rest}`
+    ? ParamFrom<Param> & RouteParams<`/${Rest}`>
+    : Path extends `${string}:${infer Param}`
+      ? ParamFrom<Param>
+      : {};
+
+// Registry indirection ------------------------------------------------------
+export interface RegisteredRoutes {
+  // Users augment with `paths: RoutePaths<typeof routes>`.
+}
+
+export type RegisteredPaths = RegisteredRoutes extends {
+  paths: infer P extends string;
+}
+  ? P
+  : string;
+
+export type RoutePaths<M> = M extends {
+  __tree?: infer T extends readonly RouteDef[];
+}
+  ? AbsolutePaths<T>
+  : never;
+```
+
+`AbsolutePaths` emits the absolute pattern for every node that has a `view` or a `layout` (the route ids a consumer can legitimately name; layouts read params too, e.g. `project-layout.tsx`), and descends into `children` joining segments. It correctly walks layout-group nesting, which is the gotcha that bit primitive #3: the leaf `/demo/projects/:projectId/issues/:issueId` is present here even though `RoutesManifest.flat` omits it. `RouteParams` handles required (`:id`), optional (`:id?`), and the preact-iso modifier suffixes (`*`, `+`); a paramless pattern yields `{}`.
+
+## Reshapes (no casts; backward-compatible)
+
+Two changes to `define-routes.tsx` so a `const`-inferred tree satisfies the constraint and so `typeof routes` carries the literal tree:
+
+1. **`RouteDef.children?: RouteDef[]` -> `readonly RouteDef[]`.** Every internal consumer (`validate`, `collectServerImports`, `collectServerRoutes`, `flattenTree`) already takes `ReadonlyArray<RouteDef>`, so this is a pure widening with no call-site churn. It is required because `const` inference makes nested `children` arrays `readonly`, which the mutable `RouteDef[]` rejects.
+2. **`defineRoutes` becomes generic and `RoutesManifest` gains a phantom tree type:**
+
+```ts
+export type RoutesManifest<T extends readonly RouteDef[] = readonly RouteDef[]> = {
+  tree: ReadonlyArray<RouteDef>;
+  flat: ReadonlyArray<FlatRoute>;
+  serverImports: ReadonlyArray<LazyServerImport>;
+  serverRoutes: ReadonlyArray<ServerRoute>;
+  /** Phantom: carries the literal tree type so `RoutePaths<typeof routes>`
+   * can extract the route-pattern union. Never assigned at runtime. */
+  readonly __tree?: T;
+};
+
+export function defineRoutes<const T extends readonly RouteDef[]>(
+  tree: T
+): RoutesManifest<T> {
+  // body unchanged; the phantom is type-only
+}
+```
+
+The default type parameter means all four existing `RoutesManifest` references resolve unchanged (`packages/server/src/route-server-modules.ts`, the barrel re-export, the `Routes` props, the definition). The `const` type parameter gives users typed routes **without writing `as const`**; a caller who passes an already-widened `RouteDef[]` variable simply falls back to `string` route ids. The phantom field is optional and never constructed, so `defineRoutes`'s return literal is unchanged at runtime.
+
+## Public API (PR 1)
+
+Re-exported from the iso barrel (`packages/iso/src/index.ts`), surfaced through `hono-preact`:
+
+```ts
+// Types
+export type { RouteParams, RoutePaths } from './internal/typed-routes.js';
+export type { RegisteredRoutes } from './internal/typed-routes.js'; // for `declare module` augmentation
+// Hook (new file packages/iso/src/use-params.ts)
+export function useParams<P extends RegisteredPaths>(route: P): RouteParams<P>;
+```
+
+`useParams`:
+
+```ts
+import { useRoute } from 'preact-iso';
+import type { RegisteredPaths, RouteParams } from './internal/typed-routes.js';
+
+export function useParams<P extends RegisteredPaths>(route: P): RouteParams<P> {
+  // `route` is a type-level selector: it names which route's param shape to
+  // project. The live params come from the active route match. The structural
+  // read off `Record<string, string>` is the one sanctioned cast boundary
+  // (the runtime value genuinely lacks the literal; CLAUDE.md "structural reads").
+  void route;
+  return useRoute().pathParams as RouteParams<P>;
+}
+```
+
+Registration (one block in the user's `routes.ts`, next to the `defineRoutes` call):
+
+```ts
+export const routes = defineRoutes([...]);
+
+declare module 'hono-preact' {
+  interface RegisteredRoutes {
+    paths: RoutePaths<typeof routes>;
+  }
+}
+```
+
+After this, `useParams` (and the PR-2 loader overload) constrain the route id to the real pattern union; a typo or a deleted route is a compile error.
+
+## Loader overload (PR 2)
+
+### iso: generic `LoaderCtx` + the overload
+
+```ts
+import type { RouteHook } from 'preact-iso';
+
+export type LoaderCtx<TParams = Record<string, string>> = {
+  c: Context;
+  location: Omit<RouteHook, 'pathParams'> & { pathParams: TParams };
+  signal: AbortSignal;
+};
+
+export type Loader<T, TParams = Record<string, string>> =
+  | ((ctx: LoaderCtx<TParams>) => Promise<T>)
+  | ((ctx: LoaderCtx<TParams>) => Promise<ReadableStream<T>>)
+  | ((ctx: LoaderCtx<TParams>) => AsyncGenerator<T, void, unknown>);
+
+// Overloads on defineLoader (existing first, route-id form second):
+export function defineLoader<T>(
+  fn: Loader<T>,
+  opts?: DefineLoaderOpts<T>
+): LoaderRef<T>;
+export function defineLoader<RouteId extends RegisteredPaths, T>(
+  route: RouteId,
+  fn: Loader<T, RouteParams<RouteId>>,
+  opts?: DefineLoaderOpts<T>
+): LoaderRef<T>;
+```
+
+The defaults on `LoaderCtx<TParams>`/`Loader<T, TParams>` keep every existing `LoaderCtx`/`Loader<T>` usage identical (`pathParams: Record<string, string>`). The implementation signature normalizes the two forms: if the first argument is a string, treat the args as `[route, fn, opts]`, else `[fn, opts]`. The route id is type-level only; it is not stored on `LoaderRef` and does not change `params`/cache behavior (the cache-key `params` stays explicit via opts, unchanged).
+
+### vite codegen: make the route-id form a first-class `defineLoader`
+
+The `moduleKeyPlugin` (`packages/vite/src/module-key-plugin.ts`) threads `__moduleKey`/`__loaderName` into every `defineLoader` call inside a `.server.*` module. It currently (a) bails when `arguments.length > 2` and (b) `return`s when the first arg is a `StringLiteral` ("not a valid defineLoader fn form; skip"). Both must change or the route-id form silently gets **no `__moduleKey`**, breaking cross-route cache dedup (the entire reason `__moduleKey` exists). Required changes:
+
+- **`module-key-plugin.ts` `visitCallWithName`:** detect the route-id form (`arguments[0]` is a `StringLiteral`). For it, the fn is `arguments[1]` and opts is `arguments[2]`: with 2 args, append `, { __moduleKey, __loaderName }` after the fn; with 3 args, merge into the `arguments[2]` `ObjectExpression` (bail to a plain key if it is not an object literal, mirroring the existing 2-arg branch). Allow `arguments.length === 3` for this form. Keep the existing fn-first branch (1 arg -> append, 2 args -> merge) unchanged.
+- **`server-loaders-parser.ts` (`parseServerLoaders`):** when `call.arguments[0]` is a `StringLiteral`, the opts `ObjectExpression` is `call.arguments[2]` (not `[1]`); the `params` reader (`server-loaders-parser.ts:125`) must read from the shifted position. The returned `call` node is unchanged (still the whole `CallExpression`).
+- **`server-loader-validation.ts` / `server-exports-contract.ts`:** confirm the string-first `defineLoader(...)` call still passes export-shape validation (it is still a `defineLoader` call assigned into `serverLoaders`); add a fixture if a gap surfaces.
+- **Tests to update (currently assert the skip behavior):** `module-key-plugin.test.ts` "leaves an existing two-arg defineLoader call unchanged" (`defineLoader('movies', async () => ({}))`) must flip to assert `__moduleKey` is now injected as a third arg; add a 3-arg route-id case. `server-loaders-parser.test.ts` gains a route-id-form case asserting `optsArg` resolves to `arguments[2]`.
+
+## Dogfood migrations
+
+- **PR 1, `apps/site/src/pages/demo/project-layout.tsx`:** replace `const slug = (route.pathParams as { projectId?: string }).projectId ?? '';` with `const { projectId } = useParams('/demo/projects/:projectId');` (typed `{ projectId: string }`). `projectId` is now a non-optional `string`, so the `?? ''` guard becomes dead; drop it and use `projectId` directly. Add the `declare module` registration block to the site's `routes.ts` (next to the `defineRoutes` call).
+- **PR 2, `apps/site/src/pages/demo/issue.server.ts`:** change the `issue` loader to `defineLoader('/demo/projects/:projectId/issues/:issueId', issueLoader)` (and the sibling `comments`/`activity` loaders likewise if they read params), so `ctx.location.pathParams.issueId` / `.projectId` are typed `string` instead of `Record<string,string>` index access. Loader bodies are otherwise unchanged.
+
+## Docs
+
+- **PR 1:** a "Typed route params" section on `apps/site/src/pages/docs/layouts.mdx` (it already introduces dynamic segments and `pathParams.id` for views/layouts at line ~35), showing the one-time `declare module` registration and `useParams('/route/:id')`. Follow the `add-docs-page` conventions (prose + example + a short API note). No new page.
+- **PR 2:** extend `apps/site/src/pages/docs/loaders.mdx` (its "Example: detail page (using route params)" section documents `location.pathParams`) with the `defineLoader('/route/:id', fn)` form and a note that `ctx.location.pathParams` is then typed.
+
+## Tests
+
+**PR 1 (`packages/iso/src/__tests__/`):**
+- A **type-level test** (a `.ts` file with `Expect<Equal<...>>` assertions, like the spike, run under the normal `pnpm typecheck`) for `AbsolutePaths` over a layout-group tree (asserting the deep leaf pattern is present), `RouteParams` (single/multi/optional/empty), and the `RegisteredPaths` `string` fallback. This is the real oracle for the type machinery.
+- A **runtime test** for `useParams`: render a harness inside a route match (mock `useRoute` to return `{ pathParams: { projectId: 'p1' } }`, the `page.test.tsx` mock precedent) and assert `useParams('/demo/projects/:projectId')` returns `{ projectId: 'p1' }`.
+- A **typecheck guard** that `defineRoutes([...])` (no `as const`) still yields a usable `RoutePaths<typeof routes>` and that an existing `defineRoutes` caller without registration still compiles.
+
+**PR 2:**
+- iso: a runtime test that `defineLoader('/r/:id', fn)` returns a `LoaderRef` behaviorally identical to `defineLoader(fn)` (the route id is inert at runtime), and a type-level test that `ctx.location.pathParams` is typed from the route id.
+- vite: the updated `module-key-plugin.test.ts` (route-id form gets `__moduleKey` injected, 2-arg and 3-arg) and `server-loaders-parser.test.ts` (opts position shift). Run the full vite plugin suite to catch validation regressions.
+
+## Breaking changes
+
+None intended. `useParams`/`RouteParams`/`RoutePaths`/`RegisteredRoutes` and the `defineLoader` overload are additive. `RouteDef.children` widening to `readonly` and `RoutesManifest`/`defineLoader` going generic are source-compatible (defaults + readonly-as-supertype). The site migrations are behavior-preserving. The only behavior change is internal to the Vite plugin: a string-first `defineLoader` call, previously skipped, now gets `__moduleKey` threaded (this is a fix, not a break; no production code used that form before).
+
+## Out of scope (deferred)
+
+- **Dev-mode "named the wrong route" guard.** `useParams` constrains the id to a *valid* pattern but cannot statically prove it matches the *active* route; a dev-only `console.warn` when the active path does not match the named pattern (using the existing `RouteManifestContext` + a matcher) is a nice hardening, deferred to keep PR 1 iso-only and context-free.
+- **Auto-deriving the cache-key `params` from the route id** in `defineLoader(routeId, fn)` (would change cache behavior; keep `params` explicit).
+- **Search-param typing** (`searchParams` stays `Record<string, string>`; no schema layer).
+- **File-based routing** (the only way to get zero-declaration inference; a much larger change, not one of the six primitives).
+- The remaining Section C primitives (#5 single-source guards, #6 content-glob route helper).

--- a/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
+++ b/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
@@ -281,7 +281,7 @@ The route id autocompletes/validates against `RegisteredPaths` exactly like `def
 
 ### Dogfood + docs
 
-`apps/site/src/pages/demo/issue.server.ts` moves to `serverRoute('/demo/projects/:projectId/issues/:issueId')` + inline `route.loader(...)` (drops the `ISSUE_ROUTE` const, the `IssueParams` alias, and the three `LoaderCtx<IssueParams>` annotations). Docs (`layouts.mdx` typed-params section, `loaders.mdx` typed-loader subsection) lead with `serverRoute` as the recommended form, with `defineLoader(routeId, fn)` noted as the lower-level / shared-loader door.
+`apps/site/src/pages/demo/issue.server.ts` moves to `serverRoute('/demo/projects/:projectId/issues/:issueId')` + inline `route.loader(...)` (drops the `ISSUE_ROUTE` const, the `IssueParams` alias, and the three `LoaderCtx<IssueParams>` annotations). The `loaders.mdx` typed-loader subsection leads with `serverRoute` as the recommended form, with `defineLoader(routeId, fn)` noted as the lower-level / shared-loader door. The `layouts.mdx` typed-params section stays scoped to `useParams` (the client hook) and is unchanged.
 
 ### Tests
 

--- a/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
+++ b/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
@@ -242,3 +242,48 @@ None intended. `useParams`/`RouteParams`/`RoutePaths`/`RegisteredRoutes` and the
 - **Search-param typing** (`searchParams` stays `Record<string, string>`; no schema layer).
 - **File-based routing** (the only way to get zero-declaration inference; a much larger change, not one of the six primitives).
 - The remaining Section C primitives (#5 single-source guards, #6 content-glob route helper).
+
+## Addendum (2026-06-13): `serverRoute` factory
+
+Folded into the same PR after a design discussion. `defineLoader(routeId, fn)` types loader params but repeats the route id (and, for standalone loaders, the `LoaderCtx<RouteParams<...>>` annotation) per loader. `serverRoute(routeId)` names the route **once per server module** and returns a `.loader(fn)` that infers `ctx.location.pathParams` from the route's pattern, the dominant one-page-one-loader case.
+
+### Portability note (why this is sound)
+
+The route id is **type-level only** (runtime-inert, never stored on the `LoaderRef`), so a loader's runtime portability is unchanged. The fn-first `defineLoader(fn)` form (params `Record<string,string>`) and the explicit `defineLoader(routeId, fn)` form both remain for route-agnostic or shared-across-routes loaders; `serverRoute` is opt-in sugar over the latter, not a constraint. A shared loader written standalone and typed to the param subset it uses (`LoaderCtx<{ id: string }>`) still binds at any route supplying those params via `defineLoader`.
+
+### API (`packages/iso/src/server-route.ts`)
+
+```ts
+export interface RouteServer<RouteId extends string> {
+  loader<T>(
+    fn: Loader<T, RouteParams<RouteId>>,
+    opts?: DefineLoaderOpts<T>
+  ): LoaderRef<T>;
+}
+
+export function serverRoute<const RouteId extends RegisteredPaths>(
+  route: RouteId
+): RouteServer<RouteId> {
+  return { loader: (fn, opts) => defineLoader(route, fn, opts) };
+}
+```
+
+The route id autocompletes/validates against `RegisteredPaths` exactly like `defineLoader(routeId, ...)`. Barrel-exported (`serverRoute`, `type RouteServer`).
+
+### Vite codegen
+
+`route.loader(fn, opts?)` has the same argument order as fn-first `defineLoader(fn, opts?)`, so the existing injection path handles it once the callee is recognized. Two guard widenings, no new branch:
+
+- `server-loaders-parser.ts` `parseServerLoaders`: accept a `serverLoaders` property value whose callee is a `defineLoader` identifier **or** a non-computed member call with property `loader` (`route.loader(...)`). Its `optsArg` is `arguments[1]` (fn-first), already handled.
+- `module-key-plugin.ts` `visitCallWithName`: same callee widening; `.loader(...)` is not a string-first call so it flows through the fn-first append/merge path, threading `__moduleKey`/`__loaderName` into `.loader`'s opts. At runtime `serverRoute.loader` forwards that opts into `defineLoader(route, fn, opts)`, so the cache key threads identically.
+
+`server-loader-validation.ts` is unaffected: it validates export *names* and `pageUse` shape only; `const route = serverRoute(...)` is a non-exported local and never inspects per-loader call shapes. Recognizing `.loader(...)` is safe by the `serverLoaders` contract (its values must be `LoaderRef`s, and only `defineLoader`/`route.loader` produce them).
+
+### Dogfood + docs
+
+`apps/site/src/pages/demo/issue.server.ts` moves to `serverRoute('/demo/projects/:projectId/issues/:issueId')` + inline `route.loader(...)` (drops the `ISSUE_ROUTE` const, the `IssueParams` alias, and the three `LoaderCtx<IssueParams>` annotations). Docs (`layouts.mdx` typed-params section, `loaders.mdx` typed-loader subsection) lead with `serverRoute` as the recommended form, with `defineLoader(routeId, fn)` noted as the lower-level / shared-loader door.
+
+### Tests
+
+- iso: `serverRoute('/r/:id').loader(fn)` returns a `LoaderRef` behaviorally identical to `defineLoader('/r/:id', fn)`; the route id is inert at runtime.
+- vite: `module-key-plugin.test.ts` injects `__moduleKey`/`__loaderName` into a `serverLoaders = { x: route.loader(fn) }` entry; `server-loaders-parser.test.ts` returns an entry for a `.loader(...)` value with the right name + optsArg.

--- a/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
+++ b/docs/superpowers/specs/2026-06-12-typed-route-params-design.md
@@ -9,9 +9,9 @@
 
 1. **Full inference, validated typed-routing (option 1), via a type-only registry (mechanism A).** The user names the route once per consumer (`useParams('/demo/projects/:projectId')`); that string is constrained to the union of real route patterns; the param object is derived from the named pattern. No file-based routing (loaders/components are decoupled from the route table by thunks, so types cannot flow definition->use automatically), and no codegen step (the type machinery is ~45 self-contained lines of template-literal types). This is the realistic ceiling for inference in a manifest-based router.
 2. **No new dependency, no TypeScript upgrade.** The workspace already runs `typescript@6.0.3` (an earlier "4.9.4" reading was a stray global Homebrew `tsc` shadowing the workspace binary; `pnpm -r exec tsc`, which `pnpm typecheck` uses, resolves the local 6.0.3). `const` type parameters and recursive template-literal types are native. A spike (`AbsolutePaths` + `RouteParams` + registry fallback, typechecked under `tsc@6.0.3 --strict`) confirmed every assertion. No helper lib (`type-fest`, a codegen router) earns its keep here.
-3. **Loaders are covered via a `defineLoader(routeId, fn)` overload** (user's choice). The route id comes first so TypeScript can use it to contextually type `ctx` in the loader fn (a later argument cannot constrain an earlier one, which is why an opts-bag `{ route }` cannot type `ctx`). This drags in the Vite codegen (see PR 2) because the plugin currently treats a string-first `defineLoader` as an invalid form and skips it.
+3. **Loaders are covered via a `defineLoader(routeId, fn)` overload** (user's choice). The route id comes first so TypeScript can use it to contextually type `ctx` in the loader fn (a later argument cannot constrain an earlier one, which is why an opts-bag `{ route }` cannot type `ctx`). This drags in the Vite codegen (see the loader-overload section) because the plugin currently treats a string-first `defineLoader` as an invalid form and skips it.
 4. **Graceful degradation before registration.** With no `declare module` augmentation, `RegisteredPaths` falls back to `string`, so `useParams`/`defineLoader(routeId, ...)` still compile and return the param shape for whatever literal is passed. Registration only adds validation of the route id against the real table.
-5. **Ship as two PRs.** PR 1 (iso-only) lands the shared type machinery + `useParams` + the `project-layout.tsx` migration. PR 2 (iso + vite) lands the `defineLoader` overload + the codegen changes + the `issue.server.ts` migration. This mirrors the primitive #1 split (#91 iso / #92 ui), keeps each PR focused and reviewable, and isolates the codegen risk in PR 2.
+5. **Ship as one PR** (iso + vite + site). The type machinery, `useParams`, the `defineLoader` overload, the Vite codegen changes, and both site migrations land together. The two halves share the same type machinery (`typed-routes.ts`, `RegisteredRoutes`, `RouteParams`) and reshapes, so a single PR keeps the feature coherent; the plan sequences the codegen work as its own tasks so the risk stays isolated within the PR.
 
 ## The type machinery (internal `packages/iso/src/internal/typed-routes.ts`)
 
@@ -126,7 +126,7 @@ export function defineRoutes<const T extends readonly RouteDef[]>(
 
 The default type parameter means all four existing `RoutesManifest` references resolve unchanged (`packages/server/src/route-server-modules.ts`, the barrel re-export, the `Routes` props, the definition). The `const` type parameter gives users typed routes **without writing `as const`**; a caller who passes an already-widened `RouteDef[]` variable simply falls back to `string` route ids. The phantom field is optional and never constructed, so `defineRoutes`'s return literal is unchanged at runtime.
 
-## Public API (PR 1)
+## Public API: `useParams`
 
 Re-exported from the iso barrel (`packages/iso/src/index.ts`), surfaced through `hono-preact`:
 
@@ -166,9 +166,9 @@ declare module 'hono-preact' {
 }
 ```
 
-After this, `useParams` (and the PR-2 loader overload) constrain the route id to the real pattern union; a typo or a deleted route is a compile error.
+After this, `useParams` (and the `defineLoader` overload) constrain the route id to the real pattern union; a typo or a deleted route is a compile error.
 
-## Loader overload (PR 2)
+## Loader overload: `defineLoader(routeId, fn)`
 
 ### iso: generic `LoaderCtx` + the overload
 
@@ -211,22 +211,23 @@ The `moduleKeyPlugin` (`packages/vite/src/module-key-plugin.ts`) threads `__modu
 
 ## Dogfood migrations
 
-- **PR 1, `apps/site/src/pages/demo/project-layout.tsx`:** replace `const slug = (route.pathParams as { projectId?: string }).projectId ?? '';` with `const { projectId } = useParams('/demo/projects/:projectId');` (typed `{ projectId: string }`). `projectId` is now a non-optional `string`, so the `?? ''` guard becomes dead; drop it and use `projectId` directly. Add the `declare module` registration block to the site's `routes.ts` (next to the `defineRoutes` call).
-- **PR 2, `apps/site/src/pages/demo/issue.server.ts`:** change the `issue` loader to `defineLoader('/demo/projects/:projectId/issues/:issueId', issueLoader)` (and the sibling `comments`/`activity` loaders likewise if they read params), so `ctx.location.pathParams.issueId` / `.projectId` are typed `string` instead of `Record<string,string>` index access. Loader bodies are otherwise unchanged.
+- **`apps/site/src/pages/routes.ts` (or wherever `defineRoutes` is called):** add the `declare module 'hono-preact' { interface RegisteredRoutes { paths: RoutePaths<typeof routes> } }` registration block next to the `defineRoutes` call. This unlocks validated route ids for every `useParams`/`defineLoader(routeId, ...)` in the app.
+- **`apps/site/src/pages/demo/project-layout.tsx`:** replace `const slug = (route.pathParams as { projectId?: string }).projectId ?? '';` with `const { projectId } = useParams('/demo/projects/:projectId');` (typed `{ projectId: string }`). `projectId` is now a non-optional `string`, so the `?? ''` guard becomes dead; drop it and use `projectId` directly.
+- **`apps/site/src/pages/demo/issue.server.ts`:** change the `issue` loader to `defineLoader('/demo/projects/:projectId/issues/:issueId', issueLoader)` (and the sibling `comments`/`activity` loaders likewise if they read params), so `ctx.location.pathParams.issueId` / `.projectId` are typed `string` instead of `Record<string,string>` index access. Loader bodies are otherwise unchanged.
 
 ## Docs
 
-- **PR 1:** a "Typed route params" section on `apps/site/src/pages/docs/layouts.mdx` (it already introduces dynamic segments and `pathParams.id` for views/layouts at line ~35), showing the one-time `declare module` registration and `useParams('/route/:id')`. Follow the `add-docs-page` conventions (prose + example + a short API note). No new page.
-- **PR 2:** extend `apps/site/src/pages/docs/loaders.mdx` (its "Example: detail page (using route params)" section documents `location.pathParams`) with the `defineLoader('/route/:id', fn)` form and a note that `ctx.location.pathParams` is then typed.
+- A "Typed route params" section on `apps/site/src/pages/docs/layouts.mdx` (it already introduces dynamic segments and `pathParams.id` for views/layouts at line ~35), showing the one-time `declare module` registration and `useParams('/route/:id')`. Follow the `add-docs-page` conventions (prose + example + a short API note). No new page.
+- Extend `apps/site/src/pages/docs/loaders.mdx` (its "Example: detail page (using route params)" section documents `location.pathParams`) with the `defineLoader('/route/:id', fn)` form and a note that `ctx.location.pathParams` is then typed.
 
 ## Tests
 
-**PR 1 (`packages/iso/src/__tests__/`):**
+**Type machinery + `useParams` (`packages/iso/src/__tests__/`):**
 - A **type-level test** (a `.ts` file with `Expect<Equal<...>>` assertions, like the spike, run under the normal `pnpm typecheck`) for `AbsolutePaths` over a layout-group tree (asserting the deep leaf pattern is present), `RouteParams` (single/multi/optional/empty), and the `RegisteredPaths` `string` fallback. This is the real oracle for the type machinery.
 - A **runtime test** for `useParams`: render a harness inside a route match (mock `useRoute` to return `{ pathParams: { projectId: 'p1' } }`, the `page.test.tsx` mock precedent) and assert `useParams('/demo/projects/:projectId')` returns `{ projectId: 'p1' }`.
 - A **typecheck guard** that `defineRoutes([...])` (no `as const`) still yields a usable `RoutePaths<typeof routes>` and that an existing `defineRoutes` caller without registration still compiles.
 
-**PR 2:**
+**Loader overload:**
 - iso: a runtime test that `defineLoader('/r/:id', fn)` returns a `LoaderRef` behaviorally identical to `defineLoader(fn)` (the route id is inert at runtime), and a type-level test that `ctx.location.pathParams` is typed from the route id.
 - vite: the updated `module-key-plugin.test.ts` (route-id form gets `__moduleKey` injected, 2-arg and 3-arg) and `server-loaders-parser.test.ts` (opts position shift). Run the full vite plugin suite to catch validation regressions.
 
@@ -236,7 +237,7 @@ None intended. `useParams`/`RouteParams`/`RoutePaths`/`RegisteredRoutes` and the
 
 ## Out of scope (deferred)
 
-- **Dev-mode "named the wrong route" guard.** `useParams` constrains the id to a *valid* pattern but cannot statically prove it matches the *active* route; a dev-only `console.warn` when the active path does not match the named pattern (using the existing `RouteManifestContext` + a matcher) is a nice hardening, deferred to keep PR 1 iso-only and context-free.
+- **Dev-mode "named the wrong route" guard.** `useParams` constrains the id to a *valid* pattern but cannot statically prove it matches the *active* route; a dev-only `console.warn` when the active path does not match the named pattern (using the existing `RouteManifestContext` + a matcher) is a nice hardening, deferred to keep `useParams` context-free.
 - **Auto-deriving the cache-key `params` from the route id** in `defineLoader(routeId, fn)` (would change cache behavior; keep `params` explicit).
 - **Search-param typing** (`searchParams` stays `Record<string, string>`; no schema layer).
 - **File-based routing** (the only way to get zero-declaration inference; a much larger change, not one of the six primitives).

--- a/packages/iso/src/__tests__/define-loader-route-id.test.ts
+++ b/packages/iso/src/__tests__/define-loader-route-id.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { defineLoader, type LoaderCtx } from '../define-loader.js';
+
+describe('defineLoader(routeId, fn) overload', () => {
+  it('returns a LoaderRef behaviorally identical to defineLoader(fn)', () => {
+    const fn = async (_ctx: LoaderCtx<{ id: string }>) => ({ ok: true });
+    const ref = defineLoader('/things/:id', fn);
+    expect(typeof ref.__id).toBe('symbol');
+    expect(ref.fn).toBe(fn);
+    expect(ref.params).toEqual([]);
+    expect(typeof ref.invalidate).toBe('function');
+  });
+
+  it('threads opts through the third argument', () => {
+    const fn = async (_ctx: LoaderCtx<{ id: string }>) => ({ ok: true });
+    const ref = defineLoader('/things/:id', fn, { params: ['q'] });
+    expect(ref.params).toEqual(['q']);
+  });
+
+  it('still supports the fn-first form', () => {
+    const fn = async () => ({ ok: true });
+    const ref = defineLoader(fn, { params: '*' });
+    expect(ref.fn).toBe(fn);
+    expect(ref.params).toBe('*');
+  });
+});

--- a/packages/iso/src/__tests__/server-route.test.ts
+++ b/packages/iso/src/__tests__/server-route.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { serverRoute } from '../server-route.js';
+import { defineLoader, type LoaderCtx } from '../define-loader.js';
+
+describe('serverRoute', () => {
+  it('loader() returns a LoaderRef behaviorally identical to defineLoader(routeId, fn)', () => {
+    const route = serverRoute('/things/:id');
+    const fn = async (_ctx: LoaderCtx<{ id: string }>) => ({ ok: true });
+    const viaFactory = route.loader(fn);
+    const viaDirect = defineLoader('/things/:id', fn);
+
+    expect(typeof viaFactory.__id).toBe('symbol');
+    expect(viaFactory.fn).toBe(fn);
+    expect(viaFactory.params).toEqual(viaDirect.params);
+    expect(typeof viaFactory.invalidate).toBe('function');
+  });
+
+  it('forwards opts through to defineLoader', () => {
+    const route = serverRoute('/things/:id');
+    const ref = route.loader(
+      async (_ctx: LoaderCtx<{ id: string }>) => ({ ok: true }),
+      { params: ['q'] }
+    );
+    expect(ref.params).toEqual(['q']);
+  });
+});

--- a/packages/iso/src/__tests__/use-params.test.tsx
+++ b/packages/iso/src/__tests__/use-params.test.tsx
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/preact';
 import { useParams } from '../use-params.js';
 
-const mockRoute = { path: '/demo/projects/p1', searchParams: {}, pathParams: {} as Record<string, string> };
+const mockRoute = {
+  path: '/demo/projects/p1',
+  searchParams: {},
+  pathParams: {} as Record<string, string>,
+};
 vi.mock('preact-iso', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return { ...actual, useRoute: () => mockRoute };

--- a/packages/iso/src/__tests__/use-params.test.tsx
+++ b/packages/iso/src/__tests__/use-params.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { useParams } from '../use-params.js';
+
+const mockRoute = { path: '/demo/projects/p1', searchParams: {}, pathParams: {} as Record<string, string> };
+vi.mock('preact-iso', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useRoute: () => mockRoute };
+});
+
+afterEach(cleanup);
+
+function Harness({ onParams }: { onParams: (p: unknown) => void }) {
+  const params = useParams('/demo/projects/:projectId');
+  onParams(params);
+  return null;
+}
+
+describe('useParams', () => {
+  it('returns the live route pathParams for the named route', () => {
+    mockRoute.pathParams = { projectId: 'p1' };
+    let seen: unknown;
+    render(<Harness onParams={(p) => (seen = p)} />);
+    expect(seen).toEqual({ projectId: 'p1' });
+  });
+});

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -7,6 +7,7 @@ import type {
 import { useContext } from 'preact/hooks';
 import type { Context } from 'hono';
 import type { RouteHook } from 'preact-iso';
+import type { RegisteredPaths, RouteParams } from './internal/typed-routes.js';
 import { createCache, type LoaderCache } from './cache.js';
 import { LoaderDataContext, LoaderErrorContext } from './internal/contexts.js';
 import { Loader as LoaderHost } from './internal/loader.js';
@@ -15,16 +16,16 @@ import type { LoaderUse } from './internal/use-types.js';
 import type { Middleware } from './define-middleware.js';
 import type { StreamObserver } from './define-stream-observer.js';
 
-export type LoaderCtx = {
+export type LoaderCtx<TParams = Record<string, string>> = {
   c: Context;
-  location: RouteHook;
+  location: Omit<RouteHook, 'pathParams'> & { pathParams: TParams };
   signal: AbortSignal;
 };
 
-export type Loader<T> =
-  | ((ctx: LoaderCtx) => Promise<T>)
-  | ((ctx: LoaderCtx) => Promise<ReadableStream<T>>)
-  | ((ctx: LoaderCtx) => AsyncGenerator<T, void, unknown>);
+export type Loader<T, TParams = Record<string, string>> =
+  | ((ctx: LoaderCtx<TParams>) => Promise<T>)
+  | ((ctx: LoaderCtx<TParams>) => Promise<ReadableStream<T>>)
+  | ((ctx: LoaderCtx<TParams>) => AsyncGenerator<T, void, unknown>);
 
 export interface LoaderRef<T> {
   readonly __id: symbol;
@@ -163,7 +164,26 @@ function validateTimeoutMs(
 export function defineLoader<T>(
   fn: Loader<T>,
   opts?: DefineLoaderOpts<T>
-): LoaderRef<T> {
+): LoaderRef<T>;
+export function defineLoader<RouteId extends RegisteredPaths, T>(
+  route: RouteId,
+  fn: Loader<T, RouteParams<RouteId>>,
+  opts?: DefineLoaderOpts<T>
+): LoaderRef<T>;
+export function defineLoader(
+  fnOrRoute: Loader<unknown> | string,
+  fnOrOpts?: Loader<unknown> | DefineLoaderOpts<unknown>,
+  maybeOpts?: DefineLoaderOpts<unknown>
+): LoaderRef<unknown> {
+  // Normalize the two overload forms. The route id is type-level only (it
+  // selects the param shape for the loader fn); it is not stored on the ref
+  // and does not affect cache/`params` behavior.
+  const isRouteForm = typeof fnOrRoute === 'string';
+  const fn = (isRouteForm ? fnOrOpts : fnOrRoute) as Loader<unknown>;
+  const opts = (
+    isRouteForm ? maybeOpts : fnOrOpts
+  ) as DefineLoaderOpts<unknown> | undefined;
+
   validateTimeoutMs(opts?.timeoutMs, 'defineLoader');
   const idKey = opts?.__moduleKey
     ? opts.__loaderName
@@ -181,22 +201,22 @@ export function defineLoader<T>(
       // Keyed loaders: dedupe the auto-attached cache by __id so every
       // importer of the same .server module shares one LoaderCache.
       const shared = getSharedCaches();
-      const existing = shared.get(__id) as LoaderCache<T> | undefined;
+      const existing = shared.get(__id) as LoaderCache<unknown> | undefined;
       if (existing) {
         cache = existing;
       } else {
-        cache = createCache<T>();
+        cache = createCache<unknown>();
         shared.set(__id, cache as LoaderCache<unknown>);
       }
     } else {
       // Unkeyed loaders only happen when consumers call defineLoader(fn)
       // directly without the plugin transform (i.e. in tests). Each call
       // gets a fresh cache.
-      cache = createCache<T>();
+      cache = createCache<unknown>();
     }
   }
 
-  const ref: LoaderRef<T> = {
+  const ref: LoaderRef<unknown> = {
     __id,
     __moduleKey: opts?.__moduleKey,
     __loaderName: opts?.__loaderName,
@@ -217,7 +237,7 @@ export function defineLoader<T>(
           'loader.useData() must be called inside a `loader.View` render function or inside a `loader.Boundary`.'
         );
       }
-      return ctx.data as T;
+      return ctx.data as unknown;
     },
     useError() {
       return useContext(LoaderErrorContext);
@@ -229,7 +249,7 @@ export function defineLoader<T>(
     // and only deref at call time (component render), so the cycle is safe;
     // both are fully initialized before any consumer can invoke them.
     Boundary: ({ fallback, errorFallback, children }) =>
-      h(LoaderHost<T>, {
+      h(LoaderHost<unknown>, {
         loader: ref,
         fallback,
         errorFallback,
@@ -240,7 +260,7 @@ export function defineLoader<T>(
         h(ref.Boundary, {
           fallback: viewOpts?.fallback,
           errorFallback: viewOpts?.errorFallback,
-          children: h(ViewRenderer<T>, {
+          children: h(ViewRenderer<unknown>, {
             loaderRef: ref,
             props,
             render,

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -180,9 +180,9 @@ export function defineLoader(
   // and does not affect cache/`params` behavior.
   const isRouteForm = typeof fnOrRoute === 'string';
   const fn = (isRouteForm ? fnOrOpts : fnOrRoute) as Loader<unknown>;
-  const opts = (
-    isRouteForm ? maybeOpts : fnOrOpts
-  ) as DefineLoaderOpts<unknown> | undefined;
+  const opts = (isRouteForm ? maybeOpts : fnOrOpts) as
+    | DefineLoaderOpts<unknown>
+    | undefined;
 
   validateTimeoutMs(opts?.timeoutMs, 'defineLoader');
   const idKey = opts?.__moduleKey

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -100,8 +100,9 @@ export type DefineLoaderOpts<T> = {
 
 // Stash a shared cache map on globalThis so duplicate copies of
 // @hono-preact/iso (workspace hoisting quirks) still see the same map.
-// The serverOnlyPlugin emits a `defineLoader(fn, { __moduleKey })` call at
-// EVERY importer of a `.server.*` module, so without this dedup each
+// The module-key plugin threads `{ __moduleKey }` into every `defineLoader`
+// call (both the `defineLoader(fn, opts)` and `defineLoader(routeId, fn, opts)`
+// forms) at EVERY importer of a `.server.*` module, so without this dedup each
 // importer would get its own private LoaderCache and `ref.invalidate()`
 // would only clear the calling importer's copy. That breaks cross-route
 // invalidation (movie.tsx invalidating `moviesListLoader` no longer flushes

--- a/packages/iso/src/define-routes.tsx
+++ b/packages/iso/src/define-routes.tsx
@@ -35,7 +35,7 @@ export type RouteDef = {
   view?: LazyImport<ComponentType<ViewProps>>;
   layout?: LazyImport<ComponentType<LayoutProps>>;
   server?: LazyServerImport;
-  children?: RouteDef[];
+  children?: readonly RouteDef[];
 };
 
 export type FlatRoute = {
@@ -65,7 +65,9 @@ export type ServerRoute = {
   ancestors: ReadonlyArray<LazyServerImport>;
 };
 
-export type RoutesManifest = {
+export type RoutesManifest<
+  T extends readonly RouteDef[] = readonly RouteDef[],
+> = {
   tree: ReadonlyArray<RouteDef>;
   flat: ReadonlyArray<FlatRoute>;
   serverImports: ReadonlyArray<LazyServerImport>;
@@ -77,6 +79,12 @@ export type RoutesManifest = {
    * existing call sites only need the lazy thunks.
    */
   serverRoutes: ReadonlyArray<ServerRoute>;
+  /**
+   * Phantom: carries the literal route-tree type so `RoutePaths<typeof routes>`
+   * can extract the route-pattern union for typed params. Never assigned at
+   * runtime; the `?` keeps the `defineRoutes` return object unchanged.
+   */
+  readonly __tree?: T;
 };
 
 // preact-iso's `Route<P>` and `Router` carry strict generics that reject our
@@ -452,7 +460,9 @@ function flattenTree(
   return out;
 }
 
-export function defineRoutes(tree: RouteDef[]): RoutesManifest {
+export function defineRoutes<const T extends readonly RouteDef[]>(
+  tree: T
+): RoutesManifest<T> {
   validate(tree);
   const viewCache = new Map<unknown, ComponentType<ViewProps>>();
   const keyCache = new Map<ComponentType<ViewProps>, string>();

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -19,6 +19,13 @@ export type {
   ViewProps,
 } from './define-routes.js';
 
+// Typed route params.
+export type {
+  RouteParams,
+  RoutePaths,
+  RegisteredRoutes,
+} from './internal/typed-routes.js';
+
 // Server bindings.
 export { defineLoader } from './define-loader.js';
 export type {

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -52,6 +52,7 @@ export type {
   UseOptimisticActionResult,
 } from './optimistic-action.js';
 export { useNavigate, type NavigateOptions } from './use-navigate.js';
+export { useParams } from './use-params.js';
 
 // Active-route detection.
 export {

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -33,6 +33,8 @@ export type {
   LoaderCtx,
   Loader as LoaderFn,
 } from './define-loader.js';
+export { serverRoute } from './server-route.js';
+export type { RouteServer } from './server-route.js';
 export { defineAction, useAction, TimeoutError } from './action.js';
 export type {
   ActionStub,

--- a/packages/iso/src/internal/typed-routes.ts
+++ b/packages/iso/src/internal/typed-routes.ts
@@ -1,5 +1,3 @@
-import type { RouteDef } from '../define-routes.js';
-
 // Absolute-path extraction. Mirrors the runtime join in define-routes.tsx:
 //   here = parent === '' ? path : (path === '' ? parent : `${parent}/${path}`)
 // and the `/`-root reset (a layout/grouping at `/` joins children from '').
@@ -11,19 +9,24 @@ type Here<Parent extends string, Path extends string> = Parent extends ''
 
 type NextParent<H extends string> = H extends '/' ? '' : H;
 
-type NodePaths<R extends RouteDef, Parent extends string> = Here<
-  Parent,
-  R['path']
-> extends infer H
-  ? H extends string
-    ?
-        | (R extends { view: unknown } ? H : never)
-        | (R extends { layout: unknown } ? H : never)
-        | (R extends { children: infer C }
-            ? C extends readonly RouteDef[]
+// Read each node STRUCTURALLY (its `path` literal, the presence of `view` /
+// `layout` keys, and its `children`). Crucially we do NOT constrain nodes to
+// `RouteDef`: that assignability check would resolve each node's
+// `view`/`layout`/`server` import thunk module types, and those leaf modules
+// consume the route registry (`useParams`, `defineLoader(routeId, ...)`),
+// forming a type cycle. Reading keys + the `path` literal never resolves them.
+type NodePaths<R, Parent extends string> = R extends {
+  path: infer P extends string;
+}
+  ? Here<Parent, P> extends infer H
+    ? H extends string
+      ?
+          | (R extends { view: unknown } ? H : never)
+          | (R extends { layout: unknown } ? H : never)
+          | (R extends { children: infer C extends readonly unknown[] }
               ? AbsolutePaths<C, NextParent<H>>
-              : never
-            : never)
+              : never)
+      : never
     : never
   : never;
 
@@ -33,14 +36,10 @@ type NodePaths<R extends RouteDef, Parent extends string> = Here<
  * which `RoutesManifest.flat` omits.
  */
 export type AbsolutePaths<
-  T extends readonly RouteDef[],
+  T extends readonly unknown[],
   Parent extends string = '',
-> = T extends readonly [infer Head, ...infer Tail]
-  ? Head extends RouteDef
-    ? Tail extends readonly RouteDef[]
-      ? NodePaths<Head, Parent> | AbsolutePaths<Tail, Parent>
-      : never
-    : never
+> = T extends readonly [infer Head, ...infer Tail extends readonly unknown[]]
+  ? NodePaths<Head, Parent> | AbsolutePaths<Tail, Parent>
   : never;
 
 // Param extraction. Handles required `:id`, optional `:id?`, and the preact-iso
@@ -92,9 +91,21 @@ export type RegisteredPaths = RegisteredRoutes extends {
   ? P
   : string;
 
-/** The route-pattern union of a manifest produced by `defineRoutes`. */
-export type RoutePaths<M> = M extends {
-  __tree?: infer T extends readonly RouteDef[];
-}
-  ? AbsolutePaths<T>
-  : never;
+/**
+ * The route-pattern union for an app. Accepts either the route tree array
+ * (use `typeof routeTree` from `const routeTree = [...] as const`) or a manifest
+ * produced by `defineRoutes`.
+ *
+ * Prefer the tree form in the `declare module` registration. Referencing the
+ * manifest (`typeof routes`) there forms a type cycle: the manifest is built by
+ * `defineRoutes` (a value imported from `hono-preact`), and TypeScript eagerly
+ * evaluates the module augmentation while resolving that value, so the
+ * augmentation ends up depending on the very binding it annotates. A tree array
+ * is a plain literal that does not depend on any `hono-preact` value, so it
+ * breaks the cycle.
+ */
+export type RoutePaths<M> = M extends readonly unknown[]
+  ? AbsolutePaths<M>
+  : M extends { __tree?: infer T extends readonly unknown[] }
+    ? AbsolutePaths<T>
+    : never;

--- a/packages/iso/src/internal/typed-routes.ts
+++ b/packages/iso/src/internal/typed-routes.ts
@@ -1,0 +1,100 @@
+import type { RouteDef } from '../define-routes.js';
+
+// Absolute-path extraction. Mirrors the runtime join in define-routes.tsx:
+//   here = parent === '' ? path : (path === '' ? parent : `${parent}/${path}`)
+// and the `/`-root reset (a layout/grouping at `/` joins children from '').
+type Here<Parent extends string, Path extends string> = Parent extends ''
+  ? Path
+  : Path extends ''
+    ? Parent
+    : `${Parent}/${Path}`;
+
+type NextParent<H extends string> = H extends '/' ? '' : H;
+
+type NodePaths<R extends RouteDef, Parent extends string> = Here<
+  Parent,
+  R['path']
+> extends infer H
+  ? H extends string
+    ?
+        | (R extends { view: unknown } ? H : never)
+        | (R extends { layout: unknown } ? H : never)
+        | (R extends { children: infer C }
+            ? C extends readonly RouteDef[]
+              ? AbsolutePaths<C, NextParent<H>>
+              : never
+            : never)
+    : never
+  : never;
+
+/**
+ * The union of absolute route patterns for every view/layout node in a route
+ * tree (the ids a consumer can legitimately name). Walks layout-group nesting,
+ * which `RoutesManifest.flat` omits.
+ */
+export type AbsolutePaths<
+  T extends readonly RouteDef[],
+  Parent extends string = '',
+> = T extends readonly [infer Head, ...infer Tail]
+  ? Head extends RouteDef
+    ? Tail extends readonly RouteDef[]
+      ? NodePaths<Head, Parent> | AbsolutePaths<Tail, Parent>
+      : never
+    : never
+  : never;
+
+// Param extraction. Handles required `:id`, optional `:id?`, and the preact-iso
+// modifier suffixes `*` / `+`. A pattern with no `:param` yields `{}`.
+type ParamKey<Seg extends string> = Seg extends `${infer Name}?`
+  ? { optional: true; name: Name }
+  : Seg extends `${infer Name}*`
+    ? { optional: true; name: Name }
+    : Seg extends `${infer Name}+`
+      ? { optional: false; name: Name }
+      : { optional: false; name: Seg };
+
+type ParamFrom<Seg extends string> =
+  ParamKey<Seg> extends { optional: infer O; name: infer N extends string }
+    ? O extends true
+      ? { [K in N]?: string }
+      : { [K in N]: string }
+    : never;
+
+/** Extract the path-params object type from an absolute route pattern. */
+export type RouteParams<Path extends string> =
+  Path extends `${string}:${infer Param}/${infer Rest}`
+    ? ParamFrom<Param> & RouteParams<`/${Rest}`>
+    : Path extends `${string}:${infer Param}`
+      ? ParamFrom<Param>
+      : {};
+
+/**
+ * Augment this interface to register your app's routes for typed params:
+ *
+ * ```ts
+ * declare module 'hono-preact' {
+ *   interface RegisteredRoutes {
+ *     paths: RoutePaths<typeof routes>;
+ *   }
+ * }
+ * ```
+ *
+ * Until registered, `RegisteredPaths` falls back to `string` (the param hooks
+ * still work; they just accept any string and project its param shape).
+ */
+export interface RegisteredRoutes {
+  // augmented by users
+}
+
+export type RegisteredPaths = RegisteredRoutes extends {
+  paths: infer P extends string;
+}
+  ? P
+  : string;
+
+/** The route-pattern union of a manifest produced by `defineRoutes`. */
+export type RoutePaths<M> = M extends {
+  __tree?: infer T extends readonly RouteDef[];
+}
+  ? AbsolutePaths<T>
+  : never;

--- a/packages/iso/src/server-route.ts
+++ b/packages/iso/src/server-route.ts
@@ -1,0 +1,45 @@
+import {
+  defineLoader,
+  type DefineLoaderOpts,
+  type Loader,
+  type LoaderRef,
+} from './define-loader.js';
+import type { RegisteredPaths, RouteParams } from './internal/typed-routes.js';
+
+export interface RouteServer<RouteId extends string> {
+  /**
+   * Define a loader for this server module's route. `ctx.location.pathParams`
+   * is typed from the route's pattern, so no per-loader route id and no
+   * `LoaderCtx<...>` annotation are needed.
+   */
+  loader<T>(
+    fn: Loader<T, RouteParams<RouteId>>,
+    opts?: DefineLoaderOpts<T>
+  ): LoaderRef<T>;
+}
+
+/**
+ * Bind a server module to its route once. `route.loader(fn)` then infers
+ * `ctx.location.pathParams` from the route's pattern; the route id autocompletes
+ * and validates against your registered routes.
+ *
+ * ```ts
+ * const route = serverRoute('/movies/:id');
+ * export const serverLoaders = {
+ *   default: route.loader(async ({ location }) => getMovie(location.pathParams.id)),
+ * };
+ * ```
+ *
+ * This is opt-in sugar over `defineLoader(routeId, fn)` for the common
+ * one-module-one-route case. The route id is type-level only (inert at runtime);
+ * for route-agnostic or shared-across-routes loaders, use `defineLoader`
+ * directly. The Vite `moduleKeyPlugin` recognizes `route.loader(...)` calls in
+ * `serverLoaders` and threads the module key just as it does for `defineLoader`.
+ */
+export function serverRoute<const RouteId extends RegisteredPaths>(
+  route: RouteId
+): RouteServer<RouteId> {
+  return {
+    loader: (fn, opts) => defineLoader(route, fn, opts),
+  };
+}

--- a/packages/iso/src/use-params.ts
+++ b/packages/iso/src/use-params.ts
@@ -1,0 +1,20 @@
+import { useRoute } from 'preact-iso';
+import type { RegisteredPaths, RouteParams } from './internal/typed-routes.js';
+
+/**
+ * Typed route params for the named route. `route` is a type-level selector that
+ * names which route's param shape to project; the live param values come from
+ * the active route match. Constrain to the registered route union once an app
+ * adds the `declare module 'hono-preact'` registration; until then any string
+ * is accepted and its param shape projected.
+ *
+ * ```tsx
+ * const { projectId } = useParams('/demo/projects/:projectId');
+ * ```
+ */
+export function useParams<P extends RegisteredPaths>(route: P): RouteParams<P> {
+  void route; // type-level only; the live params come from the route match.
+  // The structural read off Record<string, string> is the one sanctioned cast
+  // boundary: the runtime value lacks the literal that `route` names.
+  return useRoute().pathParams as RouteParams<P>;
+}

--- a/packages/vite/src/__tests__/module-key-plugin.test.ts
+++ b/packages/vite/src/__tests__/module-key-plugin.test.ts
@@ -98,20 +98,34 @@ describe('moduleKeyPlugin defineLoader threading', () => {
     );
   });
 
-  it('leaves an existing two-arg defineLoader call unchanged', () => {
-    // Legacy (name, fn) form is still supported until the cleanup task; the
-    // plugin should not touch calls that already have a second argument.
+  it('threads __moduleKey into the route-id form (two args)', () => {
     const plugin = makePlugin();
     const code = [
       `import { defineLoader } from '@hono-preact/iso';`,
-      `export const loader = defineLoader('movies', async () => ({}));`,
+      `export const loader = defineLoader('/movies/:id', async () => ({}));`,
     ].join('\n');
     const result = plugin.transform.call(
       {} as any,
       code,
       '/Users/me/repo/src/pages/movies.server.ts'
     );
-    expect(result?.code).toContain(`defineLoader('movies', async () => ({}))`);
-    expect(result?.code).not.toContain('__moduleKey: ');
+    expect(result?.code).toContain(
+      `defineLoader('/movies/:id', async () => ({}), { __moduleKey: "src/pages/movies" })`
+    );
+  });
+
+  it('merges __moduleKey into the route-id form opts (three args)', () => {
+    const plugin = makePlugin();
+    const code = [
+      `import { defineLoader } from '@hono-preact/iso';`,
+      `export const loader = defineLoader('/movies/:id', async () => ({}), { params: ['q'] });`,
+    ].join('\n');
+    const result = plugin.transform.call(
+      {} as any,
+      code,
+      '/Users/me/repo/src/pages/movies.server.ts'
+    );
+    expect(result?.code).toContain('__moduleKey: "src/pages/movies"');
+    expect(result?.code).toContain(`params: ['q']`);
   });
 });

--- a/packages/vite/src/__tests__/module-key-server-loaders.test.ts
+++ b/packages/vite/src/__tests__/module-key-server-loaders.test.ts
@@ -45,6 +45,27 @@ describe('moduleKeyPlugin: serverLoaders walking', () => {
     expect(out).toContain('__moduleKey: "src/pages/foo"');
   });
 
+  it('injects __moduleKey + __loaderName into serverRoute().loader(...) calls', () => {
+    const code = `
+      import { serverRoute } from '@hono-preact/iso';
+      const route = serverRoute('/movies/:id');
+      export const serverLoaders = {
+        summary: route.loader(async () => ({})),
+        cast: route.loader(async function* () { yield {}; }, { params: ['q'] }),
+      };
+    `;
+    const out = transform(code, '/Users/me/repo/src/pages/movie.server.ts');
+    // 1-arg .loader(): opts appended after the fn.
+    expect(out).toContain(
+      '__moduleKey: "src/pages/movie", __loaderName: "summary"'
+    );
+    // 2-arg .loader(fn, opts): merged into the existing opts object.
+    expect(out).toContain(
+      '__moduleKey: "src/pages/movie", __loaderName: "cast"'
+    );
+    expect(out).toContain("params: ['q']");
+  });
+
   it('does not inject opts when defineLoader already has a second arg', () => {
     const code = `
       import { defineLoader } from '@hono-preact/iso';

--- a/packages/vite/src/__tests__/server-loaders-parser.test.ts
+++ b/packages/vite/src/__tests__/server-loaders-parser.test.ts
@@ -117,6 +117,26 @@ describe('parseServerLoaders', () => {
     const [entry] = parseServerLoaders(program);
     expect(entry.optsArg).toBeNull();
   });
+
+  it('reads opts from the third arg for the route-id form', () => {
+    const program = parseProgram(`
+      export const serverLoaders = {
+        x: defineLoader('/things/:id', async () => ({}), { params: ['q'] }),
+      };
+    `);
+    const [entry] = parseServerLoaders(program);
+    expect(entry.optsArg?.type).toBe('ObjectExpression');
+  });
+
+  it('route-id form with no opts has optsArg === null', () => {
+    const program = parseProgram(`
+      export const serverLoaders = {
+        x: defineLoader('/things/:id', async () => ({})),
+      };
+    `);
+    const [entry] = parseServerLoaders(program);
+    expect(entry.optsArg).toBeNull();
+  });
 });
 
 describe('use exports', () => {

--- a/packages/vite/src/__tests__/server-loaders-parser.test.ts
+++ b/packages/vite/src/__tests__/server-loaders-parser.test.ts
@@ -137,6 +137,22 @@ describe('parseServerLoaders', () => {
     const [entry] = parseServerLoaders(program);
     expect(entry.optsArg).toBeNull();
   });
+
+  it('recognizes serverRoute().loader(...) factory calls', () => {
+    const program = parseProgram(`
+      const route = serverRoute('/things/:id');
+      export const serverLoaders = {
+        a: route.loader(async () => ({})),
+        b: route.loader(async () => ({}), { params: ['q'] }),
+      };
+    `);
+    const entries = parseServerLoaders(program);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].name).toBe('a');
+    expect(entries[0].optsArg).toBeNull();
+    expect(entries[1].name).toBe('b');
+    expect(entries[1].optsArg?.type).toBe('ObjectExpression');
+  });
 });
 
 describe('use exports', () => {

--- a/packages/vite/src/module-key-plugin.ts
+++ b/packages/vite/src/module-key-plugin.ts
@@ -7,7 +7,7 @@ import {
   LOADER_NAME_OPTION,
 } from '@hono-preact/iso/internal/runtime';
 import { deriveModuleKey } from './module-key.js';
-import { parseServerLoaders } from './server-loaders-parser.js';
+import { isLoaderCall, parseServerLoaders } from './server-loaders-parser.js';
 import { BABEL_PARSER_PLUGINS } from './parser-options.js';
 
 // Built from MODULE_KEY_EXPORT so the already-transformed check cannot
@@ -77,12 +77,7 @@ export function moduleKeyPlugin(): Plugin {
         node: CallExpression,
         loaderName: string | undefined
       ) => {
-        if (
-          node.callee.type !== 'Identifier' ||
-          node.callee.name !== 'defineLoader'
-        ) {
-          return;
-        }
+        if (!isLoaderCall(node)) return;
         const args = node.arguments;
         if (args.length === 0) return;
 

--- a/packages/vite/src/module-key-plugin.ts
+++ b/packages/vite/src/module-key-plugin.ts
@@ -83,35 +83,52 @@ export function moduleKeyPlugin(): Plugin {
         ) {
           return;
         }
-        if (node.arguments.length === 0 || node.arguments.length > 2) return;
-        const fnArg = node.arguments[0];
-        if (fnArg.type === 'StringLiteral') return; // not a valid defineLoader fn form; skip
+        const args = node.arguments;
+        if (args.length === 0) return;
 
-        if (node.arguments.length === 1) {
-          const insertAt = fnArg.end;
-          if (insertAt == null) return;
-          const namePart = loaderName
-            ? `, ${LOADER_NAME_OPTION}: ${JSON.stringify(loaderName)}`
-            : '';
+        const namePartAfter = loaderName
+          ? `, ${LOADER_NAME_OPTION}: ${JSON.stringify(loaderName)}`
+          : '';
+        const namePartBefore = loaderName
+          ? `${LOADER_NAME_OPTION}: ${JSON.stringify(loaderName)}, `
+          : '';
+        const appendOptsAfter = (afterEnd: number) =>
+          s.appendRight(
+            afterEnd,
+            `, { ${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}${namePartAfter} }`
+          );
+        const mergeInto = (opts: (typeof args)[number]) => {
+          if (opts.type !== 'ObjectExpression') return;
+          const insertAt = opts.properties[0]?.start ?? opts.start! + 1;
           s.appendRight(
             insertAt,
-            `, { ${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}${namePart} }`
+            `${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}, ${namePartBefore}`
           );
+        };
+
+        const isRouteForm = args[0].type === 'StringLiteral';
+        if (isRouteForm) {
+          // defineLoader('/r/:id', fn) | defineLoader('/r/:id', fn, opts)
+          if (args.length < 2 || args.length > 3) return;
+          if (args.length === 2) {
+            const fnEnd = args[1].end;
+            if (fnEnd == null) return;
+            appendOptsAfter(fnEnd);
+          } else {
+            mergeInto(args[2]);
+          }
           return;
         }
 
-        // arguments.length === 2: merge __moduleKey/__loaderName into the
-        // existing opts object literal. Bail if it isn't an ObjectExpression.
-        const optsArg = node.arguments[1];
-        if (optsArg.type !== 'ObjectExpression') return;
-        const insertAt = optsArg.properties[0]?.start ?? optsArg.start! + 1;
-        const namePart = loaderName
-          ? `${LOADER_NAME_OPTION}: ${JSON.stringify(loaderName)}, `
-          : '';
-        s.appendRight(
-          insertAt,
-          `${MODULE_KEY_EXPORT}: ${JSON.stringify(key)}, ${namePart}`
-        );
+        // fn-first form: defineLoader(fn) | defineLoader(fn, opts)
+        if (args.length > 2) return;
+        if (args.length === 1) {
+          const fnEnd = args[0].end;
+          if (fnEnd == null) return;
+          appendOptsAfter(fnEnd);
+          return;
+        }
+        mergeInto(args[1]);
       };
 
       // Walk serverLoaders entries via the shared parser, then mutate each call.

--- a/packages/vite/src/server-loaders-parser.ts
+++ b/packages/vite/src/server-loaders-parser.ts
@@ -61,11 +61,31 @@ export function findUseExports(program: Program): ParsedUseExport[] {
 export type ParsedLoaderEntry = {
   /** Loader name (the key in serverLoaders, e.g. "summary"). */
   name: string;
-  /** The defineLoader(...) CallExpression node -- for AST-mutation consumers. */
+  /** The loader CallExpression node -- for AST-mutation consumers. */
   call: CallExpression;
-  /** The opts ObjectExpression if defineLoader has 2 args; otherwise null. */
+  /** The opts ObjectExpression if the call has an opts arg; otherwise null. */
   optsArg: ObjectExpression | null;
 };
+
+/**
+ * Whether a call expression produces a loader inside `serverLoaders`. Matches
+ * both `defineLoader(...)` and the `serverRoute(...).loader(...)` /
+ * `route.loader(...)` factory form (a non-computed `.loader` member call). The
+ * `serverLoaders` contract guarantees its values are `LoaderRef`s, and only
+ * these two forms produce them, so matching `.loader(...)` here is safe.
+ */
+export function isLoaderCall(call: CallExpression): boolean {
+  const callee = call.callee;
+  if (callee.type === 'Identifier' && callee.name === 'defineLoader') {
+    return true;
+  }
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'loader'
+  );
+}
 
 /**
  * Walk a parsed program for `export const serverLoaders = { name: defineLoader(fn, opts?), ... }`.
@@ -101,11 +121,7 @@ export function parseServerLoaders(program: Program): ParsedLoaderEntry[] {
           continue;
 
         const call = prop.value as CallExpression;
-        if (
-          call.callee.type !== 'Identifier' ||
-          call.callee.name !== 'defineLoader'
-        )
-          continue;
+        if (!isLoaderCall(call)) continue;
 
         // The route-id overload `defineLoader('/r/:id', fn, opts?)` shifts the
         // opts object to the third argument; the fn-first form keeps it second.

--- a/packages/vite/src/server-loaders-parser.ts
+++ b/packages/vite/src/server-loaders-parser.ts
@@ -107,10 +107,15 @@ export function parseServerLoaders(program: Program): ParsedLoaderEntry[] {
         )
           continue;
 
-        const secondArg = call.arguments[1];
+        // The route-id overload `defineLoader('/r/:id', fn, opts?)` shifts the
+        // opts object to the third argument; the fn-first form keeps it second.
+        const isRouteForm = call.arguments[0]?.type === 'StringLiteral';
+        const optsCandidate = isRouteForm
+          ? call.arguments[2]
+          : call.arguments[1];
         const optsArg =
-          secondArg?.type === 'ObjectExpression'
-            ? (secondArg as ObjectExpression)
+          optsCandidate?.type === 'ObjectExpression'
+            ? (optsCandidate as ObjectExpression)
             : null;
 
         entries.push({ name: prop.key.name, call, optsArg });


### PR DESCRIPTION
## Summary

Section C primitive #4: full, validated route-param inference, TanStack-style, with **no codegen** of source and **no new dependency**. You name a route once, the name is checked against your real route table, and the params are derived from the route's pattern.

- `useParams('/demo/projects/:projectId')` returns `{ projectId: string }` (replaces a `pathParams as {...}` cast in the site).
- `defineLoader('/demo/projects/:projectId/issues/:issueId', fn)` types `ctx.location.pathParams` from the route pattern (replaces stringly `pathParams.id` access).
- One-time registration: `declare module 'hono-preact' { interface RegisteredRoutes { paths: RoutePaths<typeof routeTree> } }`.

The type engine (`AbsolutePaths` + `RouteParams`) is ~45 lines of template-literal types in `packages/iso/src/internal/typed-routes.ts`. Before registration, `useParams` degrades gracefully (accepts any string, projects its params).

## Notable design points

- **`defineRoutes<const T>`** preserves the literal route tree (`RouteDef.children` widened to `readonly`, `RoutesManifest<T>` gains a phantom `__tree`). Backward-compatible via the default type parameter.
- **`defineLoader(routeId, fn)` is a new overload**; the existing Vite `moduleKeyPlugin` is taught the new arity so `__moduleKey` is still threaded (it previously skipped string-first calls). This is the only build-transform change, and it is maintenance to an existing transform, not new codegen.
- **Register against the route tree, not the manifest.** Keying off `typeof routes` (the `defineRoutes` return) forms a type cycle, and the type engine is deliberately **structural** (reads `path` + `view`/`layout` key presence, never constrains nodes to `RouteDef`) so deriving the paths never resolves the leaf modules that themselves consume the registry. A compile-time oracle (`apps/site/src/typed-route-params.assert.ts`) plus the dogfood prove the registration actually constrains `useParams` end-to-end.

Spec: `docs/superpowers/specs/2026-06-12-typed-route-params-design.md`. Plan: `docs/superpowers/plans/2026-06-12-typed-route-params.md`.

## Test Plan

- [x] `pnpm --filter '@hono-preact/*' --filter hono-preact build`
- [x] `pnpm format:check`
- [x] `pnpm typecheck` (includes the site type-shape oracle)
- [x] `pnpm test` (1208 pass; one worker-start flake under load, confirmed passing in isolation)
- [x] `pnpm test:integration` (4/4)
- [x] `pnpm --filter site build` (confirms the route-id loader codegen end-to-end)
- [x] New unit tests: `use-params.test.tsx`, `define-loader-route-id.test.ts`, updated `module-key-plugin.test.ts` + `server-loaders-parser.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)