### PR TITLE
refactor(ui): share the on-open-highlight effect

### DIFF
--- a/packages/ui/src/__tests__/highlight-selected-on-open.test.tsx
+++ b/packages/ui/src/__tests__/highlight-selected-on-open.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/preact';
+import {
+  useHighlightSelectedOnOpen,
+  type ListNavigation,
+} from '../list-navigation.js';
+
+afterEach(cleanup);
+
+function makeNav(selectedFlags: boolean[]): {
+  nav: ListNavigation;
+  setActiveItem: ReturnType<typeof vi.fn>;
+} {
+  const setActiveItem = vi.fn();
+  const els = selectedFlags.map((selected) => {
+    const el = document.createElement('div');
+    el.setAttribute('role', 'option');
+    if (selected) el.setAttribute('aria-selected', 'true');
+    return el;
+  });
+  const nav: ListNavigation = {
+    onKeyDown: () => {},
+    getItems: () => els,
+    setActiveItem,
+  };
+  return { nav, setActiveItem };
+}
+
+function Probe(props: { nav: ListNavigation; open: boolean }) {
+  useHighlightSelectedOnOpen(props.nav, props.open);
+  return null;
+}
+
+describe('useHighlightSelectedOnOpen', () => {
+  it('on open, activates the selected option', () => {
+    const { nav, setActiveItem } = makeNav([false, true, false]);
+    render(<Probe nav={nav} open />);
+    expect(setActiveItem).toHaveBeenCalledWith(1);
+  });
+
+  it('on open with none selected, activates the first', () => {
+    const { nav, setActiveItem } = makeNav([false, false]);
+    render(<Probe nav={nav} open />);
+    expect(setActiveItem).toHaveBeenCalledWith(0);
+  });
+
+  it('does nothing when closed', () => {
+    const { nav, setActiveItem } = makeNav([true]);
+    render(<Probe nav={nav} open={false} />);
+    expect(setActiveItem).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the list is empty', () => {
+    const { nav, setActiveItem } = makeNav([]);
+    render(<Probe nav={nav} open />);
+    expect(setActiveItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/combobox/combobox.tsx
+++ b/packages/ui/src/combobox/combobox.tsx
@@ -27,7 +27,10 @@ import {
   type SelectionProps,
 } from '../listbox/selection.js';
 import type { OptionEntry } from '../listbox/selection.js';
-import { useListNavigation } from '../list-navigation.js';
+import {
+  useListNavigation,
+  useHighlightSelectedOnOpen,
+} from '../list-navigation.js';
 import {
   ComboboxContext,
   useComboboxContext,
@@ -559,16 +562,7 @@ export function ComboboxInput(props: ComboboxInputProps): VNode {
     }
   });
 
-  // On open, highlight the selected option (single) or the first option.
-  useLayoutEffect(() => {
-    if (!ctx.open) return;
-    const list = nav.getItems();
-    if (list.length === 0) return;
-    const selectedIdx = list.findIndex(
-      (el) => el.getAttribute('aria-selected') === 'true'
-    );
-    nav.setActiveItem(selectedIdx >= 0 ? selectedIdx : 0);
-  }, [ctx.open]);
+  useHighlightSelectedOnOpen(nav, ctx.open);
 
   // Auto-highlight the first option whenever the filtered set changes while
   // open, in list/both modes (so Enter commits the top match).

--- a/packages/ui/src/list-navigation.ts
+++ b/packages/ui/src/list-navigation.ts
@@ -1,5 +1,6 @@
 // packages/ui/src/list-navigation.ts
 import type { RefObject } from 'preact';
+import { useLayoutEffect } from 'preact/hooks';
 import { useTypeahead } from './use-typeahead.js';
 
 // --- pure helpers (relocated from menu/navigation.ts) ---
@@ -172,4 +173,23 @@ export function useListNavigation(
     getItems: items,
     setActiveItem: (i) => activate(items(), i),
   };
+}
+
+// On open, move the active descendant to the selected option (or the first if
+// none). Shared by Select.Trigger and Combobox.Input. Deps are [open] only:
+// `nav` is recreated every render, so the effect captures it and re-runs only
+// when `open` toggles (getItems/setActiveItem read live refs at run time).
+export function useHighlightSelectedOnOpen(
+  nav: ListNavigation,
+  open: boolean
+): void {
+  useLayoutEffect(() => {
+    if (!open) return;
+    const list = nav.getItems();
+    if (list.length === 0) return;
+    const selectedIdx = list.findIndex(
+      (el) => el.getAttribute('aria-selected') === 'true'
+    );
+    nav.setActiveItem(selectedIdx >= 0 ? selectedIdx : 0);
+  }, [open]);
 }

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -6,19 +6,16 @@ import {
   type JSX,
   type VNode,
 } from 'preact';
-import {
-  useId,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'preact/hooks';
+import { useId, useMemo, useRef, useState } from 'preact/hooks';
 import { renderElement, type RenderProp } from '../render-element.js';
 import { useControllableState } from '../use-controllable-state.js';
 import type { Side, Align, PositioningProps } from '../use-position.js';
 import { Positioner } from '../positioner.js';
 import { useDismiss } from '../use-dismiss.js';
-import { useListNavigation } from '../list-navigation.js';
+import {
+  useListNavigation,
+  useHighlightSelectedOnOpen,
+} from '../list-navigation.js';
 import {
   useListboxSelection,
   useRegisterOption,
@@ -177,16 +174,7 @@ export function SelectTrigger(props: SelectTriggerProps): VNode {
     typeahead: ctx.typeahead,
   });
 
-  // On open, set the active descendant to the selected option (or the first).
-  useLayoutEffect(() => {
-    if (!ctx.open) return;
-    const list = nav.getItems();
-    if (list.length === 0) return;
-    const selectedIdx = list.findIndex(
-      (el) => el.getAttribute('aria-selected') === 'true'
-    );
-    nav.setActiveItem(selectedIdx >= 0 ? selectedIdx : 0);
-  }, [ctx.open]);
+  useHighlightSelectedOnOpen(nav, ctx.open);
 
   const handleClick = (event: JSX.TargetedMouseEvent<HTMLButtonElement>) => {
     onClick?.(event);


### PR DESCRIPTION
## Summary

Last Section E Group 1 dedup. `Select.Trigger` and `Combobox.Input` ran a byte-identical layout effect that, on open, moves the active descendant to the selected option (or the first if none). Extract it into a shared `useHighlightSelectedOnOpen(nav, open)` hook in `list-navigation.ts` (its natural home, alongside `useListNavigation`/`ListNavigation`).

- Both call sites become `useHighlightSelectedOnOpen(nav, ctx.open);`. Deps stay `[open]` (the effect deliberately re-runs only on open toggle; `nav` is recreated each render and captured).
- Combobox's *separate* "highlight-first-on-filter-change" effect is unaffected (different trigger/deps).
- `select.tsx` drops its now-unused `useLayoutEffect` import; Combobox keeps it (four other effects).

Pure dedup, behavior-preserving.

## Test Plan

- [x] Added a focused unit test for the hook (selected → activated; none → first; closed → no-op; empty → no-op)
- [x] Existing Select/Combobox nav tests stay green
- [x] Full six-step CI: build, format:check, typecheck, test:coverage (222 files / 1258 tests), test:integration (4), site build

🤖 Generated with [Claude Code](https://claude.com/claude-code)