### PR TITLE
feat: route-level modulepreload hints (prototype)

### DIFF
--- a/packages/server/src/__tests__/render-preload.test.tsx
+++ b/packages/server/src/__tests__/render-preload.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import type { JSX } from 'preact';
+import { renderPage } from '../render.js';
+import type { RoutePreloadMap } from '../route-preload-tags.js';
+
+function Page(): JSX.Element {
+  return (
+    <html>
+      <head></head>
+      <body>
+        <main>hello</main>
+      </body>
+    </html>
+  );
+}
+
+async function renderAt(
+  path: string,
+  routePreload?: RoutePreloadMap
+): Promise<string> {
+  const app = new Hono();
+  app.get('*', (c) => renderPage(c, <Page />, { routePreload }));
+  const res = await app.request('http://localhost' + path);
+  return await res.text();
+}
+
+const MAP: RoutePreloadMap = {
+  '/docs/quick-start': [
+    '/static/DocsLayout-abc.js',
+    '/static/quick-start-def.js',
+  ],
+};
+
+describe('renderPage route modulepreload', () => {
+  it('injects modulepreload links for the matched route, inside <head>', async () => {
+    const body = await renderAt('/docs/quick-start', MAP);
+    const layoutTag =
+      '<link rel="modulepreload" href="/static/DocsLayout-abc.js" crossorigin />';
+    const viewTag =
+      '<link rel="modulepreload" href="/static/quick-start-def.js" crossorigin />';
+    expect(body).toContain(layoutTag);
+    expect(body).toContain(viewTag);
+
+    const headEnd = body.indexOf('</head>');
+    expect(headEnd).toBeGreaterThan(-1);
+    expect(body.indexOf(layoutTag)).toBeLessThan(headEnd);
+    expect(body.indexOf(viewTag)).toBeLessThan(headEnd);
+  });
+
+  it('injects nothing when the request path does not match any pattern', async () => {
+    const body = await renderAt('/some/other/page', MAP);
+    expect(body).not.toContain('modulepreload');
+  });
+
+  it('injects nothing when no route-preload map is provided', async () => {
+    const body = await renderAt('/docs/quick-start');
+    expect(body).not.toContain('modulepreload');
+  });
+});

