### PR TITLE
feat(site): Demo/Code tabs on component docs pages

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -11,10 +11,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "hono-preact-ui": "workspace:*",
-    "hono-preact": "workspace:*",
     "@shikijs/rehype": "^4.0.2",
     "hono": "^4.12.14",
+    "hono-preact": "workspace:*",
+    "hono-preact-ui": "workspace:*",
     "hoofd": "^1.7.3",
     "lucide-preact": "^1.14.0",
     "preact": "^10.29.1",
@@ -26,9 +26,9 @@
   "devDependencies": {
     "@babel/parser": "^8.0.0",
     "@babel/types": "^8.0.0",
+    "@cloudflare/vite-plugin": "^1.37.1",
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",
-    "@cloudflare/vite-plugin": "^1.37.1",
     "@hono/node-server": "^1.19.14",
     "@mdx-js/rollup": "^3.1.1",
     "@preact/preset-vite": "^2.10.5",
@@ -41,6 +41,7 @@
     "remark-gfm": "^4.0.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "sass-embedded": "^1.99.0",
+    "shiki": "^4.0.2",
     "tailwindcss": "^4.2.2",
     "typescript": "*",
     "vite": "*",

--- a/apps/site/src/components/docs/CodeTabs.tsx
+++ b/apps/site/src/components/docs/CodeTabs.tsx
@@ -1,5 +1,5 @@
-import { toChildArray, type ComponentChildren, type VNode } from 'preact';
-import { useRef, useState } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+import { Tabs } from './Tabs.js';
 import { CopyButton } from './CopyButton.js';
 
 interface CodeTabsProps {
@@ -10,39 +10,19 @@ interface CodeTabsProps {
   children: ComponentChildren;
 }
 
-// Tabbed, copyable code examples. Shows one highlighted block at a time and
-// copies the active block's text (read from the DOM, so it copies the raw
-// source rather than the highlighting markup).
+// Tabbed, copyable code examples. Built on the shared Tabs primitive; copies
+// the active block's text (read from the DOM, so it copies the raw source
+// rather than the highlighting markup).
 export function CodeTabs({ labels, children }: CodeTabsProps) {
-  const panels = toChildArray(children).filter(
-    (c): c is VNode => typeof c === 'object'
-  );
-  const [active, setActive] = useState(0);
-  const panelRef = useRef<HTMLDivElement>(null);
-
   return (
-    <div class="docs-codetabs">
-      <div class="docs-codetabs__tablist" role="tablist">
-        {labels.map((label, i) => (
-          <button
-            key={label}
-            type="button"
-            role="tab"
-            aria-selected={i === active}
-            class="docs-codetabs__tab"
-            onClick={() => setActive(i)}
-          >
-            {label}
-          </button>
-        ))}
-        <CopyButton
-          class="docs-codetabs__copy"
-          getText={() => panelRef.current?.textContent ?? ''}
-        />
-      </div>
-      <div class="docs-codetabs__panel" ref={panelRef}>
-        {panels[active]}
-      </div>
-    </div>
+    <Tabs
+      class="docs-tabs"
+      labels={labels}
+      accessory={({ getActiveText }) => (
+        <CopyButton class="docs-tabs__copy" getText={getActiveText} />
+      )}
+    >
+      {children}
+    </Tabs>
   );
 }

--- a/apps/site/src/components/docs/Example.tsx
+++ b/apps/site/src/components/docs/Example.tsx
@@ -1,10 +1,38 @@
 import type { ComponentChildren } from 'preact';
+import { Tabs } from './Tabs.js';
+import { CopyButton } from './CopyButton.js';
 
 interface ExampleProps {
   children: ComponentChildren;
+  // Build-time highlighted HTML of the source that powers this demo, imported
+  // via `'./FooDemo.tsx?highlighted'`. When present, the demo is shown in a
+  // Demo|Code tab strip; when absent, just the bordered demo frame.
+  code?: string;
 }
 
-// A bordered frame that hosts a live component demo on a docs page.
-export function Example({ children }: ExampleProps) {
-  return <div class="docs-example">{children}</div>;
+// Hosts a live component demo on a docs page. With `code`, shows Demo|Code tabs
+// (the Code tab is the real source that renders the demo, so it cannot drift).
+export function Example({ children, code }: ExampleProps) {
+  if (code == null) {
+    return <div class="docs-example">{children}</div>;
+  }
+  return (
+    <Tabs
+      class="docs-tabs docs-example-tabs"
+      labels={['Demo', 'Code']}
+      accessory={({ active, getActiveText }) =>
+        // Copy applies to the Code panel only (index 1).
+        active === 1 ? (
+          <CopyButton class="docs-tabs__copy" getText={getActiveText} />
+        ) : null
+      }
+    >
+      <div class="docs-example-tabs__demo">{children}</div>
+      <div
+        class="docs-example-tabs__code"
+        // Trusted: our own files, highlighted at build time.
+        dangerouslySetInnerHTML={{ __html: code }}
+      />
+    </Tabs>
+  );
 }

--- a/apps/site/src/components/docs/PopoverDemo.tsx
+++ b/apps/site/src/components/docs/PopoverDemo.tsx
@@ -1,57 +1,48 @@
-import { Popover } from 'hono-preact-ui';
 import { useState } from 'preact/hooks';
+import { PopoverExample } from './PopoverExample.js';
 
 const SIDES = ['top', 'right', 'bottom', 'left'] as const;
 const ALIGNS = ['start', 'center', 'end'] as const;
 
-// Interactive placement explorer. The side/align controls live INSIDE the popup
-// on purpose: a click inside the popover is not an outside-press, so the popover
-// stays open and repositions live as you change them. Styling is in root.css
-// (.docs-popover* / .docs-placement*).
+// Placement explorer harness around the PopoverExample core. The controls live
+// outside the popover so the core can be driven by props. The Code tab shows
+// PopoverExample, the real usage. Styling: .docs-placement* in root.css.
 export function PopoverDemo() {
   const [side, setSide] = useState<(typeof SIDES)[number]>('bottom');
   const [align, setAlign] = useState<(typeof ALIGNS)[number]>('center');
   return (
-    <Popover.Root side={side} align={align}>
-      <Popover.Trigger class="docs-popover-trigger">
-        Open popover
-      </Popover.Trigger>
-      <Popover.Positioner class="docs-popover-positioner">
-        <Popover.Popup class="docs-popover" aria-label="Placement explorer">
-          <Popover.Arrow class="docs-popover__arrow" />
-          <Popover.Title class="docs-popover__title">Placement</Popover.Title>
-          <Popover.Description class="docs-popover__desc">
-            The popover is anchored {side}, aligned {align}.
-          </Popover.Description>
-          <div class="docs-placement__group" role="group" aria-label="Side">
-            {SIDES.map((s) => (
-              <button
-                key={s}
-                type="button"
-                class="docs-placement__option"
-                data-active={s === side}
-                onClick={() => setSide(s)}
-              >
-                {s}
-              </button>
-            ))}
-          </div>
-          <div class="docs-placement__group" role="group" aria-label="Align">
-            {ALIGNS.map((a) => (
-              <button
-                key={a}
-                type="button"
-                class="docs-placement__option"
-                data-active={a === align}
-                onClick={() => setAlign(a)}
-              >
-                {a}
-              </button>
-            ))}
-          </div>
-          <Popover.Close class="docs-popover-close">Done</Popover.Close>
-        </Popover.Popup>
-      </Popover.Positioner>
-    </Popover.Root>
+    <div class="docs-placement">
+      <div class="docs-placement__controls">
+        <div class="docs-placement__group" role="group" aria-label="Side">
+          {SIDES.map((s) => (
+            <button
+              key={s}
+              type="button"
+              class="docs-placement__option"
+              data-active={s === side}
+              onClick={() => setSide(s)}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+        <div class="docs-placement__group" role="group" aria-label="Align">
+          {ALIGNS.map((a) => (
+            <button
+              key={a}
+              type="button"
+              class="docs-placement__option"
+              data-active={a === align}
+              onClick={() => setAlign(a)}
+            >
+              {a}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div class="docs-placement__stage">
+        <PopoverExample side={side} align={align} />
+      </div>
+    </div>
   );
 }

--- a/apps/site/src/components/docs/PopoverDemo.tsx
+++ b/apps/site/src/components/docs/PopoverDemo.tsx
@@ -1,48 +1,57 @@
+import { Popover } from 'hono-preact-ui';
 import { useState } from 'preact/hooks';
-import { PopoverExample } from './PopoverExample.js';
 
 const SIDES = ['top', 'right', 'bottom', 'left'] as const;
 const ALIGNS = ['start', 'center', 'end'] as const;
 
-// Placement explorer harness around the PopoverExample core. The controls live
-// outside the popover so the core can be driven by props. The Code tab shows
-// PopoverExample, the real usage. Styling: .docs-placement* in root.css.
+// Interactive placement explorer. The side/align controls live INSIDE the popup
+// on purpose: a click inside the popover is not an outside-press, so the popover
+// stays open and repositions live as you change them. Styling is in root.css
+// (.docs-popover* / .docs-placement*).
 export function PopoverDemo() {
   const [side, setSide] = useState<(typeof SIDES)[number]>('bottom');
   const [align, setAlign] = useState<(typeof ALIGNS)[number]>('center');
   return (
-    <div class="docs-placement">
-      <div class="docs-placement__controls">
-        <div class="docs-placement__group" role="group" aria-label="Side">
-          {SIDES.map((s) => (
-            <button
-              key={s}
-              type="button"
-              class="docs-placement__option"
-              data-active={s === side}
-              onClick={() => setSide(s)}
-            >
-              {s}
-            </button>
-          ))}
-        </div>
-        <div class="docs-placement__group" role="group" aria-label="Align">
-          {ALIGNS.map((a) => (
-            <button
-              key={a}
-              type="button"
-              class="docs-placement__option"
-              data-active={a === align}
-              onClick={() => setAlign(a)}
-            >
-              {a}
-            </button>
-          ))}
-        </div>
-      </div>
-      <div class="docs-placement__stage">
-        <PopoverExample side={side} align={align} />
-      </div>
-    </div>
+    <Popover.Root side={side} align={align}>
+      <Popover.Trigger class="docs-popover-trigger">
+        Open popover
+      </Popover.Trigger>
+      <Popover.Positioner class="docs-popover-positioner">
+        <Popover.Popup class="docs-popover" aria-label="Placement explorer">
+          <Popover.Arrow class="docs-popover__arrow" />
+          <Popover.Title class="docs-popover__title">Placement</Popover.Title>
+          <Popover.Description class="docs-popover__desc">
+            The popover is anchored {side}, aligned {align}.
+          </Popover.Description>
+          <div class="docs-placement__group" role="group" aria-label="Side">
+            {SIDES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                class="docs-placement__option"
+                data-active={s === side}
+                onClick={() => setSide(s)}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+          <div class="docs-placement__group" role="group" aria-label="Align">
+            {ALIGNS.map((a) => (
+              <button
+                key={a}
+                type="button"
+                class="docs-placement__option"
+                data-active={a === align}
+                onClick={() => setAlign(a)}
+              >
+                {a}
+              </button>
+            ))}
+          </div>
+          <Popover.Close class="docs-popover-close">Done</Popover.Close>
+        </Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Root>
   );
 }

--- a/apps/site/src/components/docs/PopoverExample.tsx
+++ b/apps/site/src/components/docs/PopoverExample.tsx
@@ -1,0 +1,29 @@
+import { Popover } from 'hono-preact-ui';
+
+interface PopoverExampleProps {
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  align?: 'start' | 'center' | 'end';
+}
+
+export function PopoverExample({
+  side = 'bottom',
+  align = 'center',
+}: PopoverExampleProps) {
+  return (
+    <Popover.Root side={side} align={align}>
+      <Popover.Trigger class="docs-popover-trigger">
+        Open popover
+      </Popover.Trigger>
+      <Popover.Positioner class="docs-popover-positioner">
+        <Popover.Popup class="docs-popover">
+          <Popover.Arrow class="docs-popover__arrow" />
+          <Popover.Title class="docs-popover__title">Settings</Popover.Title>
+          <Popover.Description class="docs-popover__desc">
+            Adjust your preferences.
+          </Popover.Description>
+          <Popover.Close class="docs-popover-close">Done</Popover.Close>
+        </Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Root>
+  );
+}

--- a/apps/site/src/components/docs/Tabs.tsx
+++ b/apps/site/src/components/docs/Tabs.tsx
@@ -23,7 +23,12 @@ interface TabsProps {
 // panels rendered with inactive ones hidden (so SSR content is present and the
 // active panel never remounts on switch). The shared primitive behind CodeTabs
 // and the Demo|Code tabs in Example.
-export function Tabs({ labels, children, accessory, class: className }: TabsProps) {
+export function Tabs({
+  labels,
+  children,
+  accessory,
+  class: className,
+}: TabsProps) {
   const panels = toChildArray(children).filter(
     (c): c is VNode => typeof c === 'object'
   );
@@ -53,7 +58,9 @@ export function Tabs({ labels, children, accessory, class: className }: TabsProp
         {labels.map((label, i) => (
           <button
             key={label}
-            ref={(el) => { tabRefs.current[i] = el; }}
+            ref={(el) => {
+              tabRefs.current[i] = el;
+            }}
             type="button"
             role="tab"
             id={`${baseId}-tab-${i}`}
@@ -71,7 +78,9 @@ export function Tabs({ labels, children, accessory, class: className }: TabsProp
       {panels.map((panel, i) => (
         <div
           key={labels[i]}
-          ref={(el) => { panelRefs.current[i] = el; }}
+          ref={(el) => {
+            panelRefs.current[i] = el;
+          }}
           role="tabpanel"
           id={`${baseId}-panel-${i}`}
           aria-labelledby={`${baseId}-tab-${i}`}

--- a/apps/site/src/components/docs/Tabs.tsx
+++ b/apps/site/src/components/docs/Tabs.tsx
@@ -57,7 +57,7 @@ export function Tabs({ labels, children, accessory, class: className }: TabsProp
             type="button"
             role="tab"
             id={`${baseId}-tab-${i}`}
-            aria-selected={i === active}
+            aria-selected={i === active ? 'true' : 'false'}
             aria-controls={`${baseId}-panel-${i}`}
             tabIndex={i === active ? 0 : -1}
             class="docs-tabs__tab"
@@ -70,7 +70,7 @@ export function Tabs({ labels, children, accessory, class: className }: TabsProp
       </div>
       {panels.map((panel, i) => (
         <div
-          key={i}
+          key={labels[i]}
           ref={(el) => { panelRefs.current[i] = el; }}
           role="tabpanel"
           id={`${baseId}-panel-${i}`}

--- a/apps/site/src/components/docs/Tabs.tsx
+++ b/apps/site/src/components/docs/Tabs.tsx
@@ -1,0 +1,86 @@
+import { toChildArray, type ComponentChildren, type VNode } from 'preact';
+import { useId, useRef, useState } from 'preact/hooks';
+
+// Arg passed to the optional tablist accessory (e.g. a copy button) so it can
+// react to which panel is showing and read its text.
+export interface TabsAccessoryArgs {
+  active: number;
+  getActiveText: () => string;
+}
+
+interface TabsProps {
+  // One label per panel, in order.
+  labels: string[];
+  // The panels, one per label (in docs these are fenced code blocks or demos).
+  children: ComponentChildren;
+  // Rendered at the end of the tablist.
+  accessory?: (args: TabsAccessoryArgs) => ComponentChildren;
+  // Class on the outer container (callers supply card styling).
+  class?: string;
+}
+
+// Accessible tab strip: roving tabindex, arrow/Home/End navigation, and all
+// panels rendered with inactive ones hidden (so SSR content is present and the
+// active panel never remounts on switch). The shared primitive behind CodeTabs
+// and the Demo|Code tabs in Example.
+export function Tabs({ labels, children, accessory, class: className }: TabsProps) {
+  const panels = toChildArray(children).filter(
+    (c): c is VNode => typeof c === 'object'
+  );
+  const [active, setActive] = useState(0);
+  const baseId = useId();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const panelRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  const getActiveText = () => panelRefs.current[active]?.textContent ?? '';
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    const last = labels.length - 1;
+    let next = active;
+    if (e.key === 'ArrowRight') next = active === last ? 0 : active + 1;
+    else if (e.key === 'ArrowLeft') next = active === 0 ? last : active - 1;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = last;
+    else return;
+    e.preventDefault();
+    setActive(next);
+    tabRefs.current[next]?.focus();
+  };
+
+  return (
+    <div class={className}>
+      <div class="docs-tabs__tablist" role="tablist" onKeyDown={onKeyDown}>
+        {labels.map((label, i) => (
+          <button
+            key={label}
+            ref={(el) => { tabRefs.current[i] = el; }}
+            type="button"
+            role="tab"
+            id={`${baseId}-tab-${i}`}
+            aria-selected={i === active}
+            aria-controls={`${baseId}-panel-${i}`}
+            tabIndex={i === active ? 0 : -1}
+            class="docs-tabs__tab"
+            onClick={() => setActive(i)}
+          >
+            {label}
+          </button>
+        ))}
+        {accessory?.({ active, getActiveText })}
+      </div>
+      {panels.map((panel, i) => (
+        <div
+          key={i}
+          ref={(el) => { panelRefs.current[i] = el; }}
+          role="tabpanel"
+          id={`${baseId}-panel-${i}`}
+          aria-labelledby={`${baseId}-tab-${i}`}
+          hidden={i !== active}
+          class="docs-tabs__panel"
+        >
+          {panel}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/site/src/components/docs/TooltipDemo.tsx
+++ b/apps/site/src/components/docs/TooltipDemo.tsx
@@ -1,12 +1,12 @@
-import { Tooltip } from 'hono-preact-ui';
 import { useState } from 'preact/hooks';
+import { TooltipExample } from './TooltipExample.js';
 
 const SIDES = ['top', 'right', 'bottom', 'left'] as const;
 const ALIGNS = ['start', 'center', 'end'] as const;
 
-// Placement explorer: pick a side and alignment, then hover (or focus) the
-// trigger to see the tooltip appear there. Styling is in root.css
-// (.docs-tooltip* / .docs-placement*).
+// Placement explorer harness around the TooltipExample core. The controls exist
+// only here (the docs Code tab shows TooltipExample, the real usage). Styling is
+// in root.css (.docs-tooltip* / .docs-placement*).
 export function TooltipDemo() {
   const [side, setSide] = useState<(typeof SIDES)[number]>('top');
   const [align, setAlign] = useState<(typeof ALIGNS)[number]>('center');
@@ -41,17 +41,7 @@ export function TooltipDemo() {
         </div>
       </div>
       <div class="docs-placement__stage">
-        <Tooltip.Root side={side} align={align}>
-          <Tooltip.Trigger class="docs-tooltip-trigger">
-            Hover me
-          </Tooltip.Trigger>
-          <Tooltip.Positioner class="docs-tooltip-positioner">
-            <Tooltip.Popup class="docs-tooltip">
-              <Tooltip.Arrow class="docs-tooltip__arrow" />
-              Saved to your library
-            </Tooltip.Popup>
-          </Tooltip.Positioner>
-        </Tooltip.Root>
+        <TooltipExample side={side} align={align} />
       </div>
     </div>
   );

--- a/apps/site/src/components/docs/TooltipExample.tsx
+++ b/apps/site/src/components/docs/TooltipExample.tsx
@@ -1,0 +1,23 @@
+import { Tooltip } from 'hono-preact-ui';
+
+interface TooltipExampleProps {
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  align?: 'start' | 'center' | 'end';
+}
+
+export function TooltipExample({
+  side = 'top',
+  align = 'center',
+}: TooltipExampleProps) {
+  return (
+    <Tooltip.Root side={side} align={align}>
+      <Tooltip.Trigger class="docs-tooltip-trigger">Hover me</Tooltip.Trigger>
+      <Tooltip.Positioner class="docs-tooltip-positioner">
+        <Tooltip.Popup class="docs-tooltip">
+          <Tooltip.Arrow class="docs-tooltip__arrow" />
+          Saved to your library
+        </Tooltip.Popup>
+      </Tooltip.Positioner>
+    </Tooltip.Root>
+  );
+}

--- a/apps/site/src/components/docs/UseListboxSelectionDemo.tsx
+++ b/apps/site/src/components/docs/UseListboxSelectionDemo.tsx
@@ -1,85 +1,23 @@
-import { useListboxSelection } from 'hono-preact-ui';
-import { useId, useLayoutEffect, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
+import { UseListboxSelectionExample } from './UseListboxSelectionExample.js';
 
-const FRUITS = ['Apple', 'Banana', 'Cherry', 'Date'];
-
-// A small option row that registers itself in the selection's label registry and
-// reflects/toggles its own selected state. Prop types for isSelected/toggle/
-// register mirror the actual hook return types (all accept unknown) so no cast
-// is needed.
-function Option(props: {
-  value: string;
-  isSelected: (v: unknown) => boolean;
-  toggle: (v: unknown) => void;
-  register: (id: string, value: unknown, label: string) => () => void;
-}) {
-  const { value, isSelected, toggle, register } = props;
-  const id = useId();
-  useLayoutEffect(() => register(id, value, value), [id, value, register]);
-  const selected = isSelected(value);
-  return (
-    <li
-      id={id}
-      role="option"
-      aria-selected={selected}
-      data-selected={selected ? '' : undefined}
-      class="docs-listboxsel-option"
-      onClick={() => toggle(value)}
-    >
-      {value}
-    </li>
-  );
-}
-
-// The selection core shared by Select and Combobox: single/multi value tracking,
-// a label registry resolving display labels in DOM order, and hidden form-field
-// serialization. Toggle multi-select; the readout shows selectedLabels() and the
-// hidden fields render below. Styling: .docs-listboxsel* in root.css.
+// Explorer harness around the UseListboxSelectionExample core. The multiple
+// checkbox exists only here (the docs Code tab shows UseListboxSelectionExample,
+// the real usage). Resets the selection when the mode switches so stale values
+// from one mode don't carry over. Styling: .docs-listboxsel* in root.css.
 export function UseListboxSelectionDemo() {
   const [multiple, setMultiple] = useState(false);
-  const [value, setValue] = useState<string | string[] | undefined>(undefined);
-  const [, setOpen] = useState(true);
-
-  const sel = useListboxSelection<string>({
-    value,
-    setValue: (next) => setValue(next),
-    multiple,
-    setOpen,
-    name: 'fruit',
-  });
-
   return (
     <div class="docs-listboxsel">
       <label class="docs-listboxsel-mode">
         <input
           type="checkbox"
           checked={multiple}
-          onChange={(e) => {
-            setMultiple(e.currentTarget.checked);
-            setValue(undefined);
-          }}
+          onChange={(e) => setMultiple(e.currentTarget.checked)}
         />
         multiple
       </label>
-      <ul
-        role="listbox"
-        aria-multiselectable={multiple}
-        class="docs-listboxsel-list"
-      >
-        {FRUITS.map((f) => (
-          <Option
-            key={f}
-            value={f}
-            isSelected={sel.isSelected}
-            toggle={sel.toggle}
-            register={sel.registerOption}
-          />
-        ))}
-      </ul>
-      <p class="docs-listboxsel-readout">
-        selected: <strong>{sel.selectedLabels().join(', ') || '(none)'}</strong>
-      </p>
-      {sel.hiddenFields}
+      <UseListboxSelectionExample key={String(multiple)} multiple={multiple} />
     </div>
   );
 }

--- a/apps/site/src/components/docs/UseListboxSelectionExample.tsx
+++ b/apps/site/src/components/docs/UseListboxSelectionExample.tsx
@@ -1,0 +1,78 @@
+import { useListboxSelection } from 'hono-preact-ui';
+import { useId, useLayoutEffect, useState } from 'preact/hooks';
+
+const FRUITS = ['Apple', 'Banana', 'Cherry', 'Date'];
+
+// A small option row that registers itself in the selection's label registry and
+// reflects/toggles its own selected state. Prop types for isSelected/toggle/
+// register mirror the actual hook return types (all accept unknown) so no cast
+// is needed.
+function Option(props: {
+  value: string;
+  isSelected: (v: unknown) => boolean;
+  toggle: (v: unknown) => void;
+  register: (id: string, value: unknown, label: string) => () => void;
+}) {
+  const { value, isSelected, toggle, register } = props;
+  const id = useId();
+  useLayoutEffect(() => register(id, value, value), [id, value, register]);
+  const selected = isSelected(value);
+  return (
+    <li
+      id={id}
+      role="option"
+      aria-selected={selected}
+      data-selected={selected ? '' : undefined}
+      class="docs-listboxsel-option"
+      onClick={() => toggle(value)}
+    >
+      {value}
+    </li>
+  );
+}
+
+interface UseListboxSelectionExampleProps {
+  multiple?: boolean;
+}
+
+// The selection core shared by Select and Combobox: single/multi value tracking,
+// a label registry resolving display labels in DOM order, and hidden form-field
+// serialization. Styling: .docs-listboxsel* in root.css.
+export function UseListboxSelectionExample({
+  multiple = false,
+}: UseListboxSelectionExampleProps) {
+  const [value, setValue] = useState<string | string[] | undefined>(undefined);
+  const [, setOpen] = useState(true);
+
+  const sel = useListboxSelection<string>({
+    value,
+    setValue: (next) => setValue(next),
+    multiple,
+    setOpen,
+    name: 'fruit',
+  });
+
+  return (
+    <div class="docs-listboxsel">
+      <ul
+        role="listbox"
+        aria-multiselectable={multiple}
+        class="docs-listboxsel-list"
+      >
+        {FRUITS.map((f) => (
+          <Option
+            key={f}
+            value={f}
+            isSelected={sel.isSelected}
+            toggle={sel.toggle}
+            register={sel.registerOption}
+          />
+        ))}
+      </ul>
+      <p class="docs-listboxsel-readout">
+        selected: <strong>{sel.selectedLabels().join(', ') || '(none)'}</strong>
+      </p>
+      {sel.hiddenFields}
+    </div>
+  );
+}

--- a/apps/site/src/components/docs/UseListboxSelectionExample.tsx
+++ b/apps/site/src/components/docs/UseListboxSelectionExample.tsx
@@ -53,7 +53,7 @@ export function UseListboxSelectionExample({
   });
 
   return (
-    <div class="docs-listboxsel">
+    <>
       <ul
         role="listbox"
         aria-multiselectable={multiple}
@@ -73,6 +73,6 @@ export function UseListboxSelectionExample({
         selected: <strong>{sel.selectedLabels().join(', ') || '(none)'}</strong>
       </p>
       {sel.hiddenFields}
-    </div>
+    </>
   );
 }

--- a/apps/site/src/components/docs/UsePositionDemo.tsx
+++ b/apps/site/src/components/docs/UsePositionDemo.tsx
@@ -1,23 +1,15 @@
-import { usePosition } from 'hono-preact-ui';
-import { useRef, useState } from 'preact/hooks';
+import { useState } from 'preact/hooks';
+import { UsePositionExample } from './UsePositionExample.js';
 
 const SIDES = ['top', 'right', 'bottom', 'left'] as const;
 const ALIGNS = ['start', 'center', 'end'] as const;
 
-// Bare placement: usePosition anchors the floating box to the button and applies
-// position:fixed/left/top itself, resolving a final side/align after collision
-// handling (the readout shows the resolved values, which can differ from the
-// requested side near a viewport edge). Deliberately not a popover. Styling:
-// .docs-useposition* in root.css.
+// Placement explorer harness around the UsePositionExample core. The fieldset
+// controls exist only here (the docs Code tab shows UsePositionExample, the real
+// usage). Styling: .docs-useposition* in root.css.
 export function UsePositionDemo() {
-  const anchorRef = useRef<HTMLButtonElement>(null);
-  const floatingRef = useRef<HTMLDivElement>(null);
-  const [open, setOpen] = useState(false);
   const [side, setSide] = useState<(typeof SIDES)[number]>('bottom');
   const [align, setAlign] = useState<(typeof ALIGNS)[number]>('center');
-
-  const pos = usePosition({ open, anchorRef, floatingRef, side, align });
-
   return (
     <div class="docs-useposition">
       <div class="docs-useposition-controls">
@@ -50,24 +42,7 @@ export function UsePositionDemo() {
           ))}
         </fieldset>
       </div>
-      <button
-        ref={anchorRef}
-        type="button"
-        class="docs-useposition-anchor"
-        onClick={() => setOpen((o) => !o)}
-      >
-        {open ? 'Hide' : 'Show'} box
-      </button>
-      {open ? (
-        <div
-          ref={floatingRef}
-          class="docs-useposition-box"
-          data-side={pos.side}
-          data-align={pos.align}
-        >
-          resolved: {pos.side} / {pos.align}
-        </div>
-      ) : null}
+      <UsePositionExample side={side} align={align} />
     </div>
   );
 }

--- a/apps/site/src/components/docs/UsePositionExample.tsx
+++ b/apps/site/src/components/docs/UsePositionExample.tsx
@@ -20,7 +20,7 @@ export function UsePositionExample({
   const pos = usePosition({ open, anchorRef, floatingRef, side, align });
 
   return (
-    <div class="docs-useposition">
+    <>
       <button
         ref={anchorRef}
         type="button"
@@ -39,6 +39,6 @@ export function UsePositionExample({
           resolved: {pos.side} / {pos.align}
         </div>
       ) : null}
-    </div>
+    </>
   );
 }

--- a/apps/site/src/components/docs/UsePositionExample.tsx
+++ b/apps/site/src/components/docs/UsePositionExample.tsx
@@ -1,0 +1,44 @@
+import { usePosition } from 'hono-preact-ui';
+import { useRef, useState } from 'preact/hooks';
+
+interface UsePositionExampleProps {
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  align?: 'start' | 'center' | 'end';
+}
+
+// Demonstrates usePosition: a button anchors a floating box that tracks it via
+// position:fixed. The resolved side/align (after collision handling) is shown
+// inside the box. Styling: .docs-useposition* in root.css.
+export function UsePositionExample({
+  side = 'bottom',
+  align = 'center',
+}: UsePositionExampleProps) {
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const pos = usePosition({ open, anchorRef, floatingRef, side, align });
+
+  return (
+    <div class="docs-useposition">
+      <button
+        ref={anchorRef}
+        type="button"
+        class="docs-useposition-anchor"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? 'Hide' : 'Show'} box
+      </button>
+      {open ? (
+        <div
+          ref={floatingRef}
+          class="docs-useposition-box"
+          data-side={pos.side}
+          data-align={pos.align}
+        >
+          resolved: {pos.side} / {pos.align}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/site/src/components/docs/__tests__/CodeTabs.test.tsx
+++ b/apps/site/src/components/docs/__tests__/CodeTabs.test.tsx
@@ -16,6 +16,36 @@ describe('Example', () => {
     expect(getByText('demo')).toBeTruthy();
     expect(container.querySelector('.docs-example')).toBeTruthy();
   });
+
+  it('renders Demo|Code tabs when code is provided', () => {
+    const { getByRole, getByText } = render(
+      <Example code={'<pre class="shiki">const a = 1;</pre>'}>
+        <span>live-demo</span>
+      </Example>
+    );
+    expect(getByRole('tab', { name: 'Demo' })).toBeTruthy();
+    expect(getByRole('tab', { name: 'Code' })).toBeTruthy();
+    // Demo active by default.
+    const demoPanel = getByText('live-demo').closest(
+      '[role="tabpanel"]'
+    ) as HTMLElement;
+    expect(demoPanel.hidden).toBe(false);
+  });
+
+  it('shows the Copy button only on the Code tab', () => {
+    const { getByRole, queryByRole } = render(
+      <Example code={'<pre class="shiki">const a = 1;</pre>'}>
+        <span>live-demo</span>
+      </Example>
+    );
+    expect(
+      queryByRole('button', { name: 'Copy code to clipboard' })
+    ).toBeNull();
+    fireEvent.click(getByRole('tab', { name: 'Code' }));
+    expect(
+      getByRole('button', { name: 'Copy code to clipboard' })
+    ).toBeTruthy();
+  });
 });
 
 describe('CodeTabs', () => {

--- a/apps/site/src/components/docs/__tests__/CodeTabs.test.tsx
+++ b/apps/site/src/components/docs/__tests__/CodeTabs.test.tsx
@@ -35,12 +35,17 @@ describe('CodeTabs', () => {
       value: { writeText: vi.fn() },
       configurable: true,
     });
-    const { getByRole, getByText, queryByText } = render(tabs());
-    expect(getByText('css-code')).toBeTruthy();
-    expect(queryByText('tailwind-code')).toBeNull();
+    const { getByRole, getByText } = render(tabs());
+    const cssPanel = getByText('css-code').closest('[role="tabpanel"]') as HTMLElement;
+    const twPanel = getByText('tailwind-code').closest(
+      '[role="tabpanel"]'
+    ) as HTMLElement;
+    expect(cssPanel.hidden).toBe(false);
+    expect(twPanel.hidden).toBe(true);
 
     fireEvent.click(getByRole('tab', { name: 'Tailwind' }));
-    expect(getByText('tailwind-code')).toBeTruthy();
+    expect(cssPanel.hidden).toBe(true);
+    expect(twPanel.hidden).toBe(false);
   });
 
   it('copies the active block text via the Copy button', () => {

--- a/apps/site/src/components/docs/__tests__/CodeTabs.test.tsx
+++ b/apps/site/src/components/docs/__tests__/CodeTabs.test.tsx
@@ -66,7 +66,9 @@ describe('CodeTabs', () => {
       configurable: true,
     });
     const { getByRole, getByText } = render(tabs());
-    const cssPanel = getByText('css-code').closest('[role="tabpanel"]') as HTMLElement;
+    const cssPanel = getByText('css-code').closest(
+      '[role="tabpanel"]'
+    ) as HTMLElement;
     const twPanel = getByText('tailwind-code').closest(
       '[role="tabpanel"]'
     ) as HTMLElement;

--- a/apps/site/src/components/docs/__tests__/Tabs.test.tsx
+++ b/apps/site/src/components/docs/__tests__/Tabs.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/preact';
+import { Tabs } from '../Tabs.js';
+
+afterEach(cleanup);
+
+function panelFor(el: HTMLElement) {
+  return el.closest('[role="tabpanel"]') as HTMLElement;
+}
+
+describe('Tabs', () => {
+  function basic() {
+    return (
+      <Tabs labels={['One', 'Two']}>
+        <p>first</p>
+        <p>second</p>
+      </Tabs>
+    );
+  }
+
+  it('selects the first tab by default and renders all panels', () => {
+    const { getByRole, getByText } = render(basic());
+    expect(getByRole('tab', { name: 'One' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
+    // Both panels exist; the inactive one is hidden.
+    expect(panelFor(getByText('first')).hidden).toBe(false);
+    expect(panelFor(getByText('second')).hidden).toBe(true);
+  });
+
+  it('switches the active panel on click', () => {
+    const { getByRole, getByText } = render(basic());
+    fireEvent.click(getByRole('tab', { name: 'Two' }));
+    expect(panelFor(getByText('first')).hidden).toBe(true);
+    expect(panelFor(getByText('second')).hidden).toBe(false);
+  });
+
+  it('moves selection with ArrowRight/ArrowLeft and wraps', () => {
+    const { getByRole } = render(basic());
+    const tablist = getByRole('tablist');
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    expect(getByRole('tab', { name: 'Two' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' }); // wraps to first
+    expect(getByRole('tab', { name: 'One' }).getAttribute('aria-selected')).toBe(
+      'true'
+    );
+  });
+
+  it('links each tab to its panel via aria-controls', () => {
+    const { getByRole, getByText } = render(basic());
+    const tab = getByRole('tab', { name: 'One' });
+    expect(tab.getAttribute('aria-controls')).toBe(panelFor(getByText('first')).id);
+  });
+
+  it('renders an accessory and passes it the active index', () => {
+    const { getByText, getByRole } = render(
+      <Tabs
+        labels={['One', 'Two']}
+        accessory={({ active }) => <span>active:{active}</span>}
+      >
+        <p>first</p>
+        <p>second</p>
+      </Tabs>
+    );
+    expect(getByText('active:0')).toBeTruthy();
+    fireEvent.click(getByRole('tab', { name: 'Two' }));
+    expect(getByText('active:1')).toBeTruthy();
+  });
+});

--- a/apps/site/src/components/docs/__tests__/Tabs.test.tsx
+++ b/apps/site/src/components/docs/__tests__/Tabs.test.tsx
@@ -21,11 +21,13 @@ describe('Tabs', () => {
 
   it('selects the first tab by default and renders all panels', () => {
     const { getByRole, getByText } = render(basic());
-    expect(getByRole('tab', { name: 'One' }).getAttribute('aria-selected')).toBe(
-      'true'
-    );
+    expect(
+      getByRole('tab', { name: 'One' }).getAttribute('aria-selected')
+    ).toBe('true');
     // Inactive tab must explicitly declare aria-selected="false" (not omitted).
-    expect(getByRole('tab', { name: 'Two' }).getAttribute('aria-selected')).toBe('false');
+    expect(
+      getByRole('tab', { name: 'Two' }).getAttribute('aria-selected')
+    ).toBe('false');
     // Both panels exist; the inactive one is hidden.
     expect(panelFor(getByText('first')).hidden).toBe(false);
     expect(panelFor(getByText('second')).hidden).toBe(true);
@@ -42,19 +44,21 @@ describe('Tabs', () => {
     const { getByRole } = render(basic());
     const tablist = getByRole('tablist');
     fireEvent.keyDown(tablist, { key: 'ArrowRight' });
-    expect(getByRole('tab', { name: 'Two' }).getAttribute('aria-selected')).toBe(
-      'true'
-    );
+    expect(
+      getByRole('tab', { name: 'Two' }).getAttribute('aria-selected')
+    ).toBe('true');
     fireEvent.keyDown(tablist, { key: 'ArrowRight' }); // wraps to first
-    expect(getByRole('tab', { name: 'One' }).getAttribute('aria-selected')).toBe(
-      'true'
-    );
+    expect(
+      getByRole('tab', { name: 'One' }).getAttribute('aria-selected')
+    ).toBe('true');
   });
 
   it('links each tab to its panel via aria-controls', () => {
     const { getByRole, getByText } = render(basic());
     const tab = getByRole('tab', { name: 'One' });
-    expect(tab.getAttribute('aria-controls')).toBe(panelFor(getByText('first')).id);
+    expect(tab.getAttribute('aria-controls')).toBe(
+      panelFor(getByText('first')).id
+    );
   });
 
   it('renders an accessory and passes it the active index', () => {

--- a/apps/site/src/components/docs/__tests__/Tabs.test.tsx
+++ b/apps/site/src/components/docs/__tests__/Tabs.test.tsx
@@ -24,6 +24,8 @@ describe('Tabs', () => {
     expect(getByRole('tab', { name: 'One' }).getAttribute('aria-selected')).toBe(
       'true'
     );
+    // Inactive tab must explicitly declare aria-selected="false" (not omitted).
+    expect(getByRole('tab', { name: 'Two' }).getAttribute('aria-selected')).toBe('false');
     // Both panels exist; the inactive one is hidden.
     expect(panelFor(getByText('first')).hidden).toBe(false);
     expect(panelFor(getByText('second')).hidden).toBe(true);

--- a/apps/site/src/highlighted.d.ts
+++ b/apps/site/src/highlighted.d.ts
@@ -1,0 +1,6 @@
+// `import html from './FooDemo.tsx?highlighted'` yields the file's Shiki-
+// highlighted HTML as a string (produced by vite-plugin-highlight at build).
+declare module '*?highlighted' {
+  const html: string;
+  export default html;
+}

--- a/apps/site/src/pages/docs/__tests__/example-code-gate.test.ts
+++ b/apps/site/src/pages/docs/__tests__/example-code-gate.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const componentsDir = resolve(here, '../components');
+
+// Every live demo on a component page must show its source. This catches a demo
+// that ships without a Code tab (an <Example> missing the `code` prop).
+describe('component-page demos expose their source', () => {
+  const files = readdirSync(componentsDir).filter((f) => f.endsWith('.mdx'));
+
+  for (const file of files) {
+    it(`${file}: every <Example> passes code`, () => {
+      const src = readFileSync(resolve(componentsDir, file), 'utf8');
+      // Match each opening <Example ...> tag and require a `code` attribute.
+      const openTags = src.match(/<Example(\s[^>]*?)?>/g) ?? [];
+      for (const tag of openTags) {
+        expect(tag, `${file}: ${tag}`).toMatch(/\bcode=/);
+      }
+    });
+  }
+});

--- a/apps/site/src/pages/docs/components/combobox.mdx
+++ b/apps/site/src/pages/docs/components/combobox.mdx
@@ -1,9 +1,13 @@
 import { Example } from '../../../components/docs/Example.js';
 import { CodeTabs } from '../../../components/docs/CodeTabs.js';
 import { ComboboxDemo } from '../../../components/docs/ComboboxDemo.js';
+import comboboxCode from '../../../components/docs/ComboboxDemo.tsx?highlighted';
 import { ComboboxMultiDemo } from '../../../components/docs/ComboboxMultiDemo.js';
+import comboboxMultiCode from '../../../components/docs/ComboboxMultiDemo.tsx?highlighted';
 import { ComboboxCreatableDemo } from '../../../components/docs/ComboboxCreatableDemo.js';
+import comboboxCreatableCode from '../../../components/docs/ComboboxCreatableDemo.tsx?highlighted';
 import { ComboboxInlineDemo } from '../../../components/docs/ComboboxInlineDemo.js';
+import comboboxInlineCode from '../../../components/docs/ComboboxInlineDemo.tsx?highlighted';
 
 # Combobox
 
@@ -33,7 +37,7 @@ The minimal form is a single `Combobox.Input`. Focus it (or click it) to open,
 type to filter; the consumer renders the matching options while the component
 handles navigation and selection. A single select commits and closes on pick.
 
-<Example>
+<Example code={comboboxCode}>
   <ComboboxDemo />
 </Example>
 
@@ -43,54 +47,25 @@ are dismiss-safe), and `Combobox.Trigger` is the chevron toggle. Picking keeps
 the popup open; `Combobox.Value` renders the chips; Backspace on an empty input
 removes the last one.
 
-<Example>
+<Example code={comboboxMultiCode}>
   <ComboboxMultiDemo />
 </Example>
 
 Creatable: when nothing matches, a "Create …" option appears and adds the new
 value through `onCreate`.
 
-<Example>
+<Example code={comboboxCreatableCode}>
   <ComboboxCreatableDemo />
 </Example>
 
 With `autocomplete="both"`, the input inline-completes to the first match; Enter
 or Tab accepts it, Backspace dismisses it and keeps typing.
 
-<Example>
+<Example code={comboboxInlineCode}>
   <ComboboxInlineDemo />
 </Example>
 
 ## Usage
-
-```tsx
-import { Combobox, matchSubstring } from 'hono-preact-ui';
-import { useState } from 'preact/hooks';
-
-const FRUITS = ['Apple', 'Banana', 'Cherry', 'Orange', 'Lemon'];
-
-export function FruitCombobox() {
-  const [query, setQuery] = useState('');
-  const filtered = FRUITS.filter((f) => matchSubstring(f, query));
-
-  return (
-    <Combobox.Root onInputChange={setQuery}>
-      <Combobox.Input placeholder="Search fruit…" aria-label="Fruit" />
-      <Combobox.Status />
-      <Combobox.Positioner>
-        <Combobox.Popup aria-label="Fruit">
-          {filtered.map((f) => (
-            <Combobox.Option key={f} value={f}>
-              {f}
-            </Combobox.Option>
-          ))}
-          <Combobox.Empty>No results</Combobox.Empty>
-        </Combobox.Popup>
-      </Combobox.Positioner>
-    </Combobox.Root>
-  );
-}
-```
 
 The only required part is `Combobox.Input` (it carries `role="combobox"`); it
 opens on focus by default and anchors the popup to itself. Everything else is an

--- a/apps/site/src/pages/docs/components/context-menu.mdx
+++ b/apps/site/src/pages/docs/components/context-menu.mdx
@@ -1,6 +1,7 @@
 import { Example } from '../../../components/docs/Example.js';
 import { CodeTabs } from '../../../components/docs/CodeTabs.js';
 import { ContextMenuDemo } from '../../../components/docs/ContextMenuDemo.js';
+import contextMenuCode from '../../../components/docs/ContextMenuDemo.tsx?highlighted';
 
 # Context Menu
 
@@ -15,34 +16,11 @@ style it through the `data-state`, `data-highlighted`, `data-disabled`,
 
 ## Demo
 
-<Example>
+<Example code={contextMenuCode}>
   <ContextMenuDemo />
 </Example>
 
 ## Usage
-
-```tsx
-import { ContextMenu } from 'hono-preact-ui';
-
-export function Canvas() {
-  return (
-    <ContextMenu.Root>
-      <ContextMenu.Trigger>
-        <div class="canvas">Right-click anywhere on the canvas</div>
-      </ContextMenu.Trigger>
-      <ContextMenu.Positioner>
-        <ContextMenu.Popup aria-label="Canvas">
-          <ContextMenu.Item onSelect={() => cut()}>Cut</ContextMenu.Item>
-          <ContextMenu.Item onSelect={() => copy()}>Copy</ContextMenu.Item>
-          <ContextMenu.Item onSelect={() => paste()}>Paste</ContextMenu.Item>
-          <ContextMenu.Separator />
-          <ContextMenu.Item disabled>Undo</ContextMenu.Item>
-        </ContextMenu.Popup>
-      </ContextMenu.Positioner>
-    </ContextMenu.Root>
-  );
-}
-```
 
 `ContextMenu.Trigger` wraps the right-clickable region; it captures the pointer
 position and opens the menu there. The other parts (`Positioner`, `Popup`,

--- a/apps/site/src/pages/docs/components/dialog.mdx
+++ b/apps/site/src/pages/docs/components/dialog.mdx
@@ -1,6 +1,7 @@
 import { Example } from '../../../components/docs/Example.js';
 import { CodeTabs } from '../../../components/docs/CodeTabs.js';
 import { DialogDemo } from '../../../components/docs/DialogDemo.js';
+import dialogCode from '../../../components/docs/DialogDemo.tsx?highlighted';
 
 # Dialog
 
@@ -11,28 +12,9 @@ composition. It ships unstyled: style it through the `data-state` contract.
 
 ## Demo
 
-<Example>
+<Example code={dialogCode}>
   <DialogDemo />
 </Example>
-
-## Usage
-
-```tsx
-import { Dialog } from 'hono-preact-ui';
-
-export function Subscribe() {
-  return (
-    <Dialog.Root>
-      <Dialog.Trigger>Open dialog</Dialog.Trigger>
-      <Dialog.Popup>
-        <Dialog.Title>Subscribe</Dialog.Title>
-        <Dialog.Description>Get notified when we ship.</Dialog.Description>
-        <Dialog.Close>Close</Dialog.Close>
-      </Dialog.Popup>
-    </Dialog.Root>
-  );
-}
-```
 
 ## Styling
 

--- a/apps/site/src/pages/docs/components/menu.mdx
+++ b/apps/site/src/pages/docs/components/menu.mdx
@@ -1,6 +1,7 @@
 import { Example } from '../../../components/docs/Example.js';
 import { CodeTabs } from '../../../components/docs/CodeTabs.js';
 import { MenuDemo } from '../../../components/docs/MenuDemo.js';
+import menuCode from '../../../components/docs/MenuDemo.tsx?highlighted';
 
 # Menu
 
@@ -18,49 +19,11 @@ in the tab order; reserve Menu for commands.
 
 ## Demo
 
-<Example>
+<Example code={menuCode}>
   <MenuDemo />
 </Example>
 
 ## Usage
-
-```tsx
-import { Menu } from 'hono-preact-ui';
-
-export function Actions() {
-  return (
-    <Menu.Root>
-      <Menu.Trigger>Actions</Menu.Trigger>
-      <Menu.Positioner>
-        <Menu.Popup aria-label="Actions">
-          <Menu.Item onSelect={() => create()}>New file</Menu.Item>
-          <Menu.Item onSelect={() => open()}>Open</Menu.Item>
-          <Menu.Separator />
-          <Menu.CheckboxItem defaultChecked>Word wrap</Menu.CheckboxItem>
-          <Menu.Separator />
-          <Menu.Group>
-            <Menu.GroupLabel>Density</Menu.GroupLabel>
-            <Menu.RadioGroup defaultValue="comfortable">
-              <Menu.RadioItem value="comfortable">Comfortable</Menu.RadioItem>
-              <Menu.RadioItem value="compact">Compact</Menu.RadioItem>
-            </Menu.RadioGroup>
-          </Menu.Group>
-          <Menu.Separator />
-          <Menu.SubmenuRoot>
-            <Menu.SubmenuTrigger>Share</Menu.SubmenuTrigger>
-            <Menu.SubmenuPositioner>
-              <Menu.SubmenuPopup aria-label="Share">
-                <Menu.Item>Copy link</Menu.Item>
-                <Menu.Item>Email</Menu.Item>
-              </Menu.SubmenuPopup>
-            </Menu.SubmenuPositioner>
-          </Menu.SubmenuRoot>
-        </Menu.Popup>
-      </Menu.Positioner>
-    </Menu.Root>
-  );
-}
-```
 
 `Menu.Item` activates and closes the menu on click or Enter; call
 `event.preventDefault()` in its `onSelect` to keep the menu open after a choice.

--- a/apps/site/src/pages/docs/components/merge-refs.mdx
+++ b/apps/site/src/pages/docs/components/merge-refs.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { MergeRefsDemo } from '../../../components/docs/MergeRefsDemo.js';
+import mergeRefsCode from '../../../components/docs/MergeRefsDemo.tsx?highlighted';
 
 # mergeRefs
 
@@ -11,7 +12,7 @@ skipped.
 
 ## Demo
 
-<Example>
+<Example code={mergeRefsCode}>
   <MergeRefsDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/popover.mdx
+++ b/apps/site/src/pages/docs/components/popover.mdx
@@ -1,6 +1,7 @@
 import { Example } from '../../../components/docs/Example.js';
 import { CodeTabs } from '../../../components/docs/CodeTabs.js';
 import { PopoverDemo } from '../../../components/docs/PopoverDemo.js';
+import popoverCode from '../../../components/docs/PopoverExample.tsx?highlighted';
 
 # Popover
 
@@ -12,31 +13,9 @@ and `data-align` contract.
 
 ## Demo
 
-<Example>
+<Example code={popoverCode}>
   <PopoverDemo />
 </Example>
-
-## Usage
-
-```tsx
-import { Popover } from 'hono-preact-ui';
-
-export function Settings() {
-  return (
-    <Popover.Root>
-      <Popover.Trigger>Open popover</Popover.Trigger>
-      <Popover.Positioner>
-        <Popover.Popup>
-          <Popover.Arrow />
-          <Popover.Title>Settings</Popover.Title>
-          <Popover.Description>Adjust your preferences.</Popover.Description>
-          <Popover.Close>Done</Popover.Close>
-        </Popover.Popup>
-      </Popover.Positioner>
-    </Popover.Root>
-  );
-}
-```
 
 ## Styling
 

--- a/apps/site/src/pages/docs/components/render-element.mdx
+++ b/apps/site/src/pages/docs/components/render-element.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { RenderElementDemo } from '../../../components/docs/RenderElementDemo.js';
+import renderElementCode from '../../../components/docs/RenderElementDemo.tsx?highlighted';
 
 # renderElement
 
@@ -12,7 +13,7 @@ either.
 
 ## Demo
 
-<Example>
+<Example code={renderElementCode}>
   <RenderElementDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/select.mdx
+++ b/apps/site/src/pages/docs/components/select.mdx
@@ -1,7 +1,9 @@
 import { Example } from '../../../components/docs/Example.js';
 import { CodeTabs } from '../../../components/docs/CodeTabs.js';
 import { SelectDemo } from '../../../components/docs/SelectDemo.js';
+import selectCode from '../../../components/docs/SelectDemo.tsx?highlighted';
 import { SelectMultiDemo } from '../../../components/docs/SelectMultiDemo.js';
+import selectMultiCode from '../../../components/docs/SelectMultiDemo.tsx?highlighted';
 
 # Select
 
@@ -25,46 +27,18 @@ your own data, which runs on the server too.
 A single select closes when you pick an option; the trigger shows the chosen
 label.
 
-<Example>
+<Example code={selectCode}>
   <SelectDemo />
 </Example>
 
 A multiple select toggles each option and stays open; the trigger joins the
 selected labels.
 
-<Example>
+<Example code={selectMultiCode}>
   <SelectMultiDemo />
 </Example>
 
 ## Usage
-
-```tsx
-import { Select } from 'hono-preact-ui';
-
-export function FruitPicker() {
-  return (
-    <Select.Root name="fruit">
-      <Select.Trigger>
-        <Select.Value placeholder="Pick a fruit" />
-      </Select.Trigger>
-      <Select.Positioner>
-        <Select.Popup aria-label="Fruit">
-          <Select.Option value="apple">Apple</Select.Option>
-          <Select.Option value="banana">Banana</Select.Option>
-          <Select.Option value="cherry" disabled>
-            Cherry
-          </Select.Option>
-          <Select.OptionGroup>
-            <Select.OptionGroupLabel>Citrus</Select.OptionGroupLabel>
-            <Select.Option value="orange">Orange</Select.Option>
-            <Select.Option value="lemon">Lemon</Select.Option>
-          </Select.OptionGroup>
-        </Select.Popup>
-      </Select.Positioner>
-    </Select.Root>
-  );
-}
-```
 
 Set `multiple` on `Select.Root` for multi-selection: picking an option toggles
 it and keeps the popup open, and the value becomes an array. Pass a `value` /

--- a/apps/site/src/pages/docs/components/tooltip.mdx
+++ b/apps/site/src/pages/docs/components/tooltip.mdx
@@ -1,6 +1,7 @@
 import { Example } from '../../../components/docs/Example.js';
 import { CodeTabs } from '../../../components/docs/CodeTabs.js';
 import { TooltipDemo } from '../../../components/docs/TooltipDemo.js';
+import tooltipCode from '../../../components/docs/TooltipExample.tsx?highlighted';
 
 # Tooltip
 
@@ -13,29 +14,9 @@ only in a tooltip. It ships unstyled: style it through the `data-state`,
 
 ## Demo
 
-<Example>
+<Example code={tooltipCode}>
   <TooltipDemo />
 </Example>
-
-## Usage
-
-```tsx
-import { Tooltip } from 'hono-preact-ui';
-
-export function SaveHint() {
-  return (
-    <Tooltip.Root>
-      <Tooltip.Trigger>Hover me</Tooltip.Trigger>
-      <Tooltip.Positioner>
-        <Tooltip.Popup>
-          <Tooltip.Arrow />
-          Saved to your library
-        </Tooltip.Popup>
-      </Tooltip.Positioner>
-    </Tooltip.Root>
-  );
-}
-```
 
 The trigger opens after a short delay on hover and immediately on focus. Set
 `openDelay` and `closeDelay` on `Tooltip.Root` to tune the timing.

--- a/apps/site/src/pages/docs/components/use-controllable-state.mdx
+++ b/apps/site/src/pages/docs/components/use-controllable-state.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UseControllableStateDemo } from '../../../components/docs/UseControllableStateDemo.js';
+import useControllableStateCode from '../../../components/docs/UseControllableStateDemo.tsx?highlighted';
 
 # useControllableState
 
@@ -11,7 +12,7 @@ across renders, so you can list it in effect dependencies without re-subscribing
 
 ## Demo
 
-<Example>
+<Example code={useControllableStateCode}>
   <UseControllableStateDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/use-dismiss.mdx
+++ b/apps/site/src/pages/docs/components/use-dismiss.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UseDismissDemo } from '../../../components/docs/UseDismissDemo.js';
+import useDismissCode from '../../../components/docs/UseDismissDemo.tsx?highlighted';
 
 # useDismiss
 
@@ -11,7 +12,7 @@ See also: [useFocusReturn](/docs/components/use-focus-return), [usePosition](/do
 
 ## Demo
 
-<Example>
+<Example code={useDismissCode}>
   <UseDismissDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/use-focus-return.mdx
+++ b/apps/site/src/pages/docs/components/use-focus-return.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UseFocusReturnDemo } from '../../../components/docs/UseFocusReturnDemo.js';
+import useFocusReturnCode from '../../../components/docs/UseFocusReturnDemo.tsx?highlighted';
 
 # useFocusReturn
 
@@ -10,7 +11,7 @@ of the page, which is what a non-modal overlay wants.
 
 ## Demo
 
-<Example>
+<Example code={useFocusReturnCode}>
   <UseFocusReturnDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/use-list-navigation.mdx
+++ b/apps/site/src/pages/docs/components/use-list-navigation.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UseListNavigationDemo } from '../../../components/docs/UseListNavigationDemo.js';
+import useListNavigationCode from '../../../components/docs/UseListNavigationDemo.tsx?highlighted';
 
 # useListNavigation
 
@@ -17,7 +18,7 @@ trigger keeps focus).
 
 ## Demo
 
-<Example>
+<Example code={useListNavigationCode}>
   <UseListNavigationDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/use-listbox-selection.mdx
+++ b/apps/site/src/pages/docs/components/use-listbox-selection.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UseListboxSelectionDemo } from '../../../components/docs/UseListboxSelectionDemo.js';
+import useListboxSelectionCode from '../../../components/docs/UseListboxSelectionExample.tsx?highlighted';
 
 # useListboxSelection
 
@@ -14,7 +15,7 @@ See also: [useListNavigation](/docs/components/use-list-navigation), [Select](/d
 
 ## Demo
 
-<Example>
+<Example code={useListboxSelectionCode}>
   <UseListboxSelectionDemo />
 </Example>
 
@@ -54,39 +55,3 @@ function useListboxSelection<Value = string>(
 | `labelFor`       | `(value: unknown) => string`        | Resolve a single value's display label.                            |
 | `optionCount`    | `number`                            | Number of currently-registered options.                            |
 | `hiddenFields`   | `ComponentChild[] \| null`          | Hidden `<input>`s for native form submission, or `null`.           |
-
-## Example
-
-```tsx
-import { useListboxSelection } from 'hono-preact-ui';
-import { useState } from 'preact/hooks';
-
-function CustomSelect() {
-  const [value, setValue] = useState<string | undefined>(undefined);
-  const [, setOpen] = useState(false);
-
-  const selection = useListboxSelection<string>({
-    value,
-    setValue: (next) => setValue(Array.isArray(next) ? next[0] : next),
-    multiple: false,
-    setOpen,
-    name: 'fruit',
-  });
-
-  return (
-    <ul role="listbox">
-      {['apple', 'pear'].map((v) => (
-        <li
-          key={v}
-          role="option"
-          aria-selected={selection.isSelected(v)}
-          onClick={() => selection.toggle(v)}
-        >
-          {v}
-        </li>
-      ))}
-      {selection.hiddenFields}
-    </ul>
-  );
-}
-```

--- a/apps/site/src/pages/docs/components/use-listbox-selection.mdx
+++ b/apps/site/src/pages/docs/components/use-listbox-selection.mdx
@@ -31,17 +31,17 @@ function useListboxSelection<Value = string>(
 
 ## Options
 
-| Option           | Type                               | Notes                                                                        |
-| ---------------- | ---------------------------------- | ---------------------------------------------------------------------------- |
-| `value`          | `Value \| Value[] \| undefined`    | The controlled selected value(s).                                            |
-| `setValue`       | `(next: Value \| Value[]) => void` | Called with the next selection.                                              |
-| `multiple`       | `boolean`                          | Whether multiple options can be selected.                                    |
-| `setOpen`        | `(open: boolean) => void`          | Called to close the control after a single-select choice.                    |
-| `isValueEqual`   | `(a: Value, b: Value) => boolean`  | Optional. Custom equality; defaults to `Object.is`.                          |
-| `serializeValue` | `(value: Value) => string`         | Optional. Serializes a value for the hidden form field.                      |
-| `itemToString`   | `(value: Value) => string`         | Optional. Resolves a display label when no option is registered for a value. |
-| `name`           | `string`                           | Optional. Hidden form-field name; enables native form submission.            |
-| `disabled`       | `boolean`                          | Optional. Disables selection.                                                |
+| Option           | Type                               | Notes                                                                                         |
+| ---------------- | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `value`          | `Value \| Value[] \| undefined`    | The controlled selected value(s).                                                             |
+| `setValue`       | `(next: Value \| Value[]) => void` | Called with the next selection: a bare `Value` in single-select, a `Value[]` in multi-select. |
+| `multiple`       | `boolean`                          | Whether multiple options can be selected.                                                     |
+| `setOpen`        | `(open: boolean) => void`          | Called to close the control after a single-select choice.                                     |
+| `isValueEqual`   | `(a: Value, b: Value) => boolean`  | Optional. Custom equality; defaults to `Object.is`.                                           |
+| `serializeValue` | `(value: Value) => string`         | Optional. Serializes a value for the hidden form field.                                       |
+| `itemToString`   | `(value: Value) => string`         | Optional. Resolves a display label when no option is registered for a value.                  |
+| `name`           | `string`                           | Optional. Hidden form-field name; enables native form submission.                             |
+| `disabled`       | `boolean`                          | Optional. Disables selection.                                                                 |
 
 ## Result
 

--- a/apps/site/src/pages/docs/components/use-position.mdx
+++ b/apps/site/src/pages/docs/components/use-position.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UsePositionDemo } from '../../../components/docs/UsePositionDemo.js';
+import usePositionCode from '../../../components/docs/UsePositionExample.tsx?highlighted';
 
 # usePosition
 
@@ -9,7 +10,7 @@ a reference element, updating on scroll and resize.
 
 ## Demo
 
-<Example>
+<Example code={usePositionCode}>
   <UsePositionDemo />
 </Example>
 
@@ -60,33 +61,3 @@ interface PositionState {
 | `align`  | `'start' \| 'center' \| 'end'`           | Resolved alignment.                     |
 | `arrowX` | `number \| null`                         | Arrow x offset in px, or null.          |
 | `arrowY` | `number \| null`                         | Arrow y offset in px, or null.          |
-
-## Example
-
-```tsx
-import { usePosition } from 'hono-preact-ui';
-import { useRef } from 'preact/hooks';
-
-function Anchored({ open }: { open: boolean }) {
-  const anchorRef = useRef<HTMLButtonElement>(null);
-  const floatingRef = useRef<HTMLDivElement>(null);
-  const { side, align } = usePosition({
-    open,
-    anchorRef,
-    floatingRef,
-    side: 'bottom',
-    align: 'center',
-    offset: 8,
-  });
-  return (
-    <>
-      <button ref={anchorRef}>Anchor</button>
-      {open ? (
-        <div ref={floatingRef} data-side={side} data-align={align}>
-          floating
-        </div>
-      ) : null}
-    </>
-  );
-}
-```

--- a/apps/site/src/pages/docs/components/use-positioner.mdx
+++ b/apps/site/src/pages/docs/components/use-positioner.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UsePositionerDemo } from '../../../components/docs/UsePositionerDemo.js';
+import usePositionerCode from '../../../components/docs/UsePositionerDemo.tsx?highlighted';
 
 # usePositioner
 
@@ -14,7 +15,7 @@ See also: [usePosition](/docs/components/use-position), [usePresence](/docs/comp
 
 ## Demo
 
-<Example>
+<Example code={usePositionerCode}>
   <UsePositionerDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/use-presence.mdx
+++ b/apps/site/src/pages/docs/components/use-presence.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UsePresenceDemo } from '../../../components/docs/UsePresenceDemo.js';
+import usePresenceCode from '../../../components/docs/UsePresenceDemo.tsx?highlighted';
 
 # usePresence
 
@@ -12,7 +13,7 @@ exactly as before.
 
 ## Demo
 
-<Example>
+<Example code={usePresenceCode}>
   <UsePresenceDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/use-safe-area.mdx
+++ b/apps/site/src/pages/docs/components/use-safe-area.mdx
@@ -1,6 +1,7 @@
 import { SafeAreaDiagram } from '../../../components/docs/SafeAreaDiagram.js';
 import { Example } from '../../../components/docs/Example.js';
 import { UseSafeAreaDemo } from '../../../components/docs/UseSafeAreaDemo.js';
+import useSafeAreaCode from '../../../components/docs/UseSafeAreaDemo.tsx?highlighted';
 
 # useSafeArea
 
@@ -18,7 +19,7 @@ See also: [usePosition](/docs/components/use-position), [useDismiss](/docs/compo
 
 ## Demo
 
-<Example>
+<Example code={useSafeAreaCode}>
   <UseSafeAreaDemo />
 </Example>
 

--- a/apps/site/src/pages/docs/components/use-typeahead.mdx
+++ b/apps/site/src/pages/docs/components/use-typeahead.mdx
@@ -1,5 +1,6 @@
 import { Example } from '../../../components/docs/Example.js';
 import { UseTypeaheadDemo } from '../../../components/docs/UseTypeaheadDemo.js';
+import useTypeaheadCode from '../../../components/docs/UseTypeaheadDemo.tsx?highlighted';
 
 # useTypeahead
 
@@ -7,7 +8,7 @@ import { UseTypeaheadDemo } from '../../../components/docs/UseTypeaheadDemo.js';
 
 ## Demo
 
-<Example>
+<Example code={useTypeaheadCode}>
   <UseTypeaheadDemo />
 </Example>
 

--- a/apps/site/src/shiki/__tests__/fixtures/sample.tsx
+++ b/apps/site/src/shiki/__tests__/fixtures/sample.tsx
@@ -1,0 +1,3 @@
+export function Sample() {
+  return <span>hi</span>;
+}

--- a/apps/site/src/shiki/__tests__/highlight.test.ts
+++ b/apps/site/src/shiki/__tests__/highlight.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { highlightCode } from '../highlight.js';
+import { highlightPlugin } from '../vite-plugin-highlight.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = resolve(here, 'fixtures/sample.tsx');
 
 describe('highlightCode', () => {
   it('returns Shiki HTML for tsx source', async () => {
@@ -15,5 +21,26 @@ describe('highlightCode', () => {
     // defaultColor: 'light' inlines color:; the dark theme is carried as a
     // --shiki-dark custom property that root.css promotes in dark mode.
     expect(html).toContain('--shiki-dark');
+  });
+});
+
+describe('highlightPlugin', () => {
+  it('ignores ids without the ?highlighted query', async () => {
+    const plugin = highlightPlugin();
+    const load = plugin.load as (id: string) => Promise<string | null>;
+    expect(await load.call({ addWatchFile() {} }, fixture)).toBeNull();
+  });
+
+  it('loads a ?highlighted id as a default-exported HTML string', async () => {
+    const plugin = highlightPlugin();
+    const load = plugin.load as (id: string) => Promise<string | null>;
+    const watched: string[] = [];
+    const out = await load.call(
+      { addWatchFile: (f: string) => watched.push(f) },
+      `${fixture}?highlighted`
+    );
+    expect(out).toContain('export default');
+    expect(out).toContain('class=\\"shiki'); // escaped inside the JSON string
+    expect(watched).toContain(fixture);
   });
 });

--- a/apps/site/src/shiki/__tests__/highlight.test.ts
+++ b/apps/site/src/shiki/__tests__/highlight.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { highlightCode } from '../highlight.js';
+
+describe('highlightCode', () => {
+  it('returns Shiki HTML for tsx source', async () => {
+    const html = await highlightCode('const answer: number = 42;', 'tsx');
+    expect(html).toContain('class="shiki');
+    expect(html).toContain('<pre');
+    // The identifier survives as text inside the highlighted markup.
+    expect(html).toContain('answer');
+  });
+
+  it('emits the dual-theme CSS variables (light + dark)', async () => {
+    const html = await highlightCode('const x = 1;', 'tsx');
+    // defaultColor: 'light' inlines color:; the dark theme is carried as a
+    // --shiki-dark custom property that root.css promotes in dark mode.
+    expect(html).toContain('--shiki-dark');
+  });
+});

--- a/apps/site/src/shiki/highlight.ts
+++ b/apps/site/src/shiki/highlight.ts
@@ -1,0 +1,33 @@
+import { createHighlighter, type Highlighter } from 'shiki';
+import {
+  SHIKI_THEMES,
+  SHIKI_DEFAULT_COLOR,
+  SHIKI_LANGS,
+} from './shiki-config.js';
+
+// Lazily create one highlighter and reuse it across files (creating one per
+// call is slow). The promise is cached so concurrent callers share the instance.
+let highlighterPromise: Promise<Highlighter> | null = null;
+function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: Object.values(SHIKI_THEMES),
+      langs: [...SHIKI_LANGS],
+    });
+  }
+  return highlighterPromise;
+}
+
+// Highlight a code string to HTML using the shared dual-theme config, so the
+// output matches the site's fenced code blocks exactly.
+export async function highlightCode(
+  code: string,
+  lang: string
+): Promise<string> {
+  const highlighter = await getHighlighter();
+  return highlighter.codeToHtml(code, {
+    lang,
+    themes: SHIKI_THEMES,
+    defaultColor: SHIKI_DEFAULT_COLOR,
+  });
+}

--- a/apps/site/src/shiki/shiki-config.ts
+++ b/apps/site/src/shiki/shiki-config.ts
@@ -9,7 +9,14 @@ export const SHIKI_THEMES = {
 
 export const SHIKI_DEFAULT_COLOR = 'light';
 
-export const SHIKI_LANGS = ['ts', 'tsx', 'bash', 'jsonc', 'mdx', 'css'] as const;
+export const SHIKI_LANGS = [
+  'ts',
+  'tsx',
+  'bash',
+  'jsonc',
+  'mdx',
+  'css',
+] as const;
 
 // Options object in the exact shape `@shikijs/rehype` expects.
 export const rehypeShikiOptions = {

--- a/apps/site/src/shiki/shiki-config.ts
+++ b/apps/site/src/shiki/shiki-config.ts
@@ -1,0 +1,19 @@
+// Single source of truth for Shiki highlighting on the docs site. Consumed by
+// the MDX rehype plugin (fenced code blocks) and by the build-time highlight
+// plugin (demo source shown in Code tabs), so both render identically and the
+// dark-mode swap in root.css (.shiki / [data-theme='dark']) works for both.
+export const SHIKI_THEMES = {
+  light: 'github-light',
+  dark: 'github-dark',
+} as const;
+
+export const SHIKI_DEFAULT_COLOR = 'light';
+
+export const SHIKI_LANGS = ['ts', 'tsx', 'bash', 'jsonc', 'mdx', 'css'] as const;
+
+// Options object in the exact shape `@shikijs/rehype` expects.
+export const rehypeShikiOptions = {
+  themes: SHIKI_THEMES,
+  defaultColor: SHIKI_DEFAULT_COLOR,
+  langs: [...SHIKI_LANGS],
+};

--- a/apps/site/src/shiki/vite-plugin-highlight.ts
+++ b/apps/site/src/shiki/vite-plugin-highlight.ts
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises';
+import type { Plugin } from 'vite';
+import { highlightCode } from './highlight.js';
+
+const QUERY = '?highlighted';
+
+// Resolves `import html from './FooDemo.tsx?highlighted'` to the file's source,
+// Shiki-highlighted at build time, exported as an HTML string. No runtime
+// highlighter is shipped to the client.
+export function highlightPlugin(): Plugin {
+  return {
+    name: 'docs-highlight',
+    enforce: 'pre',
+    async resolveId(source, importer) {
+      if (!source.endsWith(QUERY)) return null;
+      const base = source.slice(0, -QUERY.length);
+      const resolved = await this.resolve(base, importer, { skipSelf: true });
+      return resolved ? resolved.id + QUERY : null;
+    },
+    async load(id) {
+      if (!id.endsWith(QUERY)) return null;
+      const file = id.slice(0, -QUERY.length);
+      // Track the source so edits trigger HMR / rebuild (we read it directly
+      // rather than importing it, so Vite would not otherwise watch it).
+      this.addWatchFile(file);
+      const code = await readFile(file, 'utf8');
+      // Demo files are .tsx; fall back to the raw extension for anything else.
+      const lang = file.split('.').pop() ?? 'txt';
+      const html = await highlightCode(code, lang);
+      return `export default ${JSON.stringify(html)};`;
+    },
+  };
+}

--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -683,6 +683,23 @@ html:active-view-transition-type(demo-within)::view-transition-new(demo-sidebar)
     var(--surface);
 }
 
+/* Demo panel inside the Demo|Code tab strip: same dotted interactive surface
+   as .docs-example, but without the outer border/margin/radius (the .docs-tabs
+   card already provides those). */
+.docs-example-tabs__demo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  min-height: 9rem;
+  padding: 2rem;
+  background:
+    radial-gradient(circle at 1px 1px, var(--border-color) 1px, transparent 0) 0
+      0 / 16px 16px,
+    var(--surface);
+}
+
 /* Demo buttons: a primary (trigger) and a secondary (close). */
 .docs-dialog-trigger,
 .docs-dialog-close {

--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -386,7 +386,7 @@
    it reads against the white page, with the 1px border), and the github-dark
    background in dark mode (matching the dark syntax colors). */
 .mdx-content pre,
-.docs-codetabs__panel pre {
+.docs-tabs__panel pre {
   background-color: var(--code-surface) !important;
 }
 
@@ -455,7 +455,7 @@
    desktop there is room to the right of the content column, so let them grow
    past it (capped so they never exceed the viewport). */
 @media (min-width: 768px) {
-  .docs-codetabs,
+  .docs-tabs,
   .mdx-content > pre,
   .mdx-content > table {
     width: min(calc(100% + 9rem), calc(100vw - 240px - 6rem));
@@ -889,13 +889,13 @@ html:active-view-transition-type(demo-within)::view-transition-new(demo-sidebar)
 /* Tabbed, copyable code examples. The tab bar uses the docs theme; the code
    panel is a Shiki-highlighted fenced block (github-dark), so it matches every
    other code sample on the site. */
-.docs-codetabs {
+.docs-tabs {
   margin: 1.25rem 0;
   border: 1px solid var(--border-color);
   border-radius: 0.625rem;
   overflow: hidden;
 }
-.docs-codetabs__tablist {
+.docs-tabs__tablist {
   display: flex;
   align-items: stretch;
   gap: 0.25rem;
@@ -903,7 +903,7 @@ html:active-view-transition-type(demo-within)::view-transition-new(demo-sidebar)
   background: var(--surface-subtle);
   border-bottom: 1px solid var(--border-color);
 }
-.docs-codetabs__tab {
+.docs-tabs__tab {
   appearance: none;
   font: inherit;
   font-size: 0.8125rem;
@@ -918,14 +918,14 @@ html:active-view-transition-type(demo-within)::view-transition-new(demo-sidebar)
     color 120ms ease,
     border-color 120ms ease;
 }
-.docs-codetabs__tab:hover {
+.docs-tabs__tab:hover {
   color: var(--foreground);
 }
-.docs-codetabs__tab[aria-selected='true'] {
+.docs-tabs__tab[aria-selected='true'] {
   color: var(--foreground);
   border-bottom-color: var(--accent);
 }
-.docs-codetabs__copy {
+.docs-tabs__copy {
   appearance: none;
   font: inherit;
   font-size: 0.75rem;
@@ -943,13 +943,13 @@ html:active-view-transition-type(demo-within)::view-transition-new(demo-sidebar)
     background-color 120ms ease,
     border-color 120ms ease;
 }
-.docs-codetabs__copy:hover {
+.docs-tabs__copy:hover {
   color: var(--foreground);
   background: var(--surface);
 }
 /* The panel holds a Shiki <pre>; sit it flush in the rounded card (the card's
    own border delineates it, so the pre needs none of its own). */
-.docs-codetabs__panel pre {
+.docs-tabs__panel pre {
   margin: 0;
   border: none;
   border-radius: 0;

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -3,6 +3,7 @@ import { cloudflareAdapter } from 'hono-preact/adapter-cloudflare';
 import mdx, { type Options as MdxOptions } from '@mdx-js/rollup';
 import remarkGfm from 'remark-gfm';
 import rehypeShiki from '@shikijs/rehype';
+import { rehypeShikiOptions } from './src/shiki/shiki-config.js';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
@@ -23,13 +24,9 @@ const mdxOptions = {
   rehypePlugins: [
     [
       rehypeShiki,
-      {
-        // Dual theme: the light theme is the inline default; CSS in root.css
-        // switches to the dark theme's colors when the docs are in dark mode.
-        themes: { light: 'github-light', dark: 'github-dark' },
-        defaultColor: 'light',
-        langs: ['ts', 'tsx', 'bash', 'jsonc', 'mdx', 'css'],
-      },
+      // Dual theme: light is the inline default; root.css switches to the dark
+      // theme's colors in dark mode. Shared with the demo-source highlighter.
+      rehypeShikiOptions,
     ],
   ],
 } satisfies MdxOptions;

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -4,6 +4,7 @@ import mdx, { type Options as MdxOptions } from '@mdx-js/rollup';
 import remarkGfm from 'remark-gfm';
 import rehypeShiki from '@shikijs/rehype';
 import { rehypeShikiOptions } from './src/shiki/shiki-config.js';
+import { highlightPlugin } from './src/shiki/vite-plugin-highlight.js';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
@@ -108,6 +109,7 @@ export default defineConfig((env) => ({
     sourcemap: visualize && env.mode === 'client',
   },
   plugins: [
+    highlightPlugin(),
     honoPreact({ adapter: cloudflareAdapter() }),
     {
       name: 'emit-llms-txt',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       sass-embedded:
         specifier: ^1.99.0
         version: 1.99.0
+      shiki:
+        specifier: ^4.0.2
+        version: 4.0.2
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -958,89 +961,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1137,36 +1156,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1270,36 +1295,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -1374,66 +1405,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1572,24 +1616,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2825,24 +2873,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3310,7 +3362,7 @@ packages:
     engines: {node: '>=20'}
 
   preact-iso@https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777:
-    resolution: {tarball: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/preactjs/preact-iso/tar.gz/22460942e6e0ff9b9d4a8a9cf16222ad59797777}
     version: 2.11.1
     peerDependencies:
       preact: '>=10 || >= 11.0.0-0'
@@ -3554,48 +3606,56 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-arm@1.99.0:
     resolution: {integrity: sha512-d4IjJZrX2+AwB2YCy1JySwdptJECNP/WfAQLUl8txI3ka8/d3TUI155GtelnoZUkio211PwIeFvvAeZ9RXPQnw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.99.0:
     resolution: {integrity: sha512-Hi2bt/IrM5P4FBKz6EcHAlniwfpoz9mnTdvSd58y+avA3SANM76upIkAdSayA8ZGwyL3gZokru1AKDPF9lJDNw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-arm@1.99.0:
     resolution: {integrity: sha512-2gvHOupgIw3ytatXT4nFUow71LFbuOZPEwG+HUzcNQDH8ue4Ez8cr03vsv5MDv3lIjOKcXwDvWD980t18MwkoQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.99.0:
     resolution: {integrity: sha512-mKqGvVaJ9rHMqyZsF0kikQe4NO0f4osb67+X6nLhBiVDKvyazQHJ3zJQreNefIE36yL2sjHIclSB//MprzaQDg==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-musl-x64@1.99.0:
     resolution: {integrity: sha512-huhgOMmOc30r7CH7qbRbT9LerSEGSnWuS4CYNOskr9BvNeQp4dIneFufNRGZ7hkOAxUM8DglxIZJN/cyAT95Ew==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: musl
 
   sass-embedded-linux-riscv64@1.99.0:
     resolution: {integrity: sha512-mevFPIFAVhrH90THifxLfOntFmHtcEKOcdWnep2gJ0X4DVva4AiVIRlQe/7w9JFx5+gnDRE1oaJJkzuFUuYZsA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-linux-x64@1.99.0:
     resolution: {integrity: sha512-9k7IkULqIZdCIVt4Mboryt6vN8Mjmm3EhI1P3mClU5y5i3wLK5ExC3cbVWk047KsID/fvB1RLslqghXJx5BoxA==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: glibc
 
   sass-embedded-unknown-all@1.99.0:
     resolution: {integrity: sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==}


### PR DESCRIPTION
## Summary

Adds a Demo/Code tab to every component documentation page, so each live demo also shows the real source that powers it. Built on a new accessible docs `Tabs` primitive, which now also backs the existing CSS/Tailwind `CodeTabs`.

## How it works

- **Build-time highlighting.** A Vite plugin resolves `import code from './FooDemo.tsx?highlighted'` to Shiki-highlighted HTML at build time, reusing one shared Shiki config so demo source renders identically to MDX fences. No syntax highlighter ships to the client.
- **`Tabs` primitive.** Roving tabindex, full ARIA (tablist/tab/tabpanel, aria-selected/controls/labelledby), renders all panels with inactive ones `hidden`. `CodeTabs` was refactored onto it (behavior parity plus an a11y upgrade). `Example` gained an optional `code` prop that renders Demo/Code tabs.
- **Single source of truth.** The Code tab shows the actual file that renders the demo. 19 WYSIWYG demos are shown as-is; 4 explorers (tooltip, popover, use-position, use-listbox-selection) were split into a clean core (shown) plus a harness (rendered live with the explorer controls), so the sample stays clean and cannot drift.
- **Doc gate.** A test fails if any component `<Example>` ships without `code`.

## Testing

All six CI-mirror steps pass: framework build, format:check, typecheck, unit tests (236 files / 1440), integration, site build. Visual check in Firefox confirmed both WYSIWYG and explorer pages render the tabs correctly with no console errors.

## Notes

- The design spec and implementation plan are already on `main` (docs/superpowers/specs and plans, dated 2026-06-17).
- ui and framework packages are unchanged; this is apps/site only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)