### PR TITLE
chore(site): AGENTS.md conformance audit + drift gate

### DIFF
--- a/apps/site/src/__tests__/agents-conformance-checker.ts
+++ b/apps/site/src/__tests__/agents-conformance-checker.ts
@@ -69,16 +69,43 @@ export function collectCasts(
   tsx: boolean
 ): { expr: string }[] {
   const ast = parseSource(source, tsx);
-  const out: { expr: string }[] = [];
+
+  // Collect every cast node first, then build a Set of nodes that are the
+  // direct `.expression` child of another cast (i.e. the inner half of a chain
+  // like `x as unknown as Foo`). Those inner nodes are excluded so that a chain
+  // counts as one cast at the outermost level.
+  //
+  // NOTE: range-containment would be wrong here. `(x as T).foo as U` has two
+  // independent casts that happen to be range-nested; we must report both.
+  // Only direct `.expression` parentage is the correct predicate.
+  const castNodes: AnyNode[] = [];
   walk(ast.program, (n) => {
     if (n.type === 'TSAsExpression' || n.type === 'TSTypeAssertion') {
-      if (isAsConst(n.typeAnnotation as AnyNode | undefined)) return;
-      const text = source
-        .slice(n.start ?? 0, n.end ?? 0)
-        .replace(/\s+/g, ' ')
-        .trim();
-      out.push({ expr: text });
+      castNodes.push(n);
     }
   });
+
+  // Build the set of nodes that are the direct inner expression of some cast.
+  const innerNodes = new Set<AnyNode>();
+  for (const node of castNodes) {
+    const expr = node.expression as AnyNode | undefined;
+    if (
+      expr &&
+      (expr.type === 'TSAsExpression' || expr.type === 'TSTypeAssertion')
+    ) {
+      innerNodes.add(expr);
+    }
+  }
+
+  const out: { expr: string }[] = [];
+  for (const n of castNodes) {
+    if (innerNodes.has(n)) continue;
+    if (isAsConst(n.typeAnnotation as AnyNode | undefined)) continue;
+    const text = source
+      .slice(n.start ?? 0, n.end ?? 0)
+      .replace(/\s+/g, ' ')
+      .trim();
+    out.push({ expr: text });
+  }
   return out;
 }

--- a/apps/site/src/__tests__/agents-conformance-checker.ts
+++ b/apps/site/src/__tests__/agents-conformance-checker.ts
@@ -1,0 +1,84 @@
+// AST checker for the AGENTS.md conformance gate. Pure functions over source
+// text - no filesystem. Lives under __tests__ so the live scan excludes it and
+// vitest does not collect it as a suite (the include glob matches *.test.ts).
+//
+// `any` is used freely here to walk Babel's untyped node graph generically;
+// this is test infrastructure, excluded from the gate's own scan.
+import { parse } from '@babel/parser';
+
+type AnyNode = { type?: string; start?: number; end?: number } & Record<
+  string,
+  unknown
+>;
+
+function parseSource(source: string, tsx: boolean) {
+  return parse(source, {
+    sourceType: 'module',
+    plugins: tsx ? ['typescript', 'jsx'] : ['typescript'],
+    errorRecovery: true,
+  });
+}
+
+// Visit every node in the tree. Recurses into arrays and objects that look
+// like AST nodes (have a string `type`); skips position/comment metadata.
+function walk(node: unknown, visit: (n: AnyNode) => void): void {
+  if (!node || typeof node !== 'object') return;
+  const n = node as AnyNode;
+  if (typeof n.type === 'string') visit(n);
+  for (const key of Object.keys(n)) {
+    if (key === 'loc' || key === 'start' || key === 'end' || key === 'range')
+      continue;
+    const val = n[key];
+    if (Array.isArray(val)) {
+      for (const child of val) walk(child, visit);
+    } else if (val && typeof val === 'object') {
+      walk(val, visit);
+    }
+  }
+}
+
+export function collectImports(source: string, tsx: boolean): string[] {
+  const ast = parseSource(source, tsx);
+  const out: string[] = [];
+  walk(ast.program, (n) => {
+    if (
+      (n.type === 'ImportDeclaration' ||
+        n.type === 'ExportNamedDeclaration' ||
+        n.type === 'ExportAllDeclaration' ||
+        n.type === 'ImportExpression') &&
+      n.source &&
+      typeof (n.source as AnyNode).value === 'string'
+    ) {
+      out.push((n.source as AnyNode).value as string);
+    }
+  });
+  return out;
+}
+
+function isAsConst(typeAnnotation: AnyNode | undefined): boolean {
+  // `x as const` parses to a TSAsExpression whose typeAnnotation is a
+  // TSTypeReference to the identifier `const`.
+  if (!typeAnnotation) return false;
+  if (typeAnnotation.type !== 'TSTypeReference') return false;
+  const name = typeAnnotation.typeName as AnyNode | undefined;
+  return name?.type === 'Identifier' && name.name === 'const';
+}
+
+export function collectCasts(
+  source: string,
+  tsx: boolean
+): { expr: string }[] {
+  const ast = parseSource(source, tsx);
+  const out: { expr: string }[] = [];
+  walk(ast.program, (n) => {
+    if (n.type === 'TSAsExpression' || n.type === 'TSTypeAssertion') {
+      if (isAsConst(n.typeAnnotation as AnyNode | undefined)) return;
+      const text = source
+        .slice(n.start ?? 0, n.end ?? 0)
+        .replace(/\s+/g, ' ')
+        .trim();
+      out.push({ expr: text });
+    }
+  });
+  return out;
+}

--- a/apps/site/src/__tests__/agents-conformance-checker.ts
+++ b/apps/site/src/__tests__/agents-conformance-checker.ts
@@ -64,10 +64,7 @@ function isAsConst(typeAnnotation: AnyNode | undefined): boolean {
   return name?.type === 'Identifier' && name.name === 'const';
 }
 
-export function collectCasts(
-  source: string,
-  tsx: boolean
-): { expr: string }[] {
+export function collectCasts(source: string, tsx: boolean): { expr: string }[] {
   const ast = parseSource(source, tsx);
 
   // Collect every cast node first, then build a Set of nodes that are the

--- a/apps/site/src/__tests__/agents-conformance.test.ts
+++ b/apps/site/src/__tests__/agents-conformance.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectImports,
+  collectCasts,
+} from './agents-conformance-checker.js';
+
+describe('conformance checker (self-test)', () => {
+  it('collectImports finds static, re-export, and dynamic specifiers', () => {
+    const src = `
+      import { useState } from 'preact/hooks';
+      import x from 'react';
+      export { y } from '@hono-preact/iso';
+      const m = await import('hono-preact/internal');
+    `;
+    const specs = collectImports(src, false);
+    expect(specs).toContain('preact/hooks');
+    expect(specs).toContain('react');
+    expect(specs).toContain('@hono-preact/iso');
+    expect(specs).toContain('hono-preact/internal');
+  });
+
+  it('collectCasts finds as-expressions and angle-bracket assertions', () => {
+    const src = `
+      const a = foo as Bar;
+      const b = <Baz>qux;
+      const c = e.data as WorkerOutMsg;
+    `;
+    const casts = collectCasts(src, false).map((c) => c.expr);
+    expect(casts).toContain('foo as Bar');
+    expect(casts).toContain('e.data as WorkerOutMsg');
+    expect(casts.some((c) => c.includes('Baz'))).toBe(true);
+  });
+
+  it('collectCasts ignores `as const`', () => {
+    const casts = collectCasts(`const a = [1, 2] as const;`, false);
+    expect(casts).toHaveLength(0);
+  });
+
+  it('collectCasts handles tsx and ignores generic calls / import aliases', () => {
+    const src = `
+      import { Map as MapIcon } from 'lucide-preact';
+      const r = useRef<HTMLDivElement>(null);
+      const v = (x) => x;
+    `;
+    expect(collectCasts(src, true)).toHaveLength(0);
+  });
+});

--- a/apps/site/src/__tests__/agents-conformance.test.ts
+++ b/apps/site/src/__tests__/agents-conformance.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import {
   collectImports,
@@ -43,5 +46,64 @@ describe('conformance checker (self-test)', () => {
       const v = (x) => x;
     `;
     expect(collectCasts(src, true)).toHaveLength(0);
+  });
+});
+
+const here = dirname(fileURLToPath(import.meta.url));
+const siteSrc = resolve(here, '..'); // apps/site/src
+
+function appCodeFiles(): string[] {
+  const files: string[] = [];
+  const walkDir = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__') continue;
+        walkDir(resolve(dir, entry.name));
+      } else if (/\.(ts|tsx)$/.test(entry.name)) {
+        files.push(resolve(dir, entry.name));
+      }
+    }
+  };
+  walkDir(siteSrc);
+  return files;
+}
+
+const relativeToSiteSrc = (abs: string) =>
+  relative(siteSrc, abs).split('\\').join('/');
+
+describe('AGENTS.md conformance (live apps/site)', () => {
+  const files = appCodeFiles();
+
+  it('R1: no react / react-dom imports', () => {
+    const violations: string[] = [];
+    for (const f of files) {
+      const tsx = f.endsWith('.tsx');
+      for (const spec of collectImports(readFileSync(f, 'utf8'), tsx)) {
+        if (/^react(-dom)?(\/|$)/.test(spec)) {
+          violations.push(`${relativeToSiteSrc(f)}: imports '${spec}'`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Use preact/hooks and preact, not react:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('R2: framework imports stay on the public surface', () => {
+    const violations: string[] = [];
+    for (const f of files) {
+      const tsx = f.endsWith('.tsx');
+      for (const spec of collectImports(readFileSync(f, 'utf8'), tsx)) {
+        if (spec.includes('/internal') || spec.startsWith('@hono-preact/')) {
+          violations.push(`${relativeToSiteSrc(f)}: imports '${spec}'`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Import from the public surface (hono-preact, hono-preact/page, ` +
+        `hono-preact/server, hono-preact-ui), not internals:\n${violations.join('\n')}`
+    ).toEqual([]);
   });
 });

