### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Full walkthrough: [Docs · Quick start](https://framework.sbesh.com/docs/quick-s
 
 ## Status
 
-`v0.5.0`. Pre-1.0; expect changes between minor versions.
+`v0.6.0`. Pre-1.0; expect changes between minor versions.
 
 ## Contributing
 

--- a/docs/superpowers/specs/2026-06-14-v0.6-release-notes.md
+++ b/docs/superpowers/specs/2026-06-14-v0.6-release-notes.md
@@ -83,14 +83,18 @@ All of these are mechanical to migrate.
   route instead of `definePage({ use })`. `Page` no longer accepts `use` or
   `location`. The single `use` list now gates render and loader/action RPC
   together, so the separate `loaderUse` / `actionUse` convention is gone.
-- **`useRouteChange` removed.** Use the `onAfterSwap` view-transition lifecycle
-  callback to run work after a navigation commits.
-- **Mutable `env` moved to `hono-preact/internal/runtime`.** If you imported the
-  mutable `env` binding directly (rare), import it from the internal-runtime
-  entry point.
-- **Server resolver factories and framework-emitted iso plumbing moved to
-  `/internal/runtime`.** These were never part of the documented public API;
-  this only affects code that imported framework internals.
+- **`useRouteChange` removed.** Run post-navigation work from
+  `useViewTransitionLifecycle({ onAfterSwap })` instead (the `RouteChangeHandler`
+  type was removed with it).
+- **`getViewTransitionDirection` removed.** Navigation direction is now delivered
+  to the view-transition types callback: `subscribeViewTransitionTypes` and
+  `useViewTransitionTypes` receive `{ to, from, direction }`, where `direction`
+  is the still-exported `NavDirection`.
+- **A few advanced exports moved behind `/internal/runtime`.** The mutable `env`
+  binding and framework-emitted server plumbing (the loaders handler, resolver
+  factories) are no longer on the main entry points. If you imported them
+  directly, pull them from `hono-preact/internal/runtime` (or
+  `hono-preact/server/internal/runtime`). Typical apps never imported these.
 
 ## Upgrading
 

--- a/docs/superpowers/specs/2026-06-14-v0.6-release-notes.md
+++ b/docs/superpowers/specs/2026-06-14-v0.6-release-notes.md
@@ -1,0 +1,114 @@
+# hono-preact v0.6.0: release notes
+
+**Released:** 2026-06-14
+
+v0.6.0 is the largest release since the framework's first cut. It lands the
+backlog from the primitives DX review: a client-navigation toolkit, typed route
+params, single-source page guards, a form lifecycle, a content-glob route
+helper, an LLM-facing documentation layer, and a hardened public/internal
+boundary. It carries a handful of breaking changes, all small and mechanical to
+migrate.
+
+It also debuts a companion package: **`hono-preact-ui@0.1.0`**, a standalone
+library of unstyled, accessible Preact UI primitives (Dialog, Popover, Tooltip,
+Menu, Context Menu, Select, Combobox). It versions independently and is released
+on its own line; see its own notes.
+
+## Highlights
+
+### Client navigation toolkit
+
+Three additions make in-app navigation a first-class, typed concern:
+
+- `useNavigate()` returns an imperative `navigate(href, options)` for navigating
+  from event handlers and effects, not just `<a>` clicks.
+- `usePrefetch()` (and the standalone `prefetch()`) warm a route's code and
+  loader data on intent, for example on link hover or focus, so the destination
+  is ready before the click.
+- Active-route detection: `useRouteMatch()` and `useRouteActive()` report
+  whether a route is current (with exact/nested options), and `NavLink` is a
+  link that styles itself from that state.
+
+### Typed route params
+
+`useParams()` reads the current route's params, and `defineLoader(routeId)` /
+`serverRoute` type a loader against the params its route actually declares. The
+typing is pure type-level inference keyed off the route tree: no codegen, no
+build step, no generated registry to keep in sync.
+
+### Single-source page guards
+
+A route node now takes a `use` array of guards that gates **both** the route's
+render and its loader/action RPC from one place, and inherits down the tree to
+child routes. This replaces the previous split where `definePage({ use })`
+guarded render and a separate convention guarded the server calls. One list,
+one source of truth, applied uniformly.
+
+### Form lifecycle
+
+Progressively-enhanced forms and actions gain `onSuccess`, `onError`,
+`invalidate`, and `reset` hooks, plus shared invalidation so a successful
+mutation can refresh the loader data it affected. Custom Select/Combobox inputs
+from `hono-preact-ui` also reset correctly on a native form reset.
+
+### Content-glob routes
+
+`contentRoutes()` turns an `import.meta.glob` map of content modules (MDX/markdown
+pages) into route definitions in one call, so a docs or content site declares its
+routes from the filesystem instead of by hand.
+
+### LLM-facing documentation and scaffolding
+
+The project now ships machine-readable docs and agent-aware scaffolding:
+
+- Generated `llms.txt` and `llms-full.txt` so coding assistants can load an
+  accurate, current description of the framework's API.
+- `create-hono-preact` scaffolds an `AGENTS.md` into new apps, and a new
+  `add-agents` CLI command adds it to an existing app.
+- Several framework error messages were sharpened to say what went wrong and
+  what to do about it.
+
+### Hardened public/internal boundary
+
+The framework's advanced and framework-emitted plumbing moved behind explicit
+`/internal/runtime` entry points, leaving the main entry points a curated public
+surface. Most apps import only the public API and are unaffected; the change
+matters only if you reached into internals.
+
+## Breaking changes
+
+All of these are mechanical to migrate.
+
+- **Page guards moved to the route node.** Declare guards as a `use` array on the
+  route instead of `definePage({ use })`. `Page` no longer accepts `use` or
+  `location`. The single `use` list now gates render and loader/action RPC
+  together, so the separate `loaderUse` / `actionUse` convention is gone.
+- **`useRouteChange` removed.** Use the `onAfterSwap` view-transition lifecycle
+  callback to run work after a navigation commits.
+- **Mutable `env` moved to `hono-preact/internal/runtime`.** If you imported the
+  mutable `env` binding directly (rare), import it from the internal-runtime
+  entry point.
+- **Server resolver factories and framework-emitted iso plumbing moved to
+  `/internal/runtime`.** These were never part of the documented public API;
+  this only affects code that imported framework internals.
+
+## Upgrading
+
+```bash
+npm install hono-preact@0.6.0
+```
+
+Scaffold a new app with the matching CLI:
+
+```bash
+npm create hono-preact@0.6.0
+```
+
+Then apply the breaking-change migrations above. If you don't use page guards,
+`useRouteChange`, or framework internals, v0.6.0 is a drop-in upgrade.
+
+The UI component library is released separately:
+
+```bash
+npm install hono-preact-ui@0.1.0
+```