--- a/packages/server/src/__tests__/render-preload.test.tsx
+++ b/packages/server/src/__tests__/render-preload.test.tsx
@@ -26,19 +26,19 @@ async function renderAt(
 }
 
 const MAP: RoutePreloadMap = {
-  '/docs/quick-start': [
-    '/static/DocsLayout-abc.js',
-    '/static/quick-start-def.js',
-  ],
+  '/docs/quick-start': {
+    high: ['/static/DocsLayout-abc.js'],
+    low: ['/static/quick-start-def.js'],
+  },
 };
 
 describe('renderPage route modulepreload', () => {
-  it('injects modulepreload links for the matched route, inside <head>', async () => {
+  it('injects layout (high) and view (low-priority) modulepreload links inside <head>', async () => {
     const body = await renderAt('/docs/quick-start', MAP);
     const layoutTag =
       '<link rel="modulepreload" href="/static/DocsLayout-abc.js" crossorigin />';
     const viewTag =
-      '<link rel="modulepreload" href="/static/quick-start-def.js" crossorigin />';
+      '<link rel="modulepreload" href="/static/quick-start-def.js" crossorigin fetchpriority="low" />';
     expect(body).toContain(layoutTag);
     expect(body).toContain(viewTag);
 

--- a/packages/server/src/__tests__/route-preload-tags.test.ts
+++ b/packages/server/src/__tests__/route-preload-tags.test.ts
@@ -7,33 +7,48 @@ describe('routePreloadTags', () => {
   });
 
   it('returns empty string when no pattern matches', () => {
-    const map = { '/docs/quick-start': ['/static/a.js'] };
+    const map = { '/docs/quick-start': { high: ['/static/a.js'], low: [] } };
     expect(routePreloadTags(map, '/somewhere/else')).toBe('');
   });
 
   it('returns empty string when the matched pattern has no hrefs', () => {
-    const map = { '/docs/quick-start': [] };
+    const map = { '/docs/quick-start': { high: [], low: [] } };
     expect(routePreloadTags(map, '/docs/quick-start')).toBe('');
   });
 
-  it('emits one modulepreload link per href, with crossorigin', () => {
+  it('emits layout chunks at default priority and view chunks with fetchpriority=low', () => {
     const map = {
-      '/docs/quick-start': ['/static/DocsLayout.js', '/static/quick-start.js'],
+      '/docs/quick-start': {
+        high: ['/static/DocsLayout.js'],
+        low: ['/static/quick-start.js'],
+      },
     };
     const out = routePreloadTags(map, '/docs/quick-start');
     expect(out).toContain(
       '<link rel="modulepreload" href="/static/DocsLayout.js" crossorigin />'
     );
     expect(out).toContain(
-      '<link rel="modulepreload" href="/static/quick-start.js" crossorigin />'
+      '<link rel="modulepreload" href="/static/quick-start.js" crossorigin fetchpriority="low" />'
     );
-    expect(out.match(/rel="modulepreload"/g)?.length).toBe(2);
+    // The layout link must NOT carry fetchpriority; the view link must.
+    expect(out).not.toContain('DocsLayout.js" crossorigin fetchpriority');
+    expect(out.match(/fetchpriority="low"/g)?.length).toBe(1);
+  });
+
+  it('emits high links before low links', () => {
+    const map = {
+      '/p': { high: ['/static/layout.js'], low: ['/static/view.js'] },
+    };
+    const out = routePreloadTags(map, '/p');
+    expect(out.indexOf('/static/layout.js')).toBeLessThan(
+      out.indexOf('/static/view.js')
+    );
   });
 
   it('picks the most specific pattern when several match (literal over param)', () => {
     const map = {
-      '/docs/:slug': ['/static/generic.js'],
-      '/docs/quick-start': ['/static/specific.js'],
+      '/docs/:slug': { high: [], low: ['/static/generic.js'] },
+      '/docs/quick-start': { high: [], low: ['/static/specific.js'] },
     };
     const out = routePreloadTags(map, '/docs/quick-start');
     expect(out).toContain('/static/specific.js');
@@ -41,7 +56,12 @@ describe('routePreloadTags', () => {
   });
 
   it('matches a parameterized pattern for a concrete URL', () => {
-    const map = { '/demo/projects/:projectId': ['/static/project.js'] };
+    const map = {
+      '/demo/projects/:projectId': {
+        high: ['/static/project-layout.js'],
+        low: ['/static/project.js'],
+      },
+    };
     const out = routePreloadTags(map, '/demo/projects/42');
     expect(out).toContain('/static/project.js');
   });

--- a/packages/server/src/__tests__/route-preload-tags.test.ts
+++ b/packages/server/src/__tests__/route-preload-tags.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { routePreloadTags } from '../route-preload-tags.js';
+
+describe('routePreloadTags', () => {
+  it('returns empty string when the map is undefined', () => {
+    expect(routePreloadTags(undefined, '/docs/quick-start')).toBe('');
+  });
+
+  it('returns empty string when no pattern matches', () => {
+    const map = { '/docs/quick-start': ['/static/a.js'] };
+    expect(routePreloadTags(map, '/somewhere/else')).toBe('');
+  });
+
+  it('returns empty string when the matched pattern has no hrefs', () => {
+    const map = { '/docs/quick-start': [] };
+    expect(routePreloadTags(map, '/docs/quick-start')).toBe('');
+  });
+
+  it('emits one modulepreload link per href, with crossorigin', () => {
+    const map = {
+      '/docs/quick-start': ['/static/DocsLayout.js', '/static/quick-start.js'],
+    };
+    const out = routePreloadTags(map, '/docs/quick-start');
+    expect(out).toContain(
+      '<link rel="modulepreload" href="/static/DocsLayout.js" crossorigin />'
+    );
+    expect(out).toContain(
+      '<link rel="modulepreload" href="/static/quick-start.js" crossorigin />'
+    );
+    expect(out.match(/rel="modulepreload"/g)?.length).toBe(2);
+  });
+
+  it('picks the most specific pattern when several match (literal over param)', () => {
+    const map = {
+      '/docs/:slug': ['/static/generic.js'],
+      '/docs/quick-start': ['/static/specific.js'],
+    };
+    const out = routePreloadTags(map, '/docs/quick-start');
+    expect(out).toContain('/static/specific.js');
+    expect(out).not.toContain('/static/generic.js');
+  });
+
+  it('matches a parameterized pattern for a concrete URL', () => {
+    const map = { '/demo/projects/:projectId': ['/static/project.js'] };
+    const out = routePreloadTags(map, '/demo/projects/42');
+    expect(out).toContain('/static/project.js');
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,9 @@
 export { HonoContext, useHonoContext } from './context.js';
 export { renderPage } from './render.js';
+// `RoutePreloadMap` is exported as a type only: it appears in renderPage's
+// public options signature. `routePreloadTags` stays internal (render.tsx
+// imports it directly; the generated core-app only forwards the map).
+export type { RoutePreloadMap } from './route-preload-tags.js';
 export {
   loadersHandler,
   type LoadersHandlerOptions,

--- a/packages/server/src/page-action-handler.ts
+++ b/packages/server/src/page-action-handler.ts
@@ -28,6 +28,7 @@ import {
 } from './sse.js';
 import type { ActionEntry } from './page-action-resolvers.js';
 import { pickAccept } from './accept.js';
+import type { RoutePreloadMap } from './route-preload-tags.js';
 import type { VNode } from 'preact';
 
 export interface PageActionHandlerOptions {
@@ -56,7 +57,7 @@ export interface PageActionHandlerOptions {
   renderPage: (
     c: Context,
     node: VNode,
-    opts: { appConfig?: AppConfig }
+    opts: { appConfig?: AppConfig; routePreload?: RoutePreloadMap }
   ) => Promise<Response>;
   /**
    * Resolves the VNode to render for the given URL path. Returns null when
@@ -66,6 +67,8 @@ export interface PageActionHandlerOptions {
   resolvePageNode: (path: string) => VNode | null;
   /** App-level middleware/observer array from defineApp({ use }). */
   appConfig?: AppConfig;
+  /** Build-generated route-preload map, forwarded to renderPage. */
+  routePreload?: RoutePreloadMap;
   /**
    * Default timeout in milliseconds for actions that don't declare their
    * own timeoutMs. Defaults to 30000. Pass false to disable the default.
@@ -150,6 +153,7 @@ export function pageActionHandler(
     renderPage,
     resolvePageNode,
     appConfig,
+    routePreload,
     defaultTimeoutMs = 30_000,
     onError,
   } = opts;
@@ -337,7 +341,7 @@ export function pageActionHandler(
         }
         return c.text('Action failed', 500);
       }
-      const rendered = await renderPage(c, node, { appConfig });
+      const rendered = await renderPage(c, node, { appConfig, routePreload });
       if (
         resolution.kind === 'outcome' &&
         resolution.outcome.__outcome === 'deny'

--- a/packages/server/src/render.tsx
+++ b/packages/server/src/render.tsx
@@ -24,6 +24,10 @@ import {
 } from '@hono-preact/iso/internal';
 import type { ServerLoaderStream } from '@hono-preact/iso/internal';
 import { speculationRulesTag } from './speculation-rules.js';
+import {
+  routePreloadTags,
+  type RoutePreloadMap,
+} from './route-preload-tags.js';
 import { translateRootOutcome } from './outcome-translation.js';
 
 function escapeHtml(str: string): string {
@@ -89,7 +93,11 @@ function buildActionResultContext(): ActionResultContextValue {
 export async function renderPage(
   c: Context,
   node: VNode,
-  options?: { defaultTitle?: string; appConfig?: AppConfig }
+  options?: {
+    defaultTitle?: string;
+    appConfig?: AppConfig;
+    routePreload?: RoutePreloadMap;
+  }
 ): Promise<Response> {
   const dispatcher = createDispatcher();
   const previousEnv = env.current;
@@ -206,6 +214,7 @@ export async function renderPage(
     titleSource != null ? `<title>${escapeHtml(titleSource)}</title>` : '',
     ...metas.map((m) => `<meta ${toAttrs(m)} />`),
     ...links.map((l) => `<link ${toAttrs(l)} />`),
+    routePreloadTags(options?.routePreload, new URL(c.req.url).pathname),
     speculationRulesTag(options?.appConfig ?? {}),
   ]
     .filter(Boolean)

--- a/packages/server/src/route-preload-tags.ts
+++ b/packages/server/src/route-preload-tags.ts
@@ -1,0 +1,51 @@
+import { findBestPattern } from './route-pattern.js';
+
+/**
+ * Build-generated map from route pattern to the client chunk URLs the route
+ * needs (its matched layout + view chunks and their transitive static
+ * imports, with the client entry's own closure subtracted). Emitted by the
+ * vite plugin's route-preload generator and threaded into `renderPage`.
+ *
+ * Keys are route patterns (e.g. `/docs/:slug`, `/docs/quick-start`) matched
+ * against the request path with `findBestPattern`. Values are absolute,
+ * origin-relative hrefs (e.g. `/static/quick-start-BH8CGeNi.js`).
+ */
+export type RoutePreloadMap = Record<string, readonly string[]>;
+
+// Minimal attribute escape. The hrefs are framework-generated chunk paths, not
+// user input, but escaping keeps the emitted tag well-formed if a chunk name
+// ever contains a reserved character.
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Emit `<link rel="modulepreload">` tags for the chunks the matched route
+ * needs, so the browser fetches the route's layout/view chunks in parallel
+ * with the client entry instead of discovering them several hops into the
+ * module graph. Returns '' when there is no map, no match, or no chunks (so
+ * the head injection degrades to current behavior).
+ *
+ * `crossorigin` is required: module scripts are fetched in CORS mode, and a
+ * modulepreload without it would prime a second, separately-keyed request.
+ */
+export function routePreloadTags(
+  map: RoutePreloadMap | undefined,
+  urlPath: string
+): string {
+  if (!map) return '';
+  const pattern = findBestPattern(Object.keys(map), urlPath);
+  if (!pattern) return '';
+  const hrefs = map[pattern];
+  if (!hrefs || hrefs.length === 0) return '';
+  return hrefs
+    .map(
+      (href) =>
+        `<link rel="modulepreload" href="${escapeAttr(href)}" crossorigin />`
+    )
+    .join('\n        ');
+}

--- a/packages/server/src/route-preload-tags.ts
+++ b/packages/server/src/route-preload-tags.ts
@@ -2,15 +2,21 @@ import { findBestPattern } from './route-pattern.js';
 
 /**
  * Build-generated map from route pattern to the client chunk URLs the route
- * needs (its matched layout + view chunks and their transitive static
- * imports, with the client entry's own closure subtracted). Emitted by the
- * vite plugin's route-preload generator and threaded into `renderPage`.
+ * needs, split by fetch priority. Emitted by the vite plugin's route-preload
+ * generator and threaded into `renderPage`.
  *
  * Keys are route patterns (e.g. `/docs/:slug`, `/docs/quick-start`) matched
  * against the request path with `findBestPattern`. Values are absolute,
- * origin-relative hrefs (e.g. `/static/quick-start-BH8CGeNi.js`).
+ * origin-relative hrefs (e.g. `/static/quick-start-BH8CGeNi.js`):
+ * - `high`: layout-chain chunks, emitted at modulepreload's default priority.
+ * - `low`: leaf view/content chunks, emitted with `fetchpriority="low"` since
+ *   the content is already server-rendered and should not contend with
+ *   render-critical resources for bandwidth.
  */
-export type RoutePreloadMap = Record<string, readonly string[]>;
+export type RoutePreloadMap = Record<
+  string,
+  { high: readonly string[]; low: readonly string[] }
+>;
 
 // Minimal attribute escape. The hrefs are framework-generated chunk paths, not
 // user input, but escaping keeps the emitted tag well-formed if a chunk name
@@ -40,12 +46,19 @@ export function routePreloadTags(
   if (!map) return '';
   const pattern = findBestPattern(Object.keys(map), urlPath);
   if (!pattern) return '';
-  const hrefs = map[pattern];
-  if (!hrefs || hrefs.length === 0) return '';
-  return hrefs
-    .map(
+  const entry = map[pattern];
+  if (!entry) return '';
+  const { high = [], low = [] } = entry;
+  if (high.length === 0 && low.length === 0) return '';
+  const tags = [
+    ...high.map(
       (href) =>
         `<link rel="modulepreload" href="${escapeAttr(href)}" crossorigin />`
-    )
-    .join('\n        ');
+    ),
+    ...low.map(
+      (href) =>
+        `<link rel="modulepreload" href="${escapeAttr(href)}" crossorigin fetchpriority="low" />`
+    ),
+  ];
+  return tags.join('\n        ');
 }

--- a/packages/vite/src/__tests__/hono-preact.test.ts
+++ b/packages/vite/src/__tests__/hono-preact.test.ts
@@ -29,12 +29,13 @@ describe('honoPreact plugin assembly', () => {
   it('emits the framework plugins in pipeline order, then the adapter plugins, then preact', () => {
     const plugins = honoPreact({ adapter: fakeAdapter() }) as NamedPlugin[];
     const names = plugins.map((p) => p.name);
-    expect(names.slice(0, 8)).toEqual([
+    expect(names.slice(0, 9)).toEqual([
       'hono-preact:config',
       'hono-preact:client-shim',
       'hono-preact:client-entry',
       'hono-preact:server-entry',
       'server-loader-validation',
+      'hono-preact:route-preload',
       'module-key',
       'server-only',
       'hono-preact:guard-strip',

--- a/packages/vite/src/__tests__/route-preload.test.ts
+++ b/packages/vite/src/__tests__/route-preload.test.ts
@@ -123,27 +123,26 @@ describe('resolvePreloadMap', () => {
   const chains = extractRouteChains(ROUTES_SRC, ROUTES_ABS, fakeGlob);
   const map = resolvePreloadMap(chains, manifest, { rootDir: '/proj' });
 
-  it('resolves the matched chain to its chunk hrefs, minus the client-entry closure', () => {
+  it('splits the matched chain into high (layout) and low (view), minus the entry closure', () => {
     // DocsLayout pulls jsxRuntime/hooks/route-active; quick-start pulls
-    // jsxRuntime. The entry already loads jsxRuntime + hooks, so only
-    // DocsLayout, route-active, and quick-start remain.
-    expect(map['/docs/quick-start']).toEqual([
-      '/static/DocsLayout.js',
-      '/static/route-active.js',
-      '/static/quick-start.js',
-    ]);
+    // jsxRuntime. The entry already loads jsxRuntime + hooks, so the layout
+    // contributes DocsLayout + route-active (high) and the view contributes
+    // quick-start (low).
+    expect(map['/docs/quick-start']).toEqual({
+      high: ['/static/DocsLayout.js', '/static/route-active.js'],
+      low: ['/static/quick-start.js'],
+    });
   });
 
-  it('subtracts the eager entry closure for a plain leaf', () => {
-    expect(map['/']).toEqual(['/static/home.js']);
+  it('puts a layout-less leaf entirely in low (its content is SSR-rendered)', () => {
+    expect(map['/']).toEqual({ high: [], low: ['/static/home.js'] });
   });
 
-  it('omits patterns whose chunks are entirely in the entry closure', () => {
-    // A pattern resolving only to eager chunks would have no hrefs and is
-    // dropped. (No such pattern here; assert the shape stays a string[].)
-    for (const hrefs of Object.values(map)) {
-      expect(Array.isArray(hrefs)).toBe(true);
-      expect(hrefs.length).toBeGreaterThan(0);
+  it('emits well-formed { high, low } shapes with at least one href', () => {
+    for (const entry of Object.values(map)) {
+      expect(Array.isArray(entry.high)).toBe(true);
+      expect(Array.isArray(entry.low)).toBe(true);
+      expect(entry.high.length + entry.low.length).toBeGreaterThan(0);
     }
   });
 
@@ -152,6 +151,6 @@ describe('resolvePreloadMap', () => {
       rootDir: '/proj',
       base: '/assets/',
     });
-    expect(based['/']).toEqual(['/assets/static/home.js']);
+    expect(based['/']).toEqual({ high: [], low: ['/assets/static/home.js'] });
   });
 });

--- a/packages/vite/src/__tests__/route-preload.test.ts
+++ b/packages/vite/src/__tests__/route-preload.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractRouteChains,
+  resolvePreloadMap,
+  type ClientManifest,
+  type GlobExpander,
+} from '../route-preload.js';
+
+const ROUTES_SRC = `
+import { defineRoutes, contentRoutes } from 'hono-preact';
+import { MdxArticle } from './components/MdxArticle.js';
+const routeTree = [
+  { path: '/', view: () => import('./pages/home.js') },
+  {
+    path: '/docs',
+    layout: () => import('./components/DocsLayout.js'),
+    children: [
+      ...contentRoutes(import.meta.glob('./pages/docs/**/*.mdx'), {
+        wrapper: MdxArticle,
+      }),
+      { path: '*', view: () => import('./components/DocsNotFound.js') },
+    ],
+  },
+  {
+    path: '/demo',
+    layout: () => import('./pages/demo/demo-layout.js'),
+    children: [
+      { path: '', view: () => import('./pages/demo/index.js') },
+      {
+        path: 'projects',
+        use: requireSession,
+        children: [
+          { path: ':projectId', view: () => import('./pages/demo/project.js') },
+        ],
+      },
+    ],
+  },
+  { path: '*', view: () => import('./pages/not-found.js') },
+] as const;
+export default defineRoutes(routeTree);
+`;
+
+const ROUTES_ABS = '/proj/src/routes.ts';
+
+const fakeGlob: GlobExpander = (pattern) => {
+  if (pattern === './pages/docs/**/*.mdx') {
+    return ['./pages/docs/quick-start.mdx', './pages/docs/routing.mdx'];
+  }
+  return [];
+};
+
+describe('extractRouteChains', () => {
+  const chains = extractRouteChains(ROUTES_SRC, ROUTES_ABS, fakeGlob);
+  const byPattern = new Map(chains.map((c) => [c.pattern, c.sources]));
+
+  it('maps a top-level literal view to its source', () => {
+    expect(byPattern.get('/')).toEqual(['/proj/src/pages/home.js']);
+    expect(byPattern.get('*')).toEqual(['/proj/src/pages/not-found.js']);
+  });
+
+  it('expands contentRoutes glob entries under the layout, with the layout in the chain', () => {
+    expect(byPattern.get('/docs/quick-start')).toEqual([
+      '/proj/src/components/DocsLayout.js',
+      '/proj/src/pages/docs/quick-start.mdx',
+    ]);
+    expect(byPattern.get('/docs/routing')).toEqual([
+      '/proj/src/components/DocsLayout.js',
+      '/proj/src/pages/docs/routing.mdx',
+    ]);
+  });
+
+  it('includes the layout for a literal leaf inside a layout group', () => {
+    expect(byPattern.get('/docs/*')).toEqual([
+      '/proj/src/components/DocsLayout.js',
+      '/proj/src/components/DocsNotFound.js',
+    ]);
+  });
+
+  it('accumulates layout ancestors across nested groups and bare groupings', () => {
+    // /demo (layout) -> projects (bare grouping, no module) -> :projectId (view)
+    expect(byPattern.get('/demo/projects/:projectId')).toEqual([
+      '/proj/src/pages/demo/demo-layout.js',
+      '/proj/src/pages/demo/project.js',
+    ]);
+    // index child ('') resolves to the group's own path
+    expect(byPattern.get('/demo')).toEqual([
+      '/proj/src/pages/demo/demo-layout.js',
+      '/proj/src/pages/demo/index.js',
+    ]);
+  });
+});
+
+describe('resolvePreloadMap', () => {
+  const manifest: ClientManifest = {
+    'virtual:hono-preact/client': {
+      file: 'static/client.js',
+      isEntry: true,
+      imports: ['_jsxRuntime.js', '_hooks.js'],
+    },
+    '_jsxRuntime.js': { file: 'static/jsxRuntime.js' },
+    '_hooks.js': { file: 'static/hooks.js' },
+    '_route-active.js': { file: 'static/route-active.js' },
+    'src/components/DocsLayout.tsx': {
+      file: 'static/DocsLayout.js',
+      src: 'src/components/DocsLayout.tsx',
+      isDynamicEntry: true,
+      imports: ['_jsxRuntime.js', '_hooks.js', '_route-active.js'],
+    },
+    'src/pages/docs/quick-start.mdx': {
+      file: 'static/quick-start.js',
+      src: 'src/pages/docs/quick-start.mdx',
+      isDynamicEntry: true,
+      imports: ['_jsxRuntime.js'],
+    },
+    'src/pages/home.tsx': {
+      file: 'static/home.js',
+      src: 'src/pages/home.tsx',
+      isDynamicEntry: true,
+      imports: ['_jsxRuntime.js', '_hooks.js'],
+    },
+  };
+
+  const chains = extractRouteChains(ROUTES_SRC, ROUTES_ABS, fakeGlob);
+  const map = resolvePreloadMap(chains, manifest, { rootDir: '/proj' });
+
+  it('resolves the matched chain to its chunk hrefs, minus the client-entry closure', () => {
+    // DocsLayout pulls jsxRuntime/hooks/route-active; quick-start pulls
+    // jsxRuntime. The entry already loads jsxRuntime + hooks, so only
+    // DocsLayout, route-active, and quick-start remain.
+    expect(map['/docs/quick-start']).toEqual([
+      '/static/DocsLayout.js',
+      '/static/route-active.js',
+      '/static/quick-start.js',
+    ]);
+  });
+
+  it('subtracts the eager entry closure for a plain leaf', () => {
+    expect(map['/']).toEqual(['/static/home.js']);
+  });
+
+  it('omits patterns whose chunks are entirely in the entry closure', () => {
+    // A pattern resolving only to eager chunks would have no hrefs and is
+    // dropped. (No such pattern here; assert the shape stays a string[].)
+    for (const hrefs of Object.values(map)) {
+      expect(Array.isArray(hrefs)).toBe(true);
+      expect(hrefs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('respects a non-root base', () => {
+    const based = resolvePreloadMap(chains, manifest, {
+      rootDir: '/proj',
+      base: '/assets/',
+    });
+    expect(based['/']).toEqual(['/assets/static/home.js']);
+  });
+});

--- a/packages/vite/src/__tests__/server-entry.test.ts
+++ b/packages/vite/src/__tests__/server-entry.test.ts
@@ -11,6 +11,7 @@ import {
   generatedEntryWrapperAbsPath,
   serverEntryPlugin,
 } from '../server-entry.js';
+import { ROUTE_PRELOAD_PLACEHOLDER } from '../route-preload.js';
 
 // Minimal adapter stub for plugin tests that only check file-writing behavior.
 const stubAdapter = {
@@ -71,7 +72,7 @@ describe('generateCoreAppModule', () => {
     expect(src).toContain('resolvePageUseByPath: pageUseResolver.byPath');
     // renderPage receives appConfig as a third argument.
     expect(src).toContain(
-      `(c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes }))), { appConfig })`
+      `(c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes }))), { appConfig, routePreload })`
     );
   });
 
@@ -140,6 +141,16 @@ describe('generateCoreAppModule', () => {
     expect(src).toContain(`resolverByPath: pageActionResolvers.byPath`);
     expect(src).toContain(`resolvePageUseByPath: pageUseResolver.byPath`);
 
+    // Route-preload: the generated module declares the placeholder the
+    // route-preload plugin string-replaces in the built worker bundle, and
+    // forwards the map into both render paths. The placeholder text must stay
+    // in sync with ROUTE_PRELOAD_PLACEHOLDER or the build-time replacement
+    // silently no-ops.
+    expect(src).toContain(
+      `const routePreload = ${ROUTE_PRELOAD_PLACEHOLDER} || {};`
+    );
+    expect(src).toContain(`routePreload,`);
+
     // Hono pipeline in correct order: /__loaders POST, then wildcard POST (actions),
     // then wildcard GET (SSR).
     const loadersIdx = src.indexOf(`'/__loaders'`);
@@ -149,7 +160,7 @@ describe('generateCoreAppModule', () => {
     expect(actionPostIdx).toBeGreaterThan(loadersIdx);
     expect(catchallIdx).toBeGreaterThan(actionPostIdx);
     expect(src).toContain(
-      `(c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes }))), { appConfig })`
+      `(c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes }))), { appConfig, routePreload })`
     );
     // defaultTitle is no longer threaded through renderPage by the framework.
     expect(src).not.toContain('defaultTitle');

--- a/packages/vite/src/hono-preact.ts
+++ b/packages/vite/src/hono-preact.ts
@@ -4,6 +4,7 @@ import { CLIENT_ENTRY_FILE } from '@hono-preact/iso/internal/runtime';
 import { clientShimPlugin } from './client-shim.js';
 import { clientEntryPlugin, VIRTUAL_CLIENT_ENTRY_ID } from './client-entry.js';
 import { serverLoaderValidationPlugin } from './server-loader-validation.js';
+import { routePreloadPlugin } from './route-preload.js';
 import { moduleKeyPlugin } from './module-key-plugin.js';
 import { serverOnlyPlugin } from './server-only.js';
 import { guardStripPlugin } from './guard-strip.js';
@@ -77,6 +78,10 @@ export function honoPreact(options: HonoPreactOptions): Plugin[] {
         environments: {
           client: {
             build: {
+              // Emit the client manifest so the route-preload plugin can map
+              // each route's source module to its hashed output chunk(s) and
+              // emit <link rel="modulepreload"> hints at SSR time.
+              manifest: true,
               rollupOptions: {
                 input: [clientEntry],
                 output: {
@@ -106,6 +111,7 @@ export function honoPreact(options: HonoPreactOptions): Plugin[] {
       entryWrapperPath,
     }),
     serverLoaderValidationPlugin(),
+    routePreloadPlugin({ routes }),
     moduleKeyPlugin(),
     serverOnlyPlugin(),
     guardStripPlugin(),

--- a/packages/vite/src/route-preload.ts
+++ b/packages/vite/src/route-preload.ts
@@ -44,7 +44,16 @@ export type ClientManifest = Record<
   }
 >;
 
-export type RoutePreloadMap = Record<string, string[]>;
+/**
+ * Per-pattern preload hrefs split by fetch priority:
+ * - `high`: layout-chain chunks. They gate the hydration shell, so they keep
+ *   modulepreload's default (High) priority.
+ * - `low`: the leaf view/content chunk(s). The page content is already in the
+ *   SSR HTML, so these are emitted with `fetchpriority="low"` to avoid
+ *   contending with render-critical resources (CSS, fonts, the client entry)
+ *   for bandwidth during first paint.
+ */
+export type RoutePreloadMap = Record<string, { high: string[]; low: string[] }>;
 
 // ---------------------------------------------------------------------------
 // Route-path joining + content-route slug rules. Kept byte-compatible with
@@ -370,10 +379,15 @@ function entryClosure(manifest: ClientManifest): Set<string> {
 }
 
 /**
- * Resolve route module chains to a pattern -> preload-href map against the
- * client manifest. Each pattern's hrefs are the union of its modules' static
- * chunk closures, minus the client entry's own closure (those chunks are
- * already fetched via the entry script), prefixed with the build base.
+ * Resolve route module chains to a pattern -> { high, low } preload map against
+ * the client manifest.
+ *
+ * Each chain is `[...layouts, view]` (outer layout first, leaf view last). The
+ * layout chunks (and their static imports) go in `high`; the view chunk's
+ * own chunks go in `low`. Both sets subtract the client entry's closure (those
+ * chunks load eagerly via the entry script anyway), and `low` also subtracts
+ * `high` so a chunk shared by layout and view is preloaded once, at the higher
+ * priority. Hrefs are prefixed with the build base.
  */
 export function resolvePreloadMap(
   chains: readonly RouteModuleChain[],
@@ -386,20 +400,34 @@ export function resolvePreloadMap(
   const href = (file: string): string =>
     (base.endsWith('/') ? base : base + '/') + file;
 
+  const chunksOf = (sources: readonly string[]): Set<string> => {
+    const files = new Set<string>();
+    for (const src of sources) {
+      const manifestKey = bySource.get(stripExt(src));
+      if (manifestKey)
+        collectStaticChunks(manifestKey, manifest, files, new Set());
+    }
+    return files;
+  };
+
   const map: RoutePreloadMap = {};
   for (const chain of chains) {
-    const files = new Set<string>();
-    for (const src of chain.sources) {
-      const manifestKey = bySource.get(stripExt(src));
-      if (!manifestKey) continue;
-      collectStaticChunks(manifestKey, manifest, files, new Set());
+    const layoutSources = chain.sources.slice(0, -1);
+    const viewSource = chain.sources[chain.sources.length - 1];
+    const highFiles = chunksOf(layoutSources);
+    const viewFiles = viewSource ? chunksOf([viewSource]) : new Set<string>();
+
+    const high: string[] = [];
+    for (const file of highFiles) {
+      if (!eager.has(file)) high.push(href(file));
     }
-    const hrefs: string[] = [];
-    for (const file of files) {
-      if (eager.has(file)) continue;
-      hrefs.push(href(file));
+    const low: string[] = [];
+    for (const file of viewFiles) {
+      if (!eager.has(file) && !highFiles.has(file)) low.push(href(file));
     }
-    if (hrefs.length > 0) map[chain.pattern] = hrefs;
+    if (high.length > 0 || low.length > 0) {
+      map[chain.pattern] = { high, low };
+    }
   }
   return map;
 }

--- a/packages/vite/src/route-preload.ts
+++ b/packages/vite/src/route-preload.ts
@@ -1,0 +1,527 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import type { Plugin } from 'vite';
+import { parse } from '@babel/parser';
+import { isExpression } from '@babel/types';
+import type {
+  ArrayExpression,
+  Expression,
+  Node,
+  ObjectExpression,
+} from '@babel/types';
+import { BABEL_PARSER_PLUGINS } from './parser-options.js';
+
+/**
+ * Build-time route-preload map generation (prototype).
+ *
+ * Approach 1 from the network-dependency-tree investigation: at build time,
+ * map each route pattern to the client chunks its matched layout/view modules
+ * need, so the SSR layer can emit `<link rel="modulepreload">` hints and the
+ * browser fetches the route chunk in parallel with the client entry instead of
+ * three hops down the module graph.
+ *
+ * This file owns the two pure transforms (route-tree -> module chains, and
+ * chains + manifest -> preload href map) plus the vite plugin that runs them
+ * against the real `routes.ts` and client manifest.
+ */
+
+/** A leaf route and the source modules it pulls in (outer layout -> leaf view). */
+export type RouteModuleChain = {
+  pattern: string;
+  /** Absolute source paths (as written, extension intact), outermost first. */
+  sources: string[];
+};
+
+/** Vite client manifest, narrowed to the fields we read. */
+export type ClientManifest = Record<
+  string,
+  {
+    file: string;
+    src?: string;
+    isEntry?: boolean;
+    isDynamicEntry?: boolean;
+    imports?: string[];
+  }
+>;
+
+export type RoutePreloadMap = Record<string, string[]>;
+
+// ---------------------------------------------------------------------------
+// Route-path joining + content-route slug rules. Kept byte-compatible with
+// `joinRoutePath` (define-routes) and `commonDirPrefix`/`defaultSlug`
+// (content-routes) so build-time patterns match the runtime registrations.
+// ---------------------------------------------------------------------------
+
+function joinRoutePath(parentPath: string, childPath: string): string {
+  if (parentPath === '') return childPath;
+  return childPath === '' ? parentPath : parentPath + '/' + childPath;
+}
+
+function commonDirPrefix(keys: readonly string[]): string {
+  if (keys.length === 0) return '';
+  let prefix = keys[0];
+  for (let i = 1; i < keys.length; i++) {
+    const k = keys[i];
+    let j = 0;
+    while (j < prefix.length && j < k.length && prefix[j] === k[j]) j++;
+    prefix = prefix.slice(0, j);
+    if (prefix === '') break;
+  }
+  const lastSlash = prefix.lastIndexOf('/');
+  return lastSlash === -1 ? '' : prefix.slice(0, lastSlash + 1);
+}
+
+function defaultSlug(key: string, base: string): string {
+  let s = key.startsWith(base) ? key.slice(base.length) : key;
+  s = s.replace(/\.[^./]+$/, '');
+  s = s.replace(/(^|\/)index$/, '');
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// AST extraction
+// ---------------------------------------------------------------------------
+
+/** Glob expander: returns module keys (with leading `./`) relative to fromDir. */
+export type GlobExpander = (globPattern: string, fromDir: string) => string[];
+
+function isObjectExpression(n: Node | null | undefined): n is ObjectExpression {
+  return !!n && n.type === 'ObjectExpression';
+}
+
+function getProperty(
+  obj: ObjectExpression,
+  name: string
+): Expression | undefined {
+  for (const p of obj.properties) {
+    if (
+      p.type === 'ObjectProperty' &&
+      !p.computed &&
+      ((p.key.type === 'Identifier' && p.key.name === name) ||
+        (p.key.type === 'StringLiteral' && p.key.value === name)) &&
+      // ObjectProperty.value unions Expression | PatternLike (the latter only
+      // in destructuring patterns). In a route object literal it is always an
+      // Expression; narrow with the predicate rather than casting.
+      isExpression(p.value)
+    ) {
+      return p.value;
+    }
+  }
+  return undefined;
+}
+
+function stringLiteralValue(n: Node | null | undefined): string | undefined {
+  return n && n.type === 'StringLiteral' ? n.value : undefined;
+}
+
+/** Extract the specifier from a `() => import('spec')` thunk. */
+function importThunkSpecifier(n: Node | null | undefined): string | undefined {
+  if (!n || n.type !== 'ArrowFunctionExpression') return undefined;
+  const body = n.body;
+  if (
+    body.type === 'ImportExpression' &&
+    body.source.type === 'StringLiteral'
+  ) {
+    return body.source.value;
+  }
+  return undefined;
+}
+
+/** Match `import.meta.glob('lit')` and return the literal pattern. */
+function importMetaGlobPattern(n: Node): string | undefined {
+  if (n.type !== 'CallExpression') return undefined;
+  const callee = n.callee;
+  if (
+    callee.type !== 'MemberExpression' ||
+    callee.property.type !== 'Identifier' ||
+    callee.property.name !== 'glob' ||
+    callee.object.type !== 'MetaProperty'
+  ) {
+    return undefined;
+  }
+  return stringLiteralValue(n.arguments[0]);
+}
+
+/** Match `contentRoutes(import.meta.glob('lit'), { base?: 'lit' })`. */
+function contentRoutesCall(
+  n: Node
+): { globPattern: string; base?: string; hasCustomSlug: boolean } | undefined {
+  if (n.type !== 'CallExpression') return undefined;
+  if (n.callee.type !== 'Identifier' || n.callee.name !== 'contentRoutes') {
+    return undefined;
+  }
+  const first = n.arguments[0];
+  if (!first) return undefined;
+  const globPattern = importMetaGlobPattern(first);
+  if (globPattern == null) return undefined;
+  let base: string | undefined;
+  let hasCustomSlug = false;
+  const opts = n.arguments[1];
+  if (opts && opts.type === 'ObjectExpression') {
+    base = stringLiteralValue(getProperty(opts, 'base'));
+    hasCustomSlug = getProperty(opts, 'slug') !== undefined;
+  }
+  return { globPattern, base, hasCustomSlug };
+}
+
+/** Resolve the `defineRoutes(ARG)` argument to its array literal. */
+function findRouteArray(ast: ReturnType<typeof parse>): ArrayExpression | null {
+  let argExpr: Expression | null = null;
+  const body = ast.program.body;
+  for (const stmt of body) {
+    const decl =
+      stmt.type === 'ExportDefaultDeclaration' ? stmt.declaration : undefined;
+    const call =
+      decl && decl.type === 'CallExpression'
+        ? decl
+        : stmt.type === 'ExpressionStatement' &&
+            stmt.expression.type === 'CallExpression'
+          ? stmt.expression
+          : undefined;
+    if (
+      call &&
+      call.callee.type === 'Identifier' &&
+      call.callee.name === 'defineRoutes'
+    ) {
+      // arguments[0] unions Expression | SpreadElement | ArgumentPlaceholder;
+      // narrow with the predicate rather than casting.
+      const arg = call.arguments[0];
+      if (arg && isExpression(arg)) argExpr = arg;
+      break;
+    }
+  }
+  if (!argExpr) return null;
+
+  const unwrap = (e: Expression): Expression =>
+    e.type === 'TSAsExpression' || e.type === 'TSSatisfiesExpression'
+      ? unwrap(e.expression)
+      : e;
+  argExpr = unwrap(argExpr);
+
+  if (argExpr.type === 'ArrayExpression') return argExpr;
+
+  // Identifier reference: resolve `const X = [...] as const`.
+  if (argExpr.type === 'Identifier') {
+    const name = argExpr.name;
+    for (const stmt of body) {
+      if (stmt.type !== 'VariableDeclaration') continue;
+      for (const d of stmt.declarations) {
+        if (d.id.type === 'Identifier' && d.id.name === name && d.init) {
+          const init = unwrap(d.init);
+          if (init.type === 'ArrayExpression') return init;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk the route-tree AST into one chain per leaf (view) route. Layout
+ * ancestors accumulate as the walk descends, so each leaf carries its full
+ * outer-to-inner module list. `contentRoutes(import.meta.glob(...))` spreads
+ * are expanded via the injected `expandGlob`.
+ *
+ * Unsupported shapes (non-literal `view`, custom `slug`, exotic globs) are
+ * reported through `warn` and skipped, so those routes fall back to today's
+ * no-preload behavior rather than silently emitting wrong hints.
+ */
+export function extractRouteChains(
+  source: string,
+  routesAbsPath: string,
+  expandGlob: GlobExpander,
+  warn: (msg: string) => void = () => {}
+): RouteModuleChain[] {
+  const ast = parse(source, {
+    sourceType: 'module',
+    plugins: BABEL_PARSER_PLUGINS,
+    errorRecovery: true,
+  });
+  const arr = findRouteArray(ast);
+  if (!arr) {
+    warn('could not locate the defineRoutes([...]) route array; skipping');
+    return [];
+  }
+
+  const routesDir = path.dirname(routesAbsPath);
+  const toAbs = (spec: string): string => path.resolve(routesDir, spec);
+  const chains: RouteModuleChain[] = [];
+
+  const walkElements = (
+    elements: ArrayExpression['elements'],
+    parentPattern: string,
+    layoutStack: string[]
+  ): void => {
+    for (const el of elements) {
+      if (!el) continue;
+
+      if (el.type === 'SpreadElement') {
+        const content = contentRoutesCall(el.argument);
+        if (!content) {
+          warn(
+            `unsupported spread in route children at ${parentPattern || '/'}; skipping`
+          );
+          continue;
+        }
+        if (content.hasCustomSlug) {
+          warn(
+            `contentRoutes at ${parentPattern || '/'} uses a custom slug() — ` +
+              `cannot replicate it at build time; skipping its preload hints`
+          );
+          continue;
+        }
+        const keys = expandGlob(content.globPattern, routesDir);
+        const base = content.base ?? commonDirPrefix(keys);
+        for (const key of keys) {
+          const slug = defaultSlug(key, base);
+          const pattern = joinRoutePath(parentPattern, slug);
+          chains.push({
+            pattern,
+            sources: [...layoutStack, toAbs(key)],
+          });
+        }
+        continue;
+      }
+
+      if (!isObjectExpression(el)) continue;
+      const routePath = stringLiteralValue(getProperty(el, 'path'));
+      if (routePath == null) {
+        warn('route node without a string `path`; skipping');
+        continue;
+      }
+      const here = joinRoutePath(parentPattern, routePath);
+      const viewSpec = importThunkSpecifier(getProperty(el, 'view'));
+      const layoutSpec = importThunkSpecifier(getProperty(el, 'layout'));
+      const childrenExpr = getProperty(el, 'children');
+      const children =
+        childrenExpr && childrenExpr.type === 'ArrayExpression'
+          ? childrenExpr.elements
+          : undefined;
+
+      if (viewSpec) {
+        chains.push({
+          pattern: here,
+          sources: [...layoutStack, toAbs(viewSpec)],
+        });
+      } else if (layoutSpec && children) {
+        walkElements(children, here, [...layoutStack, toAbs(layoutSpec)]);
+      } else if (children) {
+        // Bare grouping: prefix children, no layout module of its own.
+        walkElements(children, here, layoutStack);
+      } else if (getProperty(el, 'view') && !viewSpec) {
+        warn(
+          `route ${here}: \`view\` is not a literal import() thunk; skipping`
+        );
+      }
+    }
+  };
+
+  walkElements(arr.elements, '', []);
+  return chains;
+}
+
+// ---------------------------------------------------------------------------
+// Manifest resolution
+// ---------------------------------------------------------------------------
+
+function stripExt(p: string): string {
+  return p.replace(/\.[^./]+$/, '');
+}
+
+/** Index manifest entries by absolute source path without extension. */
+function indexBySource(
+  manifest: ClientManifest,
+  rootDir: string
+): Map<string, string> {
+  // key (abs-source-no-ext) -> manifest key
+  const index = new Map<string, string>();
+  for (const [key, entry] of Object.entries(manifest)) {
+    const src = entry.src ?? (key.startsWith('_') ? undefined : key);
+    if (!src) continue;
+    index.set(stripExt(path.resolve(rootDir, src)), key);
+  }
+  return index;
+}
+
+/** Collect a manifest entry's chunk file plus its transitive static imports. */
+function collectStaticChunks(
+  manifestKey: string,
+  manifest: ClientManifest,
+  out: Set<string>,
+  seen: Set<string>
+): void {
+  if (seen.has(manifestKey)) return;
+  seen.add(manifestKey);
+  const entry = manifest[manifestKey];
+  if (!entry) return;
+  out.add(entry.file);
+  for (const imp of entry.imports ?? []) {
+    collectStaticChunks(imp, manifest, out, seen);
+  }
+}
+
+/** The chunk-file closure of the client entry (already fetched eagerly). */
+function entryClosure(manifest: ClientManifest): Set<string> {
+  const out = new Set<string>();
+  for (const [key, entry] of Object.entries(manifest)) {
+    if (entry.isEntry) collectStaticChunks(key, manifest, out, new Set());
+  }
+  return out;
+}
+
+/**
+ * Resolve route module chains to a pattern -> preload-href map against the
+ * client manifest. Each pattern's hrefs are the union of its modules' static
+ * chunk closures, minus the client entry's own closure (those chunks are
+ * already fetched via the entry script), prefixed with the build base.
+ */
+export function resolvePreloadMap(
+  chains: readonly RouteModuleChain[],
+  manifest: ClientManifest,
+  opts: { rootDir: string; base?: string }
+): RoutePreloadMap {
+  const base = opts.base ?? '/';
+  const bySource = indexBySource(manifest, opts.rootDir);
+  const eager = entryClosure(manifest);
+  const href = (file: string): string =>
+    (base.endsWith('/') ? base : base + '/') + file;
+
+  const map: RoutePreloadMap = {};
+  for (const chain of chains) {
+    const files = new Set<string>();
+    for (const src of chain.sources) {
+      const manifestKey = bySource.get(stripExt(src));
+      if (!manifestKey) continue;
+      collectStaticChunks(manifestKey, manifest, files, new Set());
+    }
+    const hrefs: string[] = [];
+    for (const file of files) {
+      if (eager.has(file)) continue;
+      hrefs.push(href(file));
+    }
+    if (hrefs.length > 0) map[chain.pattern] = hrefs;
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Glob expansion (fs-backed). Supports `<dir>/**/*.<ext>` and `<dir>/*.<ext>`.
+// ---------------------------------------------------------------------------
+
+function expandGlobFs(globPattern: string, fromDir: string): string[] {
+  const m = globPattern.match(/^(.*?)(\*\*\/)?\*(\.[^./*]+)$/);
+  if (!m) return [];
+  const literalPrefix = m[1].replace(/^\.\//, '');
+  const recursive = !!m[2];
+  const ext = m[3];
+  const baseDir = path.resolve(fromDir, literalPrefix);
+  const keys: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (recursive) walk(full);
+      } else if (e.isFile() && e.name.endsWith(ext)) {
+        const rel = path.relative(fromDir, full).split(path.sep).join('/');
+        keys.push('./' + rel);
+      }
+    }
+  };
+  walk(baseDir);
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/** Token the generated core-app uses as a placeholder for the inlined map. */
+export const ROUTE_PRELOAD_PLACEHOLDER = 'globalThis.__HP_ROUTE_PRELOAD__';
+
+export interface RoutePreloadPluginOptions {
+  routes: string; // project-relative or absolute path to routes.ts
+}
+
+/**
+ * Generate the route-preload map after the client build and inline it into the
+ * already-emitted worker bundle.
+ *
+ * Threading note (prototype): the worker environment builds BEFORE the client
+ * environment, so the client manifest does not exist when the worker is
+ * bundled. Rather than reorder the build, this plugin waits for the client
+ * `closeBundle` (which runs last, with the manifest written), computes the map,
+ * and string-replaces the `globalThis.__HP_ROUTE_PRELOAD__` placeholder the
+ * generated core-app left in the unminified worker bundle. A cleaner long-term
+ * threading (assets-binding read, or a manifest-injection pass) is noted in the
+ * PR.
+ */
+export function routePreloadPlugin(opts: RoutePreloadPluginOptions): Plugin {
+  let root = process.cwd();
+  let routesAbsPath = '';
+  let base = '/';
+
+  return {
+    name: 'hono-preact:route-preload',
+    apply: 'build',
+    configResolved(config) {
+      root = config.root;
+      base = config.base || '/';
+      routesAbsPath = path.isAbsolute(opts.routes)
+        ? opts.routes
+        : path.resolve(config.root, opts.routes);
+    },
+    closeBundle() {
+      // Only act after the client build, whose manifest we read.
+      const envName = (this as { environment?: { name?: string } }).environment
+        ?.name;
+      if (envName !== 'client') return;
+
+      const manifestPath = path.resolve(
+        root,
+        'dist/client/.vite/manifest.json'
+      );
+      const workerEntry = path.resolve(root, 'dist/hono_preact/index.js');
+      if (!fs.existsSync(manifestPath) || !fs.existsSync(workerEntry)) return;
+
+      let manifest: ClientManifest;
+      try {
+        manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      } catch {
+        this.warn('route-preload: client manifest unreadable; skipping');
+        return;
+      }
+
+      const source = fs.readFileSync(routesAbsPath, 'utf8');
+      const chains = extractRouteChains(
+        source,
+        routesAbsPath,
+        expandGlobFs,
+        (m) => this.warn(`route-preload: ${m}`)
+      );
+      const map = resolvePreloadMap(chains, manifest, { rootDir: root, base });
+
+      const worker = fs.readFileSync(workerEntry, 'utf8');
+      if (!worker.includes(ROUTE_PRELOAD_PLACEHOLDER)) {
+        this.warn(
+          'route-preload: placeholder not found in worker bundle; ' +
+            'preload hints will be inactive'
+        );
+        return;
+      }
+      const patched = worker.replace(
+        ROUTE_PRELOAD_PLACEHOLDER,
+        JSON.stringify(map)
+      );
+      fs.writeFileSync(workerEntry, patched, 'utf8');
+      this.info(
+        `route-preload: inlined preload map for ${Object.keys(map).length} route patterns`
+      );
+    },
+  };
+}

--- a/packages/vite/src/server-entry.ts
+++ b/packages/vite/src/server-entry.ts
@@ -59,6 +59,12 @@ export function generateCoreAppModule(
     `const serverModules = routeServerModules(routes);\n` +
     `const pageUseResolver = makePageUseResolver(routes);\n` +
     `const pageActionResolvers = makePageActionResolvers(routes.serverRoutes, { dev });\n` +
+    // Route-preload map: the route-preload plugin string-replaces this
+    // placeholder in the built worker bundle with the generated
+    // pattern -> chunk-hrefs map (the client manifest it needs does not exist
+    // until after this worker build, so it is inlined post-build). Falls back
+    // to {} in dev and if the replacement never runs.
+    `const routePreload = globalThis.__HP_ROUTE_PRELOAD__ || {};\n` +
     `\n` +
     `export const app = new Hono()\n` +
     apiMount +
@@ -69,8 +75,9 @@ export function generateCoreAppModule(
     `    renderPage,\n` +
     `    resolvePageNode: () => h(Layout, null, h(LocationProvider, null, h(Routes, { routes }))),\n` +
     `    appConfig,\n` +
+    `    routePreload,\n` +
     `  }))\n` +
-    `  .get('*', (c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes }))), { appConfig }));\n` +
+    `  .get('*', (c) => renderPage(c, h(Layout, null, h(LocationProvider, null, h(Routes, { routes }))), { appConfig, routePreload }));\n` +
     `\n` +
     `export default app;\n`
   );


### PR DESCRIPTION
## What

Prototype of **Approach 1** from the network-dependency-tree investigation: emit `<link rel="modulepreload">` for the matched route's chunks in the SSR `<head>`, so the browser fetches a route's layout/view chunks **in parallel with `client.js`** instead of discovering them 3-4 hops down the module graph.

This is the follow-up to the CLS fix (#117) and targets the third Lighthouse audit (Network dependency tree). It is **score-neutral** (that audit is informative) and improves **hydration/TTI on real, high-latency networks**, not first paint (content is already SSR'd).

## How (build-time map + request-time lookup)

- **`packages/vite/src/route-preload.ts`** — enables the client `build.manifest`, AST-walks `routes.ts` into one source-module chain per leaf pattern (accumulating layout ancestors), expanding `contentRoutes(import.meta.glob(...))` spreads by replicating the runtime slug rules. Resolves each chain to its client chunks + transitive static imports via the manifest, **minus the client entry's own closure** (those are already fetched eagerly).
- **`packages/server/src/route-preload-tags.ts`** — `routePreloadTags(map, urlPath)` picks the best pattern with the existing `findBestPattern` and emits the links. Wired into `renderPage`'s head next to `speculationRulesTag`, and threaded through `pageActionHandler`'s re-render path.

## Verified end-to-end on `apps/site`

The built worker serves, for `/docs/quick-start`:

```html
<link rel="modulepreload" href="/static/DocsLayout-B0kTOIX1.js" crossorigin />
<link rel="modulepreload" href="/static/route-active-Bvb617LW.js" crossorigin />
<link rel="modulepreload" href="/static/quick-start-BH8CGeNi.js" crossorigin />
```

Those are exactly the three chunks that sat at **depth 4** in the report. The eager runtime chunks (jsxRuntime/hooks/MdxArticle) are correctly subtracted. The build inlines a map for **52 route patterns**.

## ⚠️ Prototype shortcuts / limitations (call these out in review)

1. **Threading is a string-replace.** The worker environment builds *before* the client, so the client manifest doesn't exist when the worker is bundled. The plugin waits for the client `closeBundle`, builds the map, and replaces a `globalThis.__HP_ROUTE_PRELOAD__` placeholder in the (unminified) worker bundle (`dist/hono_preact/index.js`). It degrades gracefully (placeholder → `{}`) if the replace ever doesn't run, and a test pins the placeholder to the plugin's constant. **A cleaner production threading** (e.g. read the map via the Cloudflare ASSETS binding at runtime, a dedicated manifest-injection pass, or persuading the build to run client-first) is the main open design question.
2. **Cloudflare-adapter-coupled.** The post-process hardcodes `dist/hono_preact/index.js`. The node adapter path is untouched.
3. **Route-shape coverage.** The AST walker handles the patterns `apps/site` uses (literal `view`/`layout`, layout groups, bare groupings, params, default-slug `contentRoutes`). Custom `slug()` functions, exotic globs, and non-literal thunks are logged and skipped (those routes fall back to today's no-preload behavior) rather than emitting wrong hints.
4. **No opt-in flag yet.** It's on by default for the build; a `defineApp({ modulePreload })` switch is a design decision deferred to the real version.

## Tests

New: `route-preload.test.ts` (chain extraction incl. contentRoutes glob + manifest resolution + entry-closure subtraction), `route-preload-tags.test.ts` (matching/emission), `render-preload.test.tsx` (links injected through `renderPage` for the matched path, absent otherwise). Updated the plugin-list and generated-core-app assertions for the new plugin/option, and added a guard pinning the generated placeholder to `ROUTE_PRELOAD_PLACEHOLDER`.

All six CI steps pass locally: framework build, format:check, typecheck, 1411 unit tests, 4 integration tests, site build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: preload split by fetch priority (commit 35cec46)

Layout-chain chunks keep modulepreload's default (High) priority; the leaf **view/content** chunk is emitted with **`fetchpriority="low"`** (its content is already SSR'd, so it shouldn't contend with render-critical CSS/fonts/entry for bandwidth). `RoutePreloadMap` is now `{ high, low }` per pattern. `fetchpriority` degrades gracefully on unsupported browsers (falls back to High = prior behavior).

**Controlled A/B (1 machine, Lighthouse 12.6.1, 4 runs each, only view-chunk priority varied):** no measurable difference, FCP 1514 vs 1520 ms, LCP 1671 vs 1675 ms, perf 99, CLS 0, chain 3-deep on both legs. The route chunks here are ~10 KB, below what simulated throttling resolves. Kept as the more honest default that can matter for large view chunks / real networks. Takeaway: the earlier FCP-contention hypothesis was **not** supported, the CI FCP swing was run/machine variance, not preload priority. The real wins (CLS 0, chain depth 4→3) are stable regardless.
