### PR TITLE
chore(deps): migrate @babel/* AST tooling to Babel 8

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -24,8 +24,8 @@
     "react-is": "npm:@preact/compat"
   },
   "devDependencies": {
-    "@babel/parser": "^7.29.2",
-    "@babel/types": "^7.29.0",
+    "@babel/parser": "^8.0.0",
+    "@babel/types": "^8.0.0",
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",
     "@cloudflare/vite-plugin": "^1.37.1",

--- a/packages/hono-preact/package.json
+++ b/packages/hono-preact/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "author": "Steven Beshensky",
   "engines": {
-    "node": ">=20"
+    "node": "^22.18.0 || >=24.11.0"
   },
   "files": [
     "dist",
@@ -75,9 +75,9 @@
     "prepublishOnly": "tsc && node scripts/consolidate.mjs"
   },
   "dependencies": {
-    "@babel/parser": "^7.29.2",
-    "@babel/traverse": "^7.29.0",
-    "@babel/types": "^7.29.0",
+    "@babel/parser": "^8.0.0",
+    "@babel/traverse": "^8.0.0",
+    "@babel/types": "^8.0.0",
     "@preact/preset-vite": "^2.10.5",
     "magic-string": "^0.30.21"
   },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "author": "Steven Beshensky",
   "engines": {
-    "node": ">=20"
+    "node": "^22.18.0 || >=24.11.0"
   },
   "files": [
     "dist",
@@ -46,9 +46,9 @@
     "prepublishOnly": "tsc"
   },
   "dependencies": {
-    "@babel/parser": "^7.29.2",
-    "@babel/traverse": "^7.29.0",
-    "@babel/types": "^7.29.0",
+    "@babel/parser": "^8.0.0",
+    "@babel/traverse": "^8.0.0",
+    "@babel/types": "^8.0.0",
     "@hono-preact/iso": "workspace:*",
     "magic-string": "^0.30.21"
   },
@@ -78,7 +78,6 @@
     "@cloudflare/vite-plugin": "^1.37.1",
     "@hono/node-server": "^1.19.14",
     "@hono/node-ws": "^1.3.1",
-    "@types/babel__traverse": "^7.28.0",
     "@types/ws": "^8.5.0",
     "hono": "^4.12.14",
     "preact": "^10.29.1",

--- a/packages/vite/src/__tests__/server-only-plugin.test.ts
+++ b/packages/vite/src/__tests__/server-only-plugin.test.ts
@@ -286,6 +286,23 @@ describe('dynamic import() rewriting for .server.* sources', () => {
     expect(result).toBeUndefined();
   });
 
+  it('does not crash on a malformed no-arg import() alongside a real .server import', () => {
+    // Under `errorRecovery`, a no-arg `import()` parses to an ImportExpression
+    // with no `source`. The walker must skip it rather than throw on
+    // `source.type`, while still rewriting the genuine .server import.
+    const code = [
+      `const broken = () => import();`,
+      `const lazy = () => import('./auth.server.js');`,
+    ].join('\n');
+    const result = transform(code, '/Users/me/repo/src/pages/page.tsx');
+    expect(result).toBeDefined();
+    expect(result?.code).toContain(
+      'Promise.resolve({ __moduleKey: "src/pages/auth" })'
+    );
+    // The malformed no-arg import has no .server source, so it is left as-is.
+    expect(result?.code).toContain('import()');
+  });
+
   it('leaves dynamic .server.* imports untouched in SSR builds', () => {
     const code = `const m = () => import('./foo.server.ts');`;
     const result = transform(code, '/Users/me/repo/src/routes.ts', {

--- a/packages/vite/src/ast-walkers.ts
+++ b/packages/vite/src/ast-walkers.ts
@@ -1,9 +1,9 @@
 import traverse from '@babel/traverse';
 import type { NodePath } from '@babel/traverse';
 import type {
-  CallExpression,
   File,
   ImportDeclaration,
+  ImportExpression,
   Node,
 } from '@babel/types';
 
@@ -13,24 +13,21 @@ export type DynamicServerImport = {
   source: string;
 };
 
-// @babel/traverse is CJS; under some Node ESM interop the callable lands on
-// `.default`. Normalize to the function. (Acceptable module-interop boundary.)
-const traverseFn =
-  (traverse as unknown as { default?: typeof traverse }).default ?? traverse;
-
-// Collect `import('...server...')` dynamic-import call sites. A dynamic import
-// is an `import(...)` CallExpression whose callee is the `Import` node; we keep
-// the ones whose first argument is a `.server[.jt]sx?` string literal so the
+// Collect `import('...server...')` dynamic-import call sites. Babel parses a
+// dynamic import as an `ImportExpression` whose `source` is the specifier; we
+// keep the ones whose source is a `.server[.jt]sx?` string literal so the
 // transform can replace the body with a resolved stub.
 export function findDynamicServerImports(
   ast: File | Node,
   found: DynamicServerImport[]
 ): void {
-  traverseFn(ast, {
-    CallExpression(path: NodePath<CallExpression>) {
+  traverse(ast, {
+    ImportExpression(path: NodePath<ImportExpression>) {
       const { node } = path;
-      if (node.callee.type !== 'Import') return;
-      const arg = node.arguments[0];
+      // `source` is typed non-null, but under `errorRecovery` a malformed
+      // `import()` (e.g. no argument) yields an ImportExpression with no
+      // source, so the optional chain guards before reading `.type`.
+      const arg = node.source;
       if (
         arg?.type === 'StringLiteral' &&
         /\.server(\.[jt]sx?)?$/.test(arg.value)

--- a/packages/vite/src/parser-options.ts
+++ b/packages/vite/src/parser-options.ts
@@ -10,6 +10,10 @@ import type { ParserOptions } from '@babel/parser';
  * should not get a silent code-walk failure where the framework expected to
  * find a `defineLoader(...)` call and ran past it.
  *
+ * Import attributes (`with { ... }`) and explicit resource management
+ * (`using` / `await using`) parse by default in Babel 8, so they no longer
+ * need dedicated plugins; the syntaxes above still round-trip without them.
+ *
  * Each call site adds `sourceType: 'module'` and `errorRecovery: true`
  * separately because both are universal at our call sites and the
  * `ParserOptions` shape carries them as top-level fields.
@@ -19,6 +23,4 @@ export const BABEL_PARSER_PLUGINS: ParserOptions['plugins'] = [
   'jsx',
   'decorators',
   'decoratorAutoAccessors',
-  'importAttributes',
-  'explicitResourceManagement',
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,11 +109,11 @@ importers:
         version: '@preact/compat@18.3.2(preact@10.29.1)'
     devDependencies:
       '@babel/parser':
-        specifier: ^7.29.2
-        version: 7.29.2
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/types':
-        specifier: ^7.29.0
-        version: 7.29.0
+        specifier: ^8.0.0
+        version: 8.0.0
       '@cloudflare/vite-plugin':
         specifier: ^1.37.1
         version: 1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)
@@ -188,14 +188,14 @@ importers:
   packages/hono-preact:
     dependencies:
       '@babel/parser':
-        specifier: ^7.29.2
-        version: 7.29.2
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/traverse':
-        specifier: ^7.29.0
-        version: 7.29.0
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/types':
-        specifier: ^7.29.0
-        version: 7.29.0
+        specifier: ^8.0.0
+        version: 8.0.0
       '@cloudflare/vite-plugin':
         specifier: ^1.37.1
         version: 1.37.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))(workerd@1.20260515.1)(wrangler@4.92.0)
@@ -309,14 +309,14 @@ importers:
   packages/vite:
     dependencies:
       '@babel/parser':
-        specifier: ^7.29.2
-        version: 7.29.2
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/traverse':
-        specifier: ^7.29.0
-        version: 7.29.0
+        specifier: ^8.0.0
+        version: 8.0.0
       '@babel/types':
-        specifier: ^7.29.0
-        version: 7.29.0
+        specifier: ^8.0.0
+        version: 8.0.0
       '@hono-preact/iso':
         specifier: workspace:*
         version: link:../iso
@@ -339,9 +339,6 @@ importers:
       '@hono/node-ws':
         specifier: ^1.3.1
         version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.14))(hono@4.12.14)
-      '@types/babel__traverse':
-        specifier: ^7.28.0
-        version: 7.28.0
       '@types/ws':
         specifier: ^8.5.0
         version: 8.18.1
@@ -377,6 +374,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -389,6 +390,10 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
@@ -400,6 +405,10 @@ packages:
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-imports@7.28.6':
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
@@ -419,9 +428,17 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.0':
+    resolution: {integrity: sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -434,6 +451,11 @@ packages:
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.0':
+    resolution: {integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-syntax-jsx@7.28.6':
@@ -462,13 +484,25 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@8.0.0':
+    resolution: {integrity: sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.0':
+    resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1611,9 +1645,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
-
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1631,6 +1662,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -4213,6 +4247,11 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.0
+      js-tokens: 10.0.0
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
@@ -4243,6 +4282,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
@@ -4256,6 +4304,8 @@ snapshots:
       semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -4277,7 +4327,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@8.0.0': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -4289,6 +4343,10 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.0
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -4321,6 +4379,12 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4333,10 +4397,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.0
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.0
+      obug: 2.1.1
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@8.0.0':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.0
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -5288,10 +5367,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5312,6 +5387,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/jsesc@2.5.1': {}
 
   '@types/mdast@4.0.4':
     dependencies:


### PR DESCRIPTION
## Summary

Babel 8 shipped (GA: `@babel/parser`/`traverse`/`types` at `8.0.0`). This migrates the framework's only Babel surface, the build-time AST tooling in the Vite plugin, from `^7.29` to `^8.0`.

The packages are used purely as programmatic AST tooling (parse / traverse / type guards), not as a compiler or preset.

## Changes

- **Bump `@babel/parser`, `@babel/traverse`, `@babel/types`** `^7.29 → ^8.0` in `packages/vite`, `packages/hono-preact`, and `apps/site`.
- **Dynamic-import AST shape (the real code break).** Babel 8 parses `import('...')` as an `ImportExpression` (with a `source` field) instead of a `CallExpression` whose callee is an `Import` node. `findDynamicServerImports` in `ast-walkers.ts` matched the old shape, so under Babel 8 it found zero dynamic `.server.*` imports and `serverOnlyPlugin` would stop stubbing them in the client bundle. Rewrote the walker to match `ImportExpression`.
- **Dropped the `@babel/traverse` CJS-interop hack** (`(traverse as unknown as {...}).default ?? traverse`). Babel 8 traverse is native ESM with a callable default export, so `traverse(...)` works directly, removing an `as unknown as` cast.
- **Removed `importAttributes` and `explicitResourceManagement` parser plugins.** Both syntaxes (`import ... with { ... }`, `using` / `await using`) are default-on in Babel 8 and are no longer valid plugin names (the v8 types reject them). Verified both still round-trip with the reduced plugin set.
- **Removed the redundant `@types/babel__traverse`** devDependency; Babel 8 traverse ships its own type declarations.
- **Raised `engines.node`** to `^22.18.0 || >=24.11.0` on the packages carrying babel as a runtime dependency (`packages/vite`, `packages/hono-preact` umbrella) to match Babel 8's required Node floor.

## Breaking change

The published `hono-preact` and `@hono-preact/vite` packages now require Node `^22.18.0 || >=24.11.0` (was `>=20`), because their build-time Babel tooling does. Should ship documented in the next release.

## Behavior note

Babel 8 removed the legacy `import ... assert { type: 'json' }` syntax (only the modern `with { ... }` survives). Every framework code-walk runs with `errorRecovery: true`, so a stray legacy `assert` in user code degrades to a recovered parse rather than crashing the walk.

## Verification

Regression confirmed before the fix: on Babel 8, the 3 dynamic-import rewrite tests in `server-only-plugin.test.ts` failed, then went green after the `ImportExpression` change.

Full six-step CI mirror, all green:

- build framework dist
- `format:check`
- `typecheck`
- `test:coverage` (228 files / 1381 tests)
- `test:integration` (real build exercising the Vite plugin transforms)
- `site build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)