--- a/packages/create-hono-preact/package.json
+++ b/packages/create-hono-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-hono-preact",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffold a new hono-preact app.",
   "keywords": [
     "hono-preact",

--- a/packages/create-hono-preact/templates/cloudflare/package.json
+++ b/packages/create-hono-preact/templates/cloudflare/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "hono": "^4.12.14",
-    "hono-preact": "^0.5.0",
+    "hono-preact": "^0.6.0",
     "preact": "^10.29.1",
     "preact-iso": "github:preactjs/preact-iso#v3"
   },

--- a/packages/create-hono-preact/templates/node/package.json
+++ b/packages/create-hono-preact/templates/node/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "hono": "^4.12.14",
-    "hono-preact": "^0.5.0",
+    "hono-preact": "^0.6.0",
     "preact": "^10.29.1",
     "preact-iso": "github:preactjs/preact-iso#v3"
   },

--- a/packages/hono-preact/package.json
+++ b/packages/hono-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono-preact",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Hono on the edge, Preact in the browser, manifest driven routes, typed RPC, streaming everywhere.",
   "keywords": [
     "hono",


### PR DESCRIPTION
## Release prep: hono-preact + create-hono-preact v0.6.0

Bumps the framework and CLI to **0.6.0** (lockstep) and the template pins to `^0.6.0`, and adds the v0.6 release notes. This release drains the framework backlog from the primitives DX review.

### Version changes
- `hono-preact`: 0.5.1 → **0.6.0**
- `create-hono-preact`: 0.5.0 → **0.6.0** (lockstep)
- template `hono-preact` pins (cloudflare + node): `^0.5.0` → `^0.6.0`

### Why 0.6.0 (minor)
Pre-1.0, and the release carries real breaking changes (page guards moved to route nodes, `useRouteChange` removed, mutable `env` demoted), so a minor bump per the lockstep versioning policy.

### What's in it (framework)
Navigation toolkit (`useNavigate`, `usePrefetch`/`prefetch`, `useRouteMatch`/`useRouteActive`/`NavLink`), typed route params (`useParams` + `defineLoader(routeId)`/`serverRoute`, pure-type), single-source page guards (`use` on route nodes), form lifecycle (`onSuccess`/`onError`/`invalidate`/`reset`), `contentRoutes`, LLM-facing docs (`llms.txt` + scaffolder `AGENTS.md` + `add-agents` CLI + sharpened errors), and the `/internal/runtime` boundary hardening.

The `hono-preact-ui` component library (Dialog, Popover, Tooltip, Menu, Select, Combobox, …) ships **separately** as `hono-preact-ui@0.1.0` (plumbing merged in #108).

### Verification
Full CI mirror green locally: build (framework + ui), `format:check`, `typecheck`, **1350 unit tests**, **4 integration tests** (incl. scaffold against the new pins), site build. `pnpm release:dry` passes the lockstep check and resolves the v0.6 notes file.

### After merge (OTP-gated, run by maintainer)
```sh
pnpm release        # publishes hono-preact@0.6.0 + create-hono-preact@0.6.0, tags v0.6.0
pnpm release:ui     # publishes hono-preact-ui@0.1.0, tags hono-preact-ui@0.1.0
gh release create v0.6.0 -F docs/superpowers/specs/2026-06-14-v0.6-release-notes.md --latest
gh release create 'hono-preact-ui@0.1.0' -F docs/superpowers/specs/2026-06-14-ui-v0.1-release-notes.md --title 'hono-preact-ui@0.1.0'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