--- a/apps/site/src/__tests__/agents-conformance.test.ts
+++ b/apps/site/src/__tests__/agents-conformance.test.ts
@@ -2,10 +2,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { resolve, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
-import {
-  collectImports,
-  collectCasts,
-} from './agents-conformance-checker.js';
+import { collectImports, collectCasts } from './agents-conformance-checker.js';
 
 describe('conformance checker (self-test)', () => {
   it('collectImports finds static, re-export, and dynamic specifiers', () => {
@@ -152,7 +149,8 @@ describe('AGENTS.md conformance (live apps/site)', () => {
     {
       file: 'components/demo/TaskCard.tsx',
       expr: 'e as PointerEvent',
-      reason: 'bridging the Preact pointer-handler event to the DOM PointerEvent',
+      reason:
+        'bridging the Preact pointer-handler event to the DOM PointerEvent',
     },
     {
       file: 'components/demo/TaskActions.tsx',
@@ -192,14 +190,14 @@ describe('AGENTS.md conformance (live apps/site)', () => {
     expect(
       violations,
       `Reshape the type (predicate, typed binding, generic value) or add an ` +
-        `allowlist entry with a reason:\n${violations.join('\n')}`,
+        `allowlist entry with a reason:\n${violations.join('\n')}`
     ).toEqual([]);
 
     // Honesty: every allowlist entry must still correspond to a real cast.
     const stale = [...allowed].filter((k) => !seen.has(k));
     expect(
       stale,
-      `Remove stale allowlist entries:\n${stale.join('\n')}`,
+      `Remove stale allowlist entries:\n${stale.join('\n')}`
     ).toEqual([]);
   });
 });

--- a/apps/site/src/__tests__/agents-conformance.test.ts
+++ b/apps/site/src/__tests__/agents-conformance.test.ts
@@ -47,6 +47,19 @@ describe('conformance checker (self-test)', () => {
     `;
     expect(collectCasts(src, true)).toHaveLength(0);
   });
+
+  it('collectCasts reports only the outermost cast of an as-chain', () => {
+    // `x as unknown as Foo` is a single chained cast; the inner `x as unknown`
+    // is just the `.expression` of the outer and must not appear as a separate
+    // entry. But `(x as T).foo as U` is two independent casts and both should
+    // be reported.
+    const chain = collectCasts('const a = x as unknown as Foo;', false);
+    expect(chain).toHaveLength(1);
+    expect(chain[0].expr).toBe('x as unknown as Foo');
+
+    const independent = collectCasts('const b = (x as T).foo as U;', false);
+    expect(independent).toHaveLength(2);
+  });
 });
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -104,6 +117,89 @@ describe('AGENTS.md conformance (live apps/site)', () => {
       violations,
       `Import from the public surface (hono-preact, hono-preact/page, ` +
         `hono-preact/server, hono-preact-ui), not internals:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  // Genuine type-cast boundaries. Each entry is keyed by repo-relative file
+  // path plus the exact (whitespace-collapsed) cast expression, and carries a
+  // one-line reason. Prefer reshaping the type over adding an entry here.
+  const CAST_ALLOWLIST: { file: string; expr: string; reason: string }[] = [
+    {
+      file: 'demo/session.ts',
+      expr: 'JSON.parse(raw) as CookiePayload',
+      reason: 'parsing an untrusted cookie payload (acceptable boundary)',
+    },
+    {
+      file: 'hooks/use-board-drag.ts',
+      expr: 'card.cloneNode(true) as HTMLElement',
+      reason: 'Node.cloneNode returns Node; the source is an HTMLElement',
+    },
+    {
+      file: 'hooks/use-board-drag.ts',
+      expr: 'e.currentTarget as HTMLElement',
+      reason: 'DOM event currentTarget is EventTarget | null at the type level',
+    },
+    {
+      file: 'components/HeroShader.tsx',
+      expr: 'e.data as WorkerOutMsg',
+      reason: 'Worker MessageEvent.data is any (untyped postMessage boundary)',
+    },
+    {
+      file: 'components/shader-worker.ts',
+      expr: 'e.data as WorkerInMsg',
+      reason: 'Worker MessageEvent.data is any (untyped postMessage boundary)',
+    },
+    {
+      file: 'components/demo/TaskCard.tsx',
+      expr: 'e as PointerEvent',
+      reason: 'bridging the Preact pointer-handler event to the DOM PointerEvent',
+    },
+    {
+      file: 'components/demo/TaskActions.tsx',
+      expr: 'v as TaskStatus',
+      reason:
+        'MenuRadioGroup.onValueChange yields string; values are the fixed TaskStatus set',
+    },
+    {
+      file: 'components/demo/TaskActions.tsx',
+      expr: 'v as TaskPriority',
+      reason:
+        'MenuRadioGroup.onValueChange yields string; values are the fixed TaskPriority set',
+    },
+    {
+      file: 'components/shader-worker.ts',
+      expr: 'self as unknown as { postMessage(message: WorkerOutMsg): void }',
+      reason:
+        'worker global: the DOM lib types self as Window, whose postMessage signature differs from a worker; narrow the one method we call',
+    },
+  ];
+
+  it('R5: no casts outside the allowlist', () => {
+    const allowed = new Set(CAST_ALLOWLIST.map((e) => `${e.file}|${e.expr}`));
+    const seen = new Set<string>();
+    const violations: string[] = [];
+    for (const f of files) {
+      const rel = relativeToSiteSrc(f);
+      const tsx = f.endsWith('.tsx');
+      for (const { expr } of collectCasts(readFileSync(f, 'utf8'), tsx)) {
+        const key = `${rel}|${expr}`;
+        seen.add(key);
+        if (!allowed.has(key)) {
+          violations.push(`${rel}: ${expr}`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Reshape the type (predicate, typed binding, generic value) or add an ` +
+        `allowlist entry with a reason:\n${violations.join('\n')}`,
+    ).toEqual([]);
+
+    // Honesty: every allowlist entry must still correspond to a real cast.
+    const stale = [...allowed].filter((k) => !seen.has(k));
+    expect(
+      stale,
+      `Remove stale allowlist entries:\n${stale.join('\n')}`,
     ).toEqual([]);
   });
 });

--- a/apps/site/src/components/demo/pickers.tsx
+++ b/apps/site/src/components/demo/pickers.tsx
@@ -30,10 +30,10 @@ export function StatusSelect({
   onChange: (v: TaskStatus) => void;
 }) {
   return (
-    <Select.Root
+    <Select.Root<TaskStatus>
       value={value}
       onValueChange={(v) =>
-        onChange((Array.isArray(v) ? (v[0] ?? value) : v) as TaskStatus)
+        onChange(Array.isArray(v) ? (v[0] ?? value) : v)
       }
     >
       <Select.Trigger class={triggerCls}>
@@ -63,10 +63,10 @@ export function PrioritySelect({
   onChange: (v: TaskPriority) => void;
 }) {
   return (
-    <Select.Root
+    <Select.Root<TaskPriority>
       value={value}
       onValueChange={(v) =>
-        onChange((Array.isArray(v) ? (v[0] ?? value) : v) as TaskPriority)
+        onChange(Array.isArray(v) ? (v[0] ?? value) : v)
       }
     >
       <Select.Trigger class={triggerCls}>
@@ -115,10 +115,10 @@ export function AssigneeCombobox({
   const filtered = options.filter((o) => matchSubstring(o.name, query));
 
   return (
-    <Combobox.Root
+    <Combobox.Root<string>
       value={value ?? ''}
       onValueChange={(v) => {
-        const id = (Array.isArray(v) ? (v[0] ?? '') : v) as string;
+        const id = Array.isArray(v) ? (v[0] ?? '') : v;
         onChange(id || null);
       }}
       inputValue={query}

--- a/apps/site/src/components/demo/pickers.tsx
+++ b/apps/site/src/components/demo/pickers.tsx
@@ -32,9 +32,7 @@ export function StatusSelect({
   return (
     <Select.Root<TaskStatus>
       value={value}
-      onValueChange={(v) =>
-        onChange(Array.isArray(v) ? (v[0] ?? value) : v)
-      }
+      onValueChange={(v) => onChange(Array.isArray(v) ? (v[0] ?? value) : v)}
     >
       <Select.Trigger class={triggerCls}>
         <Select.Value />
@@ -65,9 +63,7 @@ export function PrioritySelect({
   return (
     <Select.Root<TaskPriority>
       value={value}
-      onValueChange={(v) =>
-        onChange(Array.isArray(v) ? (v[0] ?? value) : v)
-      }
+      onValueChange={(v) => onChange(Array.isArray(v) ? (v[0] ?? value) : v)}
     >
       <Select.Trigger class={triggerCls}>
         <span

--- a/apps/site/src/pages/demo/project-board.server.ts
+++ b/apps/site/src/pages/demo/project-board.server.ts
@@ -34,7 +34,9 @@ export const serverLoaders = {
     if (!project) return null;
     return {
       project,
-      users: [getUser('u-1'), getUser('u-2')].filter(Boolean) as User[],
+      users: [getUser('u-1'), getUser('u-2')].filter(
+        (u): u is User => u !== null
+      ),
       tasks: listTasksForProject(project.id),
     };
   }),

--- a/apps/site/src/pages/demo/task.tsx
+++ b/apps/site/src/pages/demo/task.tsx
@@ -171,17 +171,17 @@ const CommentsSection: FunctionComponent<{
   // or nav; invalidate() below busts the cache so that refetch is fresh.
   const addComment = useOptimisticAction(serverActions.addComment, {
     base: comments,
-    apply: (current, payload) => [
-      ...current,
-      {
+    apply: (current, payload) => {
+      const optimistic: CommentData = {
         id: `pending-${current.length}`,
         taskId: payload.taskId,
         authorId: '',
         body: payload.body,
         createdAt: Date.now(),
         author: null,
-      } as CommentData,
-    ],
+      };
+      return [...current, optimistic];
+    },
   });
   const { pending } = useFormStatus(serverActions.addComment);
 

--- a/docs/superpowers/plans/2026-06-18-site-agents-conformance.md
+++ b/docs/superpowers/plans/2026-06-18-site-agents-conformance.md
@@ -1,0 +1,584 @@
+# Site AGENTS.md Conformance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `apps/site` and the `AGENTS.md` contract agree, and add a vitest drift gate so the site cannot silently drift out of conformance again.
+
+**Architecture:** A small AST-based checker (under `apps/site/src/__tests__/`) parses each app-code source with `@babel/parser` and reports its import specifiers and type-cast expressions. A vitest gate runs the checker over `apps/site/src/**/*.{ts,tsx}` (excluding `.mdx` and `__tests__`) and asserts three rules: no `react` imports (R1), no `/internal` or `@hono-preact/*` imports (R2), and no cast outside a commented allowlist (R5). The audit reshapes every reshapeable cast and allowlists the genuine boundaries. A docs pass fixes the one incorrect line in `AGENTS.md`.
+
+**Tech Stack:** TypeScript, Preact, vitest, `@babel/parser` + `@babel/types` (both already `apps/site` devDependencies; the same parser the framework's `serverLoaderValidationPlugin` uses).
+
+## Global Constraints
+
+- No em-dashes in prose, code comments, or commit messages.
+- Do not commit or push unless explicitly authorized; subagent-driven per-task commits defined by this plan are pre-authorized once the plan is approved.
+- All work happens in the worktree `worktree-chore+site-agents-conformance`. Serena indexes the main checkout, so use rg / Read / Edit here, not Serena symbol/edit tools.
+- The gate scans **app code only**: `apps/site/src/**/*.{ts,tsx}`, excluding `**/*.mdx` and `**/__tests__/**`. Never read `.mdx` bodies in the gate.
+- Prefer reshaping a type over casting (CLAUDE.md "type casts"). Allowlisting is the fallback for genuine boundaries only.
+- After each task, run the relevant test; the plan ends each task in a green state.
+- Final pre-push verification mirrors CI exactly (six steps): `pnpm --filter '@hono-preact/*' --filter hono-preact --filter hono-preact-ui build`, `pnpm format:check`, `pnpm typecheck`, `pnpm test:coverage` (or `pnpm test`), `pnpm test:integration`, `pnpm --filter site build`. `pnpm format` fixes format:check failures.
+
+---
+
+### Task 1: Conformance checker module + self-tests
+
+Build the pure AST checker and prove it correct on in-memory fixtures (the mutation check). No filesystem or live scan yet.
+
+**Files:**
+- Create: `apps/site/src/__tests__/agents-conformance-checker.ts`
+- Create: `apps/site/src/__tests__/agents-conformance.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `collectImports(source: string, tsx: boolean): string[]` - every import/export/dynamic-import module specifier in the source.
+  - `collectCasts(source: string, tsx: boolean): { expr: string }[]` - every `x as T` / `<T>x` assertion except `as const`. `expr` is the cast's source text, whitespace-collapsed.
+
+- [ ] **Step 1: Write the failing self-tests**
+
+Create `apps/site/src/__tests__/agents-conformance.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  collectImports,
+  collectCasts,
+} from './agents-conformance-checker.js';
+
+describe('conformance checker (self-test)', () => {
+  it('collectImports finds static, re-export, and dynamic specifiers', () => {
+    const src = `
+      import { useState } from 'preact/hooks';
+      import x from 'react';
+      export { y } from '@hono-preact/iso';
+      const m = await import('hono-preact/internal');
+    `;
+    const specs = collectImports(src, false);
+    expect(specs).toContain('preact/hooks');
+    expect(specs).toContain('react');
+    expect(specs).toContain('@hono-preact/iso');
+    expect(specs).toContain('hono-preact/internal');
+  });
+
+  it('collectCasts finds as-expressions and angle-bracket assertions', () => {
+    const src = `
+      const a = foo as Bar;
+      const b = <Baz>qux;
+      const c = e.data as WorkerOutMsg;
+    `;
+    const casts = collectCasts(src, false).map((c) => c.expr);
+    expect(casts).toContain('foo as Bar');
+    expect(casts).toContain('e.data as WorkerOutMsg');
+    expect(casts.some((c) => c.includes('Baz'))).toBe(true);
+  });
+
+  it('collectCasts ignores `as const`', () => {
+    const casts = collectCasts(`const a = [1, 2] as const;`, false);
+    expect(casts).toHaveLength(0);
+  });
+
+  it('collectCasts handles tsx and ignores generic calls / import aliases', () => {
+    const src = `
+      import { Map as MapIcon } from 'lucide-preact';
+      const r = useRef<HTMLDivElement>(null);
+      const v = (x) => x;
+    `;
+    expect(collectCasts(src, true)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm exec vitest run apps/site/src/__tests__/agents-conformance.test.ts`
+Expected: FAIL - cannot resolve `./agents-conformance-checker.js`.
+
+- [ ] **Step 3: Implement the checker**
+
+Create `apps/site/src/__tests__/agents-conformance-checker.ts`:
+
+```ts
+// AST checker for the AGENTS.md conformance gate. Pure functions over source
+// text - no filesystem. Lives under __tests__ so the live scan excludes it and
+// vitest does not collect it as a suite (the include glob matches *.test.ts).
+//
+// `any` is used freely here to walk Babel's untyped node graph generically;
+// this is test infrastructure, excluded from the gate's own scan.
+import { parse } from '@babel/parser';
+
+type AnyNode = { type?: string; start?: number; end?: number } & Record<
+  string,
+  unknown
+>;
+
+function parseSource(source: string, tsx: boolean) {
+  return parse(source, {
+    sourceType: 'module',
+    plugins: tsx ? ['typescript', 'jsx'] : ['typescript'],
+    errorRecovery: true,
+  });
+}
+
+// Visit every node in the tree. Recurses into arrays and objects that look
+// like AST nodes (have a string `type`); skips position/comment metadata.
+function walk(node: unknown, visit: (n: AnyNode) => void): void {
+  if (!node || typeof node !== 'object') return;
+  const n = node as AnyNode;
+  if (typeof n.type === 'string') visit(n);
+  for (const key of Object.keys(n)) {
+    if (key === 'loc' || key === 'start' || key === 'end' || key === 'range')
+      continue;
+    const val = n[key];
+    if (Array.isArray(val)) {
+      for (const child of val) walk(child, visit);
+    } else if (val && typeof val === 'object') {
+      walk(val, visit);
+    }
+  }
+}
+
+export function collectImports(source: string, tsx: boolean): string[] {
+  const ast = parseSource(source, tsx);
+  const out: string[] = [];
+  walk(ast.program, (n) => {
+    if (
+      (n.type === 'ImportDeclaration' ||
+        n.type === 'ExportNamedDeclaration' ||
+        n.type === 'ExportAllDeclaration' ||
+        n.type === 'ImportExpression') &&
+      n.source &&
+      typeof (n.source as AnyNode).value === 'string'
+    ) {
+      out.push((n.source as AnyNode).value as string);
+    }
+  });
+  return out;
+}
+
+function isAsConst(typeAnnotation: AnyNode | undefined): boolean {
+  // `x as const` parses to a TSAsExpression whose typeAnnotation is a
+  // TSTypeReference to the identifier `const`.
+  if (!typeAnnotation) return false;
+  if (typeAnnotation.type !== 'TSTypeReference') return false;
+  const name = typeAnnotation.typeName as AnyNode | undefined;
+  return name?.type === 'Identifier' && name.name === 'const';
+}
+
+export function collectCasts(
+  source: string,
+  tsx: boolean
+): { expr: string }[] {
+  const ast = parseSource(source, tsx);
+  const out: { expr: string }[] = [];
+  walk(ast.program, (n) => {
+    if (n.type === 'TSAsExpression' || n.type === 'TSTypeAssertion') {
+      if (isAsConst(n.typeAnnotation as AnyNode | undefined)) return;
+      const text = source
+        .slice(n.start ?? 0, n.end ?? 0)
+        .replace(/\s+/g, ' ')
+        .trim();
+      out.push({ expr: text });
+    }
+  });
+  return out;
+}
+```
+
+- [ ] **Step 4: Run the self-tests to verify they pass**
+
+Run: `pnpm exec vitest run apps/site/src/__tests__/agents-conformance.test.ts`
+Expected: PASS (4 tests). If `as const` is not excluded, inspect the parsed node shape and adjust `isAsConst` (see spec risk note).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/site/src/__tests__/agents-conformance-checker.ts apps/site/src/__tests__/agents-conformance.test.ts
+git commit -m "test(site): AST conformance checker + self-tests"
+```
+
+---
+
+### Task 2: Live R1/R2 gate
+
+Wire the file walker and assert no `react` imports (R1) and no `/internal` or `@hono-preact/*` imports (R2) across app code. Both pass immediately (the tree is already clean); this locks them in.
+
+**Files:**
+- Modify: `apps/site/src/__tests__/agents-conformance.test.ts`
+
+**Interfaces:**
+- Consumes: `collectImports` from Task 1.
+- Produces: `appCodeFiles(): string[]` (absolute paths) and `relativeToSiteSrc(abs): string`, reused by Task 4.
+
+- [ ] **Step 1: Write the failing live test**
+
+Append to `apps/site/src/__tests__/agents-conformance.test.ts` (add imports at top:
+`import { readdirSync, readFileSync } from 'node:fs';`,
+`import { resolve, dirname, relative } from 'node:path';`,
+`import { fileURLToPath } from 'node:url';`):
+
+```ts
+const here = dirname(fileURLToPath(import.meta.url));
+const siteSrc = resolve(here, '..'); // apps/site/src
+
+function appCodeFiles(): string[] {
+  const files: string[] = [];
+  const walkDir = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__') continue;
+        walkDir(resolve(dir, entry.name));
+      } else if (/\.(ts|tsx)$/.test(entry.name)) {
+        files.push(resolve(dir, entry.name));
+      }
+    }
+  };
+  walkDir(siteSrc);
+  return files;
+}
+
+const relativeToSiteSrc = (abs: string) =>
+  relative(siteSrc, abs).split('\\').join('/');
+
+describe('AGENTS.md conformance (live apps/site)', () => {
+  const files = appCodeFiles();
+
+  it('R1: no react / react-dom imports', () => {
+    const violations: string[] = [];
+    for (const f of files) {
+      const tsx = f.endsWith('.tsx');
+      for (const spec of collectImports(readFileSync(f, 'utf8'), tsx)) {
+        if (/^react(-dom)?(\/|$)/.test(spec)) {
+          violations.push(`${relativeToSiteSrc(f)}: imports '${spec}'`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Use preact/hooks and preact, not react:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('R2: framework imports stay on the public surface', () => {
+    const violations: string[] = [];
+    for (const f of files) {
+      const tsx = f.endsWith('.tsx');
+      for (const spec of collectImports(readFileSync(f, 'utf8'), tsx)) {
+        if (spec.includes('/internal') || spec.startsWith('@hono-preact/')) {
+          violations.push(`${relativeToSiteSrc(f)}: imports '${spec}'`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Import from the public surface (hono-preact, hono-preact/page, ` +
+        `hono-preact/server, hono-preact-ui), not internals:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the live R1/R2 tests**
+
+Run: `pnpm exec vitest run apps/site/src/__tests__/agents-conformance.test.ts`
+Expected: PASS (R1 and R2 green; the tree is already clean). If either fails, the violation list names the file and specifier - fix the import to a public path before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/site/src/__tests__/agents-conformance.test.ts
+git commit -m "test(site): gate react and internal-import conformance (R1/R2)"
+```
+
+---
+
+### Task 3: Reshape the reshapeable casts
+
+Remove the casts that a type reshape eliminates. Each step is verified by `pnpm typecheck`. Do not touch the genuine-boundary casts (Task 4 allowlists those).
+
+**Files:**
+- Modify: `apps/site/src/pages/demo/project-board.server.ts:37`
+- Modify: `apps/site/src/pages/demo/task.tsx:183`
+- Modify: `apps/site/src/components/demo/pickers.tsx` (StatusSelect, PrioritySelect, AssigneeCombobox)
+
+- [ ] **Step 1: Reshape `filter(Boolean) as User[]` to a type predicate**
+
+In `project-board.server.ts`, replace:
+
+```ts
+      users: [getUser('u-1'), getUser('u-2')].filter(Boolean) as User[],
+```
+
+with (getUser returns `User | null`, so the predicate narrows out null):
+
+```ts
+      users: [getUser('u-1'), getUser('u-2')].filter(
+        (u): u is User => u !== null
+      ),
+```
+
+- [ ] **Step 2: Reshape `} as CommentData` to a typed binding**
+
+In `task.tsx`, change the optimistic `apply` so the new element is a typed binding rather than a cast. Replace the spread-with-cast:
+
+```ts
+    apply: (current, payload) => [
+      ...current,
+      {
+        id: `pending-${current.length}`,
+        taskId: payload.taskId,
+        authorId: '',
+        body: payload.body,
+        createdAt: Date.now(),
+        author: null,
+      } as CommentData,
+    ],
+```
+
+with:
+
+```ts
+    apply: (current, payload) => {
+      const optimistic: CommentData = {
+        id: `pending-${current.length}`,
+        taskId: payload.taskId,
+        authorId: '',
+        body: payload.body,
+        createdAt: Date.now(),
+        author: null,
+      };
+      return [...current, optimistic];
+    },
+```
+
+If `pnpm typecheck` now reports a real mismatch (a field whose type does not fit `CommentData = WithAuthor<Comment>`), that mismatch was being hidden by the cast: fix the offending field to match `CommentData` rather than reinstating the cast.
+
+- [ ] **Step 3: Reshape the picker Select casts via the generic value type**
+
+`SelectRoot` is generic: `function SelectRoot<Value = string>(props: SelectRootProps<Value>)`. Parameterize it so `onValueChange` yields the literal union and the cast disappears. In `pickers.tsx` StatusSelect, replace:
+
+```tsx
+    <Select.Root
+      value={value}
+      onValueChange={(v) =>
+        onChange((Array.isArray(v) ? (v[0] ?? value) : v) as TaskStatus)
+      }
+    >
+```
+
+with:
+
+```tsx
+    <Select.Root<TaskStatus>
+      value={value}
+      onValueChange={(v) =>
+        onChange(Array.isArray(v) ? (v[0] ?? value) : v)
+      }
+    >
+```
+
+Apply the same change to PrioritySelect with `<Select.Root<TaskPriority>>`. For AssigneeCombobox, parameterize `Combobox.Root` the same way (the value type is `string`) so `(Array.isArray(v) ? (v[0] ?? '') : v) as string` loses its `as string`.
+
+If the explicit type-argument JSX syntax (`<Select.Root<TaskStatus>>`) does not typecheck under this TS/Preact setup, fall back to a typed handler that keeps inference local: extract `const handleChange = (v: TaskStatus | TaskStatus[]) => onChange(Array.isArray(v) ? (v[0] ?? value) : v);` and pass `onValueChange={handleChange}`. The success criterion is that the checker no longer reports these casts AND `pnpm typecheck` passes - do not reintroduce a cast to satisfy the syntax.
+
+- [ ] **Step 4: Verify the reshapes typecheck and the casts are gone**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+Run a quick enumeration to confirm these specific casts are gone:
+`pnpm exec vitest run apps/site/src/__tests__/agents-conformance.test.ts` (R5 is not wired yet; this just confirms R1/R2 still pass). The authoritative R5 check arrives in Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/site/src/pages/demo/project-board.server.ts apps/site/src/pages/demo/task.tsx apps/site/src/components/demo/pickers.tsx
+git commit -m "refactor(site): reshape demo casts to typed predicates/generics"
+```
+
+---
+
+### Task 4: Live R5 gate + honest allowlist
+
+Wire the live cast assertion against a commented allowlist seeded with the genuine boundaries that remain after Task 3, and enforce stale-entry honesty.
+
+**Files:**
+- Modify: `apps/site/src/__tests__/agents-conformance.test.ts`
+
+**Interfaces:**
+- Consumes: `collectCasts` (Task 1), `appCodeFiles` / `relativeToSiteSrc` (Task 2).
+
+- [ ] **Step 1: Add the allowlist and the failing R5 test**
+
+Append to `apps/site/src/__tests__/agents-conformance.test.ts`, inside the live describe block:
+
+```ts
+  // Genuine type-cast boundaries. Each entry is keyed by repo-relative file
+  // path plus the exact (whitespace-collapsed) cast expression, and carries a
+  // one-line reason. Prefer reshaping the type over adding an entry here.
+  const CAST_ALLOWLIST: { file: string; expr: string; reason: string }[] = [
+    {
+      file: 'demo/session.ts',
+      expr: 'JSON.parse(raw) as CookiePayload',
+      reason: 'parsing an untrusted cookie payload (acceptable boundary)',
+    },
+    {
+      file: 'hooks/use-board-drag.ts',
+      expr: 'card.cloneNode(true) as HTMLElement',
+      reason: 'Node.cloneNode returns Node; the source is an HTMLElement',
+    },
+    {
+      file: 'hooks/use-board-drag.ts',
+      expr: 'e.currentTarget as HTMLElement',
+      reason: 'DOM event currentTarget is EventTarget | null at the type level',
+    },
+    {
+      file: 'components/HeroShader.tsx',
+      expr: 'e.data as WorkerOutMsg',
+      reason: 'Worker MessageEvent.data is any (untyped postMessage boundary)',
+    },
+    {
+      file: 'components/shader-worker.ts',
+      expr: 'e.data as WorkerInMsg',
+      reason: 'Worker MessageEvent.data is any (untyped postMessage boundary)',
+    },
+    {
+      file: 'components/demo/TaskCard.tsx',
+      expr: 'e as PointerEvent',
+      reason: 'bridging the Preact pointer-handler event to the DOM PointerEvent',
+    },
+    {
+      file: 'components/demo/TaskActions.tsx',
+      expr: 'v as TaskStatus',
+      reason: 'MenuRadioGroup.onValueChange yields string; values are the fixed TaskStatus set',
+    },
+    {
+      file: 'components/demo/TaskActions.tsx',
+      expr: 'v as TaskPriority',
+      reason: 'MenuRadioGroup.onValueChange yields string; values are the fixed TaskPriority set',
+    },
+  ];
+
+  it('R5: no casts outside the allowlist', () => {
+    const allowed = new Set(
+      CAST_ALLOWLIST.map((e) => `${e.file}|${e.expr}`)
+    );
+    const seen = new Set<string>();
+    const violations: string[] = [];
+    for (const f of files) {
+      const rel = relativeToSiteSrc(f);
+      const tsx = f.endsWith('.tsx');
+      for (const { expr } of collectCasts(readFileSync(f, 'utf8'), tsx)) {
+        const key = `${rel}|${expr}`;
+        seen.add(key);
+        if (!allowed.has(key)) {
+          violations.push(`${rel}: ${expr}`);
+        }
+      }
+    }
+    expect(
+      violations,
+      `Reshape the type (predicate, typed binding, generic value) or add an ` +
+        `allowlist entry with a reason:\n${violations.join('\n')}`
+    ).toEqual([]);
+
+    // Honesty: every allowlist entry must still correspond to a real cast.
+    const stale = [...allowed].filter((k) => !seen.has(k));
+    expect(stale, `Remove stale allowlist entries:\n${stale.join('\n')}`).toEqual(
+      []
+    );
+  });
+```
+
+- [ ] **Step 2: Run R5 and reconcile against the live enumeration**
+
+Run: `pnpm exec vitest run apps/site/src/__tests__/agents-conformance.test.ts`
+Expected: PASS. If R5 fails with a violation the AST found but this plan did not anticipate (for example an `as string` the regex sample missed), decide per the same rule: reshape it (re-run Task 3 style) if a type fix removes it, otherwise add a `CAST_ALLOWLIST` entry with a one-line reason. If R5 fails with a stale entry, a Task 3 reshape removed a cast that is still listed - delete that allowlist entry.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/site/src/__tests__/agents-conformance.test.ts
+git commit -m "test(site): gate type casts against an honest allowlist (R5)"
+```
+
+---
+
+### Task 5: Fix the incorrect AGENTS.md line + scan the docs corpus
+
+**Files:**
+- Modify: `packages/create-hono-preact/templates/agents/AGENTS.md` (the `.server` bullet, around line 30)
+- Modify: any `apps/site/src/pages/docs/**/*.mdx` that repeats the same contradiction (scan first)
+
+- [ ] **Step 1: Reword the AGENTS.md `.server` rule**
+
+In `AGENTS.md`, the bullet currently ends:
+
+```
+  `serverActions` are the only allowed named exports. Never import a `.server`
+  symbol into client code.
+```
+
+Replace the false sentence so it states the real contract:
+
+```
+  `serverActions` are the only allowed named exports (plus erased `export
+  type`s). Client code imports `serverLoaders` / `serverActions` and reads data
+  through them; the Vite plugin rewrites those imports into client-safe RPC
+  handles. Never put secrets or server-only helpers where they would be inlined
+  into the client; keep that logic inside the loader and action bodies.
+```
+
+- [ ] **Step 2: Scan the docs corpus for the same contradiction**
+
+Run: `rg -ni "never import.*\.server|don't import.*server|do not import.*server" apps/site/src/pages/docs`
+Expected: review every hit. Fix any prose that tells the reader not to import `serverLoaders`/`serverActions` into client code so it matches the corrected AGENTS.md wording. (If there are no hits, record that and move on.)
+
+- [ ] **Step 3: Verify the appendix invariant still holds**
+
+Run: `pnpm exec vitest run packages/create-hono-preact/__tests__/agents-appendix.test.ts`
+Expected: PASS (the edit changed prose, not the entry-point appendix list).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/create-hono-preact/templates/agents/AGENTS.md
+# plus any docs/*.mdx changed in Step 2
+git commit -m "docs(agents): correct the .server import rule to match the framework"
+```
+
+---
+
+### Task 6: Full pre-push verification + PR
+
+**Files:** none (verification + PR only)
+
+- [ ] **Step 1: Run the six CI steps in order**
+
+```bash
+pnpm --filter '@hono-preact/*' --filter hono-preact --filter hono-preact-ui build
+pnpm format:check
+pnpm typecheck
+pnpm test
+pnpm test:integration
+pnpm --filter site build
+```
+
+Expected: all pass. If `format:check` fails, run `pnpm format`, review, and commit the result. Do not proceed until every step is green and personally observed.
+
+- [ ] **Step 2: Push the branch and open the PR to `main`**
+
+(Only after explicit user authorization to push.) Open a PR whose description enumerates: the gate rules (R1/R2/R5), the cast dispositions (reshaped vs allowlisted, with reasons), the dropped R3/R4 with rationale, and the AGENTS.md correction. Then run the mandated deep PR review as the first follow-up.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Phase A audit (cast triage) -> Tasks 3, 4. Structural spot-check -> done during Task 3/4 review and recorded in the PR description (Task 6 Step 2).
+- Phase B gate (R1/R2/R5, AST, allowlist, anchoring, scan-set, self-test) -> Tasks 1, 2, 4.
+- Phase C docs correction (AGENTS.md + corpus scan + appendix re-run) -> Task 5.
+- App-code-vs-docs split (exclude .mdx + __tests__) -> Task 2 walker, reused in Task 4.
+- Dropped R3/R4 -> not gated (correctly absent); rationale recorded in the PR description.
+
+**Placeholder scan:** no TBD/TODO. The one investigation-dependent step (Task 3 Step 3 JSX generic syntax) specifies both the primary fix and a concrete fallback with an explicit success criterion, and Task 4 Step 2 gives a concrete reconcile rule for any cast the AST finds beyond the sample. These are bounded decisions with defined outcomes, not open-ended placeholders.
+
+**Type consistency:** `collectImports`/`collectCasts` signatures match between Task 1 (defined) and Tasks 2/4 (consumed). `appCodeFiles`/`relativeToSiteSrc` defined in Task 2, reused in Task 4. Allowlist key format (`${file}|${expr}`) is consistent within Task 4.

--- a/docs/superpowers/specs/2026-06-18-site-agents-conformance-design.md
+++ b/docs/superpowers/specs/2026-06-18-site-agents-conformance-design.md
@@ -1,0 +1,198 @@
+# Site AGENTS.md conformance: audit + drift gate
+
+- **Date:** 2026-06-18
+- **Status:** design (approved in brainstorming; awaiting written-spec review)
+- **Branch / worktree:** `worktree-chore+site-agents-conformance` (fresh off `main` after PR #119 merged)
+
+## Goal
+
+`apps/site` is the framework's own dogfood and de-facto reference app. The LLM
+documentation program (PR #107) hands every agent the `AGENTS.md` contract that
+prescribes how to use the framework idiomatically. This work makes `apps/site`
+faithfully embody that contract, so an agent that reads the docs and then reads
+our own code sees the same idioms, not contradictions.
+
+Two phases:
+
+- **Phase A (audit + fix):** a one-time pass that checks `apps/site` against the
+  contract and fixes or consciously accepts each divergence.
+- **Phase B (drift gate):** a vitest test that mechanically enforces the
+  checkable rules so the site cannot silently drift back out of conformance. It
+  mirrors the two drift gates already shipped in PR #107
+  (`apps/site/src/pages/docs/__tests__/exports-coverage.test.ts`,
+  `packages/create-hono-preact/__tests__/agents-appendix.test.ts`), including
+  their "honest, commented allowlist" idiom.
+
+## The contract
+
+Source of truth: `packages/create-hono-preact/templates/agents/AGENTS.md`. The
+checkable idioms it prescribes:
+
+- Routes are declared in `src/routes.ts` via `defineRoutes` / `contentRoutes`;
+  there is no file-system routing.
+- This is Preact: hooks come from `preact/hooks`, never `react`.
+- Server code lives only in colocated `*.server.ts` files, which export **only**
+  `serverLoaders` / `serverActions` (no default export) and are never imported
+  into client code.
+- Data comes from `defineLoader`; mutations are `defineAction`s and results come
+  back in the uniform `__outcome` envelope (`useActionResult` / `useFormStatus`).
+- Do not cast; let route/loader inference work (`useParams()` is typed per route).
+- Page guards are a single `use: [...]` array on a route node.
+- Import only from the documented public subpaths (`hono-preact`,
+  `hono-preact/page`, `hono-preact/server`, `hono-preact/vite`,
+  `hono-preact/adapter-cloudflare`, `hono-preact/adapter-node`); UI comes from
+  the separate `hono-preact-ui` package.
+
+## Key principle: app code vs docs
+
+The site holds two kinds of content, and they must be treated differently:
+
+- **Application code** (`.ts` / `.tsx`): the dogfood app. This is what must
+  follow the contract. Live `<Example>` `.tsx` components are app code too (they
+  are idiomatic mini-demos, not anti-pattern snippets), so they are in scope.
+- **Documentation content** (`.mdx`, and prose): the docs deliberately
+  demonstrate escape hatches and "don't do this" patterns for teaching. For
+  example, `pages/docs/optimistic-ui.mdx` imports `hono-preact/internal` on
+  purpose and the prose explicitly warns it has no semver guarantee.
+
+Therefore the audit and the gate target **app code only** and never read `.mdx`
+bodies. This mirrors the fence-aware corpus extraction lesson from the llms
+generator: documentation that shows code is not the same as code.
+
+## Rule taxonomy
+
+### Gated (mechanizable, ~zero false positives)
+
+- **R1 - No `react` / `react-dom` imports.** Hooks and JSX come from Preact.
+- **R2 - Framework imports stay on the public surface.** No import specifier
+  that (a) contains `/internal`, or (b) starts with `@hono-preact/` (the internal
+  workspace packages `iso` / `server` / `vite` / `ui`). The site must consume the
+  published `hono-preact` and `hono-preact-ui` surface, not the internals.
+- **R3 - `.server.ts` export shape.** A `*.server.ts` file may export only
+  `serverLoaders` and/or `serverActions`, and must have no default export.
+- **R4 - No server leak.** No client (non-`.server`) module may import a
+  `*.server.ts` / `*.server.tsx` module.
+
+### Gated with an honest, commented allowlist
+
+- **R5 - No casts outside accepted boundaries.** Phase A reshapes every cast it
+  can per the CLAUDE.md "type casts" guidance; the residue (genuine boundaries
+  such as FormData reads, untrusted-JSON parses, user-module structural reads)
+  goes on a commented allowlist with a one-line reason each. Any cast not on the
+  allowlist fails CI. Stale allowlist entries (a cast that no longer exists) also
+  fail, so the list stays honest. `as const` is never a cast for this purpose.
+
+### Audit-only (structural / idiomatic; not continuously gated)
+
+Routes via `defineRoutes`/`contentRoutes`; guards as `use: []` arrays; data via
+`defineLoader`; mutations via `defineAction` + `__outcome`; forms via
+`Form`/`useActionResult` rather than ad-hoc `fetch`. These are judgement calls
+where a continuous gate would produce false positives that cost more than they
+catch. The audit spot-checks each and records the result; the site already
+follows them.
+
+## Current baseline (measured in this worktree, on merged `main`)
+
+App code (`apps/site/src/**/*.{ts,tsx}`, excluding `.mdx`):
+
+- **R1:** 0 `react` imports. Already clean.
+- **R2:** 0 `/internal` imports and 0 `@hono-preact/*` imports in app code. The
+  only `/internal` reference is the deliberate teaching import in
+  `optimistic-ui.mdx`, which is out of scope. Already clean.
+- **R3 / R4:** 4 `.server.ts` files (`login`, `project-board`, `projects-shell`,
+  `task` under `pages/demo/`) to verify.
+- **R5:** ~14 casts in non-test app code (excluding `as const`), concentrated in
+  `components/demo` (6), with the rest spread across `pages/demo`, `hooks`,
+  `components`, `pages/docs`, `demo`. This is the real work of Phase A; the audit
+  enumerates the exact list and dispositions each.
+
+So R1, R2, and R4 are expected to pass on day one (the gate locks them in); R3 is
+a quick verification; R5 is where the audit spends its effort.
+
+## Phase A: audit + fix
+
+1. Enumerate every cast in non-test app code with file, expression, and context.
+2. For each: reshape away per CLAUDE.md (declare the symbol key, write a type
+   predicate, widen the source field, fix the generic) **or** classify it as an
+   accepted boundary and record the reason. Reshape is strongly preferred;
+   allowlisting is the fallback for genuine boundaries.
+3. Verify R3 on the 4 `.server.ts` files and R4 across all client imports.
+4. Spot-check the audit-only idioms and record findings.
+5. Produce the allowlist that Phase B's gate consumes, with a reason per entry.
+
+The audit's findings and dispositions live in the implementation plan and the
+final PR description, not in a separate long-lived document.
+
+## Phase B: the drift gate
+
+- **Location:** `apps/site/src/__tests__/agents-conformance.test.ts`, run by the
+  site's existing vitest project (part of `pnpm test`). It anchors its scan to
+  the repo via `fileURLToPath(import.meta.url)` so it is cwd-independent.
+- **Scan set:** all `apps/site/src/**/*.{ts,tsx}`, **excluding** `**/*.mdx` and
+  `**/__tests__/**`.
+- **Parser:** the TypeScript compiler API (`typescript` is already a dependency),
+  not regex. Each file is parsed to a `SourceFile` and walked once. AST parsing
+  is what keeps R5 free of the false positives a `\bas [A-Z]` regex would
+  produce (identifiers like `markdownAs`, multi-line casts, `as const`) and lets
+  R1/R2/R4 see real import specifiers (including type-only and re-exports) rather
+  than guessing from text.
+- **Per-rule checks:**
+  - R1 / R2: walk `ImportDeclaration` / `ExportDeclaration` / dynamic
+    `import()` module specifiers; assert none is `react`/`react-dom`, contains
+    `/internal`, or starts with `@hono-preact/`.
+  - R3: for files matching `*.server.ts`, walk top-level exports; assert the set
+    of exported names is a subset of `{serverLoaders, serverActions}` and there
+    is no default export.
+  - R4: for non-server files, assert no import specifier resolves to a
+    `*.server.{ts,tsx}` module.
+  - R5: collect every `AsExpression` (and `<T>x` angle-bracket assertion) whose
+    target type is not `const`; assert each `{file, exprText}` is present in the
+    allowlist; assert no allowlist entry is unused (stale).
+- **Allowlist shape:** an in-file `const ALLOWLIST` array of
+  `{ file, expr, reason }`, keyed by repo-relative file path plus the exact
+  cast expression text (line numbers are intentionally not used: they drift).
+  The block is commented as the single honest record of accepted boundaries.
+- **Failure messages name the fix**, in the spirit of PR #107's error-legibility
+  work: an R2 failure says which public subpath to use instead; an R5 failure
+  says "reshape the type or add an allowlist entry with a reason"; an R3 failure
+  names the only allowed exports.
+
+## Gate self-test
+
+The gate test ships with fixture-level coverage proving it actually fails when it
+should (a mutation check, per the lesson that "a regression test that passes
+against unmodified code proves nothing"): feed the checker a small in-memory
+source string containing a `react` import, an `@hono-preact/iso` import, a
+`.server.ts` with a default export, a client file importing a `.server` module,
+and an un-allowlisted cast, and assert each is reported. This keeps the checker
+honest independently of the live `apps/site` tree.
+
+## Workflow
+
+- All work in this worktree; Serena indexes the main checkout, so use
+  rg / Read / Edit here.
+- This spec is committed under `docs/superpowers/specs/`.
+- After spec review: `writing-plans` produces the implementation plan, then
+  implement, then the six-step pre-push CI gate (build, format:check, typecheck,
+  test, test:integration, site build), then open a PR to `main`.
+
+## Non-goals
+
+- Auditing or gating the scaffolder template output, other apps, or the framework
+  packages themselves. Scope is `apps/site`.
+- Gating `.mdx` documentation content.
+- The deferred PR #107 eval harness (measuring whether an LLM uses the framework
+  correctly end to end). Out of scope here.
+
+## Risks / open questions
+
+- **Module resolution for R4.** Resolving an import specifier to a concrete
+  `*.server` file path is the fiddliest part (relative specifiers, path aliases).
+  The plan should confirm the site's alias setup and keep R4's resolver simple
+  and explicit rather than reimplementing a full resolver.
+- **`typescript` availability in the site's test project.** Confirm the gate can
+  `import ts from 'typescript'` under the site's vitest config; if not, add it as
+  a devDependency to the site package.
+- **Allowlist churn.** If the audit cannot reshape many casts, a large allowlist
+  is a smell pointing back at the types. Prefer reshaping; treat a long allowlist
+  as a finding, not a destination.

--- a/docs/superpowers/specs/2026-06-18-site-agents-conformance-design.md
+++ b/docs/superpowers/specs/2026-06-18-site-agents-conformance-design.md
@@ -1,27 +1,35 @@
 # Site AGENTS.md conformance: audit + drift gate
 
 - **Date:** 2026-06-18
-- **Status:** design (approved in brainstorming; awaiting written-spec review)
+- **Status:** design (approved; revised after planning-phase investigation)
 - **Branch / worktree:** `worktree-chore+site-agents-conformance` (fresh off `main` after PR #119 merged)
 
 ## Goal
 
 `apps/site` is the framework's own dogfood and de-facto reference app. The LLM
 documentation program (PR #107) hands every agent the `AGENTS.md` contract that
-prescribes how to use the framework idiomatically. This work makes `apps/site`
-faithfully embody that contract, so an agent that reads the docs and then reads
-our own code sees the same idioms, not contradictions.
+prescribes how to use the framework idiomatically. This work makes the site and
+the contract agree, so an agent that reads the docs and then reads our own code
+sees the same idioms, not contradictions.
 
-Two phases:
+Conformance is **bidirectional**: where the code diverges from the contract,
+usually the code is wrong and we fix it; but where the contract misstates the
+framework, the contract is wrong and we fix that instead. The planning-phase
+investigation found one of each kind (see Findings below).
 
-- **Phase A (audit + fix):** a one-time pass that checks `apps/site` against the
-  contract and fixes or consciously accepts each divergence.
+Three workstreams:
+
+- **Phase A (audit + fix):** a one-time pass that checks `apps/site` app code
+  against the contract and fixes or consciously accepts each divergence. The
+  concrete work is type-cast triage.
 - **Phase B (drift gate):** a vitest test that mechanically enforces the
   checkable rules so the site cannot silently drift back out of conformance. It
-  mirrors the two drift gates already shipped in PR #107
+  mirrors the two drift gates shipped in PR #107
   (`apps/site/src/pages/docs/__tests__/exports-coverage.test.ts`,
   `packages/create-hono-preact/__tests__/agents-appendix.test.ts`), including
   their "honest, commented allowlist" idiom.
+- **Phase C (docs correction):** fix the one incorrect line in `AGENTS.md` and
+  scan the docs corpus for the same contradiction.
 
 ## The contract
 
@@ -31,11 +39,11 @@ checkable idioms it prescribes:
 - Routes are declared in `src/routes.ts` via `defineRoutes` / `contentRoutes`;
   there is no file-system routing.
 - This is Preact: hooks come from `preact/hooks`, never `react`.
-- Server code lives only in colocated `*.server.ts` files, which export **only**
-  `serverLoaders` / `serverActions` (no default export) and are never imported
-  into client code.
-- Data comes from `defineLoader`; mutations are `defineAction`s and results come
-  back in the uniform `__outcome` envelope (`useActionResult` / `useFormStatus`).
+- Server code lives only in colocated `*.server.ts` files, which export
+  `serverLoaders` / `serverActions` (plus erased `export type`s); no default
+  export.
+- Data comes from `defineLoader`; mutations are `defineAction`s with the uniform
+  `__outcome` envelope (`useActionResult` / `useFormStatus`).
 - Do not cast; let route/loader inference work (`useParams()` is typed per route).
 - Page guards are a single `use: [...]` array on a route node.
 - Import only from the documented public subpaths (`hono-preact`,
@@ -56,8 +64,36 @@ The site holds two kinds of content, and they must be treated differently:
   purpose and the prose explicitly warns it has no semver guarantee.
 
 Therefore the audit and the gate target **app code only** and never read `.mdx`
-bodies. This mirrors the fence-aware corpus extraction lesson from the llms
-generator: documentation that shows code is not the same as code.
+bodies. (Phase C edits docs deliberately and separately.) This mirrors the
+fence-aware corpus extraction lesson from the llms generator: documentation that
+shows code is not the same as code.
+
+## Findings from the planning investigation
+
+These shaped the rule set; recorded so the rationale is not lost.
+
+1. **Importing `serverLoaders` / `serverActions` from a `.server` file into
+   client components is the intended, documented mechanism**, not a leak.
+   `loaders.mdx` shows `import { serverLoaders } from './movies.server.js'`
+   followed by `serverLoaders.default.useData()`; the Vite plugin rewrites that
+   import into a client-safe RPC Proxy stub that POSTs to `/__loaders`. The demo
+   does exactly this (`project-board.tsx`, `TaskCard.tsx`, `Board.tsx`,
+   `NewTaskDialog.tsx`). A "no `.server` import in client code" rule would reject
+   correct, idiomatic code. **The demo is right.**
+
+2. **`AGENTS.md` line 30 is wrong.** It says *"Never import a `.server` symbol
+   into client code,"* which contradicts finding 1 and the framework's own
+   mechanism. An agent obeying it literally could not read loader data the
+   documented way. **The contract is wrong** (Phase C fixes it).
+
+3. **`.server.ts` export shape is already build-enforced.**
+   `packages/vite/src/server-loader-validation.ts`
+   (`serverLoaderValidationPlugin`) fails the build if a `.server.*` file has a
+   default export, an `export *`, or any value named export other than
+   `serverLoaders` / `serverActions`. It explicitly exempts `export type`
+   (`server-loader-validation.ts:39`), which is why the demo's
+   `export type BoardData` / `ShellData` are fine. A vitest gate for this would
+   be pure duplication.
 
 ## Rule taxonomy
 
@@ -68,131 +104,157 @@ generator: documentation that shows code is not the same as code.
   that (a) contains `/internal`, or (b) starts with `@hono-preact/` (the internal
   workspace packages `iso` / `server` / `vite` / `ui`). The site must consume the
   published `hono-preact` and `hono-preact-ui` surface, not the internals.
-- **R3 - `.server.ts` export shape.** A `*.server.ts` file may export only
-  `serverLoaders` and/or `serverActions`, and must have no default export.
-- **R4 - No server leak.** No client (non-`.server`) module may import a
-  `*.server.ts` / `*.server.tsx` module.
-
-### Gated with an honest, commented allowlist
-
 - **R5 - No casts outside accepted boundaries.** Phase A reshapes every cast it
   can per the CLAUDE.md "type casts" guidance; the residue (genuine boundaries
-  such as FormData reads, untrusted-JSON parses, user-module structural reads)
-  goes on a commented allowlist with a one-line reason each. Any cast not on the
+  such as DOM API reads, Worker `MessageEvent.data`, untrusted-JSON parses) goes
+  on a commented allowlist with a one-line reason each. Any cast not on the
   allowlist fails CI. Stale allowlist entries (a cast that no longer exists) also
   fail, so the list stays honest. `as const` is never a cast for this purpose.
 
-### Audit-only (structural / idiomatic; not continuously gated)
+### Not gated, by design
+
+- **`.server.ts` export shape:** already enforced by `serverLoaderValidationPlugin`
+  at build time (finding 3). Not re-gated.
+- **Server/client import boundary:** importing `serverLoaders`/`serverActions`
+  into client code is the intended mechanism (finding 1). There is no
+  import-level leak rule to enforce; runtime safety is the Vite plugin's job. (If
+  the site ever grew a `src/server/*` helper directory, a "client must not import
+  `@/server/*`" rule would become worthwhile; it has none today, so YAGNI.)
+
+### Audit-only (structural / idiomatic; spot-checked, not continuously gated)
 
 Routes via `defineRoutes`/`contentRoutes`; guards as `use: []` arrays; data via
 `defineLoader`; mutations via `defineAction` + `__outcome`; forms via
-`Form`/`useActionResult` rather than ad-hoc `fetch`. These are judgement calls
-where a continuous gate would produce false positives that cost more than they
-catch. The audit spot-checks each and records the result; the site already
-follows them.
+`Form`/`useActionResult`. Judgement calls where a continuous gate would produce
+false positives that cost more than they catch. The audit spot-checks each; the
+site already follows them.
 
 ## Current baseline (measured in this worktree, on merged `main`)
 
-App code (`apps/site/src/**/*.{ts,tsx}`, excluding `.mdx`):
+App code (`apps/site/src/**/*.{ts,tsx}`, excluding `.mdx` and `__tests__`):
 
-- **R1:** 0 `react` imports. Already clean.
-- **R2:** 0 `/internal` imports and 0 `@hono-preact/*` imports in app code. The
-  only `/internal` reference is the deliberate teaching import in
-  `optimistic-ui.mdx`, which is out of scope. Already clean.
-- **R3 / R4:** 4 `.server.ts` files (`login`, `project-board`, `projects-shell`,
-  `task` under `pages/demo/`) to verify.
-- **R5:** ~14 casts in non-test app code (excluding `as const`), concentrated in
-  `components/demo` (6), with the rest spread across `pages/demo`, `hooks`,
-  `components`, `pages/docs`, `demo`. This is the real work of Phase A; the audit
-  enumerates the exact list and dispositions each.
+- **R1:** 0 `react` imports. Clean; the gate locks it in.
+- **R2:** 0 `/internal` imports and 0 `@hono-preact/*` imports. The only
+  `/internal` reference is the deliberate teaching import in `optimistic-ui.mdx`,
+  which is out of scope. Clean; the gate locks it in.
+- **R5:** ~12 real `X as Type` assertions (a naive `\bas [A-Z]` regex over-counts
+  badly: it catches `useRef<T>(`, `querySelectorAll<T>(`, `import { X as Y }`,
+  and `<T>() =>` generics, none of which are casts - which is exactly why the
+  gate must use an AST, not a regex). The real casts:
+  - **Genuine boundaries (expected to land on the allowlist):**
+    `cloneNode(true) as HTMLElement` and `e.currentTarget as HTMLElement`
+    (use-board-drag), `e as PointerEvent` (TaskCard), `e.data as WorkerOutMsg`
+    (HeroShader) and `e.data as WorkerInMsg` (shader-worker),
+    `JSON.parse(raw) as CookiePayload` (session).
+  - **Reshapeable (expected to be fixed):** `filter(Boolean) as User[]`
+    (project-board.server - replace with a `(u): u is User =>` type predicate,
+    the canonical CLAUDE.md example), `} as CommentData` (task.tsx - type the
+    binding/return instead), and the picker cluster `v as TaskStatus` /
+    `v as TaskPriority` in `components/demo/pickers.tsx` and
+    `components/demo/TaskActions.tsx` (reshape by typing the generic
+    Select/Combobox value so the union flows through).
 
-So R1, R2, and R4 are expected to pass on day one (the gate locks them in); R3 is
-a quick verification; R5 is where the audit spends its effort.
+The exact final partition (fixed vs allowlisted) is the audit's deliverable; the
+checker built in Phase B is the tool that enumerates it precisely.
 
 ## Phase A: audit + fix
 
-1. Enumerate every cast in non-test app code with file, expression, and context.
-2. For each: reshape away per CLAUDE.md (declare the symbol key, write a type
-   predicate, widen the source field, fix the generic) **or** classify it as an
-   accepted boundary and record the reason. Reshape is strongly preferred;
-   allowlisting is the fallback for genuine boundaries.
-3. Verify R3 on the 4 `.server.ts` files and R4 across all client imports.
-4. Spot-check the audit-only idioms and record findings.
-5. Produce the allowlist that Phase B's gate consumes, with a reason per entry.
+1. Run the R5 collector (built in Phase B) with an empty allowlist to enumerate
+   every cast with file + expression.
+2. For each: reshape away per CLAUDE.md (type predicate, typed binding, generic
+   value type) **or** classify it as an accepted boundary. Reshape is strongly
+   preferred; allowlisting is the fallback for genuine boundaries.
+3. Spot-check the audit-only idioms and record findings.
+4. The residue becomes the Phase B allowlist, one reason per entry.
 
-The audit's findings and dispositions live in the implementation plan and the
-final PR description, not in a separate long-lived document.
+Findings and dispositions live in the implementation plan and the PR
+description, not a separate long-lived document.
 
 ## Phase B: the drift gate
 
-- **Location:** `apps/site/src/__tests__/agents-conformance.test.ts`, run by the
-  site's existing vitest project (part of `pnpm test`). It anchors its scan to
-  the repo via `fileURLToPath(import.meta.url)` so it is cwd-independent.
+- **Files:**
+  - `apps/site/src/__tests__/agents-conformance-checker.ts` - the checker:
+    parse a source file and collect its import specifiers, and its cast
+    expressions. Pure functions over source text, no filesystem. (Lives under
+    `__tests__` so the live scan excludes it and vitest does not collect it as a
+    suite - the `include` glob only matches `*.test.{ts,tsx}`.)
+  - `apps/site/src/__tests__/agents-conformance.test.ts` - the gate: the
+    self-test fixtures (mutation check) + the live `apps/site/src` scan + the
+    allowlist. Run by the root vitest project
+    (`apps/site/src/**/__tests__/**/*.test.{ts,tsx}` is in `vitest.config.ts`'s
+    `test.include`).
+- **Anchoring:** resolve the scan root via `fileURLToPath(import.meta.url)` so it
+  is cwd-independent (same idiom as `exports-coverage.test.ts`).
 - **Scan set:** all `apps/site/src/**/*.{ts,tsx}`, **excluding** `**/*.mdx` and
-  `**/__tests__/**`.
-- **Parser:** the TypeScript compiler API (`typescript` is already a dependency),
-  not regex. Each file is parsed to a `SourceFile` and walked once. AST parsing
-  is what keeps R5 free of the false positives a `\bas [A-Z]` regex would
-  produce (identifiers like `markdownAs`, multi-line casts, `as const`) and lets
-  R1/R2/R4 see real import specifiers (including type-only and re-exports) rather
-  than guessing from text.
+  `**/__tests__/**` (the existing `exports-coverage` walker already skips
+  `__tests__`; reuse that shape).
+- **Parser:** `@babel/parser` + `@babel/types`, the repo's house AST tooling and
+  exactly what `server-loader-validation.ts` uses (both are `apps/site` dev
+  dependencies already). Parse each file with `sourceType: 'module'` and plugins
+  `['typescript']` plus `'jsx'` for `.tsx`. AST parsing is what keeps R5 free of
+  the regex false positives above and lets R1/R2 read real specifiers (including
+  type-only and re-exports).
 - **Per-rule checks:**
-  - R1 / R2: walk `ImportDeclaration` / `ExportDeclaration` / dynamic
-    `import()` module specifiers; assert none is `react`/`react-dom`, contains
-    `/internal`, or starts with `@hono-preact/`.
-  - R3: for files matching `*.server.ts`, walk top-level exports; assert the set
-    of exported names is a subset of `{serverLoaders, serverActions}` and there
-    is no default export.
-  - R4: for non-server files, assert no import specifier resolves to a
-    `*.server.{ts,tsx}` module.
-  - R5: collect every `AsExpression` (and `<T>x` angle-bracket assertion) whose
-    target type is not `const`; assert each `{file, exprText}` is present in the
+  - **R1 / R2:** collect specifiers from `ImportDeclaration`,
+    `ExportNamedDeclaration` / `ExportAllDeclaration` with a `source`, and dynamic
+    `import()` (a babel `ImportExpression`, whose `.source` carries the specifier
+    - per the Babel 8 note). Assert none is `react` / `react-dom` (or a subpath),
+    none contains `/internal`, none starts with `@hono-preact/`.
+  - **R5:** collect every `TSAsExpression` and `TSTypeAssertion` whose asserted
+    type is not `const`; assert each `{file, exprText}` is present in the
     allowlist; assert no allowlist entry is unused (stale).
 - **Allowlist shape:** an in-file `const ALLOWLIST` array of
-  `{ file, expr, reason }`, keyed by repo-relative file path plus the exact
-  cast expression text (line numbers are intentionally not used: they drift).
-  The block is commented as the single honest record of accepted boundaries.
-- **Failure messages name the fix**, in the spirit of PR #107's error-legibility
-  work: an R2 failure says which public subpath to use instead; an R5 failure
-  says "reshape the type or add an allowlist entry with a reason"; an R3 failure
-  names the only allowed exports.
+  `{ file, expr, reason }`, keyed by repo-relative file path plus the exact cast
+  expression text (line numbers are intentionally not used: they drift). The
+  block is commented as the single honest record of accepted boundaries.
+- **Failure messages name the fix** (in the spirit of PR #107's error-legibility
+  work): an R2 failure names the public subpath to use instead; an R5 failure
+  says "reshape the type or add an allowlist entry with a reason."
+
+## Phase C: docs correction
+
+1. Reword `AGENTS.md` line 30. Replace the false *"Never import a `.server`
+   symbol into client code"* with the accurate rule: client code imports
+   `serverLoaders` / `serverActions` (the Vite plugin makes them client-safe RPC
+   handles); never put secrets or server-only helpers where they would be inlined
+   into the client - keep that logic inside the loader/action bodies in the
+   `.server` file.
+2. Scan the docs corpus (`apps/site/src/pages/docs/**/*.mdx`) for the same
+   contradiction (any "never import .server" / "don't import server" phrasing)
+   and fix it consistently.
+3. Re-run the `agents-appendix` test (`packages/create-hono-preact/__tests__`) to
+   confirm the AGENTS.md edit did not break the entry-point appendix invariant.
 
 ## Gate self-test
 
-The gate test ships with fixture-level coverage proving it actually fails when it
-should (a mutation check, per the lesson that "a regression test that passes
-against unmodified code proves nothing"): feed the checker a small in-memory
-source string containing a `react` import, an `@hono-preact/iso` import, a
-`.server.ts` with a default export, a client file importing a `.server` module,
-and an un-allowlisted cast, and assert each is reported. This keeps the checker
-honest independently of the live `apps/site` tree.
+The gate ships with fixture-level coverage proving it fails when it should (a
+mutation check, per the lesson that "a regression test that passes against
+unmodified code proves nothing"): feed the checker small in-memory source strings
+containing a `react` import, an `@hono-preact/iso` import, a `hono-preact/internal`
+import, and an un-allowlisted cast, and assert each is reported; feed it a clean
+source and a sole `as const` and assert nothing is reported.
 
 ## Workflow
 
 - All work in this worktree; Serena indexes the main checkout, so use
   rg / Read / Edit here.
 - This spec is committed under `docs/superpowers/specs/`.
-- After spec review: `writing-plans` produces the implementation plan, then
-  implement, then the six-step pre-push CI gate (build, format:check, typecheck,
-  test, test:integration, site build), then open a PR to `main`.
+- After plan: implement, then the six-step pre-push CI gate (build, format:check,
+  typecheck, test, test:integration, site build), then open a PR to `main`.
 
 ## Non-goals
 
-- Auditing or gating the scaffolder template output, other apps, or the framework
-  packages themselves. Scope is `apps/site`.
-- Gating `.mdx` documentation content.
-- The deferred PR #107 eval harness (measuring whether an LLM uses the framework
-  correctly end to end). Out of scope here.
+- Auditing or gating the scaffolder template app, other apps, or the framework
+  packages themselves. Scope is `apps/site` (plus the Phase C `AGENTS.md` and
+  docs-corpus edits).
+- Re-gating `.server.ts` export shape (the build plugin owns it).
+- The deferred PR #107 eval harness. Out of scope here.
 
 ## Risks / open questions
 
-- **Module resolution for R4.** Resolving an import specifier to a concrete
-  `*.server` file path is the fiddliest part (relative specifiers, path aliases).
-  The plan should confirm the site's alias setup and keep R4's resolver simple
-  and explicit rather than reimplementing a full resolver.
-- **`typescript` availability in the site's test project.** Confirm the gate can
-  `import ts from 'typescript'` under the site's vitest config; if not, add it as
-  a devDependency to the site package.
+- **`as const` node shape.** Confirm during TDD how `@babel/parser` represents
+  `x as const` (a `TSAsExpression` whose `typeAnnotation` references `const`) so
+  R5 excludes it precisely.
 - **Allowlist churn.** If the audit cannot reshape many casts, a large allowlist
   is a smell pointing back at the types. Prefer reshaping; treat a long allowlist
   as a finding, not a destination.

--- a/packages/create-hono-preact/templates/agents/AGENTS.md
+++ b/packages/create-hono-preact/templates/agents/AGENTS.md
@@ -27,8 +27,11 @@ A page is up to four files:
 - `src/pages/home.server.ts` - loaders/actions for that page. Optional. Use
   `export const serverLoaders = { default: defineLoader(fn) }` and
   `export const serverActions = { ... }`. No default export; `serverLoaders` /
-  `serverActions` are the only allowed named exports. Never import a `.server`
-  symbol into client code.
+  `serverActions` are the only allowed named exports (plus erased `export
+  type`s). Client code imports `serverLoaders` / `serverActions` and reads data
+  through them; the Vite plugin rewrites those imports into client-safe RPC
+  handles. Never put secrets or server-only helpers where they would be inlined
+  into the client; keep that logic inside the loader and action bodies.
 - `src/routes.ts` - declares every URL and which view (and optional `.server`
   module) lives there.
 - `src/Layout.tsx` - the HTML document shell. It must render `<ClientScript />`


### PR DESCRIPTION
## What & why

`apps/site` is the framework's dogfood and de-facto reference app. The LLM docs (PR #107) hand every agent the `AGENTS.md` contract; this makes the site and that contract **agree**, so an agent that reads the docs and then reads our code sees the same idioms. Conformance turned out to be **bidirectional**: most divergences were code to fix, but one was a contract error to fix.

Spec + plan: `docs/superpowers/specs/2026-06-18-site-agents-conformance-design.md`, `docs/superpowers/plans/2026-06-18-site-agents-conformance.md`.

## The drift gate (R1/R2/R5)

New vitest gate `apps/site/src/__tests__/agents-conformance.test.ts` (+ AST checker `agents-conformance-checker.ts`), mirroring the PR #107 drift gates. It walks `apps/site/src/**/*.{ts,tsx}`, **excluding `.mdx`** (docs deliberately teach escape hatches) and `__tests__`, parsing with `@babel/parser` (the repo's house AST tool, same as `serverLoaderValidationPlugin`):

- **R1** - no `react`/`react-dom` imports (use `preact`).
- **R2** - no `/internal` or `@hono-preact/*` imports (consume the published surface).
- **R5** - no type casts outside an **honest, commented allowlist** (with a stale-entry check so the list can't rot).

It ships a mutation self-test (planted react/internal/cast violations all fail with fix-naming messages), so the gate is provably not a no-op.

## Cast audit (the real work)

12 casts triaged. **3 reshaped** (cast removed):
- `filter(Boolean) as User[]` → `(u): u is User => u !== null` type predicate.
- `{...} as CommentData` → a typed `const optimistic: CommentData` binding.
- picker `as TaskStatus`/`as TaskPriority`/`as string` → generic `Select.Root<TaskStatus>` / `Combobox.Root<string>`.

**9 allowlisted** as genuine boundaries, each with a reason: DOM API reads (`cloneNode`, `currentTarget`), Worker `MessageEvent.data` (`any`), the worker-global `self as unknown as {...}`, untrusted `JSON.parse`, the Preact→DOM `PointerEvent` bridge, and the menu `RadioGroup.onValueChange` (typed `string`) status/priority values.

## Two rules deliberately NOT gated

- **`.server.ts` export shape** is already enforced at build time by `serverLoaderValidationPlugin` (it even exempts `export type`). Re-gating it would be pure duplication.
- **"No `.server` import in client code" was wrong.** Importing `serverLoaders`/`serverActions` into client components is the framework's *documented* mechanism (`loaders.mdx`; the Vite plugin rewrites them into client-safe RPC handles). A gate forbidding it would reject idiomatic code.

## Contract fix

`packages/create-hono-preact/templates/agents/AGENTS.md` told agents *"Never import a `.server` symbol into client code"* — false, and it would make an agent unable to read loader data the documented way. Reworded to the accurate rule (client imports the handles; the Vite plugin makes them safe; keep secrets/server-only helpers inside loader/action bodies). Docs corpus scanned for the same contradiction (none found).

## Verification

Six-step CI gate green locally: framework build, `format:check`, `typecheck`, `test` (1409 tests / 233 files), `test:integration` (4), site production build. Final whole-branch review (independent mutation check + cast re-enumeration + behavioral-equivalence checks) returned **READY TO MERGE**, no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)