### PR TITLE
fix(infra): unpin CI from pnpm 10 and support pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Version derives from the `packageManager` field in package.json.
       - uses: pnpm/action-setup@v4
-        with:
-          # Pinned: pnpm 11 hit a workspace peer-dep override propagation bug
-          # against the preact-iso v3 GitHub override. Keep aligned with the
-          # `packageManager` field in package.json.
-          version: 10.18.3
 
       - uses: actions/setup-node@v4
         with:
@@ -76,9 +72,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Version derives from the `packageManager` field in package.json.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.18.3
 
       - uses: actions/setup-node@v4
         with:
@@ -122,9 +117,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Version derives from the `packageManager` field in package.json.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10.18.3
 
       - uses: actions/setup-node@v4
         with:
@@ -185,12 +179,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Version derives from the `packageManager` field in package.json.
       - uses: pnpm/action-setup@v4
-        with:
-          # Pinned: pnpm 11 hit a workspace peer-dep override propagation bug
-          # against the preact-iso v3 GitHub override. Keep aligned with the
-          # `packageManager` field in package.json.
-          version: 10.18.3
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -2,19 +2,7 @@
   "name": "hono-preact-monorepo",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.18.3",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "workerd",
-      "@parcel/watcher"
-    ],
-    "overrides": {
-      "preact-iso": "github:preactjs/preact-iso#v3",
-      "typescript": "^6.0.3",
-      "vite": "^8.0.8"
-    }
-  },
+  "packageManager": "pnpm@11.7.0",
   "scripts": {
     "dev": "pnpm --filter site run dev",
     "build": "pnpm --filter '@hono-preact/*' --filter hono-preact --filter hono-preact-ui build && pnpm --filter site build",

--- a/packages/create-hono-preact/templates/cloudflare/pnpm-workspace.yaml
+++ b/packages/create-hono-preact/templates/cloudflare/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm 11 aborts `install` when a dependency ships an unreviewed build script
+# (postinstall). This app's toolchain (esbuild, workerd, ...) ships its native
+# binaries via platform-specific packages, so those scripts are safe to skip.
+# Downgrade the abort to a warning; run `pnpm approve-builds` to opt a
+# dependency in if you ever need its build step to run.
+strictDepBuilds: false

--- a/packages/create-hono-preact/templates/node/pnpm-workspace.yaml
+++ b/packages/create-hono-preact/templates/node/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm 11 aborts `install` when a dependency ships an unreviewed build script
+# (postinstall). This app's toolchain (esbuild, ...) ships its native binaries
+# via platform-specific packages, so those scripts are safe to skip. Downgrade
+# the abort to a warning; run `pnpm approve-builds` to opt a dependency in if
+# you ever need its build step to run.
+strictDepBuilds: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,20 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+
+# pnpm 11 no longer reads the `pnpm` field in package.json; build-script
+# allowlists and dependency overrides live here instead.
+# `allowBuilds` replaces v10's `onlyBuiltDependencies` (a map, not a list).
+allowBuilds:
+  esbuild: true
+  workerd: true
+  '@parcel/watcher': true
+  sharp: false
+
+overrides:
+  # The framework targets preact-iso v3 (searchParams/pathParams RouteHook
+  # shape), which is only published on the GitHub branch. Force every
+  # workspace resolution onto it so peer deps never fall back to npm 2.x.
+  preact-iso: github:preactjs/preact-iso#v3
+  typescript: ^6.0.3
+  vite: ^8.0.8


### PR DESCRIPTION
Closes #32.

## Problem

The repo pins `packageManager` to `pnpm@10.18.3` (and pins the same version in four `ci.yml` jobs) because pnpm 11 broke the `preact-iso` v3 resolution. Re-investigating under current pnpm (11.7.0), the root cause has a single, clean explanation:

**pnpm 11 no longer reads the `pnpm` field in `package.json`.**

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides".
```

With the `preact-iso` / `typescript` / `vite` overrides silently dropped:

- `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — the committed lockfile records three `overrides`, but the (now-empty) config records none, so they disagree. This was the issue's "lockfile config mismatch", not a lockfile-format problem.
- Without the override, the framework packages that declare `preact-iso` as a `>=2.11.0` peer resolve against npm `2.11.x` (old `query`/`params` `RouteHook` shape) instead of the GitHub v3 branch (`searchParams`/`pathParams`) the code is written against.

(Note: the GitHub v3 branch's `package.json` keeps version `2.11.1`, which is why the original report read it as "npm 2.11.1". The distinguishing factor is the `RouteHook` shape, not the version number.)

## Fix (Option 2 from the issue: move resolution into workspace config)

- **`pnpm-workspace.yaml`** now holds `overrides` (so the v3 GitHub branch wins for every workspace resolution, including peers) and the build-script allowlist. The allowlist moves from the removed `onlyBuiltDependencies` (array) to pnpm 11's `allowBuilds` (map), preserving the prior intent: `esbuild`, `workerd`, `@parcel/watcher` build; `sharp` is skipped.
- **`package.json`**: `packageManager` → `pnpm@11.7.0`; the dead `pnpm` field is removed.
- **`ci.yml`**: drop the four `version: 10.18.3` pins; `pnpm/action-setup@v4` now derives the version from the `packageManager` field (single source of truth).

The committed `pnpm-lock.yaml` (`lockfileVersion: 9.0`) is **unchanged** — it already records these overrides, and a fresh pnpm 11 install leaves it byte-for-byte identical. Once pnpm 11 reads the overrides from the workspace file, the frozen install matches and passes.

## Scaffold templates

The `test:integration` suite scaffolds an app and runs `pnpm install` in it. pnpm 11 turns unreviewed dependency build scripts into a **fatal** `ERR_PNPM_IGNORED_BUILDS` (pnpm 10 only warned), so a freshly scaffolded app fails to install under pnpm 11. The `cloudflare` and `node` templates now ship a `pnpm-workspace.yaml` with `strictDepBuilds: false`, which restores the pnpm-10 behavior (warn, don't abort). These apps rely on their toolchain binaries (esbuild, workerd, ...) shipping via platform-specific packages, so skipping the build scripts is safe and avoids committing users to a brittle per-dependency allowlist.

## Verification

All six CI steps run green locally under **pnpm 11.7.0** (real exit codes, no `| tail` masking):

1. `pnpm install --frozen-lockfile`
2. build framework packages
3. `pnpm format:check`
4. `pnpm typecheck`
5. `pnpm test:coverage`
6. `pnpm test:integration` (both adapters install + build)
7. `pnpm --filter site build`