### PR TITLE
fix(release): force --latest=false on the ui GitHub release command

### DIFF
--- a/scripts/release-ui.mjs
+++ b/scripts/release-ui.mjs
@@ -111,10 +111,12 @@ const findReleaseNotes = () => {
 const notes = findReleaseNotes();
 console.log('');
 console.log(`Released ${name}@${version}. Create the GitHub release:`);
-// No --latest: the framework (hono-preact) owns the repo's "latest" badge.
+// --latest=false is REQUIRED, not optional: `gh release create` defaults to
+// "automatic" latest (newest by date wins), so omitting the flag lets a ui
+// release steal the repo's "latest" badge from the framework. Force it off.
 if (notes) {
-  console.log(`  gh release create '${tagName}' -F ${notes} --title '${name}@${version}'`);
+  console.log(`  gh release create '${tagName}' -F ${notes} --title '${name}@${version}' --latest=false`);
 } else {
-  console.log(`  gh release create '${tagName}' -F <path-to-release-notes.md> --title '${name}@${version}'`);
+  console.log(`  gh release create '${tagName}' -F <path-to-release-notes.md> --title '${name}@${version}' --latest=false`);
   console.log(`  (no release notes file found in docs/superpowers/specs/ matching ui-v${major}.${minor})`);
 }


### PR DESCRIPTION
## What

`scripts/release-ui.mjs` printed a `gh release create` command **without** `--latest`, with a comment claiming that keeps the framework's "Latest" badge. That's wrong: `gh release create` defaults `--latest` to *automatic* (newest-by-date wins), so the ui release, created a second after `v0.6.0`, took the badge.

Caught live during the v0.6.0 / hono-preact-ui@0.1.0 release: the badge landed on the ui release and had to be moved back with `gh release edit v0.6.0 --latest`.

## Fix

Print the command with an explicit `--latest=false`, and correct the comment to say the flag is required (not optional). Verified via `pnpm release:ui:dry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
