### PR TITLE
refactor(ui): dedup Arrow part + PositionerContext (Section E)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-arrow-positioner-context-dedup.md
+++ b/docs/superpowers/plans/2026-06-14-arrow-positioner-context-dedup.md
@@ -1,0 +1,1023 @@
+# Arrow + PositionerContext dedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the five byte-identical `Arrow` parts with one shared `Arrow` component, and delete the position-state round-trip that exists only so the Arrow can read the resolved position.
+
+**Architecture:** The Positioner part provides the resolved position and the arrow ref through a small shared `PositionerContext`; one shared `Arrow` consumes it. `usePositioner` owns the arrow ref and returns the position it already computes, so `position`/`setPosition`/`arrowRef` leave all five main contexts and `useMenuCore`. Migration is incremental: `usePositioner` is first made additive/back-compatible (Task 3), each component migrates independently while the build stays green (Tasks 4-8), then the temporary compatibility shim is removed (Task 9).
+
+**Tech Stack:** Preact, TypeScript, Vitest + @testing-library/preact (happy-dom), `@hono-preact/ui` (private, unpublished).
+
+**Spec:** `docs/superpowers/specs/2026-06-14-arrow-positioner-context-dedup-design.md`
+
+**Conventions for every task:**
+- Work on a feature branch (verify with `git branch --show-current` before each commit; never commit to `main`).
+- Run `pnpm format` before committing so committed files are Prettier-clean (the committed state, not just the working tree, must pass `format:check`).
+- `noUnusedLocals`/`noUnusedParameters` are on: after removing a field, delete any now-unused import (e.g. `PositionState`) or `pnpm --filter @hono-preact/ui exec tsc --noEmit` fails. That failure is the signal, not a surprise.
+- Focused test run: `pnpm exec vitest run <path/to/test>`. Per-package typecheck: `pnpm --filter @hono-preact/ui exec tsc --noEmit`.
+
+---
+
+## File structure
+
+| File | Responsibility | Task |
+|------|----------------|------|
+| `packages/ui/src/positioner-context.ts` (new) | The shared `PositionerContext` + `usePositionerContext()` | 1 |
+| `packages/ui/src/arrow.tsx` (new) | The single shared `Arrow` component + `ArrowProps` | 2 |
+| `packages/ui/src/__tests__/arrow.test.tsx` (new) | Tests for the shared Arrow + the context guard | 2 |
+| `packages/ui/src/use-positioner.ts` | Own arrowRef, return `position`+`arrowRef`, drop the publish round-trip | 3, 9 |
+| `packages/ui/src/__tests__/use-positioner.test.tsx` | Adapt to the new return shape | 3 |
+| `packages/ui/src/popover/{popover.tsx,context.ts}` | Migrate Popover | 4 |
+| `packages/ui/src/tooltip/{tooltip.tsx,context.ts}` | Migrate Tooltip | 5 |
+| `packages/ui/src/menu/{menu.tsx,context.ts,use-menu-core.ts}` | Migrate Menu (covers ContextMenu + Submenu) | 6 |
+| `packages/ui/src/select/{select.tsx,context.ts}` | Migrate Select | 7 |
+| `packages/ui/src/combobox/{combobox.tsx,context.ts}` | Migrate Combobox | 8 |
+
+The index files (`*/index.ts`) are **not** modified: each component file re-exports the shared `Arrow` under its old name (`export { Arrow as PopoverArrow }`), so the existing namespace wiring (`Arrow: PopoverArrow`) keeps working unchanged.
+
+---
+
+## Task 1: PositionerContext
+
+**Files:**
+- Create: `packages/ui/src/positioner-context.ts`
+- Test: `packages/ui/src/__tests__/positioner-context.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ui/src/__tests__/positioner-context.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { h } from 'preact';
+import {
+  PositionerContext,
+  usePositionerContext,
+} from '../positioner-context.js';
+
+afterEach(cleanup);
+
+function Consumer() {
+  const { position } = usePositionerContext();
+  return <span data-testid="side">{position.side}</span>;
+}
+
+describe('usePositionerContext', () => {
+  it('returns the provided value inside a provider', () => {
+    function Wrapper() {
+      const arrowRef = useRef<HTMLElement>(null);
+      return h(
+        PositionerContext.Provider,
+        {
+          value: {
+            position: { side: 'top', align: 'center', arrowX: null, arrowY: null },
+            arrowRef,
+          },
+        },
+        <Consumer />
+      );
+    }
+    const { getByTestId } = render(<Wrapper />);
+    expect(getByTestId('side').textContent).toBe('top');
+  });
+
+  it('throws when used outside a provider', () => {
+    expect(() => render(<Consumer />)).toThrow(
+      '<Arrow> must be rendered inside a Positioner'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/positioner-context.test.tsx`
+Expected: FAIL (`Cannot find module '../positioner-context.js'`).
+
+- [ ] **Step 3: Create the context**
+
+Create `packages/ui/src/positioner-context.ts`:
+
+```ts
+import { createContext, type RefObject } from 'preact';
+import { useContext } from 'preact/hooks';
+import type { PositionState } from './use-position.js';
+
+// Provided by each component's Positioner part, consumed by the shared Arrow.
+// Small sibling context in the spirit of SelectOptionGroupContext: it carries
+// only what the Arrow needs (the resolved position + the ref it attaches to),
+// so position changes no longer invalidate the component's main context.
+export interface PositionerContextValue {
+  position: PositionState;
+  arrowRef: RefObject<HTMLElement>;
+}
+
+export const PositionerContext = createContext<PositionerContextValue | null>(
+  null
+);
+
+export function usePositionerContext(): PositionerContextValue {
+  const ctx = useContext(PositionerContext);
+  if (!ctx) {
+    throw new Error('<Arrow> must be rendered inside a Positioner');
+  }
+  return ctx;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/positioner-context.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/positioner-context.ts packages/ui/src/__tests__/positioner-context.test.tsx
+git commit -m "feat(ui): add shared PositionerContext for Arrow"
+```
+
+---
+
+## Task 2: Shared Arrow component
+
+**Files:**
+- Create: `packages/ui/src/arrow.tsx`
+- Test: `packages/ui/src/__tests__/arrow.test.tsx`
+
+The body is lifted verbatim from the five existing `*Arrow` functions; the only change is reading `position`/`arrowRef` from `usePositionerContext()` instead of a per-component context.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/ui/src/__tests__/arrow.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { h } from 'preact';
+import { Arrow } from '../arrow.js';
+import { PositionerContext } from '../positioner-context.js';
+import type { PositionState } from '../use-position.js';
+
+afterEach(cleanup);
+
+function withPosition(position: PositionState, child: preact.VNode) {
+  function Wrapper() {
+    const arrowRef = useRef<HTMLElement>(null);
+    return h(PositionerContext.Provider, { value: { position, arrowRef } }, child);
+  }
+  return <Wrapper />;
+}
+
+describe('Arrow', () => {
+  it('renders data-side and the absolute offset from the provided position', () => {
+    const { container } = render(
+      withPosition(
+        { side: 'right', align: 'center', arrowX: 12, arrowY: 34 },
+        <Arrow data-testid="arrow" />
+      )
+    );
+    const el = container.querySelector('[data-testid="arrow"]') as HTMLElement;
+    expect(el.getAttribute('data-side')).toBe('right');
+    expect(el.style.position).toBe('absolute');
+    expect(el.style.left).toBe('12px');
+    expect(el.style.top).toBe('34px');
+  });
+
+  it('omits left/top when arrowX/arrowY are null', () => {
+    const { container } = render(
+      withPosition(
+        { side: 'top', align: 'center', arrowX: null, arrowY: null },
+        <Arrow data-testid="arrow" />
+      )
+    );
+    const el = container.querySelector('[data-testid="arrow"]') as HTMLElement;
+    expect(el.style.left).toBe('');
+    expect(el.style.top).toBe('');
+  });
+
+  it('throws when rendered outside a Positioner', () => {
+    expect(() => render(<Arrow />)).toThrow(
+      '<Arrow> must be rendered inside a Positioner'
+    );
+  });
+
+  it('reads the nearest Positioner when providers are nested (submenu case)', () => {
+    function Nested() {
+      const outerRef = useRef<HTMLElement>(null);
+      const innerRef = useRef<HTMLElement>(null);
+      return h(
+        PositionerContext.Provider,
+        {
+          value: {
+            position: { side: 'top', align: 'center', arrowX: null, arrowY: null },
+            arrowRef: outerRef,
+          },
+        },
+        h(
+          PositionerContext.Provider,
+          {
+            value: {
+              position: { side: 'left', align: 'center', arrowX: null, arrowY: null },
+              arrowRef: innerRef,
+            },
+          },
+          <Arrow data-testid="inner-arrow" />
+        )
+      );
+    }
+    const { container } = render(<Nested />);
+    const el = container.querySelector(
+      '[data-testid="inner-arrow"]'
+    ) as HTMLElement;
+    expect(el.getAttribute('data-side')).toBe('left');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/arrow.test.tsx`
+Expected: FAIL (`Cannot find module '../arrow.js'`).
+
+- [ ] **Step 3: Create the shared Arrow**
+
+Create `packages/ui/src/arrow.tsx`:
+
+```tsx
+import { type ComponentChildren, type JSX, type VNode } from 'preact';
+import { renderElement, type RenderProp } from './use-render.js';
+import type { Side } from './use-position.js';
+import { usePositionerContext } from './positioner-context.js';
+
+export type ArrowProps = {
+  render?: RenderProp<{ side: Side }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+// One Arrow for every overlay. Reads the resolved position from the enclosing
+// Positioner (via PositionerContext) and attaches the ref floating-ui measures.
+export function Arrow(props: ArrowProps): VNode {
+  const { render, children, ...rest } = props;
+  const { position, arrowRef } = usePositionerContext();
+  const { side, arrowX, arrowY } = position;
+  return renderElement<{ side: Side }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: arrowRef,
+      'data-side': side,
+      style: {
+        position: 'absolute',
+        left: arrowX != null ? `${arrowX}px` : undefined,
+        top: arrowY != null ? `${arrowY}px` : undefined,
+      },
+    },
+    state: { side },
+    children,
+  });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/arrow.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/arrow.tsx packages/ui/src/__tests__/arrow.test.tsx
+git commit -m "feat(ui): add shared Arrow component"
+```
+
+---
+
+## Task 3: usePositioner owns arrowRef and returns the position (additive)
+
+This change is **back-compatible**: existing callers keep passing `arrowRef`/`setPosition` (now optional), behavior is identical, and the new `position`/`arrowRef` return values let each component migrate independently in Tasks 4-8. The publish round-trip is kept here (guarded) and removed in Task 9.
+
+**Files:**
+- Modify: `packages/ui/src/use-positioner.ts`
+- Test: `packages/ui/src/__tests__/use-positioner.test.tsx`
+
+Current `UsePositionerOptions` (lines 28-46) declares `arrowRef: RefObject<HTMLElement>` and `setPosition: (p: PositionState) => void` as required. Current `UsePositionerResult` (lines 56-62) returns `{ isPresent, positionerProps, state }`. The hook receives `opts.arrowRef`, passes it to `usePosition`, and publishes via a `useLayoutEffect` calling `opts.setPosition(position)` (lines 79-81).
+
+- [ ] **Step 1: Update the test first (new return shape)**
+
+Replace `packages/ui/src/__tests__/use-positioner.test.tsx` with:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { usePositioner } from '../use-positioner.js';
+import type { ClientRectGetter } from '../use-position.js';
+
+afterEach(cleanup);
+
+function Harness(props: {
+  open: boolean;
+  mount: 'unmount' | 'hidden';
+  getAnchorRect?: ClientRectGetter;
+  onSide?: (side: string) => void;
+}) {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+  const { isPresent, positionerProps, position, arrowRef } = usePositioner({
+    open: props.open,
+    anchorRef,
+    floatingRef,
+    side: 'bottom',
+    align: 'start',
+    offset: 8,
+    getAnchorRect: props.getAnchorRect,
+    mount: props.mount,
+  });
+  props.onSide?.(position.side);
+  return (
+    <div>
+      <button ref={anchorRef}>anchor</button>
+      <span data-testid="present">{String(isPresent)}</span>
+      <span data-testid="has-arrow-ref">{String(arrowRef != null)}</span>
+      {props.mount === 'unmount' && !isPresent ? null : (
+        <div data-testid="floating" {...positionerProps} />
+      )}
+    </div>
+  );
+}
+
+describe('usePositioner', () => {
+  it('unmount mode: not present when closed, present when open', () => {
+    const closed = render(<Harness open={false} mount="unmount" />);
+    expect(closed.getByTestId('present').textContent).toBe('false');
+    expect(closed.queryByTestId('floating')).toBeNull();
+    cleanup();
+    const open = render(<Harness open mount="unmount" />);
+    expect(open.getByTestId('present').textContent).toBe('true');
+    expect(open.queryByTestId('floating')).not.toBeNull();
+    expect(open.getByTestId('floating').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('hidden mode: stays mounted; hidden toggles with open', () => {
+    const closed = render(<Harness open={false} mount="hidden" />);
+    expect(closed.queryByTestId('floating')).not.toBeNull();
+    expect(closed.getByTestId('floating').hasAttribute('hidden')).toBe(true);
+    cleanup();
+    const open = render(<Harness open mount="hidden" />);
+    expect(open.getByTestId('floating').hasAttribute('hidden')).toBe(false);
+  });
+
+  it('emits the neutralize style and data-side/data-align', () => {
+    const { getByTestId } = render(<Harness open mount="unmount" />);
+    const el = getByTestId('floating');
+    expect(el.style.position).toBe('fixed');
+    expect(el.getAttribute('data-side')).toBe('bottom');
+    expect(el.getAttribute('data-align')).toBe('start');
+  });
+
+  it('returns the resolved position and owns an arrow ref', () => {
+    const seen: string[] = [];
+    const { getByTestId } = render(
+      <Harness open mount="unmount" onSide={(s) => seen.push(s)} />
+    );
+    expect(getByTestId('has-arrow-ref').textContent).toBe('true');
+    expect(seen[seen.length - 1]).toBe('bottom');
+  });
+
+  it('forwards getAnchorRect to usePosition', async () => {
+    const getAnchorRect = vi.fn(() => ({
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    }));
+    render(<Harness open mount="unmount" getAnchorRect={getAnchorRect} />);
+    await waitFor(() => expect(getAnchorRect).toHaveBeenCalled());
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-positioner.test.tsx`
+Expected: FAIL (`position`/`arrowRef` are not on the result type/value yet).
+
+- [ ] **Step 3: Make arrowRef/setPosition optional, own the ref, return position+arrowRef**
+
+In `packages/ui/src/use-positioner.ts`:
+
+Add `useRef` to the hooks import (line 2):
+
+```ts
+import { useLayoutEffect, useRef } from 'preact/hooks';
+```
+
+In `UsePositionerOptions` (around lines 33 and 41), make these two optional. Replace the `arrowRef` line with:
+
+```ts
+  // Optional during the migration to PositionerContext: when omitted the hook
+  // creates and owns the ref. Removed once every component stops passing it.
+  arrowRef?: RefObject<HTMLElement>;
+```
+
+and replace the `setPosition` lines (40-41) with:
+
+```ts
+  // Optional legacy publish hook (pre-PositionerContext); removed once every
+  // component reads the position from the hook return instead.
+  setPosition?: (p: PositionState) => void;
+```
+
+In `UsePositionerResult` (lines 56-62), add `position` and `arrowRef`:
+
+```ts
+export interface UsePositionerResult {
+  isPresent: boolean;
+  positionerProps: PositionerProps;
+  state: { side: Side; align: Align };
+  // The resolved position, for a Positioner to publish via PositionerContext.
+  position: PositionState;
+  // The ref floating-ui measures and the Arrow attaches to.
+  arrowRef: RefObject<HTMLElement>;
+}
+```
+
+In the `usePositioner` body (line 64+), resolve the ref and pass it to `usePosition`. Immediately after `const presence = usePresence(opts.open);` add:
+
+```ts
+  const ownArrowRef = useRef<HTMLElement>(null);
+  const arrowRef = opts.arrowRef ?? ownArrowRef;
+```
+
+Change the `usePosition` call's `arrowRef: opts.arrowRef` to `arrowRef,`. Guard the publish effect (lines 79-81):
+
+```ts
+  // Legacy publish to the Root (back-compat during migration). No-op once a
+  // component reads `position` from this hook's return instead.
+  useLayoutEffect(() => {
+    opts.setPosition?.(position);
+  }, [position.side, position.align, position.arrowX, position.arrowY]);
+```
+
+In the `return` (lines 106-116), add `position` and `arrowRef`, and use the resolved `arrowRef` in `mergeRefs`:
+
+```ts
+  return {
+    isPresent: presence.isPresent,
+    positionerProps: {
+      ref: mergeRefs(opts.floatingRef, presence.ref),
+      hidden: opts.mount === 'hidden' && !presence.isPresent ? true : undefined,
+      'data-side': position.side,
+      'data-align': position.align,
+      style: POSITIONER_STYLE,
+    },
+    state: { side: position.side, align: position.align },
+    position,
+    arrowRef,
+  };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/use-positioner.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Verify no component broke (back-compat)**
+
+Run: `pnpm --filter @hono-preact/ui exec tsc --noEmit`
+Expected: PASS (existing Positioners still pass `arrowRef`/`setPosition`, now optional).
+
+Run: `pnpm exec vitest run packages/ui`
+Expected: PASS (whole ui suite; behavior unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/use-positioner.ts packages/ui/src/__tests__/use-positioner.test.tsx
+git commit -m "refactor(ui): usePositioner owns arrowRef and returns position"
+```
+
+---
+
+## Task 4: Migrate Popover
+
+**Files:**
+- Modify: `packages/ui/src/popover/popover.tsx`, `packages/ui/src/popover/context.ts`
+
+- [ ] **Step 1: Strip position-state from the context type**
+
+In `packages/ui/src/popover/context.ts`, remove these three lines from `PopoverContextValue` (lines 12, 22-23):
+
+```ts
+  arrowRef: RefObject<HTMLElement>;   // line 12
+  position: PositionState;            // line 22
+  setPosition: (p: PositionState) => void;  // line 23
+```
+
+Then fix imports: `PositionState` (line 4) is now unused, remove it; `RefObject` is still used (anchorRef/floatingRef/popupRef), keep it. The line-4 import becomes:
+
+```ts
+import type { Side, Align } from '../use-position.js';
+```
+
+- [ ] **Step 2: Strip position-state from the Root, wire the Positioner + Arrow**
+
+In `packages/ui/src/popover/popover.tsx`:
+
+Add imports near the top (after the existing `usePositioner` import on line 16):
+
+```ts
+import { PositionerContext } from '../positioner-context.js';
+```
+
+Remove `const arrowRef = useRef<HTMLElement>(null);` (line 49). Remove the `const [position, setPosition] = useState<PositionState>({...})` block (lines 63-68). Remove `arrowRef`, `position`, `setPosition` from the `ctx` object (lines 77, 87-88) and remove `position` from the memo dep array (line 102). The `PositionState` import (line 15) and `useState` (line 9) are now unused in this file — remove `PositionState` from the line-15 import (keep `Side`, `Align`), and remove `useState` from the line 4-10 hooks import **only if** nothing else in the file uses it (it is used only by the removed block, so remove it).
+
+Rewrite `PopoverPositioner` (lines 168-190) to drop the `arrowRef`/`setPosition` args, memoize the context value, and wrap the output:
+
+```tsx
+export function PopoverPositioner(props: PopoverPositionerProps): VNode | null {
+  const { render, children, ...rest } = props;
+  const ctx = usePopoverContext('Positioner');
+  const { isPresent, positionerProps, state, position, arrowRef } =
+    usePositioner({
+      open: ctx.open,
+      anchorRef: ctx.anchorRef,
+      floatingRef: ctx.floatingRef,
+      side: ctx.side,
+      align: ctx.align,
+      offset: ctx.offset,
+      mount: 'unmount',
+    });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
+  if (!isPresent) return null;
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
+}
+```
+
+Replace the entire `PopoverArrow` function and `PopoverArrowProps` type (lines 229-254) with a re-export of the shared Arrow:
+
+```tsx
+export { Arrow as PopoverArrow, type ArrowProps as PopoverArrowProps } from '../arrow.js';
+```
+
+(`useMemo` and `h` are already imported in this file.)
+
+- [ ] **Step 2b: Confirm an existing Arrow test is covered**
+
+The shared Arrow is exercised by `arrow.test.tsx` (Task 2). There is no popover-specific Arrow test to migrate (Popover's tests cover Trigger/Popup/Positioner/SSR). If `popover-parts.test.tsx` renders an Arrow, verify it nests it under `Popover.Positioner`; it already does (the demos and tests follow `Positioner > Popup > Arrow`).
+
+- [ ] **Step 3: Typecheck (catches any leftover unused import)**
+
+Run: `pnpm --filter @hono-preact/ui exec tsc --noEmit`
+Expected: PASS. If it reports an unused `PositionState`/`useState`/`RefObject`, remove that import and re-run.
+
+- [ ] **Step 4: Run the Popover tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/popover-root.test.tsx packages/ui/src/__tests__/popover-parts.test.tsx packages/ui/src/__tests__/popover-popup.test.tsx packages/ui/src/__tests__/popover-anchor.test.tsx packages/ui/src/__tests__/popover-presence.test.tsx packages/ui/src/__tests__/popover-ssr.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm format
+git add packages/ui/src/popover/
+git commit -m "refactor(ui): migrate Popover Arrow to PositionerContext"
+```
+
+---
+
+## Task 5: Migrate Tooltip
+
+**Files:**
+- Modify: `packages/ui/src/tooltip/tooltip.tsx`, `packages/ui/src/tooltip/context.ts`
+
+- [ ] **Step 1: Strip position-state from the context type**
+
+In `packages/ui/src/tooltip/context.ts`, remove `arrowRef` (line 15), `position` (line 21), and `setPosition` (line 22) from `TooltipContextValue`. `PositionState` is then unused; change the line-4 import to `import type { Side, Align } from '../use-position.js';` (keep the separate `RefObject` import on line 2).
+
+- [ ] **Step 2: Strip the Root, wire the Positioner + Arrow**
+
+In `packages/ui/src/tooltip/tooltip.tsx`:
+
+Add `import { PositionerContext } from '../positioner-context.js';`.
+
+Remove `const arrowRef = useRef<HTMLElement>(null);` (line 52). Remove the `const [position, setPosition] = useState<PositionState>({...})` block (lines 78-83). Remove `arrowRef`, `position`, `setPosition` from the `ctx` object (lines 93, 99-100) and `position` from the memo deps (line 112). Remove the now-unused `PositionState` import and `useState` (used only by the removed block).
+
+Rewrite `TooltipPositioner` (lines 186-208):
+
+```tsx
+export function TooltipPositioner(props: TooltipPositionerProps): VNode | null {
+  const { render, children, ...rest } = props;
+  const ctx = useTooltipContext('Positioner');
+  const { isPresent, positionerProps, state, position, arrowRef } =
+    usePositioner({
+      open: ctx.open,
+      anchorRef: ctx.anchorRef,
+      floatingRef: ctx.floatingRef,
+      side: ctx.side,
+      align: ctx.align,
+      offset: ctx.offset,
+      mount: 'unmount',
+    });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
+  if (!isPresent) return null;
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
+}
+```
+
+Replace the `TooltipArrow` function + `TooltipArrowProps` type (lines 271-296) with:
+
+```tsx
+export { Arrow as TooltipArrow, type ArrowProps as TooltipArrowProps } from '../arrow.js';
+```
+
+Confirm `useMemo` is imported (tooltip Root uses it, so it is). If `useMemo` were missing, add it to the `preact/hooks` import.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @hono-preact/ui exec tsc --noEmit`
+Expected: PASS (remove any leftover unused import it flags).
+
+- [ ] **Step 4: Run the Tooltip tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/tooltip-trigger.test.tsx packages/ui/src/__tests__/tooltip-popup.test.tsx packages/ui/src/__tests__/tooltip-presence.test.tsx packages/ui/src/__tests__/tooltip-safe-area.test.tsx packages/ui/src/__tests__/tooltip-ssr.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm format
+git add packages/ui/src/tooltip/
+git commit -m "refactor(ui): migrate Tooltip Arrow to PositionerContext"
+```
+
+---
+
+## Task 6: Migrate Menu (covers Menu, ContextMenu, Submenu)
+
+Menu, ContextMenu, and Submenu share `useMenuCore`, `MenuContext`, `MenuPositioner`, and `MenuArrow`, so migrating those four migrates all three variants. ContextMenu and Submenu need no edits of their own.
+
+**Files:**
+- Modify: `packages/ui/src/menu/use-menu-core.ts`, `packages/ui/src/menu/context.ts`, `packages/ui/src/menu/menu.tsx`
+
+- [ ] **Step 1: Strip position-state from MenuContextValue**
+
+In `packages/ui/src/menu/context.ts`, remove `arrowRef` (line 26), `position` (line 39), and `setPosition` (line 40) from `MenuContextValue`. Remove the now-unused `PositionState` from the line 4-9 import (keep `Side`, `Align`, `ClientRectGetter`); remove `RefObject` **only if** unused (it is still used by `anchorRef`/`floatingRef`/`popupRef`/`pendingEdgeRef`, so keep it).
+
+- [ ] **Step 2: Strip position-state from useMenuCore**
+
+In `packages/ui/src/menu/use-menu-core.ts`:
+
+Remove `arrowRef` from the `MenuCore` interface (line 34), and `position`/`setPosition` (lines 41-42). Remove `const arrowRef = useRef<HTMLElement>(null);` (line 69) and the `const [position, setPosition] = useState<PositionState>({...})` block (lines 77-82). Remove `arrowRef`, `position`, `setPosition` from the `menuCtx` object (lines 116, 127-128) and `position` from its memo deps (line 142). Remove `arrowRef`, `position`, `setPosition` from the final return object (lines 158, 165-166).
+
+Fix imports: `PositionState` (line 4) is now unused, remove it (keep `Side`, `Align`); `useState` is still used (`activeId`), keep it; `useRef` is still used (`floatingRef`, `popupRef`, `anchorRef`, `pendingEdgeRef`, `pointRef`), keep it.
+
+- [ ] **Step 3: Wire the Positioner + Arrow in menu.tsx**
+
+In `packages/ui/src/menu/menu.tsx`:
+
+Add `import { PositionerContext } from '../positioner-context.js';`.
+
+Rewrite `MenuPositioner` (lines 182-205), keeping `getAnchorRect` (ContextMenu needs it) and dropping `arrowRef`/`setPosition`:
+
+```tsx
+export function MenuPositioner(props: MenuPositionerProps): VNode | null {
+  const { render, children, ...rest } = props;
+  const ctx = useMenuContext('Positioner');
+  const { isPresent, positionerProps, state, position, arrowRef } =
+    usePositioner({
+      open: ctx.open,
+      anchorRef: ctx.anchorRef,
+      floatingRef: ctx.floatingRef,
+      side: ctx.side,
+      align: ctx.align,
+      offset: ctx.offset,
+      getAnchorRect: ctx.getAnchorRect,
+      mount: 'unmount',
+    });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
+  if (!isPresent) return null;
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
+}
+```
+
+Replace the `MenuArrow` function + `MenuArrowProps` type (lines 538-563) with:
+
+```tsx
+export { Arrow as MenuArrow, type ArrowProps as MenuArrowProps } from '../arrow.js';
+```
+
+Confirm `useMemo` is imported in menu.tsx; if not, add it to the `preact/hooks` import.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm --filter @hono-preact/ui exec tsc --noEmit`
+Expected: PASS (remove any leftover unused import it flags).
+
+- [ ] **Step 5: Run the Menu / ContextMenu / Submenu tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/menu-trigger.test.tsx packages/ui/src/__tests__/menu-item.test.tsx packages/ui/src/__tests__/menu-structure.test.tsx packages/ui/src/__tests__/menu-checkable.test.tsx packages/ui/src/__tests__/menu-navigation-dom.test.tsx packages/ui/src/__tests__/menu-presence.test.tsx packages/ui/src/__tests__/menu-ssr.test.tsx packages/ui/src/__tests__/menu-submenu.test.tsx packages/ui/src/__tests__/menu-submenu-safe-area.test.tsx packages/ui/src/__tests__/context-menu.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+pnpm format
+git add packages/ui/src/menu/
+git commit -m "refactor(ui): migrate Menu/ContextMenu/Submenu Arrow to PositionerContext"
+```
+
+---
+
+## Task 7: Migrate Select
+
+Select uses `mount: 'hidden'` (always rendered), so its Positioner has no `if (!isPresent) return null` gate.
+
+**Files:**
+- Modify: `packages/ui/src/select/select.tsx`, `packages/ui/src/select/context.ts`
+
+- [ ] **Step 1: Strip position-state from the context type**
+
+In `packages/ui/src/select/context.ts`, remove `arrowRef` (line 23), `position` (line 33), and `setPosition` (line 34) from `SelectContextValue`. Remove the now-unused `PositionState` import (keep `Side`, `Align`, `RefObject`).
+
+- [ ] **Step 2: Strip the Root, wire the Positioner + Arrow**
+
+In `packages/ui/src/select/select.tsx`:
+
+Add `import { PositionerContext } from '../positioner-context.js';`.
+
+Remove `const arrowRef = useRef<HTMLElement>(null);` (line 93) and the `const [position, setPosition] = useState<PositionState>({...})` block (lines 98-103). Remove `arrowRef`, `position`, `setPosition` from the `ctx` object (lines 132, 142-143) and `position` from the memo deps. Remove the now-unused `PositionState` import. `useState` is still used (`activeId`), keep it.
+
+Rewrite `SelectPositioner` (lines 300-324) - note: no `isPresent` gate (hidden mount):
+
+```tsx
+export function SelectPositioner(props: SelectPositionerProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useSelectContext('Positioner');
+  // Always rendered (mount: 'hidden') so options register their labels; the
+  // hook drives `hidden` while not present, which composes with the top-layer
+  // promotion (active only while present).
+  const { positionerProps, state, position, arrowRef } = usePositioner({
+    open: ctx.open,
+    anchorRef: ctx.anchorRef,
+    floatingRef: ctx.floatingRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+    mount: 'hidden',
+  });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
+}
+```
+
+Replace the `SelectArrow` function + `SelectArrowProps` type (lines 474-499) with:
+
+```tsx
+export { Arrow as SelectArrow, type ArrowProps as SelectArrowProps } from '../arrow.js';
+```
+
+Confirm `useMemo` is imported (Select Root uses it).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @hono-preact/ui exec tsc --noEmit`
+Expected: PASS (remove any leftover unused import it flags).
+
+- [ ] **Step 4: Run the Select tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/select-trigger.test.tsx packages/ui/src/__tests__/select-option.test.tsx packages/ui/src/__tests__/select-nav.test.tsx packages/ui/src/__tests__/select-form.test.tsx packages/ui/src/__tests__/select-presence.test.tsx packages/ui/src/__tests__/select-ssr.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm format
+git add packages/ui/src/select/
+git commit -m "refactor(ui): migrate Select Arrow to PositionerContext"
+```
+
+---
+
+## Task 8: Migrate Combobox
+
+Combobox also uses `mount: 'hidden'` and anchors to `inputRef` with a `getAnchorRect`.
+
+**Files:**
+- Modify: `packages/ui/src/combobox/combobox.tsx`, `packages/ui/src/combobox/context.ts`
+
+- [ ] **Step 1: Strip position-state from the context type**
+
+In `packages/ui/src/combobox/context.ts`, remove `arrowRef` (line 44), `position` (line 55), and `setPosition` (line 56) from `ComboboxContextValue`. `PositionState` is then unused; change the line-4 import to `import type { Side, Align } from '../use-position.js';` (keep the separate `RefObject` import on line 2 and the `OptionEntry` import on line 5).
+
+- [ ] **Step 2: Strip the Root, wire the Positioner + Arrow**
+
+In `packages/ui/src/combobox/combobox.tsx`:
+
+Add `import { PositionerContext } from '../positioner-context.js';`.
+
+Remove `const arrowRef = useRef<HTMLElement>(null);` (line 120) and the `const [position, setPosition] = useState<PositionState>({...})` block (lines 125-130). Remove `arrowRef`, `position`, `setPosition` from the `ctx` object (lines 208, 218-219) and `position` from the memo deps. Remove the now-unused `PositionState` import. `useState` is still used (`activeId`), keep it.
+
+Rewrite `ComboboxPositioner` (lines 263-294), keeping the `getAnchorRect` and `inputRef` anchor, dropping `arrowRef`/`setPosition`:
+
+```tsx
+export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = useComboboxContext('Positioner');
+  // Anchor to the <Combobox.Anchor> field if one is rendered, else the input.
+  // Both refs are stable, so the callback is stable (no autoUpdate churn).
+  const getAnchorRect = useCallback(
+    () =>
+      (
+        ctx.anchorRef.current ?? ctx.inputRef.current
+      )?.getBoundingClientRect() ?? null,
+    [ctx.anchorRef, ctx.inputRef]
+  );
+  const { positionerProps, state, position, arrowRef } = usePositioner({
+    open: ctx.open,
+    anchorRef: ctx.inputRef,
+    floatingRef: ctx.floatingRef,
+    side: ctx.side,
+    align: ctx.align,
+    offset: ctx.offset,
+    getAnchorRect,
+    mount: 'hidden',
+  });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
+}
+```
+
+Replace the `ComboboxArrow` function + `ComboboxArrowProps` type (lines 363-388) with:
+
+```tsx
+export { Arrow as ComboboxArrow, type ArrowProps as ComboboxArrowProps } from '../arrow.js';
+```
+
+Confirm `useMemo` and `useCallback` are imported (the Root uses both).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @hono-preact/ui exec tsc --noEmit`
+Expected: PASS (remove any leftover unused import it flags).
+
+- [ ] **Step 4: Run the Combobox tests**
+
+Run: `pnpm exec vitest run packages/ui/src/__tests__/combobox-root.test.tsx packages/ui/src/__tests__/combobox-input.test.tsx packages/ui/src/__tests__/combobox-option.test.tsx packages/ui/src/__tests__/combobox-popup.test.tsx packages/ui/src/__tests__/combobox-value.test.tsx packages/ui/src/__tests__/combobox-autocomplete.test.ts packages/ui/src/__tests__/combobox-controls.test.tsx packages/ui/src/__tests__/combobox-anchor-focus.test.tsx packages/ui/src/__tests__/combobox-form-reset.test.tsx packages/ui/src/__tests__/combobox-inline.test.tsx packages/ui/src/__tests__/combobox-presence.test.tsx packages/ui/src/__tests__/combobox-status.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pnpm format
+git add packages/ui/src/combobox/
+git commit -m "refactor(ui): migrate Combobox Arrow to PositionerContext"
+```
+
+---
+
+## Task 9: Remove the temporary compatibility shim from usePositioner
+
+Every component now reads `position`/`arrowRef` from the hook return and provides them via `PositionerContext`. No caller passes `arrowRef` or `setPosition`, so remove them and delete the publish round-trip.
+
+**Files:**
+- Modify: `packages/ui/src/use-positioner.ts`
+
+- [ ] **Step 1: Confirm nothing still passes the legacy options**
+
+Run: `grep -rn "setPosition\|arrowRef:" packages/ui/src --include=*.tsx --include=*.ts | grep -v "__tests__"`
+Expected: no matches that pass `setPosition` or `arrowRef:` into `usePositioner` (the only `arrowRef` references should be the hook's own internal ref and the `PositionerContextValue` field). If anything still passes them, that component was not migrated; fix it before continuing.
+
+- [ ] **Step 2: Remove the options and the publish effect**
+
+In `packages/ui/src/use-positioner.ts`:
+
+- In `UsePositionerOptions`, delete the optional `arrowRef?` and `setPosition?` fields.
+- Replace `const arrowRef = opts.arrowRef ?? ownArrowRef;` with `const arrowRef = useRef<HTMLElement>(null);` and delete the now-redundant `ownArrowRef` line.
+- Delete the legacy publish `useLayoutEffect` (the one calling `opts.setPosition?.(position)`).
+- If `useLayoutEffect` is no longer used anywhere else in the file (the top-layer promotion effect still uses it), keep the import; otherwise remove it. (The promotion effect at lines ~88-104 still uses `useLayoutEffect`, so keep it.)
+
+The final options/result/body should read: options carry `open`, `anchorRef`, `floatingRef`, `side`, `align`, `offset`, `getAnchorRect?`, `mount`; the hook owns `arrowRef` via `useRef`; it returns `{ isPresent, positionerProps, state, position, arrowRef }`.
+
+- [ ] **Step 3: Typecheck + full ui suite**
+
+Run: `pnpm --filter @hono-preact/ui exec tsc --noEmit`
+Expected: PASS.
+
+Run: `pnpm exec vitest run packages/ui`
+Expected: PASS (entire ui suite).
+
+- [ ] **Step 4: Commit**
+
+```bash
+pnpm format
+git add packages/ui/src/use-positioner.ts
+git commit -m "refactor(ui): drop legacy setPosition/arrowRef from usePositioner"
+```
+
+---
+
+## Task 10: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm the dedup actually happened**
+
+Run: `grep -rn "function .*Arrow\b" packages/ui/src --include=*.tsx | grep -v "__tests__"`
+Expected: exactly one match: `arrow.tsx` `export function Arrow`. No `PopoverArrow`/`TooltipArrow`/`MenuArrow`/`SelectArrow`/`ComboboxArrow` function definitions remain.
+
+Run: `grep -rn "position: PositionState" packages/ui/src/*/context.ts packages/ui/src/menu/use-menu-core.ts`
+Expected: no matches (position left all main contexts and useMenuCore).
+
+- [ ] **Step 2: Run the full six-step CI sequence (per CLAUDE.md)**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact build
+pnpm format:check
+pnpm typecheck
+pnpm test:coverage
+pnpm test:integration
+pnpm --filter site build
+```
+
+Expected: all six PASS. If `format:check` fails, run `pnpm format`, commit, and re-run.
+
+- [ ] **Step 3: Final state review**
+
+```bash
+git status            # working tree clean
+git log --oneline main..HEAD
+```
+
+Expected: clean tree; the commit series from Tasks 1-9. No stray files, no uncommitted format fixes.
+
+---
+
+## Notes for the final reviewer
+
+- **Replacement parity:** the five `*Arrow` parts had byte-identical bodies; confirm the shared `Arrow` reproduces the exact rendered output (`ref`, `data-side`, `position: absolute`, `left`/`top` from `arrowX`/`arrowY`, `state: { side }`). Read one deleted body from git (`git show <pre-PR-sha>:packages/ui/src/popover/popover.tsx`) and diff it mentally against `arrow.tsx`.
+- **Cross-cutting:** `floatingRef` must remain in each main context (the Popup's `useDismiss` reads it); only `position`/`setPosition`/`arrowRef` leave. Verify no Popup lost its dismiss ref.
+- **Nested submenus:** a submenu's `MenuPositioner` provides its own `PositionerContext`, so a submenu Arrow reads the submenu's position, not the parent's. Confirm `menu-submenu.test.tsx` passes.
+- **Contract tightening:** an Arrow rendered outside a Positioner now throws (was: rendered a default-position arrow). This is intended and covered by `arrow.test.tsx`.

--- a/docs/superpowers/specs/2026-06-14-arrow-positioner-context-dedup-design.md
+++ b/docs/superpowers/specs/2026-06-14-arrow-positioner-context-dedup-design.md
@@ -1,0 +1,178 @@
+# Arrow + PositionerContext dedup design
+
+**Section:** Primitives DX review, Section E ("UI: move the dedup trigger from fifth copy to second copy"), Group 1, first slice.
+
+**Source:** `docs/superpowers/research/2026-06-10-framework-primitives-dx-review.md` (Section 3 residue: "Arrow part byte-near-identical x5"; "Position-state plumbing through 6 Roots solely so Arrow can read it"; "Hand-maintained context memo dep arrays").
+
+## Goal
+
+Collapse the five byte-identical `Arrow` parts into one shared component, and eliminate the position-state round-trip that exists only so the Arrow can read the resolved position. Behavior-preserving for every real usage.
+
+## Background: the current shape
+
+The Arrow part is duplicated in five files (`popover.tsx`, `tooltip.tsx`, `menu.tsx`, `select.tsx`, `combobox.tsx`). Each body is identical except for which context hook it calls:
+
+```tsx
+export function PopoverArrow(props: PopoverArrowProps): VNode {
+  const { render, children, ...rest } = props;
+  const ctx = usePopoverContext('Arrow');
+  const { side, arrowX, arrowY } = ctx.position;
+  return renderElement<{ side: Side }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: ctx.arrowRef,
+      'data-side': side,
+      style: {
+        position: 'absolute',
+        left: arrowX != null ? `${arrowX}px` : undefined,
+        top: arrowY != null ? `${arrowY}px` : undefined,
+      },
+    },
+    state: { side },
+    children,
+  });
+}
+```
+
+The position it reads gets there by a round-trip that exists for no other reason:
+
+1. `usePosition` (inside the Positioner part, via `usePositioner`) computes and holds the live `PositionState` (`side`, `align`, `arrowX`, `arrowY`).
+2. `usePositioner` re-publishes it to the Root with a `useLayoutEffect` calling `ctx.setPosition(position)`.
+3. The Root stores it in `useState<PositionState>` and puts `position` (plus `setPosition` and `arrowRef`) into the main context value and its memo dependency array.
+4. The Arrow, always a descendant of the Positioner, reads `ctx.position` back down.
+
+Verified facts that make this safe to collapse:
+
+- **Only the Arrow reads `ctx.position`** (5 sites). Nothing else.
+- **Only the Positioner part calls `ctx.setPosition`** (5 sites, passed into `usePositioner`).
+- **`arrowRef` has exactly three roles**: declared in the Root / `useMenuCore`, passed into `usePositioner` by the Positioner, attached by the Arrow. No other readers.
+- **The Arrow is always a descendant of the Positioner** in every demo and docs example (`Positioner > Popup > Arrow`). The position only exists while open, which is exactly when the Positioner is mounted.
+- **`floatingRef` is also read by `useDismiss`** (in the Popup), so it stays in the main context. Only `position` / `setPosition` / `arrowRef` leave.
+- **Position-state is declared in five sites**, not six: the four standalone Roots (popover, tooltip, select, combobox) plus `useMenuCore`, which already centralizes it for the Menu / ContextMenu / Submenu trio.
+- **The submenu reuses `MenuPositioner`**, so it gets its own nested PositionerContext automatically.
+
+## Approach
+
+The Positioner owns the position and provides it through a small shared `PositionerContext`; one shared `Arrow` component consumes it. `usePositioner` returns the resolved position (it already computes it) and owns `arrowRef` internally instead of receiving it. The `setPosition` round-trip is deleted outright.
+
+This mirrors the existing `SelectOptionGroupContext` pattern: a small sibling context provided by one part and consumed by another.
+
+### New unit: `packages/ui/src/positioner-context.ts`
+
+```ts
+import { createContext, type RefObject } from 'preact';
+import { useContext } from 'preact/hooks';
+import type { PositionState } from './use-position.js';
+
+export interface PositionerContextValue {
+  position: PositionState;
+  arrowRef: RefObject<HTMLElement>;
+}
+
+export const PositionerContext = createContext<PositionerContextValue | null>(
+  null
+);
+
+export function usePositionerContext(): PositionerContextValue {
+  const ctx = useContext(PositionerContext);
+  if (!ctx) {
+    throw new Error('<Arrow> must be rendered inside a Positioner');
+  }
+  return ctx;
+}
+```
+
+### New unit: `packages/ui/src/arrow.tsx`
+
+The body is lifted verbatim from the five copies; the only change is sourcing `position` and `arrowRef` from `usePositionerContext()` instead of a per-component context.
+
+```tsx
+import { type ComponentChildren, type JSX, type VNode } from 'preact';
+import { renderElement, type RenderProp } from './use-render.js';
+import type { Side } from './use-position.js';
+import { usePositionerContext } from './positioner-context.js';
+
+export type ArrowProps = {
+  render?: RenderProp<{ side: Side }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+export function Arrow(props: ArrowProps): VNode {
+  const { render, children, ...rest } = props;
+  const { position, arrowRef } = usePositionerContext();
+  const { side, arrowX, arrowY } = position;
+  return renderElement<{ side: Side }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: arrowRef,
+      'data-side': side,
+      style: {
+        position: 'absolute',
+        left: arrowX != null ? `${arrowX}px` : undefined,
+        top: arrowY != null ? `${arrowY}px` : undefined,
+      },
+    },
+    state: { side },
+    children,
+  });
+}
+```
+
+### Changed unit: `packages/ui/src/use-positioner.ts`
+
+- Drop `setPosition` and `arrowRef` from `UsePositionerOptions`.
+- Create `arrowRef` internally (`const arrowRef = useRef<HTMLElement>(null)`).
+- Delete the `useLayoutEffect` that calls `opts.setPosition(position)`.
+- Return `position` (the full `PositionState`) and `arrowRef` in `UsePositionerResult`, keeping `isPresent`, `positionerProps`, and `state`.
+
+`positionerProps.ref` continues to merge `floatingRef` and the presence ref; `floatingRef` stays an option (the Popup's `useDismiss` reads it from the main context, and the Positioner element is still `floatingRef`).
+
+### Per-component cleanup (five components)
+
+For each of popover, tooltip, select, combobox Roots **and** `useMenuCore`:
+
+- Delete the `arrowRef` `useRef` and the `useState<PositionState>`.
+- Remove `arrowRef`, `position`, `setPosition` from the `*ContextValue` interface (and `MenuContextValue`), the assembled context object, and the memo dependency array. For `useMenuCore`, also remove them from the `MenuCore` result type and return object (they are only consumed via the context, confirmed at plan time).
+
+For each of the five Positioner parts:
+
+- Call the new `usePositioner` without `arrowRef` / `setPosition` arguments; destructure `position` and `arrowRef` from the result.
+- Wrap the rendered output in `<PositionerContext.Provider value={{ position, arrowRef }}>`. The early `if (!isPresent) return null` stays.
+
+For each of the five Arrow exports:
+
+- Delete the per-component `*Arrow` function and `*ArrowProps` type from the component file.
+- Re-export the shared `Arrow` / `ArrowProps` under the namespace so `Popover.Arrow`, `Tooltip.Arrow`, `Menu.Arrow`, `Select.Arrow`, `Combobox.Arrow` (and `ContextMenu.Arrow`, which aliases `Menu.Arrow`) keep working.
+
+Nested submenus get the correct (nearest) PositionerContext automatically, because `SubmenuPositioner` renders `MenuPositioner`, which provides its own PositionerContext.
+
+## Behavior notes
+
+- **Steady-state output is identical**: same `data-side`, same absolute `left`/`top` offsets, same `render` / `state` contract.
+- **One incidental improvement**: today the Arrow's `data-side` lags the Positioner's by one commit (the `setPosition` -> setState -> re-render cycle). After this change both read the same source, so they are synchronized. Not a regression.
+- **One contract tightening**: an Arrow rendered *outside* a Positioner now throws instead of rendering a default-position arrow. True in zero real usages, matches the universal convention, and is free since `@hono-preact/ui` is private and unpublished (version `0.0.0`).
+
+## Testing
+
+- **Rewrite `use-positioner` test** for the new signature: it no longer takes `setPosition` / `arrowRef`; assert it returns the resolved `position` and owns an `arrowRef`. The existing "publishes the resolved position via setPosition" case becomes "returns the resolved position".
+- **Existing per-component Arrow tests should pass unchanged** (identical rendered output). Fix any that render an Arrow without a Positioner ancestor (they would now throw) by nesting them under the component's Positioner.
+- **Add tests** (in a shared `arrow.test.tsx` or extending an existing file):
+  - The shared `Arrow` renders `data-side` and the absolute offset from its enclosing Positioner's resolved position.
+  - An `Arrow` rendered outside any Positioner throws the guard error.
+  - If the submenu renders an Arrow, a nested Arrow reads the submenu's Positioner, not the parent menu's.
+- **Verify `exports.test.ts`** still sees `.Arrow` on every namespace.
+- **Full six-step CI** before push (`build`, `format:check`, `typecheck`, `test:coverage`, `test:integration`, `site build`).
+
+## Scope boundaries
+
+In scope: the Arrow part dedup and the position-state plumbing removal described above.
+
+Explicitly out of scope (separate slices, noted for the record):
+
+- The Positioner *body* boilerplate (`if (!isPresent) return null; renderElement(...)`) is also five-times duplicated; deduping it is a separate slice.
+- The group-label context (x3) and description-registration (x2) dedups, which are the rest of Section E Group 1.
+- All of Section E Group 2 (contract standardization: delay vocabulary, `data-checked`, `Value` model, shared `PositioningProps` / `SelectionProps`, `ComboboxValueState` erasure leak).

--- a/packages/ui/src/__tests__/arrow.test.tsx
+++ b/packages/ui/src/__tests__/arrow.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { h } from 'preact';
+import { Arrow } from '../arrow.js';
+import { PositionerContext } from '../positioner-context.js';
+import type { PositionState } from '../use-position.js';
+
+afterEach(cleanup);
+
+function withPosition(position: PositionState, child: preact.VNode) {
+  function Wrapper() {
+    const arrowRef = useRef<HTMLElement>(null);
+    return h(
+      PositionerContext.Provider,
+      { value: { position, arrowRef } },
+      child
+    );
+  }
+  return <Wrapper />;
+}
+
+describe('Arrow', () => {
+  it('renders data-side and the absolute offset from the provided position', () => {
+    const { container } = render(
+      withPosition(
+        { side: 'right', align: 'center', arrowX: 12, arrowY: 34 },
+        <Arrow data-testid="arrow" />
+      )
+    );
+    const el = container.querySelector('[data-testid="arrow"]') as HTMLElement;
+    expect(el.getAttribute('data-side')).toBe('right');
+    expect(el.style.position).toBe('absolute');
+    expect(el.style.left).toBe('12px');
+    expect(el.style.top).toBe('34px');
+  });
+
+  it('omits left/top when arrowX/arrowY are null', () => {
+    const { container } = render(
+      withPosition(
+        { side: 'top', align: 'center', arrowX: null, arrowY: null },
+        <Arrow data-testid="arrow" />
+      )
+    );
+    const el = container.querySelector('[data-testid="arrow"]') as HTMLElement;
+    expect(el.style.left).toBe('');
+    expect(el.style.top).toBe('');
+  });
+
+  it('throws when rendered outside a Positioner', () => {
+    expect(() => render(<Arrow />)).toThrow(
+      '<Arrow> must be rendered inside a Positioner'
+    );
+  });
+
+  it('reads the nearest Positioner when providers are nested (submenu case)', () => {
+    function Nested() {
+      const outerRef = useRef<HTMLElement>(null);
+      const innerRef = useRef<HTMLElement>(null);
+      return h(
+        PositionerContext.Provider,
+        {
+          value: {
+            position: {
+              side: 'top',
+              align: 'center',
+              arrowX: null,
+              arrowY: null,
+            },
+            arrowRef: outerRef,
+          },
+        },
+        h(
+          PositionerContext.Provider,
+          {
+            value: {
+              position: {
+                side: 'left',
+                align: 'center',
+                arrowX: null,
+                arrowY: null,
+              },
+              arrowRef: innerRef,
+            },
+          },
+          <Arrow data-testid="inner-arrow" />
+        )
+      );
+    }
+    const { container } = render(<Nested />);
+    const el = container.querySelector(
+      '[data-testid="inner-arrow"]'
+    ) as HTMLElement;
+    expect(el.getAttribute('data-side')).toBe('left');
+  });
+});

--- a/packages/ui/src/__tests__/positioner-context.test.tsx
+++ b/packages/ui/src/__tests__/positioner-context.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import { useRef } from 'preact/hooks';
+import { h } from 'preact';
+import {
+  PositionerContext,
+  usePositionerContext,
+} from '../positioner-context.js';
+
+afterEach(cleanup);
+
+function Consumer() {
+  const { position } = usePositionerContext();
+  return <span data-testid="side">{position.side}</span>;
+}
+
+describe('usePositionerContext', () => {
+  it('returns the provided value inside a provider', () => {
+    function Wrapper() {
+      const arrowRef = useRef<HTMLElement>(null);
+      return h(
+        PositionerContext.Provider,
+        {
+          value: {
+            position: {
+              side: 'top',
+              align: 'center',
+              arrowX: null,
+              arrowY: null,
+            },
+            arrowRef,
+          },
+        },
+        <Consumer />
+      );
+    }
+    const { getByTestId } = render(<Wrapper />);
+    expect(getByTestId('side').textContent).toBe('top');
+  });
+
+  it('throws when used outside a provider', () => {
+    expect(() => render(<Consumer />)).toThrow(
+      '<Arrow> must be rendered inside a Positioner'
+    );
+  });
+});

--- a/packages/ui/src/__tests__/use-positioner.test.tsx
+++ b/packages/ui/src/__tests__/use-positioner.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/preact';
 import { useRef } from 'preact/hooks';
 import { usePositioner } from '../use-positioner.js';
-import type { PositionState, ClientRectGetter } from '../use-position.js';
+import type { ClientRectGetter } from '../use-position.js';
 
 afterEach(cleanup);
 
@@ -11,27 +11,26 @@ function Harness(props: {
   open: boolean;
   mount: 'unmount' | 'hidden';
   getAnchorRect?: ClientRectGetter;
-  onPosition?: (p: PositionState) => void;
+  onSide?: (side: string) => void;
 }) {
   const anchorRef = useRef<HTMLButtonElement>(null);
   const floatingRef = useRef<HTMLDivElement>(null);
-  const arrowRef = useRef<HTMLDivElement>(null);
-  const { isPresent, positionerProps } = usePositioner({
+  const { isPresent, positionerProps, position, arrowRef } = usePositioner({
     open: props.open,
     anchorRef,
     floatingRef,
-    arrowRef,
     side: 'bottom',
     align: 'start',
     offset: 8,
     getAnchorRect: props.getAnchorRect,
-    setPosition: (p) => props.onPosition?.(p),
     mount: props.mount,
   });
+  props.onSide?.(position.side);
   return (
     <div>
       <button ref={anchorRef}>anchor</button>
       <span data-testid="present">{String(isPresent)}</span>
+      <span data-testid="has-arrow-ref">{String(arrowRef != null)}</span>
       {props.mount === 'unmount' && !isPresent ? null : (
         <div data-testid="floating" {...positionerProps} />
       )}
@@ -53,7 +52,6 @@ describe('usePositioner', () => {
 
   it('hidden mode: stays mounted; hidden toggles with open', () => {
     const closed = render(<Harness open={false} mount="hidden" />);
-    // Always rendered, but hidden while closed.
     expect(closed.queryByTestId('floating')).not.toBeNull();
     expect(closed.getByTestId('floating').hasAttribute('hidden')).toBe(true);
     cleanup();
@@ -69,12 +67,13 @@ describe('usePositioner', () => {
     expect(el.getAttribute('data-align')).toBe('start');
   });
 
-  it('publishes the resolved position via setPosition', () => {
-    const seen: PositionState[] = [];
-    render(<Harness open mount="unmount" onPosition={(p) => seen.push(p)} />);
-    expect(seen.length).toBeGreaterThan(0);
-    expect(seen[0].side).toBe('bottom');
-    expect(seen[0].align).toBe('start');
+  it('returns the resolved position and owns an arrow ref', () => {
+    const seen: string[] = [];
+    const { getByTestId } = render(
+      <Harness open mount="unmount" onSide={(s) => seen.push(s)} />
+    );
+    expect(getByTestId('has-arrow-ref').textContent).toBe('true');
+    expect(seen[seen.length - 1]).toBe('bottom');
   });
 
   it('forwards getAnchorRect to usePosition', async () => {

--- a/packages/ui/src/arrow.tsx
+++ b/packages/ui/src/arrow.tsx
@@ -1,0 +1,33 @@
+import { type ComponentChildren, type JSX, type VNode } from 'preact';
+import { renderElement, type RenderProp } from './use-render.js';
+import type { Side } from './use-position.js';
+import { usePositionerContext } from './positioner-context.js';
+
+export type ArrowProps = {
+  render?: RenderProp<{ side: Side }>;
+  children?: ComponentChildren;
+} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
+
+// One Arrow for every overlay. Reads the resolved position from the enclosing
+// Positioner (via PositionerContext) and attaches the ref floating-ui measures.
+export function Arrow(props: ArrowProps): VNode {
+  const { render, children, ...rest } = props;
+  const { position, arrowRef } = usePositionerContext();
+  const { side, arrowX, arrowY } = position;
+  return renderElement<{ side: Side }>({
+    render,
+    defaultTag: 'div',
+    props: {
+      ...rest,
+      ref: arrowRef,
+      'data-side': side,
+      style: {
+        position: 'absolute',
+        left: arrowX != null ? `${arrowX}px` : undefined,
+        top: arrowY != null ? `${arrowY}px` : undefined,
+      },
+    },
+    state: { side },
+    children,
+  });
+}

--- a/packages/ui/src/combobox/combobox.tsx
+++ b/packages/ui/src/combobox/combobox.tsx
@@ -17,8 +17,9 @@ import {
 } from 'preact/hooks';
 import { useControllableState } from '../use-controllable-state.js';
 import { useFormReset } from '../use-form-reset.js';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 import { usePositioner } from '../use-positioner.js';
+import { PositionerContext } from '../positioner-context.js';
 import { useDismiss } from '../use-dismiss.js';
 import { renderElement, type RenderProp } from '../use-render.js';
 import { useListboxSelection, OPTION_SELECTOR } from '../listbox/selection.js';
@@ -117,17 +118,10 @@ export function ComboboxRoot<Value = string>(props: ComboboxRootProps<Value>) {
   const clearRef = useRef<HTMLElement>(null);
   const floatingRef = useRef<HTMLElement>(null);
   const listboxRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
   const baseId = useId();
   const inputId = `${baseId}-input`;
   const listboxId = `${baseId}-listbox`;
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [position, setPosition] = useState<PositionState>({
-    side,
-    align,
-    arrowX: null,
-    arrowY: null,
-  });
 
   const sel = useListboxSelection<Value>({
     value,
@@ -205,7 +199,6 @@ export function ComboboxRoot<Value = string>(props: ComboboxRootProps<Value>) {
       clearRef,
       floatingRef,
       listboxRef,
-      arrowRef,
       inputId,
       listboxId,
       disabled,
@@ -215,8 +208,6 @@ export function ComboboxRoot<Value = string>(props: ComboboxRootProps<Value>) {
       side,
       align,
       offset,
-      position,
-      setPosition,
     }),
     [
       open,
@@ -244,7 +235,6 @@ export function ComboboxRoot<Value = string>(props: ComboboxRootProps<Value>) {
       side,
       align,
       offset,
-      position,
     ]
   );
 
@@ -260,7 +250,7 @@ export type ComboboxPositionerProps = {
   children?: ComponentChildren;
 } & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
 
-export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
+export function ComboboxPositioner(props: ComboboxPositionerProps) {
   const { render, children, ...rest } = props;
   const ctx = useComboboxContext('Positioner');
   // Anchor to the <Combobox.Anchor> field if one is rendered, else the input.
@@ -272,25 +262,28 @@ export function ComboboxPositioner(props: ComboboxPositionerProps): VNode {
       )?.getBoundingClientRect() ?? null,
     [ctx.anchorRef, ctx.inputRef]
   );
-  const { positionerProps, state } = usePositioner({
+  const { positionerProps, state, position, arrowRef } = usePositioner({
     open: ctx.open,
     anchorRef: ctx.inputRef,
     floatingRef: ctx.floatingRef,
-    arrowRef: ctx.arrowRef,
     side: ctx.side,
     align: ctx.align,
     offset: ctx.offset,
     getAnchorRect,
-    setPosition: ctx.setPosition,
     mount: 'hidden',
   });
-  return renderElement<{ side: Side; align: Align }>({
-    render,
-    defaultTag: 'div',
-    props: { ...rest, ...positionerProps },
-    state,
-    children,
-  });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
 }
 
 export type ComboboxPopupProps = {
@@ -360,32 +353,10 @@ export function ComboboxAnchor(props: ComboboxAnchorProps): VNode {
   });
 }
 
-export type ComboboxArrowProps = {
-  render?: RenderProp<{ side: Side }>;
-  children?: ComponentChildren;
-} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
-
-export function ComboboxArrow(props: ComboboxArrowProps): VNode {
-  const { render, children, ...rest } = props;
-  const ctx = useComboboxContext('Arrow');
-  const { side, arrowX, arrowY } = ctx.position;
-  return renderElement<{ side: Side }>({
-    render,
-    defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: ctx.arrowRef,
-      'data-side': side,
-      style: {
-        position: 'absolute',
-        left: arrowX != null ? `${arrowX}px` : undefined,
-        top: arrowY != null ? `${arrowY}px` : undefined,
-      },
-    },
-    state: { side },
-    children,
-  });
-}
+export {
+  Arrow as ComboboxArrow,
+  type ArrowProps as ComboboxArrowProps,
+} from '../arrow.js';
 
 export type ComboboxOptionProps<Value = string> = {
   value: Value;

--- a/packages/ui/src/combobox/context.ts
+++ b/packages/ui/src/combobox/context.ts
@@ -1,7 +1,7 @@
 // packages/ui/src/combobox/context.ts
 import { createContext, type RefObject } from 'preact';
 import { useContext } from 'preact/hooks';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 import type { OptionEntry } from '../listbox/selection.js';
 
 export type AutocompleteMode = 'none' | 'list' | 'both';
@@ -41,7 +41,6 @@ export interface ComboboxContextValue {
   clearRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>;
   listboxRef: RefObject<HTMLElement>;
-  arrowRef: RefObject<HTMLElement>;
   inputId: string;
   listboxId: string;
   // flags + positioning
@@ -52,8 +51,6 @@ export interface ComboboxContextValue {
   side: Side;
   align: Align;
   offset: number;
-  position: PositionState;
-  setPosition: (p: PositionState) => void;
 }
 
 export const ComboboxContext = createContext<ComboboxContextValue | null>(null);

--- a/packages/ui/src/menu/context.ts
+++ b/packages/ui/src/menu/context.ts
@@ -1,12 +1,7 @@
 // packages/ui/src/menu/context.ts
 import { createContext, type RefObject } from 'preact';
 import { useContext } from 'preact/hooks';
-import type {
-  Side,
-  Align,
-  PositionState,
-  ClientRectGetter,
-} from '../use-position.js';
+import type { Side, Align, ClientRectGetter } from '../use-position.js';
 
 export interface MenuContextValue {
   open: boolean;
@@ -23,7 +18,6 @@ export interface MenuContextValue {
   anchorRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>; // Positioner element
   popupRef: RefObject<HTMLElement>; // Popup surface (focus + nav root)
-  arrowRef: RefObject<HTMLElement>;
   triggerId: string;
   popupId: string;
   // Roving tabindex: the id of the active item (null until open focuses one).
@@ -36,8 +30,6 @@ export interface MenuContextValue {
   offset: number;
   loop: boolean;
   typeahead: boolean;
-  position: PositionState;
-  setPosition: (p: PositionState) => void;
   // Context menu only: positions at the pointer. Undefined for Menu.
   getAnchorRect?: ClientRectGetter;
   // Context menu only: open the menu at the given pointer coordinates. Undefined

--- a/packages/ui/src/menu/menu.tsx
+++ b/packages/ui/src/menu/menu.tsx
@@ -21,6 +21,7 @@ import {
   MenuRadioGroupContext,
   useMenuRadioGroupContext,
 } from './context.js';
+import { PositionerContext } from '../positioner-context.js';
 
 export interface MenuRootProps {
   open?: boolean;
@@ -179,29 +180,33 @@ export type MenuPositionerProps = {
   children?: ComponentChildren;
 } & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
 
-export function MenuPositioner(props: MenuPositionerProps): VNode | null {
+export function MenuPositioner(props: MenuPositionerProps) {
   const { render, children, ...rest } = props;
   const ctx = useMenuContext('Positioner');
-  const { isPresent, positionerProps, state } = usePositioner({
-    open: ctx.open,
-    anchorRef: ctx.anchorRef,
-    floatingRef: ctx.floatingRef,
-    arrowRef: ctx.arrowRef,
-    side: ctx.side,
-    align: ctx.align,
-    offset: ctx.offset,
-    getAnchorRect: ctx.getAnchorRect,
-    setPosition: ctx.setPosition,
-    mount: 'unmount',
-  });
+  const { isPresent, positionerProps, state, position, arrowRef } =
+    usePositioner({
+      open: ctx.open,
+      anchorRef: ctx.anchorRef,
+      floatingRef: ctx.floatingRef,
+      side: ctx.side,
+      align: ctx.align,
+      offset: ctx.offset,
+      getAnchorRect: ctx.getAnchorRect,
+      mount: 'unmount',
+    });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
   if (!isPresent) return null;
-  return renderElement<{ side: Side; align: Align }>({
-    render,
-    defaultTag: 'div',
-    props: { ...rest, ...positionerProps },
-    state,
-    children,
-  });
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
 }
 
 export type MenuPopupProps = {
@@ -535,29 +540,7 @@ export function MenuSeparator(props: MenuSeparatorProps): VNode {
   });
 }
 
-export type MenuArrowProps = {
-  render?: RenderProp<{ side: Side }>;
-  children?: ComponentChildren;
-} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
-
-export function MenuArrow(props: MenuArrowProps): VNode {
-  const { render, children, ...rest } = props;
-  const ctx = useMenuContext('Arrow');
-  const { side, arrowX, arrowY } = ctx.position;
-  return renderElement<{ side: Side }>({
-    render,
-    defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: ctx.arrowRef,
-      'data-side': side,
-      style: {
-        position: 'absolute',
-        left: arrowX != null ? `${arrowX}px` : undefined,
-        top: arrowY != null ? `${arrowY}px` : undefined,
-      },
-    },
-    state: { side },
-    children,
-  });
-}
+export {
+  Arrow as MenuArrow,
+  type ArrowProps as MenuArrowProps,
+} from '../arrow.js';

--- a/packages/ui/src/menu/use-menu-core.ts
+++ b/packages/ui/src/menu/use-menu-core.ts
@@ -1,7 +1,7 @@
 import type { RefObject } from 'preact';
 import { useCallback, useId, useMemo, useRef, useState } from 'preact/hooks';
 import { useControllableState } from '../use-controllable-state.js';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 import type { MenuContextValue } from './context.js';
 
 export interface UseMenuCoreOptions {
@@ -31,15 +31,12 @@ export interface MenuCore {
   anchorRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>;
   popupRef: RefObject<HTMLElement>;
-  arrowRef: RefObject<HTMLElement>;
   pendingEdgeRef: RefObject<'first' | 'last'>;
   baseId: string;
   triggerId: string;
   popupId: string;
   activeId: string | null;
   setActiveId: (id: string | null) => void;
-  position: PositionState;
-  setPosition: (p: PositionState) => void;
 }
 
 export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
@@ -66,7 +63,6 @@ export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
   const anchorRef = useRef<HTMLElement>(null);
   const floatingRef = useRef<HTMLElement>(null);
   const popupRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
   const pendingEdgeRef = useRef<'first' | 'last'>('first');
 
   const baseId = useId();
@@ -74,12 +70,6 @@ export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
   const popupId = `${baseId}-popup`;
 
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [position, setPosition] = useState<PositionState>({
-    side,
-    align,
-    arrowX: null,
-    arrowY: null,
-  });
 
   // closeAll defaults to closing this menu; a parent's closeAll is injected for
   // submenus. ownCloseAll is always created (hooks can't be conditional).
@@ -113,7 +103,6 @@ export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
       anchorRef,
       floatingRef,
       popupRef,
-      arrowRef,
       triggerId,
       popupId,
       activeId,
@@ -124,8 +113,6 @@ export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
       offset,
       loop,
       typeahead,
-      position,
-      setPosition,
       getAnchorRect: pointerAnchored ? getAnchorRect : undefined,
       openAt: pointerAnchored ? openAt : undefined,
     }),
@@ -141,7 +128,6 @@ export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
       offset,
       loop,
       typeahead,
-      position,
       pointerAnchored,
       getAnchorRect,
       openAt,
@@ -155,14 +141,11 @@ export function useMenuCore(opts: UseMenuCoreOptions): MenuCore {
     anchorRef,
     floatingRef,
     popupRef,
-    arrowRef,
     pendingEdgeRef,
     baseId,
     triggerId,
     popupId,
     activeId,
     setActiveId,
-    position,
-    setPosition,
   };
 }

--- a/packages/ui/src/popover/context.ts
+++ b/packages/ui/src/popover/context.ts
@@ -1,7 +1,7 @@
 // packages/ui/src/popover/context.ts
 import { createContext, type RefObject } from 'preact';
 import { useContext } from 'preact/hooks';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 
 export interface PopoverContextValue {
   open: boolean;
@@ -9,7 +9,6 @@ export interface PopoverContextValue {
   anchorRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>; // the Positioner element
   popupRef: RefObject<HTMLElement>; // the Popup element (focus target)
-  arrowRef: RefObject<HTMLElement>;
   triggerId: string;
   popupId: string;
   titleId: string;
@@ -19,8 +18,6 @@ export interface PopoverContextValue {
   side: Side;
   align: Align;
   offset: number;
-  position: PositionState;
-  setPosition: (p: PositionState) => void;
 }
 
 export const PopoverContext = createContext<PopoverContextValue | null>(null);

--- a/packages/ui/src/popover/popover.tsx
+++ b/packages/ui/src/popover/popover.tsx
@@ -12,8 +12,9 @@ import { useDismiss } from '../use-dismiss.js';
 import { useFocusReturn } from '../use-focus-return.js';
 import { renderElement, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 import { usePositioner } from '../use-positioner.js';
+import { PositionerContext } from '../positioner-context.js';
 import { PopoverContext, usePopoverContext } from './context.js';
 
 export interface PopoverRootProps {
@@ -46,7 +47,6 @@ export function PopoverRoot(props: PopoverRootProps) {
   const anchorRef = useRef<HTMLElement>(null);
   const floatingRef = useRef<HTMLElement>(null);
   const popupRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
 
   const baseId = useId();
   const triggerId = `${baseId}-trigger`;
@@ -60,13 +60,6 @@ export function PopoverRoot(props: PopoverRootProps) {
     return () => setDescriptionCount((c) => c - 1);
   }, []);
 
-  const [position, setPosition] = useState<PositionState>({
-    side,
-    align,
-    arrowX: null,
-    arrowY: null,
-  });
-
   const ctx = useMemo(
     () => ({
       open,
@@ -74,7 +67,6 @@ export function PopoverRoot(props: PopoverRootProps) {
       anchorRef,
       floatingRef,
       popupRef,
-      arrowRef,
       triggerId,
       popupId,
       titleId,
@@ -84,8 +76,6 @@ export function PopoverRoot(props: PopoverRootProps) {
       side,
       align,
       offset,
-      position,
-      setPosition,
     }),
     [
       open,
@@ -99,7 +89,6 @@ export function PopoverRoot(props: PopoverRootProps) {
       side,
       align,
       offset,
-      position,
     ]
   );
 
@@ -165,28 +154,34 @@ export type PopoverPositionerProps = {
   children?: ComponentChildren;
 } & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
 
-export function PopoverPositioner(props: PopoverPositionerProps): VNode | null {
+// Return type left inferred: h(PositionerContext.Provider, ...) yields a VNode
+// with more specific props than VNode<{}> (matches the MenuGroup/SelectOptionGroup precedent).
+export function PopoverPositioner(props: PopoverPositionerProps) {
   const { render, children, ...rest } = props;
   const ctx = usePopoverContext('Positioner');
-  const { isPresent, positionerProps, state } = usePositioner({
-    open: ctx.open,
-    anchorRef: ctx.anchorRef,
-    floatingRef: ctx.floatingRef,
-    arrowRef: ctx.arrowRef,
-    side: ctx.side,
-    align: ctx.align,
-    offset: ctx.offset,
-    setPosition: ctx.setPosition,
-    mount: 'unmount',
-  });
+  const { isPresent, positionerProps, state, position, arrowRef } =
+    usePositioner({
+      open: ctx.open,
+      anchorRef: ctx.anchorRef,
+      floatingRef: ctx.floatingRef,
+      side: ctx.side,
+      align: ctx.align,
+      offset: ctx.offset,
+      mount: 'unmount',
+    });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
   if (!isPresent) return null;
-  return renderElement<{ side: Side; align: Align }>({
-    render,
-    defaultTag: 'div',
-    props: { ...rest, ...positionerProps },
-    state,
-    children,
-  });
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
 }
 
 export type PopoverPopupProps = {
@@ -226,32 +221,10 @@ export function PopoverPopup(props: PopoverPopupProps): VNode {
   });
 }
 
-export type PopoverArrowProps = {
-  render?: RenderProp<{ side: Side }>;
-  children?: ComponentChildren;
-} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
-
-export function PopoverArrow(props: PopoverArrowProps): VNode {
-  const { render, children, ...rest } = props;
-  const ctx = usePopoverContext('Arrow');
-  const { side, arrowX, arrowY } = ctx.position;
-  return renderElement<{ side: Side }>({
-    render,
-    defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: ctx.arrowRef,
-      'data-side': side,
-      style: {
-        position: 'absolute',
-        left: arrowX != null ? `${arrowX}px` : undefined,
-        top: arrowY != null ? `${arrowY}px` : undefined,
-      },
-    },
-    state: { side },
-    children,
-  });
-}
+export {
+  Arrow as PopoverArrow,
+  type ArrowProps as PopoverArrowProps,
+} from '../arrow.js';
 
 export type PopoverTitleProps = {
   render?: RenderProp;

--- a/packages/ui/src/positioner-context.ts
+++ b/packages/ui/src/positioner-context.ts
@@ -1,0 +1,24 @@
+import { createContext, type RefObject } from 'preact';
+import { useContext } from 'preact/hooks';
+import type { PositionState } from './use-position.js';
+
+// Provided by each component's Positioner part, consumed by the shared Arrow.
+// Small sibling context in the spirit of SelectOptionGroupContext: it carries
+// only what the Arrow needs (the resolved position + the ref it attaches to),
+// so position changes no longer invalidate the component's main context.
+export interface PositionerContextValue {
+  position: PositionState;
+  arrowRef: RefObject<HTMLElement>;
+}
+
+export const PositionerContext = createContext<PositionerContextValue | null>(
+  null
+);
+
+export function usePositionerContext(): PositionerContextValue {
+  const ctx = useContext(PositionerContext);
+  if (!ctx) {
+    throw new Error('<Arrow> must be rendered inside a Positioner');
+  }
+  return ctx;
+}

--- a/packages/ui/src/select/context.ts
+++ b/packages/ui/src/select/context.ts
@@ -1,7 +1,7 @@
 // packages/ui/src/select/context.ts
 import { createContext, type RefObject } from 'preact';
 import { useContext } from 'preact/hooks';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 
 // The value generic is erased to `unknown` at this module-level context (a
 // Preact context cannot carry a per-instance generic). The public Root/Option
@@ -20,7 +20,6 @@ export interface SelectContextValue {
   anchorRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>;
   listboxRef: RefObject<HTMLElement>;
-  arrowRef: RefObject<HTMLElement>;
   triggerId: string;
   listboxId: string;
   disabled: boolean;
@@ -30,8 +29,6 @@ export interface SelectContextValue {
   offset: number;
   loop: boolean;
   typeahead: boolean;
-  position: PositionState;
-  setPosition: (p: PositionState) => void;
 }
 
 export const SelectContext = createContext<SelectContextValue | null>(null);

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -16,7 +16,8 @@ import {
 } from 'preact/hooks';
 import { renderElement, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
+import { PositionerContext } from '../positioner-context.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useListNavigation } from '../list-navigation.js';
 import { useListboxSelection, OPTION_SELECTOR } from '../listbox/selection.js';
@@ -90,17 +91,10 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
   const anchorRef = useRef<HTMLElement>(null);
   const floatingRef = useRef<HTMLElement>(null);
   const listboxRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
   const baseId = useId();
   const triggerId = `${baseId}-trigger`;
   const listboxId = `${baseId}-listbox`;
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [position, setPosition] = useState<PositionState>({
-    side,
-    align,
-    arrowX: null,
-    arrowY: null,
-  });
 
   const sel = useListboxSelection<Value>({
     value,
@@ -129,7 +123,6 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
       anchorRef,
       floatingRef,
       listboxRef,
-      arrowRef,
       triggerId,
       listboxId,
       disabled,
@@ -139,8 +132,6 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
       offset,
       loop,
       typeahead,
-      position,
-      setPosition,
     }),
     [
       open,
@@ -159,7 +150,6 @@ export function SelectRoot<Value = string>(props: SelectRootProps<Value>) {
       offset,
       loop,
       typeahead,
-      position,
     ]
   );
 
@@ -297,30 +287,33 @@ export type SelectPositionerProps = {
   children?: ComponentChildren;
 } & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
 
-export function SelectPositioner(props: SelectPositionerProps): VNode {
+export function SelectPositioner(props: SelectPositionerProps) {
   const { render, children, ...rest } = props;
   const ctx = useSelectContext('Positioner');
   // Always rendered (mount: 'hidden') so options register their labels; the
   // hook drives `hidden` while not present, which composes with the top-layer
   // promotion (active only while present).
-  const { positionerProps, state } = usePositioner({
+  const { positionerProps, state, position, arrowRef } = usePositioner({
     open: ctx.open,
     anchorRef: ctx.anchorRef,
     floatingRef: ctx.floatingRef,
-    arrowRef: ctx.arrowRef,
     side: ctx.side,
     align: ctx.align,
     offset: ctx.offset,
-    setPosition: ctx.setPosition,
     mount: 'hidden',
   });
-  return renderElement<{ side: Side; align: Align }>({
-    render,
-    defaultTag: 'div',
-    props: { ...rest, ...positionerProps },
-    state,
-    children,
-  });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
 }
 
 export type SelectPopupProps = {
@@ -471,29 +464,7 @@ export function SelectOptionGroupLabel(
   });
 }
 
-export type SelectArrowProps = {
-  render?: RenderProp<{ side: Side }>;
-  children?: ComponentChildren;
-} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
-
-export function SelectArrow(props: SelectArrowProps): VNode {
-  const { render, children, ...rest } = props;
-  const ctx = useSelectContext('Arrow');
-  const { side, arrowX, arrowY } = ctx.position;
-  return renderElement<{ side: Side }>({
-    render,
-    defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: ctx.arrowRef,
-      'data-side': side,
-      style: {
-        position: 'absolute',
-        left: arrowX != null ? `${arrowX}px` : undefined,
-        top: arrowY != null ? `${arrowY}px` : undefined,
-      },
-    },
-    state: { side },
-    children,
-  });
-}
+export {
+  Arrow as SelectArrow,
+  type ArrowProps as SelectArrowProps,
+} from '../arrow.js';

--- a/packages/ui/src/tooltip/context.ts
+++ b/packages/ui/src/tooltip/context.ts
@@ -1,7 +1,7 @@
 // packages/ui/src/tooltip/context.ts
 import { createContext, type RefObject } from 'preact';
 import { useContext } from 'preact/hooks';
-import type { Side, Align, PositionState } from '../use-position.js';
+import type { Side, Align } from '../use-position.js';
 
 export interface TooltipContextValue {
   open: boolean;
@@ -12,14 +12,11 @@ export interface TooltipContextValue {
   cancelPending: () => void;
   anchorRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>;
-  arrowRef: RefObject<HTMLElement>;
   popupId: string;
   side: Side;
   align: Align;
   offset: number;
   closeDelay: number; // grace window for the safe corridor
-  position: PositionState;
-  setPosition: (p: PositionState) => void;
 }
 
 export const TooltipContext = createContext<TooltipContextValue | null>(null);

--- a/packages/ui/src/tooltip/tooltip.tsx
+++ b/packages/ui/src/tooltip/tooltip.tsx
@@ -1,19 +1,13 @@
 // packages/ui/src/tooltip/tooltip.tsx
 import { h, type ComponentChildren, type JSX, type VNode } from 'preact';
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from 'preact/hooks';
+import { useCallback, useEffect, useId, useMemo, useRef } from 'preact/hooks';
 import { renderElement, type RenderProp } from '../use-render.js';
 import { useControllableState } from '../use-controllable-state.js';
-import { type Side, type Align, type PositionState } from '../use-position.js';
+import { type Side, type Align } from '../use-position.js';
 import { useDismiss } from '../use-dismiss.js';
 import { useSafeArea } from '../use-safe-area.js';
 import { usePositioner } from '../use-positioner.js';
+import { PositionerContext } from '../positioner-context.js';
 import { TooltipContext, useTooltipContext } from './context.js';
 
 export interface TooltipRootProps {
@@ -49,7 +43,6 @@ export function TooltipRoot(props: TooltipRootProps) {
 
   const anchorRef = useRef<HTMLElement>(null);
   const floatingRef = useRef<HTMLElement>(null);
-  const arrowRef = useRef<HTMLElement>(null);
   const popupId = useId();
 
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -75,13 +68,6 @@ export function TooltipRoot(props: TooltipRootProps) {
   // timer cannot fire setOpen after unmount.
   useEffect(() => cancelPending, [cancelPending]);
 
-  const [position, setPosition] = useState<PositionState>({
-    side,
-    align,
-    arrowX: null,
-    arrowY: null,
-  });
-
   const ctx = useMemo(
     () => ({
       open,
@@ -90,14 +76,11 @@ export function TooltipRoot(props: TooltipRootProps) {
       cancelPending,
       anchorRef,
       floatingRef,
-      arrowRef,
       popupId,
       side,
       align,
       offset,
       closeDelay,
-      position,
-      setPosition,
     }),
     [
       open,
@@ -109,7 +92,6 @@ export function TooltipRoot(props: TooltipRootProps) {
       align,
       offset,
       closeDelay,
-      position,
     ]
   );
 
@@ -183,28 +165,32 @@ export type TooltipPositionerProps = {
   children?: ComponentChildren;
 } & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
 
-export function TooltipPositioner(props: TooltipPositionerProps): VNode | null {
+export function TooltipPositioner(props: TooltipPositionerProps) {
   const { render, children, ...rest } = props;
   const ctx = useTooltipContext('Positioner');
-  const { isPresent, positionerProps, state } = usePositioner({
-    open: ctx.open,
-    anchorRef: ctx.anchorRef,
-    floatingRef: ctx.floatingRef,
-    arrowRef: ctx.arrowRef,
-    side: ctx.side,
-    align: ctx.align,
-    offset: ctx.offset,
-    setPosition: ctx.setPosition,
-    mount: 'unmount',
-  });
+  const { isPresent, positionerProps, state, position, arrowRef } =
+    usePositioner({
+      open: ctx.open,
+      anchorRef: ctx.anchorRef,
+      floatingRef: ctx.floatingRef,
+      side: ctx.side,
+      align: ctx.align,
+      offset: ctx.offset,
+      mount: 'unmount',
+    });
+  const positionerValue = useMemo(() => ({ position, arrowRef }), [position]);
   if (!isPresent) return null;
-  return renderElement<{ side: Side; align: Align }>({
-    render,
-    defaultTag: 'div',
-    props: { ...rest, ...positionerProps },
-    state,
-    children,
-  });
+  return h(
+    PositionerContext.Provider,
+    { value: positionerValue },
+    renderElement<{ side: Side; align: Align }>({
+      render,
+      defaultTag: 'div',
+      props: { ...rest, ...positionerProps },
+      state,
+      children,
+    })
+  );
 }
 
 export type TooltipPopupProps = {
@@ -268,29 +254,7 @@ export function TooltipPopup(props: TooltipPopupProps): VNode {
   });
 }
 
-export type TooltipArrowProps = {
-  render?: RenderProp<{ side: Side }>;
-  children?: ComponentChildren;
-} & Omit<JSX.HTMLAttributes<HTMLDivElement>, 'children'>;
-
-export function TooltipArrow(props: TooltipArrowProps): VNode {
-  const { render, children, ...rest } = props;
-  const ctx = useTooltipContext('Arrow');
-  const { side, arrowX, arrowY } = ctx.position;
-  return renderElement<{ side: Side }>({
-    render,
-    defaultTag: 'div',
-    props: {
-      ...rest,
-      ref: ctx.arrowRef,
-      'data-side': side,
-      style: {
-        position: 'absolute',
-        left: arrowX != null ? `${arrowX}px` : undefined,
-        top: arrowY != null ? `${arrowY}px` : undefined,
-      },
-    },
-    state: { side },
-    children,
-  });
-}
+export {
+  Arrow as TooltipArrow,
+  type ArrowProps as TooltipArrowProps,
+} from '../arrow.js';

--- a/packages/ui/src/use-positioner.ts
+++ b/packages/ui/src/use-positioner.ts
@@ -30,18 +30,12 @@ export interface UsePositionerOptions {
   // The element the overlay is positioned against.
   anchorRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>;
-  // Optional during the migration to PositionerContext: when omitted the hook
-  // creates and owns the ref. Removed once every component stops passing it.
-  arrowRef?: RefObject<HTMLElement>;
   side: Side;
   align: Align;
   offset: number;
   // Position against a point or virtual element instead of anchorRef (e.g. a
   // pointer position). Undefined for the common anchor-element case.
   getAnchorRect?: ClientRectGetter;
-  // Optional legacy publish hook (pre-PositionerContext); removed once every
-  // component reads the position from the hook return instead.
-  setPosition?: (p: PositionState) => void;
   // 'unmount': the component returns null while closed (branch on isPresent).
   // 'hidden': the element stays mounted (so options can register their labels)
   // and is `hidden` while closed.
@@ -71,8 +65,7 @@ export interface UsePositionerResult {
 export function usePositioner(opts: UsePositionerOptions): UsePositionerResult {
   const presence = usePresence(opts.open);
 
-  const ownArrowRef = useRef<HTMLElement>(null);
-  const arrowRef = opts.arrowRef ?? ownArrowRef;
+  const arrowRef = useRef<HTMLElement>(null);
 
   const position = usePosition({
     open: presence.isPresent,
@@ -84,12 +77,6 @@ export function usePositioner(opts: UsePositionerOptions): UsePositionerResult {
     offset: opts.offset,
     getAnchorRect: opts.getAnchorRect,
   });
-
-  // Legacy publish to the Root (back-compat during migration). No-op once a
-  // component reads `position` from this hook's return instead.
-  useLayoutEffect(() => {
-    opts.setPosition?.(position);
-  }, [position.side, position.align, position.arrowX, position.arrowY]);
 
   // Promote to the native top layer. The Popover API is a hard dependency of
   // these components; on a browser without it showPopover() throws (no

--- a/packages/ui/src/use-positioner.ts
+++ b/packages/ui/src/use-positioner.ts
@@ -1,5 +1,5 @@
 import type { JSX, RefObject } from 'preact';
-import { useLayoutEffect } from 'preact/hooks';
+import { useLayoutEffect, useRef } from 'preact/hooks';
 import { usePosition } from './use-position.js';
 import type {
   Side,
@@ -30,15 +30,18 @@ export interface UsePositionerOptions {
   // The element the overlay is positioned against.
   anchorRef: RefObject<HTMLElement>;
   floatingRef: RefObject<HTMLElement>;
-  arrowRef: RefObject<HTMLElement>;
+  // Optional during the migration to PositionerContext: when omitted the hook
+  // creates and owns the ref. Removed once every component stops passing it.
+  arrowRef?: RefObject<HTMLElement>;
   side: Side;
   align: Align;
   offset: number;
   // Position against a point or virtual element instead of anchorRef (e.g. a
   // pointer position). Undefined for the common anchor-element case.
   getAnchorRect?: ClientRectGetter;
-  // Publish the resolved position so an Arrow part can read it.
-  setPosition: (p: PositionState) => void;
+  // Optional legacy publish hook (pre-PositionerContext); removed once every
+  // component reads the position from the hook return instead.
+  setPosition?: (p: PositionState) => void;
   // 'unmount': the component returns null while closed (branch on isPresent).
   // 'hidden': the element stays mounted (so options can register their labels)
   // and is `hidden` while closed.
@@ -59,25 +62,33 @@ export interface UsePositionerResult {
   isPresent: boolean;
   positionerProps: PositionerProps;
   state: { side: Side; align: Align };
+  // The resolved position, for a Positioner to publish via PositionerContext.
+  position: PositionState;
+  // The ref floating-ui measures and the Arrow attaches to.
+  arrowRef: RefObject<HTMLElement>;
 }
 
 export function usePositioner(opts: UsePositionerOptions): UsePositionerResult {
   const presence = usePresence(opts.open);
 
+  const ownArrowRef = useRef<HTMLElement>(null);
+  const arrowRef = opts.arrowRef ?? ownArrowRef;
+
   const position = usePosition({
     open: presence.isPresent,
     anchorRef: opts.anchorRef,
     floatingRef: opts.floatingRef,
-    arrowRef: opts.arrowRef,
+    arrowRef,
     side: opts.side,
     align: opts.align,
     offset: opts.offset,
     getAnchorRect: opts.getAnchorRect,
   });
 
-  // Publish the resolved position so Arrow (and any consumer) can read it.
+  // Legacy publish to the Root (back-compat during migration). No-op once a
+  // component reads `position` from this hook's return instead.
   useLayoutEffect(() => {
-    opts.setPosition(position);
+    opts.setPosition?.(position);
   }, [position.side, position.align, position.arrowX, position.arrowY]);
 
   // Promote to the native top layer. The Popover API is a hard dependency of
@@ -113,5 +124,7 @@ export function usePositioner(opts: UsePositionerOptions): UsePositionerResult {
       style: POSITIONER_STYLE,
     },
     state: { side: position.side, align: position.align },
+    position,
+    arrowRef,
   };
 }


### PR DESCRIPTION
## Summary

Section E (UI dedup), Group 1, first slice. Collapses the five byte-identical overlay `Arrow` parts into one shared component and removes the position-state round-trip that existed only so the Arrow could read the resolved position.

- New `PositionerContext` (`packages/ui/src/positioner-context.ts`): a small sibling context the Positioner provides and the Arrow consumes (carries only `position` + `arrowRef`).
- New shared `Arrow` (`packages/ui/src/arrow.tsx`): one component for all five overlays; each namespace re-exports it under its old name (`Popover.Arrow`, `Menu.Arrow`, etc.), so the public API is unchanged.
- `usePositioner` now owns the arrow ref and returns `{ ..., position, arrowRef }`; the `setPosition` publish round-trip is deleted.
- `position`/`setPosition`/`arrowRef` leave all five main contexts and `useMenuCore`; five context memo-dep arrays shrink. `floatingRef` stays (the Popup's dismiss/safe-area layer reads it).

Net: one `Arrow` instead of five, the plumbing the primitives review flagged ("position-state through the Roots solely so Arrow can read it") is gone, and the Positioner's and Arrow's `data-side` are now synchronized (previously the Arrow lagged one commit via the setState round-trip).

### Behavior change (intended)

An `Arrow` rendered outside a Positioner now throws instead of rendering a default-position arrow. True in zero real usages (every demo nests `Positioner > Popup > Arrow`), matches the universal convention, and `@hono-preact/ui` is private/unpublished so there are no consumers to migrate. Covered by a test.

## Test Plan

- [x] `@hono-preact/ui` suite green (Arrow render parity, the outside-Positioner throw, nested-submenu nearest-Positioner)
- [x] Full six-step CI: build, format:check, typecheck, test:coverage (217 files / 1242 tests), test:integration (4), site build
- [x] Replacement-parity review: shared `Arrow` is byte-equivalent to the five deleted bodies (incl. the menu-context one)
- [x] Cross-cutting review: `floatingRef`/dismiss intact per component; mount modes (`unmount`/`hidden`) and `getAnchorRect`/`inputRef` anchors preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)