### PR TITLE
feat(site): dogfood Speculation Rules via app-config (Section F)

### DIFF
--- a/apps/site/src/app-config.ts
+++ b/apps/site/src/app-config.ts
@@ -1,0 +1,8 @@
+import { defineApp } from 'hono-preact';
+
+// Dogfood the framework's Speculation Rules emitter: the docs site is navigation-
+// heavy with same-origin, idempotent GET routes, so prefetch-on-moderate-eagerness
+// is a real win (and the docs tell users to enable exactly this). The generated
+// server entry picks up this default export automatically. Per-link opt-out is
+// `data-no-prefetch`; cross-origin links (npm, GitHub) are never prefetched.
+export default defineApp({ speculation: true });


### PR DESCRIPTION
## Summary

Section F (dogfood-or-delete), F1 part 1: stand up an app-config for the docs site to dogfood the framework's Speculation Rules emitter.

```ts
// apps/site/src/app-config.ts
import { defineApp } from 'hono-preact';
export default defineApp({ speculation: true });
```

The generated server entry auto-imports this default export, so the site now emits the `<script type="speculationrules">` it tells users to enable, a genuine fit for a navigation-heavy, same-origin, idempotent-GET docs site (`data-no-prefetch` opts out per link; cross-origin links are never prefetched). Dogfoods **`defineApp`** + **`speculation`**.

### Conscious keep-undemoed decisions

The other Section-F-named features are released public API kept for users who need them, but consciously **not** dogfooded because the docs site has no honest use:

- **`defineApp.use`** — cross-cutting concerns here are page-scoped (route guards, already dogfooded); no genuine app-level middleware need.
- **loader timeouts (`timeoutMs`)** — the site's loaders are local/fast; a timeout would be contrived.
- **`defineStreamObserver`** — the site has a streaming loader but nothing useful to observe.
- **`Persist`/`PersistHost`** — no media / scroll / expensive widget to keep alive across navs.

(F2, live demos on the primitive docs pages, is a separate follow-up.)

## Test Plan

- [x] Build confirms wiring: the generated server entry imports `app-config.ts`; `appConfig.speculation === true` flows into the `nRulesTag` emitter (framework-tested)
- [x] Full six-step CI: build, format:check, typecheck, test:coverage (222 files / 1258 tests), test:integration (4), site build

🤖 Generated with [Claude Code](https://claude.com/claude-code)