### PR TITLE
perf(site): font-display: optional to eliminate font-swap CLS

### DIFF
--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -4,28 +4,28 @@
   font-family: 'Selawik';
   font-style: normal;
   font-weight: 300;
-  font-display: swap;
+  font-display: optional;
   src: url('./fonts/selawik-light.woff2') format('woff2');
 }
 @font-face {
   font-family: 'Selawik';
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: optional;
   src: url('./fonts/selawik-regular.woff2') format('woff2');
 }
 @font-face {
   font-family: 'Selawik';
   font-style: normal;
   font-weight: 600;
-  font-display: swap;
+  font-display: optional;
   src: url('./fonts/selawik-semibold.woff2') format('woff2');
 }
 @font-face {
   font-family: 'Selawik';
   font-style: normal;
   font-weight: 700;
-  font-display: swap;
+  font-display: optional;
   src: url('./fonts/selawik-bold.woff2') format('woff2');
 }
 


### PR DESCRIPTION
## What

Change the four Selawik `@font-face` declarations in `apps/site/src/styles/root.css` from `font-display: swap` to `font-display: optional`.

## Why

A mobile Lighthouse run of `/docs/quick-start` scored **96** on Performance with every metric in the green **except CLS, at 0.116** (just over the 0.10 "good" line). The "Layout shift culprits" / "Avoid large layout shifts" audits attributed essentially all of it to web-font swaps:

| Element | Layout shift score | Cause |
|---|---|---|
| `article.mdx-content > p` (body paragraph) | **0.1157** | `selawik-regular.woff2` |
| `header.docs-topbar > nav.flex` | 0.00048 | `selawik-bold.woff2` |
| `nav > a` (Components link) | 0.00014 | `selawik-semibold.woff2` |

With `swap`, the page paints body text in the fallback stack (`Segoe UI`/`system-ui`) and then reflows when Selawik loads. `font-display: optional` gives the font a short block period and, if it has not arrived, keeps the fallback for the rest of that pageview instead of swapping, so there is no reflow and font-induced CLS goes to ~0. Expected effect: CLS ~0.0006, Performance ~99-100.

**Trade-off:** a first-time visitor on a slow connection may see the fallback font for that one pageview; the font is cached for the next navigation.

## Verification

All six CI steps run locally and pass: framework `dist` build, `format:check` (CSS isn't globbed, so the change is format-neutral), `typecheck`, 1394 unit tests, 4 integration tests, and `pnpm --filter site build`. Confirmed the built+minified `root-*.css` contains 4× `font-display:optional` and 0× `font-display:swap`.

Scope note: this addresses only the CLS finding (the one metric losing score). The companion "Render blocking requests" audit reported 0 ms estimated savings (ignored), and the "Network dependency tree" finding is being handled separately as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)