### PR TITLE
Prototype: persistent live-activity bar for /demo (Persist + SSE streaming)

### DIFF
--- a/apps/site/src/__tests__/agents-conformance.test.ts
+++ b/apps/site/src/__tests__/agents-conformance.test.ts
@@ -127,6 +127,12 @@ describe('AGENTS.md conformance (live apps/site)', () => {
       reason: 'parsing an untrusted cookie payload (acceptable boundary)',
     },
     {
+      file: 'components/demo/ActivityBar.tsx',
+      expr: 'JSON.parse(ev.data) as ActivityEvent',
+      reason:
+        'parsing a JSON SSE frame from the activity endpoint (acceptable boundary)',
+    },
+    {
       file: 'hooks/use-board-drag.ts',
       expr: 'card.cloneNode(true) as HTMLElement',
       reason: 'Node.cloneNode returns Node; the source is an HTMLElement',

--- a/apps/site/src/__tests__/api.test.ts
+++ b/apps/site/src/__tests__/api.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetDemoData } from '../demo/data.js';
+import { __resetActivityForTesting } from '../demo/activity-stream.js';
+import app from '../api.js';
+
+beforeEach(() => {
+  resetDemoData();
+  __resetActivityForTesting();
+});
+
+describe('GET /api/demo/activity', () => {
+  it('streams JSON activity frames as text/event-stream (reads backfill, then aborts)', async () => {
+    const ctrl = new AbortController();
+    const res = await app.request('/api/demo/activity', {
+      signal: ctrl.signal,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    let firstData: string | null = null;
+
+    // The backfill frames are written before the first timer sleep, so they
+    // arrive in the first read(s). Bound the loop so the test can't hang.
+    for (let i = 0; i < 5 && firstData === null; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const m = buf.match(/^data: (.*)$/m);
+      if (m) firstData = m[1];
+    }
+    ctrl.abort();
+    await reader.cancel().catch(() => undefined);
+
+    expect(firstData).not.toBeNull();
+    const parsed = JSON.parse(firstData!);
+    expect(parsed).toHaveProperty('kind');
+    expect(parsed).toHaveProperty('taskId');
+    expect(['inf', 'api', 'web']).toContain(parsed.projectSlug);
+  });
+});

--- a/apps/site/src/api.ts
+++ b/apps/site/src/api.ts
@@ -1,0 +1,59 @@
+// apps/site/src/api.ts
+// User Hono app, auto-mounted by the framework ahead of its own handlers.
+// Hosts the SSE endpoint that drives the persistent demo activity bar.
+import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
+import {
+  subscribeActivity,
+  recentActivityEvents,
+  type ActivityEvent,
+} from './demo/activity-stream.js';
+import { simulateActivity } from './demo/activity-sim.js';
+
+const app = new Hono();
+
+// Hybrid stream: real actions (echoed from the in-memory bus when same-isolate)
+// race a 4-8s jittered timer that emits a simulated teammate event. The page is
+// never blocked: this is opened by the client post-hydration.
+app.get('/api/demo/activity', (c) =>
+  streamSSE(c, async (stream) => {
+    const queue: ActivityEvent[] = [];
+    let wake!: () => void;
+    let wakeP = new Promise<void>((r) => (wake = r));
+    const unsub = subscribeActivity((e) => {
+      queue.push(e);
+      wake();
+    });
+    stream.onAbort(() => {
+      unsub();
+      wake(); // break the race promptly on disconnect
+    });
+
+    // Immediate backfill so the bar is populated on connect.
+    for (const e of recentActivityEvents(5)) {
+      await stream.writeSSE({ data: JSON.stringify(e) });
+    }
+
+    try {
+      while (!stream.aborted) {
+        while (queue.length) {
+          await stream.writeSSE({ data: JSON.stringify(queue.shift()!) });
+        }
+        const tick = 4000 + Math.floor(Math.random() * 4000);
+        await Promise.race([wakeP, stream.sleep(tick)]);
+        wakeP = new Promise<void>((r) => (wake = r));
+        if (stream.aborted) break;
+        if (queue.length === 0) {
+          // Timer path (no real event this round): emit a simulated one.
+          const e = simulateActivity();
+          if (e) await stream.writeSSE({ data: JSON.stringify(e) });
+        }
+        // queue non-empty -> loop top drains real events first.
+      }
+    } finally {
+      unsub();
+    }
+  })
+);
+
+export default app;

--- a/apps/site/src/components/demo/ActivityBar.tsx
+++ b/apps/site/src/components/demo/ActivityBar.tsx
@@ -93,7 +93,7 @@ export function ActivityBar() {
 
   const latest = events[0];
   return (
-    <div class="demo-activity-bar fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface-subtle/95 backdrop-blur">
+    <div class="demo-activity-bar fixed bottom-6 right-6 z-40 w-[22rem] max-w-[90vw] overflow-hidden rounded-xl border border-border bg-surface-subtle/95 shadow-lg backdrop-blur">
       {expanded && (
         <div
           role="log"

--- a/apps/site/src/components/demo/ActivityBar.tsx
+++ b/apps/site/src/components/demo/ActivityBar.tsx
@@ -1,0 +1,127 @@
+import { subscribeViewTransitionTypes } from 'hono-preact';
+import { useEffect, useState } from 'preact/hooks';
+import { ChevronUp, ChevronDown } from 'lucide-preact';
+import type { ActivityEvent } from '../../demo/activity-stream.js';
+import type { TaskStatus } from '../../demo/data.js';
+
+const MAX = 50;
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  backlog: 'Backlog',
+  in_progress: 'In Progress',
+  in_review: 'In Review',
+  done: 'Done',
+};
+
+function describeEvent(e: ActivityEvent): string {
+  if (e.kind === 'task-created') return `${e.actor} created "${e.taskTitle}"`;
+  if (e.kind === 'task-moved')
+    return `${e.actor} moved "${e.taskTitle}" → ${STATUS_LABEL[e.to]}`;
+  return `${e.actor} commented on "${e.taskTitle}"`;
+}
+
+// Persistent live-activity bar. Mounted via <Persist> (see demo-layout), so it
+// renders inside PersistHost OUTSIDE the router: no router hooks. It owns its
+// own EventSource; the connection and accumulated feed survive intra-app
+// navigation because the component instance persists.
+export function ActivityBar() {
+  const [path, setPath] = useState(
+    typeof window === 'undefined' ? '' : window.location.pathname
+  );
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [expanded, setExpanded] = useState(false);
+  const [connected, setConnected] = useState(false);
+
+  // Learn the current path from outside the router: window on mount, then every
+  // navigation via the global (non-hook) view-transition subscription. Returns
+  // undefined so it adds no transition types; used purely for nav.to.
+  useEffect(() => {
+    setPath(window.location.pathname);
+    return subscribeViewTransitionTypes((nav) => {
+      setPath(nav.to);
+      return undefined;
+    });
+  }, []);
+
+  const isApp = path.startsWith('/demo/projects');
+
+  // Open the stream only inside the app area. Keyed on `isApp` so it stays open
+  // across intra-app navigation (dep unchanged -> no re-run) and closes on exit.
+  useEffect(() => {
+    if (!isApp || typeof EventSource === 'undefined') return;
+    const es = new EventSource('/api/demo/activity');
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    es.onmessage = (ev) => {
+      try {
+        // Trust boundary: our own endpoint. JSON parse cast is acceptable.
+        const e = JSON.parse(ev.data) as ActivityEvent;
+        setEvents((prev) => [e, ...prev].slice(0, MAX));
+      } catch {
+        // ignore a malformed frame
+      }
+    };
+    return () => {
+      es.close();
+      setConnected(false);
+    };
+  }, [isApp]);
+
+  if (typeof window === 'undefined' || !isApp) return null;
+
+  const latest = events[0];
+  return (
+    <div class="demo-activity-bar fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface-subtle/95 backdrop-blur">
+      {expanded && (
+        <div
+          role="log"
+          aria-label="Recent activity"
+          class="demo-activity-feed max-h-64 overflow-y-auto border-b border-border px-4 py-2"
+        >
+          {events.length === 0 ? (
+            <p class="py-4 text-center text-xs text-muted">No activity yet.</p>
+          ) : (
+            <ul class="space-y-1.5">
+              {events.map((e) => (
+                <li key={e.id} class="flex items-baseline gap-2 text-[13px]">
+                  <span class="text-foreground">{describeEvent(e)}</span>
+                  <span class="ml-auto shrink-0 text-[11px] uppercase tracking-wide text-muted">
+                    {e.projectSlug}
+                  </span>
+                  <time class="shrink-0 text-[11px] text-muted">
+                    {new Date(e.at).toLocaleTimeString()}
+                  </time>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      <button
+        type="button"
+        aria-label="Toggle activity feed"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((x) => !x)}
+        class="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px]"
+      >
+        <span
+          class={`h-2 w-2 shrink-0 rounded-full ${
+            connected ? 'demo-activity-pulse bg-accent' : 'bg-muted'
+          }`}
+          aria-hidden
+        />
+        <span class="min-w-0 flex-1 truncate text-foreground">
+          {latest ? describeEvent(latest) : 'Listening for activity…'}
+        </span>
+        <span class="shrink-0 rounded-full bg-foreground/5 px-2 py-0.5 text-[11px] font-semibold text-muted">
+          {events.length}
+        </span>
+        {expanded ? (
+          <ChevronDown size={15} aria-hidden />
+        ) : (
+          <ChevronUp size={15} aria-hidden />
+        )}
+      </button>
+    </div>
+  );
+}
+ActivityBar.displayName = 'ActivityBar';

--- a/apps/site/src/components/demo/ActivityBar.tsx
+++ b/apps/site/src/components/demo/ActivityBar.tsx
@@ -1,4 +1,3 @@
-import { subscribeViewTransitionTypes } from 'hono-preact';
 import { useEffect, useState } from 'preact/hooks';
 import { ChevronUp, ChevronDown } from 'lucide-preact';
 import type { ActivityEvent } from '../../demo/activity-stream.js';
@@ -31,15 +30,39 @@ export function ActivityBar() {
   const [expanded, setExpanded] = useState(false);
   const [connected, setConnected] = useState(false);
 
-  // Learn the current path from outside the router: window on mount, then every
-  // navigation via the global (non-hook) view-transition subscription. Returns
-  // undefined so it adds no transition types; used purely for nav.to.
+  // Track the current path from OUTSIDE the router (the bar renders in
+  // PersistHost, which has no router context). Observe history directly rather
+  // than the View-Transition phase: that phase only fires when
+  // document.startViewTransition runs, so on browsers without View Transitions
+  // it would never update and the bar would strand over non-/demo routes. popstate
+  // covers back/forward; pushState/replaceState cover in-app SPA navigations (which
+  // do not fire popstate). Baseline-safe on every browser; originals restored on
+  // cleanup.
   useEffect(() => {
-    setPath(window.location.pathname);
-    return subscribeViewTransitionTypes((nav) => {
-      setPath(nav.to);
-      return undefined;
-    });
+    const update = () => setPath(window.location.pathname);
+    update();
+    window.addEventListener('popstate', update);
+    const origPush = history.pushState;
+    const origReplace = history.replaceState;
+    history.pushState = function (
+      this: History,
+      ...args: Parameters<History['pushState']>
+    ) {
+      origPush.apply(this, args);
+      update();
+    };
+    history.replaceState = function (
+      this: History,
+      ...args: Parameters<History['replaceState']>
+    ) {
+      origReplace.apply(this, args);
+      update();
+    };
+    return () => {
+      window.removeEventListener('popstate', update);
+      history.pushState = origPush;
+      history.replaceState = origReplace;
+    };
   }, []);
 
   const isApp = path.startsWith('/demo/projects');

--- a/apps/site/src/components/demo/__tests__/ActivityBar.test.tsx
+++ b/apps/site/src/components/demo/__tests__/ActivityBar.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
+import { act } from 'preact/test-utils';
+import { ActivityBar } from '../ActivityBar.js';
+import type { ActivityEvent } from '../../../demo/activity-stream.js';
+
+// Minimal EventSource stub: captures the latest instance so the test can drive
+// onopen/onmessage. happy-dom has no EventSource.
+class MockEventSource {
+  static last: MockEventSource | null = null;
+  url: string;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.last = this;
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+const moved = (id: string, title: string): ActivityEvent => ({
+  id,
+  kind: 'task-moved',
+  at: 1,
+  actor: 'Bob',
+  taskId: 't-1',
+  taskTitle: title,
+  projectSlug: 'inf',
+  to: 'in_review',
+  simulated: true,
+});
+
+beforeEach(() => {
+  vi.stubGlobal('EventSource', MockEventSource);
+  MockEventSource.last = null;
+  window.history.pushState({}, '', '/demo/projects/inf');
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('ActivityBar', () => {
+  it('accumulates streamed events and shows the latest line + count', async () => {
+    render(<ActivityBar />);
+    const es = MockEventSource.last!;
+    expect(es.url).toBe('/api/demo/activity');
+
+    await act(async () => {
+      es.onopen?.();
+      es.onmessage?.({ data: JSON.stringify(moved('e1', 'Cache key')) });
+      es.onmessage?.({ data: JSON.stringify(moved('e2', 'Stream bodies')) });
+    });
+
+    // Latest event (e2) is shown; count reflects both.
+    expect(screen.getByText(/Stream bodies/)).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('expands to reveal the full feed', async () => {
+    render(<ActivityBar />);
+    const es = MockEventSource.last!;
+    await act(async () => {
+      es.onmessage?.({ data: JSON.stringify(moved('e1', 'Cache key')) });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /activity/i }));
+    });
+    // Feed region appears when expanded.
+    expect(screen.getByRole('log')).toBeTruthy();
+  });
+
+  it('renders nothing outside /demo/projects', () => {
+    window.history.pushState({}, '', '/docs/intro');
+    const { container } = render(<ActivityBar />);
+    expect(container.innerHTML).toBe('');
+    expect(MockEventSource.last).toBeNull(); // no stream opened off-app
+  });
+});

--- a/apps/site/src/components/demo/__tests__/ActivityBar.test.tsx
+++ b/apps/site/src/components/demo/__tests__/ActivityBar.test.tsx
@@ -81,4 +81,16 @@ describe('ActivityBar', () => {
     expect(container.innerHTML).toBe('');
     expect(MockEventSource.last).toBeNull(); // no stream opened off-app
   });
+
+  it('hides and is removed from the app when navigation leaves /demo/projects (no View Transitions API needed)', async () => {
+    const { container } = render(<ActivityBar />);
+    expect(MockEventSource.last).not.toBeNull(); // stream open on /demo/projects
+
+    await act(async () => {
+      window.history.pushState({}, '', '/docs/intro');
+    });
+
+    // The pushState wrapper updated the path with no startViewTransition involved.
+    expect(container.innerHTML).toBe('');
+  });
 });

--- a/apps/site/src/demo/__tests__/activity-sim.test.ts
+++ b/apps/site/src/demo/__tests__/activity-sim.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetDemoData, listAllTasks, getProject, getTask } from '../data.js';
+import { __resetActivityForTesting } from '../activity-stream.js';
+import { simulateActivity } from '../activity-sim.js';
+
+beforeEach(() => {
+  resetDemoData();
+  __resetActivityForTesting();
+});
+
+describe('simulateActivity', () => {
+  it('produces a valid display-only event referencing a real task, 200 runs', () => {
+    const ids = new Set(listAllTasks().map((t) => t.id));
+    const statusBefore = new Map(listAllTasks().map((t) => [t.id, t.status]));
+
+    for (let i = 0; i < 200; i++) {
+      const e = simulateActivity();
+      expect(e).not.toBeNull();
+      if (!e) continue;
+      expect(['task-moved', 'comment-added']).toContain(e.kind);
+      expect(ids.has(e.taskId)).toBe(true);
+      const task = getTask(e.taskId)!;
+      expect(e.projectSlug).toBe(getProject(task.projectId)!.slug);
+      expect(e.simulated).toBe(true);
+      if (e.kind === 'task-moved') {
+        expect(e.to).not.toBe(task.status); // moved somewhere new
+      }
+    }
+
+    // Display-only: the store is untouched.
+    for (const t of listAllTasks()) {
+      expect(t.status).toBe(statusBefore.get(t.id));
+    }
+  });
+});

--- a/apps/site/src/demo/__tests__/activity-stream.test.ts
+++ b/apps/site/src/demo/__tests__/activity-stream.test.ts
@@ -44,6 +44,19 @@ describe('activity bus', () => {
     expect(a.simulated).toBe(false);
     expect(b.simulated).toBe(true);
   });
+
+  it('isolates a throwing subscriber so others still receive the event', () => {
+    const seen: ActivityEvent[] = [];
+    subscribeActivity(() => {
+      throw new Error('boom');
+    });
+    subscribeActivity((e) => seen.push(e));
+    const task = getTask('t-1')!;
+    expect(() =>
+      publishActivity(taskMovedEvent(task, 'done', 'Alice'))
+    ).not.toThrow();
+    expect(seen).toHaveLength(1);
+  });
 });
 
 describe('recentActivityEvents', () => {

--- a/apps/site/src/demo/__tests__/activity-stream.test.ts
+++ b/apps/site/src/demo/__tests__/activity-stream.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetDemoData, getTask } from '../data.js';
+import {
+  publishActivity,
+  subscribeActivity,
+  taskMovedEvent,
+  commentAddedEvent,
+  taskCreatedEvent,
+  recentActivityEvents,
+  __resetActivityForTesting,
+  type ActivityEvent,
+} from '../activity-stream.js';
+
+beforeEach(() => {
+  resetDemoData();
+  __resetActivityForTesting();
+});
+
+describe('activity bus', () => {
+  it('delivers published events to subscribers', () => {
+    const seen: ActivityEvent[] = [];
+    const unsub = subscribeActivity((e) => seen.push(e));
+    const task = getTask('t-1')!;
+    publishActivity(taskMovedEvent(task, 'done', 'Alice'));
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      kind: 'task-moved',
+      taskId: 't-1',
+      to: 'done',
+      actor: 'Alice',
+      projectSlug: 'inf',
+      simulated: false,
+    });
+    unsub();
+    publishActivity(commentAddedEvent(task, 'Bob'));
+    expect(seen).toHaveLength(1); // unsubscribed: no further delivery
+  });
+
+  it('assigns unique ids and marks simulated events', () => {
+    const task = getTask('t-1')!;
+    const a = taskCreatedEvent(task, 'Alice');
+    const b = commentAddedEvent(task, 'Bob', true);
+    expect(a.id).not.toBe(b.id);
+    expect(a.simulated).toBe(false);
+    expect(b.simulated).toBe(true);
+  });
+});
+
+describe('recentActivityEvents', () => {
+  it('returns up to `limit` well-formed events newest-first from the seed store', () => {
+    const events = recentActivityEvents(5);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.length).toBeLessThanOrEqual(5);
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i - 1].at).toBeGreaterThanOrEqual(events[i].at);
+    }
+    for (const e of events) {
+      expect(typeof e.taskTitle).toBe('string');
+      expect(['inf', 'api', 'web']).toContain(e.projectSlug);
+      expect(e.simulated).toBe(false);
+    }
+  });
+});

--- a/apps/site/src/demo/activity-sim.ts
+++ b/apps/site/src/demo/activity-sim.ts
@@ -1,0 +1,29 @@
+// apps/site/src/demo/activity-sim.ts
+// Fabricated teammate activity for the demo bar's streaming heartbeat. Events
+// reference real existing tasks but are display-only: they do NOT mutate the
+// store. Limited to moves/comments so every event has a real taskId (a
+// fabricated create would need a fake id).
+import { listAllTasks, type TaskStatus } from './data.js';
+import {
+  taskMovedEvent,
+  commentAddedEvent,
+  type ActivityEvent,
+} from './activity-stream.js';
+
+const SIM_ACTORS = ['Alice', 'Bob'];
+const STATUSES: TaskStatus[] = ['backlog', 'in_progress', 'in_review', 'done'];
+
+const pick = <T>(xs: readonly T[]): T =>
+  xs[Math.floor(Math.random() * xs.length)];
+
+export function simulateActivity(): ActivityEvent | null {
+  const tasks = listAllTasks();
+  if (tasks.length === 0) return null;
+  const task = pick(tasks);
+  const actor = pick(SIM_ACTORS);
+  if (Math.random() < 0.6) {
+    const to = pick(STATUSES.filter((s) => s !== task.status));
+    return taskMovedEvent(task, to, actor, true);
+  }
+  return commentAddedEvent(task, actor, true);
+}

--- a/apps/site/src/demo/activity-sim.ts
+++ b/apps/site/src/demo/activity-sim.ts
@@ -22,6 +22,8 @@ export function simulateActivity(): ActivityEvent | null {
   const task = pick(tasks);
   const actor = pick(SIM_ACTORS);
   if (Math.random() < 0.6) {
+    // STATUSES has 4 entries and we filter out exactly one (the current status),
+    // so the array passed to pick is always non-empty (>= 3 choices).
     const to = pick(STATUSES.filter((s) => s !== task.status));
     return taskMovedEvent(task, to, actor, true);
   }

--- a/apps/site/src/demo/activity-stream.ts
+++ b/apps/site/src/demo/activity-stream.ts
@@ -1,0 +1,138 @@
+// apps/site/src/demo/activity-stream.ts
+// In-memory activity bus + event model for the persistent demo activity bar.
+// The bus is per-isolate: server actions publish real events; the SSE endpoint
+// subscribes. Builders construct events; the data store stays a pure module and
+// does not import this file.
+import {
+  listAllTasks,
+  listComments,
+  getProject,
+  getUser,
+  type Task,
+  type TaskStatus,
+} from './data.js';
+
+type EventBase = {
+  id: string;
+  at: number; // epoch ms
+  actor: string; // display name
+  taskId: string;
+  taskTitle: string;
+  projectSlug: string;
+  simulated: boolean; // true = fabricated teammate event (display-only)
+};
+
+export type ActivityEvent =
+  | (EventBase & { kind: 'task-created' })
+  | (EventBase & { kind: 'task-moved'; to: TaskStatus })
+  | (EventBase & { kind: 'comment-added' });
+
+let counter = 0;
+const nextId = (): string => `evt-${++counter}`;
+const slugOf = (task: Task): string => getProject(task.projectId)?.slug ?? '';
+
+export function taskCreatedEvent(
+  task: Task,
+  actor: string,
+  simulated = false
+): ActivityEvent {
+  return {
+    id: nextId(),
+    kind: 'task-created',
+    at: Date.now(),
+    actor,
+    taskId: task.id,
+    taskTitle: task.title,
+    projectSlug: slugOf(task),
+    simulated,
+  };
+}
+
+export function taskMovedEvent(
+  task: Task,
+  to: TaskStatus,
+  actor: string,
+  simulated = false
+): ActivityEvent {
+  return {
+    id: nextId(),
+    kind: 'task-moved',
+    at: Date.now(),
+    actor,
+    taskId: task.id,
+    taskTitle: task.title,
+    projectSlug: slugOf(task),
+    to,
+    simulated,
+  };
+}
+
+export function commentAddedEvent(
+  task: Task,
+  actor: string,
+  simulated = false
+): ActivityEvent {
+  return {
+    id: nextId(),
+    kind: 'comment-added',
+    at: Date.now(),
+    actor,
+    taskId: task.id,
+    taskTitle: task.title,
+    projectSlug: slugOf(task),
+    simulated,
+  };
+}
+
+const listeners = new Set<(e: ActivityEvent) => void>();
+
+export function publishActivity(e: ActivityEvent): void {
+  // Copy before iterating so an unsubscribe during dispatch is safe.
+  for (const l of [...listeners]) l(e);
+}
+
+export function subscribeActivity(cb: (e: ActivityEvent) => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+// Derive a few most-recent events from the seeded store (across all projects)
+// so a freshly-connected bar is immediately populated. Uses the historical
+// timestamps (not Date.now), so the backfill reads as real history.
+export function recentActivityEvents(limit = 5): ActivityEvent[] {
+  const events: ActivityEvent[] = [];
+  for (const task of listAllTasks()) {
+    const projectSlug = slugOf(task);
+    events.push({
+      id: nextId(),
+      kind: 'task-created',
+      at: task.createdAt,
+      actor: getUser(task.authorId)?.name ?? 'someone',
+      taskId: task.id,
+      taskTitle: task.title,
+      projectSlug,
+      simulated: false,
+    });
+    for (const c of listComments(task.id)) {
+      events.push({
+        id: nextId(),
+        kind: 'comment-added',
+        at: c.createdAt,
+        actor: getUser(c.authorId)?.name ?? 'someone',
+        taskId: task.id,
+        taskTitle: task.title,
+        projectSlug,
+        simulated: false,
+      });
+    }
+  }
+  return events.sort((a, b) => b.at - a.at).slice(0, limit);
+}
+
+/** Test-only reset. Do not call from production code. */
+export function __resetActivityForTesting(): void {
+  listeners.clear();
+  counter = 0;
+}

--- a/apps/site/src/demo/activity-stream.ts
+++ b/apps/site/src/demo/activity-stream.ts
@@ -87,8 +87,16 @@ export function commentAddedEvent(
 const listeners = new Set<(e: ActivityEvent) => void>();
 
 export function publishActivity(e: ActivityEvent): void {
-  // Copy before iterating so an unsubscribe during dispatch is safe.
-  for (const l of [...listeners]) l(e);
+  // Copy before iterating so an unsubscribe during dispatch is safe. Isolate each
+  // subscriber: a throwing listener must not break the publishing action or starve
+  // other subscribers.
+  for (const l of [...listeners]) {
+    try {
+      l(e);
+    } catch {
+      // ignore a misbehaving subscriber
+    }
+  }
 }
 
 export function subscribeActivity(cb: (e: ActivityEvent) => void): () => void {

--- a/apps/site/src/demo/data.ts
+++ b/apps/site/src/demo/data.ts
@@ -274,6 +274,8 @@ export const listTasksForProject = (projectId: string): Task[] =>
     .filter((t) => t.projectId === projectId)
     .sort((a, b) => a.createdAt - b.createdAt);
 
+export const listAllTasks = (): Task[] => store.tasks.slice();
+
 export const getTask = (id: string): Task | null =>
   store.tasks.find((t) => t.id === id) ?? null;
 

--- a/apps/site/src/pages/demo/demo-layout.tsx
+++ b/apps/site/src/pages/demo/demo-layout.tsx
@@ -1,5 +1,6 @@
 import type { LayoutProps } from 'hono-preact';
-import { useViewTransitionTypes } from 'hono-preact';
+import { Persist, useViewTransitionTypes } from 'hono-preact';
+import { ActivityBar } from '../../components/demo/ActivityBar.js';
 
 // Thin layout wrapping every /demo route. Its only job is to host the
 // view-transition direction hook on a node that stays mounted across all demo
@@ -24,5 +25,15 @@ export default function DemoLayout({ children }: LayoutProps) {
     if (fromProjects && toProjects) types.push('demo-within');
     return types;
   });
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      {/* Persistent live-activity bar. No `viewTransitionName` on Persist: the
+          bar is position:fixed, so its VT name lives on the bar element itself
+          (the .demo-activity-bar class) to lift it out of the root snapshot. */}
+      <Persist id="demo-activity-bar">
+        <ActivityBar />
+      </Persist>
+    </>
+  );
 }

--- a/apps/site/src/pages/demo/project-board.server.ts
+++ b/apps/site/src/pages/demo/project-board.server.ts
@@ -3,6 +3,7 @@ import {
   getProjectBySlug,
   listTasksForProject,
   getUser,
+  getTask,
   createTask,
   setTaskStatus,
   setTaskPriority,
@@ -13,6 +14,11 @@ import {
   type TaskStatus,
   type TaskPriority,
 } from '../../demo/data.js';
+import {
+  publishActivity,
+  taskCreatedEvent,
+  taskMovedEvent,
+} from '../../demo/activity-stream.js';
 import { currentUser } from '../../demo/session.js';
 import { assertCanMoveToDone } from './task-guards.js';
 
@@ -65,6 +71,7 @@ export const serverActions = {
       // the form sends '' for unassigned; coerce to null
       assigneeId: input.assigneeId || null,
     });
+    publishActivity(taskCreatedEvent(created, user.name));
     return { id: created.id };
   }),
 
@@ -81,6 +88,14 @@ export const serverActions = {
     if (input.status)
       setTaskStatus(input.taskId, input.status, user?.id ?? null);
     if (input.priority) setTaskPriority(input.taskId, input.priority);
+    if (input.status) {
+      const task = getTask(input.taskId);
+      if (task) {
+        publishActivity(
+          taskMovedEvent(task, input.status, user?.name ?? 'someone')
+        );
+      }
+    }
     return { ok: true };
   }),
 

--- a/apps/site/src/pages/demo/projects-shell.tsx
+++ b/apps/site/src/pages/demo/projects-shell.tsx
@@ -101,7 +101,7 @@ function Sidebar({
           </div>
         )}
       </aside>
-      <main class="min-w-0">{children}</main>
+      <main class="min-w-0 pb-14">{children}</main>
     </div>
   );
 }

--- a/apps/site/src/pages/demo/projects-shell.tsx
+++ b/apps/site/src/pages/demo/projects-shell.tsx
@@ -101,7 +101,7 @@ function Sidebar({
           </div>
         )}
       </aside>
-      <main class="min-w-0 pb-14">{children}</main>
+      <main class="min-w-0">{children}</main>
     </div>
   );
 }

--- a/apps/site/src/pages/demo/task.server.ts
+++ b/apps/site/src/pages/demo/task.server.ts
@@ -14,6 +14,11 @@ import {
 } from '../../demo/data.js';
 import { currentUser } from '../../demo/session.js';
 import { assertCanMoveToDone } from './task-guards.js';
+import {
+  publishActivity,
+  commentAddedEvent,
+  taskMovedEvent,
+} from '../../demo/activity-stream.js';
 
 // Bind this server module to its route once; `route.loader(fn)` then types
 // `ctx.location.pathParams` (taskId/projectId) from the route's pattern.
@@ -73,6 +78,8 @@ export const serverActions = {
         taskId: input.taskId,
         body: input.body.trim(),
       });
+      const task = getTask(input.taskId);
+      if (task) publishActivity(commentAddedEvent(task, user.name));
       return { id: c.id };
     }
   ),
@@ -84,6 +91,12 @@ export const serverActions = {
         await assertCanMoveToDone(input.taskId, user?.id);
       }
       setTaskStatus(input.taskId, input.status, user?.id ?? null);
+      const task = getTask(input.taskId);
+      if (task) {
+        publishActivity(
+          taskMovedEvent(task, input.status, user?.name ?? 'someone')
+        );
+      }
       return { ok: true };
     }
   ),

--- a/apps/site/src/styles/root.css
+++ b/apps/site/src/styles/root.css
@@ -611,6 +611,42 @@ html:active-view-transition-type(demo-within)::view-transition-new(demo-sidebar)
   animation: none;
 }
 
+/* The demo activity bar is persistent, position:fixed UI. Give it its own
+   transition name so it is lifted out of the root snapshot (otherwise the root
+   slide/fade drags it on every navigation). The name lives on the fixed bar
+   element itself, not the Persist wrapper, which would collapse to zero height
+   and fail to capture an out-of-flow child. */
+.demo-activity-bar {
+  view-transition-name: demo-activity-bar;
+}
+/* Within the app (bar present in both snapshots) freeze it: only page content
+   transitions. Scoped to demo-within only; on enter/leave the bar is in one
+   snapshot and keeps the default fade. */
+html:active-view-transition-type(demo-within)::view-transition-group(demo-activity-bar),
+html:active-view-transition-type(demo-within)::view-transition-old(demo-activity-bar),
+html:active-view-transition-type(demo-within)::view-transition-new(demo-activity-bar) {
+  animation: none;
+}
+
+/* Live-connection pulse on the status dot (not a route transition). */
+@keyframes demo-activity-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+.demo-activity-pulse {
+  animation: demo-activity-pulse 1.6s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .demo-activity-pulse {
+    animation: none;
+  }
+}
+
 @keyframes slide-in-right {
   from {
     opacity: 0;

--- a/docs/superpowers/plans/2026-06-18-demo-activity-bar.md
+++ b/docs/superpowers/plans/2026-06-18-demo-activity-bar.md
@@ -1,0 +1,1051 @@
+# Persistent live-activity bar for /demo — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bottom-docked bar to the `/demo` task board that streams a live hybrid activity feed (simulated teammates + echoed real actions) over SSE and survives intra-demo navigation because it is mounted via the framework's `Persist` component (rendered outside the router).
+
+**Architecture:** A Hono SSE endpoint in `apps/site/src/api.ts` (auto-mounted ahead of framework handlers) emits JSON activity frames: an event-driven loop races a 4-8s jittered timer (simulated teammate events) against an in-memory bus that the demo's server actions publish real events to. A client `ActivityBar` component, mounted via `<Persist>` in the demo layout, opens its own `EventSource`, accumulates events, and renders a collapsible bar. View-transition isolation mirrors the existing sidebar.
+
+**Tech Stack:** Hono `streamSSE` (`hono/streaming`, hono 4.12.14), native `EventSource`, Preact + `hono-preact` (`Persist`, `subscribeViewTransitionTypes`), Tailwind v4 tokens, Vitest + `@testing-library/preact` + happy-dom.
+
+## Global Constraints
+
+- **No em-dashes** in prose, code comments, or commit messages. Use comma, semicolon, colon, parentheses, or two sentences. (Arrows `→` in UI copy are fine.)
+- **No inline type casts.** Reshape types instead (this plan uses a discriminated union for `ActivityEvent`). The one acceptable cast is `JSON.parse(...) as ActivityEvent` at the SSE-parse trust boundary.
+- **apps/site only.** No changes to `packages/*` or any framework/published surface. No release implications.
+- **Browser support:** depend only on Baseline Widely Available platform features. `EventSource` qualifies. View Transitions stay progressive enhancement (handled by the existing isolation CSS pattern).
+- **Pre-push = the six CI steps in order** (framework build → `pnpm format:check` → `pnpm typecheck` → `pnpm test:coverage` → `pnpm test:integration` → `pnpm --filter site build`). `format:check` is the most-missed; **run `pnpm format` before every commit** and review `git status` for format-dirty files (recurring subagent trap).
+- ESM imports use the `.js` extension on relative paths (e.g. `import { x } from './data.js'`), matching the codebase.
+- Tests that render components need the file-header pragma `// @vitest-environment happy-dom`; pure-logic tests use the default node env. Reset the demo store with `resetDemoData()` and the activity bus with `__resetActivityForTesting()` in `beforeEach`.
+
+---
+
+## File Structure
+
+New:
+- `apps/site/src/demo/activity-stream.ts` — `ActivityEvent` type, in-memory bus, event builders, seed backfill.
+- `apps/site/src/demo/activity-sim.ts` — simulated teammate event generator.
+- `apps/site/src/api.ts` — Hono app with the `GET /api/demo/activity` SSE endpoint.
+- `apps/site/src/components/demo/ActivityBar.tsx` — the persistent bar component.
+- `apps/site/src/demo/__tests__/activity-stream.test.ts`
+- `apps/site/src/demo/__tests__/activity-sim.test.ts`
+- `apps/site/src/__tests__/api.test.ts`
+- `apps/site/src/components/demo/__tests__/ActivityBar.test.tsx`
+
+Modified:
+- `apps/site/src/demo/data.ts` — add `listAllTasks`.
+- `apps/site/src/pages/demo/project-board.server.ts` — publish on `createTask` / `patchTask` (move).
+- `apps/site/src/pages/demo/task.server.ts` — publish on `addComment` / `setStatus`.
+- `apps/site/src/pages/demo/demo-layout.tsx` — mount `<Persist><ActivityBar/></Persist>`.
+- `apps/site/src/pages/demo/projects-shell.tsx` — bottom padding on `<main>` so the bar never covers content.
+- `apps/site/src/styles/root.css` — VT isolation + pulse/slide-up keyframes.
+
+---
+
+## Task 1: Event model, bus, builders, backfill
+
+**Files:**
+- Modify: `apps/site/src/demo/data.ts` (add `listAllTasks` near the other reads, ~line 272)
+- Create: `apps/site/src/demo/activity-stream.ts`
+- Test: `apps/site/src/demo/__tests__/activity-stream.test.ts`
+
+**Interfaces:**
+- Consumes: from `./data.js` — `listAllTasks(): Task[]` (added here), `getProject(id): Project | null`, `getUser(id): User | null`, `listComments(taskId): Comment[]`, types `Task`, `TaskStatus`.
+- Produces:
+  - `type ActivityEvent` (discriminated union on `kind`).
+  - `publishActivity(e: ActivityEvent): void`
+  - `subscribeActivity(cb: (e: ActivityEvent) => void): () => void`
+  - `taskCreatedEvent(task: Task, actor: string, simulated?: boolean): ActivityEvent`
+  - `taskMovedEvent(task: Task, to: TaskStatus, actor: string, simulated?: boolean): ActivityEvent`
+  - `commentAddedEvent(task: Task, actor: string, simulated?: boolean): ActivityEvent`
+  - `recentActivityEvents(limit?: number): ActivityEvent[]`
+  - `__resetActivityForTesting(): void`
+
+- [ ] **Step 1: Add `listAllTasks` to `data.ts`**
+
+In `apps/site/src/demo/data.ts`, in the `// ---- Reads ----` section (just after `listTasksForProject`, ~line 276), add:
+
+```ts
+export const listAllTasks = (): Task[] => store.tasks.slice();
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/site/src/demo/__tests__/activity-stream.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetDemoData, getTask } from '../data.js';
+import {
+  publishActivity,
+  subscribeActivity,
+  taskMovedEvent,
+  commentAddedEvent,
+  taskCreatedEvent,
+  recentActivityEvents,
+  __resetActivityForTesting,
+  type ActivityEvent,
+} from '../activity-stream.js';
+
+beforeEach(() => {
+  resetDemoData();
+  __resetActivityForTesting();
+});
+
+describe('activity bus', () => {
+  it('delivers published events to subscribers', () => {
+    const seen: ActivityEvent[] = [];
+    const unsub = subscribeActivity((e) => seen.push(e));
+    const task = getTask('t-1')!;
+    publishActivity(taskMovedEvent(task, 'done', 'Alice'));
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      kind: 'task-moved',
+      taskId: 't-1',
+      to: 'done',
+      actor: 'Alice',
+      projectSlug: 'inf',
+      simulated: false,
+    });
+    unsub();
+    publishActivity(commentAddedEvent(task, 'Bob'));
+    expect(seen).toHaveLength(1); // unsubscribed: no further delivery
+  });
+
+  it('assigns unique ids and marks simulated events', () => {
+    const task = getTask('t-1')!;
+    const a = taskCreatedEvent(task, 'Alice');
+    const b = commentAddedEvent(task, 'Bob', true);
+    expect(a.id).not.toBe(b.id);
+    expect(a.simulated).toBe(false);
+    expect(b.simulated).toBe(true);
+  });
+});
+
+describe('recentActivityEvents', () => {
+  it('returns up to `limit` well-formed events newest-first from the seed store', () => {
+    const events = recentActivityEvents(5);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.length).toBeLessThanOrEqual(5);
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i - 1].at).toBeGreaterThanOrEqual(events[i].at);
+    }
+    for (const e of events) {
+      expect(typeof e.taskTitle).toBe('string');
+      expect(['inf', 'api', 'web']).toContain(e.projectSlug);
+      expect(e.simulated).toBe(false);
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Run test, verify it fails**
+
+Run: `pnpm exec vitest run apps/site/src/demo/__tests__/activity-stream.test.ts`
+Expected: FAIL (cannot resolve `../activity-stream.js`).
+
+- [ ] **Step 4: Implement `activity-stream.ts`**
+
+Create `apps/site/src/demo/activity-stream.ts`:
+
+```ts
+// apps/site/src/demo/activity-stream.ts
+// In-memory activity bus + event model for the persistent demo activity bar.
+// The bus is per-isolate: server actions publish real events; the SSE endpoint
+// subscribes. Builders construct events; the data store stays a pure module and
+// does not import this file.
+import {
+  listAllTasks,
+  listComments,
+  getProject,
+  getUser,
+  type Task,
+  type TaskStatus,
+} from './data.js';
+
+type EventBase = {
+  id: string;
+  at: number; // epoch ms
+  actor: string; // display name
+  taskId: string;
+  taskTitle: string;
+  projectSlug: string;
+  simulated: boolean; // true = fabricated teammate event (display-only)
+};
+
+export type ActivityEvent =
+  | (EventBase & { kind: 'task-created' })
+  | (EventBase & { kind: 'task-moved'; to: TaskStatus })
+  | (EventBase & { kind: 'comment-added' });
+
+let counter = 0;
+const nextId = (): string => `evt-${++counter}`;
+const slugOf = (task: Task): string => getProject(task.projectId)?.slug ?? '';
+
+export function taskCreatedEvent(
+  task: Task,
+  actor: string,
+  simulated = false
+): ActivityEvent {
+  return {
+    id: nextId(),
+    kind: 'task-created',
+    at: Date.now(),
+    actor,
+    taskId: task.id,
+    taskTitle: task.title,
+    projectSlug: slugOf(task),
+    simulated,
+  };
+}
+
+export function taskMovedEvent(
+  task: Task,
+  to: TaskStatus,
+  actor: string,
+  simulated = false
+): ActivityEvent {
+  return {
+    id: nextId(),
+    kind: 'task-moved',
+    at: Date.now(),
+    actor,
+    taskId: task.id,
+    taskTitle: task.title,
+    projectSlug: slugOf(task),
+    to,
+    simulated,
+  };
+}
+
+export function commentAddedEvent(
+  task: Task,
+  actor: string,
+  simulated = false
+): ActivityEvent {
+  return {
+    id: nextId(),
+    kind: 'comment-added',
+    at: Date.now(),
+    actor,
+    taskId: task.id,
+    taskTitle: task.title,
+    projectSlug: slugOf(task),
+    simulated,
+  };
+}
+
+const listeners = new Set<(e: ActivityEvent) => void>();
+
+export function publishActivity(e: ActivityEvent): void {
+  // Copy before iterating so an unsubscribe during dispatch is safe.
+  for (const l of [...listeners]) l(e);
+}
+
+export function subscribeActivity(cb: (e: ActivityEvent) => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+// Derive a few most-recent events from the seeded store (across all projects)
+// so a freshly-connected bar is immediately populated. Uses the historical
+// timestamps (not Date.now), so the backfill reads as real history.
+export function recentActivityEvents(limit = 5): ActivityEvent[] {
+  const events: ActivityEvent[] = [];
+  for (const task of listAllTasks()) {
+    const projectSlug = slugOf(task);
+    events.push({
+      id: nextId(),
+      kind: 'task-created',
+      at: task.createdAt,
+      actor: getUser(task.authorId)?.name ?? 'someone',
+      taskId: task.id,
+      taskTitle: task.title,
+      projectSlug,
+      simulated: false,
+    });
+    for (const c of listComments(task.id)) {
+      events.push({
+        id: nextId(),
+        kind: 'comment-added',
+        at: c.createdAt,
+        actor: getUser(c.authorId)?.name ?? 'someone',
+        taskId: task.id,
+        taskTitle: task.title,
+        projectSlug,
+        simulated: false,
+      });
+    }
+  }
+  return events.sort((a, b) => b.at - a.at).slice(0, limit);
+}
+
+/** Test-only reset. Do not call from production code. */
+export function __resetActivityForTesting(): void {
+  listeners.clear();
+  counter = 0;
+}
+```
+
+- [ ] **Step 5: Run test, verify it passes**
+
+Run: `pnpm exec vitest run apps/site/src/demo/__tests__/activity-stream.test.ts`
+Expected: PASS (all tests green).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+pnpm format
+git add apps/site/src/demo/activity-stream.ts apps/site/src/demo/data.ts apps/site/src/demo/__tests__/activity-stream.test.ts
+git commit -m "feat(demo): activity event model and in-memory bus"
+```
+
+---
+
+## Task 2: Simulated teammate generator
+
+**Files:**
+- Create: `apps/site/src/demo/activity-sim.ts`
+- Test: `apps/site/src/demo/__tests__/activity-sim.test.ts`
+
+**Interfaces:**
+- Consumes: `listAllTasks`, `getProject`, type `TaskStatus` from `./data.js`; `taskMovedEvent`, `commentAddedEvent`, type `ActivityEvent` from `./activity-stream.js`.
+- Produces: `simulateActivity(): ActivityEvent | null` — a `simulated: true` event referencing a real existing task; `null` only if the store has no tasks. Never mutates the store.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/site/src/demo/__tests__/activity-sim.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetDemoData, listAllTasks, getProject, getTask } from '../data.js';
+import { __resetActivityForTesting } from '../activity-stream.js';
+import { simulateActivity } from '../activity-sim.js';
+
+beforeEach(() => {
+  resetDemoData();
+  __resetActivityForTesting();
+});
+
+describe('simulateActivity', () => {
+  it('produces a valid display-only event referencing a real task, 200 runs', () => {
+    const ids = new Set(listAllTasks().map((t) => t.id));
+    const statusBefore = new Map(listAllTasks().map((t) => [t.id, t.status]));
+
+    for (let i = 0; i < 200; i++) {
+      const e = simulateActivity();
+      expect(e).not.toBeNull();
+      if (!e) continue;
+      expect(['task-moved', 'comment-added']).toContain(e.kind);
+      expect(ids.has(e.taskId)).toBe(true);
+      const task = getTask(e.taskId)!;
+      expect(e.projectSlug).toBe(getProject(task.projectId)!.slug);
+      expect(e.simulated).toBe(true);
+      if (e.kind === 'task-moved') {
+        expect(e.to).not.toBe(task.status); // moved somewhere new
+      }
+    }
+
+    // Display-only: the store is untouched.
+    for (const t of listAllTasks()) {
+      expect(t.status).toBe(statusBefore.get(t.id));
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pnpm exec vitest run apps/site/src/demo/__tests__/activity-sim.test.ts`
+Expected: FAIL (cannot resolve `../activity-sim.js`).
+
+- [ ] **Step 3: Implement `activity-sim.ts`**
+
+Create `apps/site/src/demo/activity-sim.ts`:
+
+```ts
+// apps/site/src/demo/activity-sim.ts
+// Fabricated teammate activity for the demo bar's streaming heartbeat. Events
+// reference real existing tasks but are display-only: they do NOT mutate the
+// store. Limited to moves/comments so every event has a real taskId (a
+// fabricated create would need a fake id).
+import { listAllTasks, type TaskStatus } from './data.js';
+import {
+  taskMovedEvent,
+  commentAddedEvent,
+  type ActivityEvent,
+} from './activity-stream.js';
+
+const SIM_ACTORS = ['Alice', 'Bob'];
+const STATUSES: TaskStatus[] = [
+  'backlog',
+  'in_progress',
+  'in_review',
+  'done',
+];
+
+const pick = <T>(xs: readonly T[]): T =>
+  xs[Math.floor(Math.random() * xs.length)];
+
+export function simulateActivity(): ActivityEvent | null {
+  const tasks = listAllTasks();
+  if (tasks.length === 0) return null;
+  const task = pick(tasks);
+  const actor = pick(SIM_ACTORS);
+  if (Math.random() < 0.6) {
+    const to = pick(STATUSES.filter((s) => s !== task.status));
+    return taskMovedEvent(task, to, actor, true);
+  }
+  return commentAddedEvent(task, actor, true);
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `pnpm exec vitest run apps/site/src/demo/__tests__/activity-sim.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+pnpm format
+git add apps/site/src/demo/activity-sim.ts apps/site/src/demo/__tests__/activity-sim.test.ts
+git commit -m "feat(demo): simulated teammate activity generator"
+```
+
+---
+
+## Task 3: SSE endpoint (`api.ts`)
+
+**Files:**
+- Create: `apps/site/src/api.ts`
+- Test: `apps/site/src/__tests__/api.test.ts`
+
+**Interfaces:**
+- Consumes: `subscribeActivity`, `recentActivityEvents`, type `ActivityEvent` from `./demo/activity-stream.js`; `simulateActivity` from `./demo/activity-sim.js`; `Hono` from `hono`; `streamSSE` from `hono/streaming`.
+- Produces: default-exported `Hono` app. The framework auto-mounts `src/api.ts` (default `api` option) ahead of its handlers. `GET /api/demo/activity` returns a `text/event-stream` whose frames are JSON-encoded `ActivityEvent`s.
+
+Note on `streamSSE` API (verified, hono 4.12.14): `stream.writeSSE({ data })`, `stream.sleep(ms)`, `stream.onAbort(fn)`, boolean `stream.aborted`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/site/src/__tests__/api.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetDemoData } from '../demo/data.js';
+import { __resetActivityForTesting } from '../demo/activity-stream.js';
+import app from '../api.js';
+
+beforeEach(() => {
+  resetDemoData();
+  __resetActivityForTesting();
+});
+
+describe('GET /api/demo/activity', () => {
+  it('streams JSON activity frames as text/event-stream (reads backfill, then aborts)', async () => {
+    const ctrl = new AbortController();
+    const res = await app.request('/api/demo/activity', {
+      signal: ctrl.signal,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    let firstData: string | null = null;
+
+    // The backfill frames are written before the first timer sleep, so they
+    // arrive in the first read(s). Bound the loop so the test can't hang.
+    for (let i = 0; i < 5 && firstData === null; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const m = buf.match(/^data: (.*)$/m);
+      if (m) firstData = m[1];
+    }
+    ctrl.abort();
+    await reader.cancel().catch(() => undefined);
+
+    expect(firstData).not.toBeNull();
+    const parsed = JSON.parse(firstData!);
+    expect(parsed).toHaveProperty('kind');
+    expect(parsed).toHaveProperty('taskId');
+    expect(['inf', 'api', 'web']).toContain(parsed.projectSlug);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pnpm exec vitest run apps/site/src/__tests__/api.test.ts`
+Expected: FAIL (cannot resolve `../api.js`).
+
+- [ ] **Step 3: Implement `api.ts`**
+
+Create `apps/site/src/api.ts`:
+
+```ts
+// apps/site/src/api.ts
+// User Hono app, auto-mounted by the framework ahead of its own handlers.
+// Hosts the SSE endpoint that drives the persistent demo activity bar.
+import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
+import {
+  subscribeActivity,
+  recentActivityEvents,
+  type ActivityEvent,
+} from './demo/activity-stream.js';
+import { simulateActivity } from './demo/activity-sim.js';
+
+const app = new Hono();
+
+// Hybrid stream: real actions (echoed from the in-memory bus when same-isolate)
+// race a 4-8s jittered timer that emits a simulated teammate event. The page is
+// never blocked: this is opened by the client post-hydration.
+app.get('/api/demo/activity', (c) =>
+  streamSSE(c, async (stream) => {
+    const queue: ActivityEvent[] = [];
+    let wake!: () => void;
+    let wakeP = new Promise<void>((r) => (wake = r));
+    const unsub = subscribeActivity((e) => {
+      queue.push(e);
+      wake();
+    });
+    stream.onAbort(() => {
+      unsub();
+      wake(); // break the race promptly on disconnect
+    });
+
+    // Immediate backfill so the bar is populated on connect.
+    for (const e of recentActivityEvents(5)) {
+      await stream.writeSSE({ data: JSON.stringify(e) });
+    }
+
+    try {
+      while (!stream.aborted) {
+        while (queue.length) {
+          await stream.writeSSE({ data: JSON.stringify(queue.shift()!) });
+        }
+        const tick = 4000 + Math.floor(Math.random() * 4000);
+        await Promise.race([wakeP, stream.sleep(tick)]);
+        wakeP = new Promise<void>((r) => (wake = r));
+        if (stream.aborted) break;
+        if (queue.length === 0) {
+          // Timer path (no real event this round): emit a simulated one.
+          const e = simulateActivity();
+          if (e) await stream.writeSSE({ data: JSON.stringify(e) });
+        }
+        // queue non-empty -> loop top drains real events first.
+      }
+    } finally {
+      unsub();
+    }
+  })
+);
+
+export default app;
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `pnpm exec vitest run apps/site/src/__tests__/api.test.ts`
+Expected: PASS. If the read loop ever hangs, the bounded `for` (max 5 reads) plus `ctrl.abort()` guarantees termination; a failure here means backfill is not being written before the first sleep.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+pnpm format
+git add apps/site/src/api.ts apps/site/src/__tests__/api.test.ts
+git commit -m "feat(demo): SSE endpoint streaming hybrid activity feed"
+```
+
+---
+
+## Task 4: The persistent `ActivityBar` component
+
+**Files:**
+- Create: `apps/site/src/components/demo/ActivityBar.tsx`
+- Test: `apps/site/src/components/demo/__tests__/ActivityBar.test.tsx`
+
+**Interfaces:**
+- Consumes: `subscribeViewTransitionTypes` from `hono-preact`; `useEffect`, `useState` from `preact/hooks`; type `ActivityEvent` from `../../demo/activity-stream.js`; type `TaskStatus` from `../../demo/data.js`.
+- Produces: named export `ActivityBar` (a Preact function component taking no props). Renders `null` on the server and when the current path is not under `/demo/projects`. Opens `EventSource('/api/demo/activity')` while under `/demo/projects`. Root element carries the `demo-activity-bar` class (for VT isolation, wired in Task 5).
+
+Notes:
+- The component lives in `PersistHost`'s tree (outside the router), so it must NOT use `useRoute`/`useParams`/`useNavigate`. Path comes from `window.location.pathname` + `subscribeViewTransitionTypes`.
+- All hooks are called unconditionally before any early `return null` (Rules of Hooks).
+- `EventSource` is guarded (`typeof EventSource === 'undefined'` -> skip) because happy-dom and SSR have none.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/site/src/components/demo/__tests__/ActivityBar.test.tsx`:
+
+```tsx
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { render, fireEvent, cleanup, screen } from '@testing-library/preact';
+import { act } from 'preact/test-utils';
+import { ActivityBar } from '../ActivityBar.js';
+import type { ActivityEvent } from '../../../demo/activity-stream.js';
+
+// Minimal EventSource stub: captures the latest instance so the test can drive
+// onopen/onmessage. happy-dom has no EventSource.
+class MockEventSource {
+  static last: MockEventSource | null = null;
+  url: string;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.last = this;
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+const moved = (id: string, title: string): ActivityEvent => ({
+  id,
+  kind: 'task-moved',
+  at: 1,
+  actor: 'Bob',
+  taskId: 't-1',
+  taskTitle: title,
+  projectSlug: 'inf',
+  to: 'in_review',
+  simulated: true,
+});
+
+beforeEach(() => {
+  vi.stubGlobal('EventSource', MockEventSource);
+  MockEventSource.last = null;
+  window.history.pushState({}, '', '/demo/projects/inf');
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('ActivityBar', () => {
+  it('accumulates streamed events and shows the latest line + count', async () => {
+    render(<ActivityBar />);
+    const es = MockEventSource.last!;
+    expect(es.url).toBe('/api/demo/activity');
+
+    await act(async () => {
+      es.onopen?.();
+      es.onmessage?.({ data: JSON.stringify(moved('e1', 'Cache key')) });
+      es.onmessage?.({ data: JSON.stringify(moved('e2', 'Stream bodies')) });
+    });
+
+    // Latest event (e2) is shown; count reflects both.
+    expect(screen.getByText(/Stream bodies/)).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('expands to reveal the full feed', async () => {
+    render(<ActivityBar />);
+    const es = MockEventSource.last!;
+    await act(async () => {
+      es.onmessage?.({ data: JSON.stringify(moved('e1', 'Cache key')) });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /activity/i }));
+    });
+    // Feed region appears when expanded.
+    expect(screen.getByRole('log')).toBeTruthy();
+  });
+
+  it('renders nothing outside /demo/projects', () => {
+    window.history.pushState({}, '', '/docs/intro');
+    const { container } = render(<ActivityBar />);
+    expect(container.innerHTML).toBe('');
+    expect(MockEventSource.last).toBeNull(); // no stream opened off-app
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `pnpm exec vitest run apps/site/src/components/demo/__tests__/ActivityBar.test.tsx`
+Expected: FAIL (cannot resolve `../ActivityBar.js`).
+
+- [ ] **Step 3: Implement `ActivityBar.tsx`**
+
+Create `apps/site/src/components/demo/ActivityBar.tsx`:
+
+```tsx
+import { subscribeViewTransitionTypes } from 'hono-preact';
+import { useEffect, useState } from 'preact/hooks';
+import { ChevronUp, ChevronDown } from 'lucide-preact';
+import type { ActivityEvent } from '../../demo/activity-stream.js';
+import type { TaskStatus } from '../../demo/data.js';
+
+const MAX = 50;
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  backlog: 'Backlog',
+  in_progress: 'In Progress',
+  in_review: 'In Review',
+  done: 'Done',
+};
+
+function describeEvent(e: ActivityEvent): string {
+  if (e.kind === 'task-created') return `${e.actor} created "${e.taskTitle}"`;
+  if (e.kind === 'task-moved')
+    return `${e.actor} moved "${e.taskTitle}" → ${STATUS_LABEL[e.to]}`;
+  return `${e.actor} commented on "${e.taskTitle}"`;
+}
+
+// Persistent live-activity bar. Mounted via <Persist> (see demo-layout), so it
+// renders inside PersistHost OUTSIDE the router: no router hooks. It owns its
+// own EventSource; the connection and accumulated feed survive intra-app
+// navigation because the component instance persists.
+export function ActivityBar() {
+  const [path, setPath] = useState(
+    typeof window === 'undefined' ? '' : window.location.pathname
+  );
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [expanded, setExpanded] = useState(false);
+  const [connected, setConnected] = useState(false);
+
+  // Learn the current path from outside the router: window on mount, then every
+  // navigation via the global (non-hook) view-transition subscription. Returns
+  // undefined so it adds no transition types; used purely for nav.to.
+  useEffect(() => {
+    setPath(window.location.pathname);
+    return subscribeViewTransitionTypes((nav) => {
+      setPath(nav.to);
+      return undefined;
+    });
+  }, []);
+
+  const isApp = path.startsWith('/demo/projects');
+
+  // Open the stream only inside the app area. Keyed on `isApp` so it stays open
+  // across intra-app navigation (dep unchanged -> no re-run) and closes on exit.
+  useEffect(() => {
+    if (!isApp || typeof EventSource === 'undefined') return;
+    const es = new EventSource('/api/demo/activity');
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    es.onmessage = (ev) => {
+      try {
+        // Trust boundary: our own endpoint. JSON parse cast is acceptable.
+        const e = JSON.parse(ev.data) as ActivityEvent;
+        setEvents((prev) => [e, ...prev].slice(0, MAX));
+      } catch {
+        // ignore a malformed frame
+      }
+    };
+    return () => {
+      es.close();
+      setConnected(false);
+    };
+  }, [isApp]);
+
+  if (typeof window === 'undefined' || !isApp) return null;
+
+  const latest = events[0];
+  return (
+    <div class="demo-activity-bar fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface-subtle/95 backdrop-blur">
+      {expanded && (
+        <div
+          role="log"
+          aria-label="Recent activity"
+          class="demo-activity-feed max-h-64 overflow-y-auto border-b border-border px-4 py-2"
+        >
+          {events.length === 0 ? (
+            <p class="py-4 text-center text-xs text-muted">No activity yet.</p>
+          ) : (
+            <ul class="space-y-1.5">
+              {events.map((e) => (
+                <li key={e.id} class="flex items-baseline gap-2 text-[13px]">
+                  <span class="text-foreground">{describeEvent(e)}</span>
+                  <span class="ml-auto shrink-0 text-[11px] uppercase tracking-wide text-muted">
+                    {e.projectSlug}
+                  </span>
+                  <time class="shrink-0 text-[11px] text-muted">
+                    {new Date(e.at).toLocaleTimeString()}
+                  </time>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      <button
+        type="button"
+        aria-label="Toggle activity feed"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((x) => !x)}
+        class="flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px]"
+      >
+        <span
+          class={`h-2 w-2 shrink-0 rounded-full ${
+            connected ? 'demo-activity-pulse bg-accent' : 'bg-muted'
+          }`}
+          aria-hidden
+        />
+        <span class="min-w-0 flex-1 truncate text-foreground">
+          {latest ? describeEvent(latest) : 'Listening for activity…'}
+        </span>
+        <span class="shrink-0 rounded-full bg-foreground/5 px-2 py-0.5 text-[11px] font-semibold text-muted">
+          {events.length}
+        </span>
+        {expanded ? (
+          <ChevronDown size={15} aria-hidden />
+        ) : (
+          <ChevronUp size={15} aria-hidden />
+        )}
+      </button>
+    </div>
+  );
+}
+ActivityBar.displayName = 'ActivityBar';
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run: `pnpm exec vitest run apps/site/src/components/demo/__tests__/ActivityBar.test.tsx`
+Expected: PASS (all three tests green).
+
+Note: the "expand" test queries `getByRole('button', { name: /activity/i })` which matches the `aria-label="Toggle activity feed"`. The latest-line test matches the rendered task title text.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+pnpm format
+git add apps/site/src/components/demo/ActivityBar.tsx apps/site/src/components/demo/__tests__/ActivityBar.test.tsx
+git commit -m "feat(demo): persistent ActivityBar component"
+```
+
+---
+
+## Task 5: Wire-up — mount, publish on actions, CSS isolation
+
+This task has no new unit tests (the builders are tested in Task 1; the publish wiring and CSS are integration/visual, verified by typecheck + site build + the manual run in the final verification). Its deliverable is the feature working end-to-end.
+
+**Files:**
+- Modify: `apps/site/src/pages/demo/demo-layout.tsx`
+- Modify: `apps/site/src/pages/demo/project-board.server.ts`
+- Modify: `apps/site/src/pages/demo/task.server.ts`
+- Modify: `apps/site/src/pages/demo/projects-shell.tsx`
+- Modify: `apps/site/src/styles/root.css`
+
+**Interfaces:**
+- Consumes: `Persist` from `hono-preact`; `ActivityBar` from `../../components/demo/ActivityBar.js`; `publishActivity`, `taskCreatedEvent`, `taskMovedEvent`, `commentAddedEvent` from `../../demo/activity-stream.js`; `getTask` from `../../demo/data.js`.
+
+- [ ] **Step 1: Mount the bar in the demo layout**
+
+Edit `apps/site/src/pages/demo/demo-layout.tsx`. Add imports at the top:
+
+```ts
+import { Persist } from 'hono-preact';
+import { ActivityBar } from '../../components/demo/ActivityBar.js';
+```
+
+Change the `return` (currently `return <>{children}</>;`) to:
+
+```tsx
+  return (
+    <>
+      {children}
+      {/* Persistent live-activity bar. No `viewTransitionName` on Persist: the
+          bar is position:fixed, so its VT name lives on the bar element itself
+          (the .demo-activity-bar class) to lift it out of the root snapshot. */}
+      <Persist id="demo-activity-bar">
+        <ActivityBar />
+      </Persist>
+    </>
+  );
+```
+
+- [ ] **Step 2: Publish real events from the board actions**
+
+Edit `apps/site/src/pages/demo/project-board.server.ts`.
+
+Add `getTask` to the existing import from `../../demo/data.js` (it currently imports `getProjectBySlug, listTasksForProject, getUser, createTask, setTaskStatus, setTaskPriority, deleteTask`), and add a new import:
+
+```ts
+import {
+  publishActivity,
+  taskCreatedEvent,
+  taskMovedEvent,
+} from '../../demo/activity-stream.js';
+```
+
+In the `createTask` action, after `const created = createTask(...)` and before `return { id: created.id };`:
+
+```ts
+    publishActivity(taskCreatedEvent(created, user.name));
+```
+
+In the `patchTask` action, after the `if (input.status) setTaskStatus(...)` line and before `return { ok: true };`:
+
+```ts
+    if (input.status) {
+      const task = getTask(input.taskId);
+      if (task) {
+        publishActivity(
+          taskMovedEvent(task, input.status, user?.name ?? 'someone')
+        );
+      }
+    }
+```
+
+(`user` is already resolved via `currentUser(ctx.c)` at the top of `patchTask`.)
+
+- [ ] **Step 3: Publish real events from the task actions**
+
+Edit `apps/site/src/pages/demo/task.server.ts`.
+
+Add a new import (it already imports `getTask` from `../../demo/data.js`):
+
+```ts
+import {
+  publishActivity,
+  commentAddedEvent,
+  taskMovedEvent,
+} from '../../demo/activity-stream.js';
+```
+
+In the `addComment` action, after `const c = addComment(...)` and before `return { id: c.id };`:
+
+```ts
+      const task = getTask(input.taskId);
+      if (task) publishActivity(commentAddedEvent(task, user.name));
+```
+
+In the `setStatus` action, after `setTaskStatus(input.taskId, input.status, ...)` and before `return { ok: true };`:
+
+```ts
+      const task = getTask(input.taskId);
+      if (task) {
+        publishActivity(
+          taskMovedEvent(task, input.status, user?.name ?? 'someone')
+        );
+      }
+```
+
+- [ ] **Step 4: Reserve space so the bar never covers content**
+
+Edit `apps/site/src/pages/demo/projects-shell.tsx`. The `Sidebar` component ends with `<main class="min-w-0">{children}</main>`. Add bottom padding so the collapsed bar (fixed at the viewport bottom) does not cover the last board row:
+
+```tsx
+      <main class="min-w-0 pb-14">{children}</main>
+```
+
+- [ ] **Step 5: Add view-transition isolation + keyframes**
+
+Edit `apps/site/src/styles/root.css`. After the `.demo-sidebar` isolation block (ends ~line 612, before the `@keyframes slide-in-right` block), add:
+
+```css
+/* The demo activity bar is persistent, position:fixed UI. Give it its own
+   transition name so it is lifted out of the root snapshot (otherwise the root
+   slide/fade drags it on every navigation). The name lives on the fixed bar
+   element itself, not the Persist wrapper, which would collapse to zero height
+   and fail to capture an out-of-flow child. */
+.demo-activity-bar {
+  view-transition-name: demo-activity-bar;
+}
+/* Within the app (bar present in both snapshots) freeze it: only page content
+   transitions. Scoped to demo-within only; on enter/leave the bar is in one
+   snapshot and keeps the default fade. */
+html:active-view-transition-type(demo-within)::view-transition-group(demo-activity-bar),
+html:active-view-transition-type(demo-within)::view-transition-old(demo-activity-bar),
+html:active-view-transition-type(demo-within)::view-transition-new(demo-activity-bar) {
+  animation: none;
+}
+
+/* Live-connection pulse on the status dot (not a route transition). */
+@keyframes demo-activity-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+.demo-activity-pulse {
+  animation: demo-activity-pulse 1.6s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .demo-activity-pulse {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 6: Typecheck and build the site**
+
+Run:
+```bash
+pnpm typecheck
+pnpm --filter site build
+```
+Expected: both succeed. Typecheck confirms the `hono-preact` `Persist` import, the discriminated-union narrowing, and the server-action edits. The site build confirms `api.ts` is picked up without tripping the catch-all-shadowing check.
+
+- [ ] **Step 7: Run the full app test suite (cross-file safety)**
+
+Run: `pnpm exec vitest run apps/site/src`
+Expected: PASS, including the unchanged demo tests (`data.test.ts`, etc.) and the three new test files.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+pnpm format
+git add apps/site/src/pages/demo/demo-layout.tsx apps/site/src/pages/demo/project-board.server.ts apps/site/src/pages/demo/task.server.ts apps/site/src/pages/demo/projects-shell.tsx apps/site/src/styles/root.css
+git commit -m "feat(demo): mount persistent activity bar and publish real actions"
+```
+
+---
+
+## Final verification (before declaring done)
+
+Run the six CI steps in order from the worktree root (per project CLAUDE.md):
+
+- [ ] **1. Framework build:** `pnpm --filter '@hono-preact/*' --filter hono-preact --filter hono-preact-ui build`
+- [ ] **2. Format:** `pnpm format:check` (if it fails, `pnpm format` then re-commit)
+- [ ] **3. Typecheck:** `pnpm typecheck`
+- [ ] **4. Unit + coverage:** `pnpm test:coverage`
+- [ ] **5. Integration:** `pnpm test:integration`
+- [ ] **6. Site build:** `pnpm --filter site build`
+- [ ] **7. `git status`** — confirm nothing format-dirty was left uncommitted (recurring subagent trap).
+
+Then a manual run (use the `run` or `verify` skill) to confirm the behaviors that unit tests can't:
+
+- [ ] The page renders immediately; the bar fills in asynchronously (no blocking on first paint).
+- [ ] The connection + accumulated feed survive board ↔ task ↔ project-list navigation (no reconnect/reset).
+- [ ] During `demo-within` transitions the bar stays rock-steady (no slide/fade with the page content). Per project memory, MCP browsers cannot visually verify view transitions; confirm by reading the computed `view-transition-name` on the bar and by eye in a real browser.
+- [ ] The bar disappears on `/docs` and reappears (reconnects, feed retained) on return to `/demo/projects`.
+- [ ] Moving a task / adding a comment yourself echoes into the bar (same-isolate, local dev).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Hybrid data source (sim + real echo) -> Task 2 (sim), Task 1 builders + Task 5 publish (real), Task 3 race loop. ✓
+- Bottom-docked + expand UI -> Task 4. ✓
+- Global cross-project feed -> backfill + events carry `projectSlug`; bar does not filter by project. ✓
+- EventSource transport -> Task 4. ✓
+- `api.ts` SSE via `streamSSE`, auto-mounted -> Task 3 + Task 5 build check. ✓
+- Persist mount in demo layout, no `viewTransitionName` prop -> Task 5 Step 1. ✓
+- VT isolation (own name on fixed element + demo-within freeze) -> Task 5 Step 5. ✓
+- Client-only / non-blocking / no hydration mismatch -> Task 4 (`null` on server, EventSource in effect). ✓
+- `data.ts` gains only `listAllTasks`; publishing in action layer -> Task 1 Step 1 + Task 5 Steps 2-3. ✓
+- Simulated events display-only -> Task 2 (asserted store-unchanged in test). ✓
+- Tests: bus/backfill, sim invariants, component -> Tasks 1/2/4; plus an endpoint test (Task 3). ✓
+
+**Refinement vs spec:** the spec said gate on `/demo`; the plan gates on `/demo/projects` (the authed app area), so the bar does not show on the `/demo` splash or `/demo/login`. This matches the spec's intent (the bar belongs to the task-board app) and aligns with the `demo-within` VT type, which only fires within `/demo/projects`. Bottom padding added via `projects-shell.tsx` (a sixth edited file beyond the spec's five) to reserve space under the fixed bar.
+
+**Placeholder scan:** none. Every code step has complete code.
+
+**Type consistency:** `ActivityEvent` discriminated union is defined once (Task 1) and consumed unchanged (Tasks 2/3/4). Builder names (`taskCreatedEvent`/`taskMovedEvent`/`commentAddedEvent`), `publishActivity`/`subscribeActivity`/`recentActivityEvents`/`__resetActivityForTesting`, and `listAllTasks` are used identically across tasks. `streamSSE` methods match the verified hono 4.12.14 surface.

--- a/docs/superpowers/specs/2026-06-18-demo-activity-bar-design.md
+++ b/docs/superpowers/specs/2026-06-18-demo-activity-bar-design.md
@@ -1,0 +1,324 @@
+# Persistent live-activity bar for `/demo`
+
+Status: design approved 2026-06-18. Prototype. Scope: `apps/site` only (no framework
+or npm-package changes), so no release implications.
+
+## Goal
+
+Dogfood the framework's `Persist` component (built but never used in the app) and its
+streaming story with a single feature: a slim bar pinned to the bottom of the `/demo`
+viewport that shows "changes happening" on the task board as a live, server-driven feed.
+
+The feature is chosen to make `Persist` *visibly earn its keep*: the bar owns a live
+streaming connection and an accumulating feed, and because it is persisted **outside the
+router**, both survive every intra-`/demo` navigation (board ↔ task ↔ project list) with
+no reconnect, reset, or flicker. A non-persisted bar would remount and drop its
+connection on every SPA hop.
+
+## Non-goals
+
+- No new framework/package surface. This is an app-level prototype.
+- Simulated teammate events are **display-only**; they do not mutate the in-memory demo
+  store or the board. (A future enhancement could make them mutate + invalidate the
+  board loader, but that is out of scope and would make the board rearrange under the
+  user.)
+- No persistence across cold starts / isolates beyond what the existing demo store
+  already does. The demo is a feature showcase, not a saved tool.
+
+## Decisions locked during brainstorming
+
+1. **Data source: hybrid.** A server-driven SSE stream emits simulated teammate activity
+   on a jittered timer (the always-on heartbeat that proves async streaming), AND echoes
+   the user's *real* actions when the action request and the open stream share an
+   isolate. On Cloudflare the two can land on different isolates, so real-action echo is
+   best-effort; the simulated heartbeat guarantees the bar is never dead. Documented as
+   such.
+2. **Shape: bottom-docked + expand.** Slim full-width fixed bar. Collapsed: live pulse
+   dot + latest event line + event count + expand chevron. Click expands a scrollable
+   recent-feed panel upward.
+3. **Feed scope: global across all projects** (always has content; survives project
+   switches). Each row shows which project it belongs to.
+4. **Transport: native `EventSource`** (auto-reconnect, dead simple) against an SSE
+   endpoint, rather than `fetch` + `ReadableStream`.
+
+## Why not the framework's streaming-loader API
+
+The headline streaming primitive (`route.loader(async function* …)` consumed via
+`loader.View`) is **route-bound**: it is initiated by the router when a route mounts and
+re-runs on every navigation. A component that must *outlive* routes cannot ride it, and
+there is no public client API to subscribe to a loader's stream from outside the router.
+
+So the bar uses the same SSE substrate the framework's own loader-streaming and internal
+SSE codec (`packages/server/src/sse.ts`) are built on: Hono's `streamSSE`
+(`hono/streaming`, present in hono 4.12.14) server-side and native `EventSource`
+client-side. The framework's `sseGeneratorResponse` is server-internal (not exported),
+so app code uses Hono's helper directly rather than reaching into framework internals.
+
+If this pattern proves valuable, a small client hook to subscribe to a streaming endpoint
+outside the router is a natural Section-C-style primitive candidate (the way the existing
+site-discovered primitives were found). That is explicitly **out of scope** here.
+
+## Architecture
+
+Three new files + small edits to four existing files. All under `apps/site`.
+
+### 1. `apps/site/src/demo/activity-stream.ts` (new) — event model + in-memory bus
+
+The shared event type and a tiny pub/sub the server action layer publishes to and the SSE
+endpoint subscribes to.
+
+```ts
+import type { TaskStatus } from './data.js';
+
+export type ActivityEvent = {
+  id: string;            // stable client key (counter + suffix)
+  kind: 'task-created' | 'task-moved' | 'comment-added';
+  at: number;            // epoch ms
+  actor: string;         // display name ("Alice", "Bob", or the signed-in user)
+  taskId: string;
+  taskTitle: string;
+  projectSlug: string;
+  to?: TaskStatus;       // only for 'task-moved'
+  simulated: boolean;    // true = fabricated teammate event (display-only)
+};
+
+export function publishActivity(e: ActivityEvent): void;       // fan out to subscribers
+export function subscribeActivity(cb: (e: ActivityEvent) => void): () => void;
+export function recentActivityEvents(limit?: number): ActivityEvent[]; // seed backfill
+export function __resetActivityForTesting(): void;             // test-only
+```
+
+- `publishActivity` / `subscribeActivity` are a `Set<cb>` fan-out. No buffering between
+  events; the SSE endpoint queues what it receives.
+- `recentActivityEvents(limit = 5)` derives a few most-recent events from the existing
+  demo store (across all projects) by reading `listAllTasks` / `listComments` /
+  `getUser` / `getProject`, so a freshly-connected bar is immediately populated with
+  real-looking history rather than waiting 4-8s for the first simulated tick. Marked
+  `simulated: false` (it is real seed history). Read-only; mutates nothing.
+- `id` generation: a module-level monotonic counter plus a short suffix so keys are
+  unique and stable.
+- `data.ts` gains one tiny read helper, `listAllTasks(): Task[]` (`store.tasks.slice()`),
+  consumed by the backfill and the simulator. No other `data.ts` changes.
+
+Import direction: `activity-stream.ts` imports **types** from `data.ts`
+(`import type`) and the read helpers at runtime; `data.ts` does **not** import
+`activity-stream.ts` (the store stays a pure data module). Publishing is done from the
+server action layer, not the store mutators — see below.
+
+### 2. `apps/site/src/demo/activity-sim.ts` (new) — simulated teammate generator
+
+```ts
+import type { ActivityEvent } from './activity-stream.js';
+export function simulateActivity(): ActivityEvent | null;
+```
+
+- Picks a random real task from `listAllTasks()`, resolves its project slug, picks a
+  random actor name from the seed users, and builds either a `task-moved` (to a random
+  status different from the task's current one) or a `comment-added` event. Returns
+  `null` only if the store is empty.
+- Limited to `task-moved` / `comment-added` so every simulated event references a **real
+  existing task** (real `taskId` + `taskTitle`). `task-created` is reserved for real user
+  actions (a fabricated create would need a fake `taskId`).
+- Marked `simulated: true`. Does **not** mutate the store. Uses `Math.random` (fine at
+  app runtime).
+
+### 3. `apps/site/src/api.ts` (new) — SSE endpoint, auto-mounted ahead of framework handlers
+
+The framework loads `src/api.ts` (default option `api: 'src/api.ts'`) if present and
+mounts its default-exported Hono app ahead of its own handlers. A specific path does not
+trip the catch-all-shadowing build check. The site has no `api.ts` today; this is the
+first.
+
+```ts
+import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
+import { subscribeActivity, recentActivityEvents, type ActivityEvent } from './demo/activity-stream.js';
+import { simulateActivity } from './demo/activity-sim.js';
+
+const app = new Hono();
+
+app.get('/api/demo/activity', (c) =>
+  streamSSE(c, async (stream) => {
+    const queue: ActivityEvent[] = [];
+    let wake!: () => void;
+    let wakeP = new Promise<void>((r) => (wake = r));
+    const unsub = subscribeActivity((e) => { queue.push(e); wake(); });
+    stream.onAbort(() => { unsub(); wake(); });           // break the loop promptly
+
+    for (const e of recentActivityEvents(5)) {            // immediate backfill
+      await stream.writeSSE({ data: JSON.stringify(e) });
+    }
+    try {
+      while (!stream.aborted) {
+        while (queue.length) await stream.writeSSE({ data: JSON.stringify(queue.shift()!) });
+        const tick = 4000 + Math.floor(Math.random() * 4000);   // 4-8s jitter
+        await Promise.race([wakeP, stream.sleep(tick)]);
+        wakeP = new Promise<void>((r) => (wake = r));
+        if (stream.aborted) break;
+        if (queue.length === 0) {                          // timer path → simulate
+          const e = simulateActivity();
+          if (e) await stream.writeSSE({ data: JSON.stringify(e) });
+        }
+        // queue non-empty → loop top drains real events first
+      }
+    } finally {
+      unsub();
+    }
+  })
+);
+
+export default app;
+```
+
+Design notes:
+- **Event-driven loop racing a jittered timer against the real-event bus.** Real events
+  (echoed user actions) flush near-immediately via `wake()`; absent any, a simulated
+  event emits every 4-8s. Abort-aware via `stream.aborted` + `onAbort` (closes the
+  subscription and breaks the race).
+- Known benign race: if a `wake()` lands in the narrow window between the race resolving
+  and `wakeP` being reassigned, that event waits until the next timer tick (≤ 8s) when the
+  loop-top drain catches it. Acceptable for a demo; noted.
+- Each frame is a JSON-encoded `data:` line — the same `text/event-stream` shape the
+  framework's SSE codec emits.
+
+### 4. `apps/site/src/components/demo/ActivityBar.tsx` (new) — the persistent bar
+
+Rendered via `<Persist id="demo-activity-bar">` (placed in the demo layout). Lives in
+`PersistHost`'s tree, i.e. **outside the router**, so it cannot use `useRoute` /
+`useParams` / `useNavigate`. It therefore:
+
+- Opens its **own** `EventSource('/api/demo/activity')` in an effect, parses each message,
+  and prepends to capped state (`events`, newest first, max ~50). The connection and the
+  accumulated feed survive intra-`/demo` navigation because the component instance
+  persists in `PersistHost`. **This is the showcase.**
+- Learns the current path from `window.location.pathname` on mount and from
+  `subscribeViewTransitionTypes((nav) => setPath(nav.to))` (public, non-hook, fires on
+  every navigation including outside a mounted router; the callback returns `undefined`
+  so it adds no transition types — used purely for the `nav.to` side-effect).
+- Derives `isDemo = path.startsWith('/demo')`. The `EventSource` effect is keyed on
+  `isDemo`: it stays open across all intra-`/demo` hops (dep unchanged → effect does not
+  re-run), and closes when the user leaves `/demo` (and reopens on return). The
+  accumulated `events` array is retained across a `/docs` round-trip because the component
+  instance lives on; only the live wire reconnects.
+- **Renders `null` when `!isDemo` or on the server** (`typeof window === 'undefined'`), so
+  it never appears over the docs/home and is purely a client-side progressive
+  enhancement. Server render contributes nothing; the bar fills in post-hydration.
+- Collapsed UI: fixed bottom bar — live pulse dot (animated while connected), latest event
+  line, event count, expand chevron. Expanded UI: a panel slides up (plain CSS, not a
+  route transition) showing the recent feed (scrollable, newest first) with per-row
+  project tag + relative time, a connection-status header, and a collapse control.
+- Styling reuses the existing demo Tailwind tokens (`bg-background`, `text-foreground`,
+  `border-border`, `bg-surface-subtle`, `text-muted`, `bg-accent`, …). The root element
+  carries the plain CSS class `demo-activity-bar` for view-transition isolation (below).
+
+### Edits to existing files
+
+- **`apps/site/src/pages/demo/demo-layout.tsx`**: render `<Persist id="demo-activity-bar"><ActivityBar /></Persist>`
+  alongside `{children}`. The demo layout wraps every `/demo` route and stays mounted
+  across all demo navigations, so it is the correct host. **No `viewTransitionName` prop
+  on `Persist`** (see isolation section).
+- **`apps/site/src/demo/data.ts`**: add `listAllTasks(): Task[]`.
+- **`apps/site/src/pages/demo/project-board.server.ts`** and **`task.server.ts`**: after a
+  successful mutating action (`createTask`, `patchTask`/`setStatus` for moves,
+  `addComment`), call `publishActivity(...)` with a `simulated: false` event built from the
+  action's known inputs (resolving task title / project slug / actor name via existing
+  reads). Publishing lives in the **action layer**, not the store, so `data.ts` stays a
+  pure store and the broadcast concern is localized to where user intent is known.
+- **`apps/site/src/styles/root.css`**: the isolation rules + a pulse keyframe for the live
+  dot + a slide-up keyframe/transition for the expand panel + bottom padding on the demo
+  content area so the collapsed bar never covers the last board row.
+
+## View-transition isolation (mirrors the sidebar, with one fixed-position twist)
+
+A persistent fixed bar that is not isolated gets captured into `::view-transition-old/new
+(root)` and visibly slides/fades with the page on every navigation. The sidebar avoids
+this (`apps/site/src/styles/root.css:601-612`); the bar gets the same treatment:
+
+```css
+/* Lift the bar out of the root snapshot so root slide/fade can't drag it. */
+.demo-activity-bar { view-transition-name: demo-activity-bar; }
+
+/* Within demo (bar present in both snapshots) freeze it: only page content transitions.
+   Scoped to demo-within ONLY — on enter/leave the bar is in one snapshot and should keep
+   the default fade, not freeze a stale copy on screen (same reasoning as .demo-sidebar). */
+html:active-view-transition-type(demo-within)::view-transition-group(demo-activity-bar),
+html:active-view-transition-type(demo-within)::view-transition-old(demo-activity-bar),
+html:active-view-transition-type(demo-within)::view-transition-new(demo-activity-bar) {
+  animation: none;
+}
+```
+
+**The fixed-position twist:** the `view-transition-name` must sit on the bar's **own fixed
+element** (the `.demo-activity-bar` class on `ActivityBar`'s root), **not** on `Persist`'s
+`viewTransitionName` prop. That prop names the `PersistSlot` wrapper `<div>`
+(`persist.tsx:50-57`); because the bar is `position: fixed` (out of flow), that wrapper
+collapses to zero height, captures nothing, and the fixed child falls back into the root
+snapshot anyway. So:
+
+- Name the bar element directly via the `.demo-activity-bar` class (mirrors `.demo-sidebar`).
+- Add the matching `demo-within` `animation: none` freeze.
+- Leave `<Persist viewTransitionName>` **unset** to avoid a second, empty named group.
+- The collapsed bar and the expand panel live under one fixed root so they isolate as a
+  single group.
+- Streaming content updates are not navigations, so they never trigger the route VT; the
+  "new event" / expand affordances are plain CSS transitions, kept separate from the route
+  transition machinery.
+
+## SSR / non-blocking guarantees
+
+- `ActivityBar` returns `null` on the server, so SSR emits nothing for it; the page is
+  fully rendered and usable immediately. No loader/page data is touched.
+- `EventSource` opens post-hydration in an effect; the feed fills in asynchronously, so
+  the page never looks like it is waiting to finish loading.
+- `PersistHost` is a separate client-only root mounted into an appended container, so there
+  is no SSR HTML for it to mismatch against — no hydration warning from rendering the bar
+  client-only. The demo layout's `Persist` renders nothing inline on the client (browser
+  path), matching the empty server contribution.
+- Fixed positioning means the bar has no place in document flow, so its client-only mount
+  causes zero layout shift; bottom padding on the demo content area reserves space under
+  the collapsed bar.
+
+## Testing
+
+Prototype-appropriate, focused on the pure logic + the component's own behavior. The
+persistence-across-navigation and the view-transition isolation are integration/visual
+concerns verified manually in the running app (and per project memory, MCP browsers can't
+visually verify view transitions — only DOM swaps / console — so VT isolation is checked
+by reading computed `view-transition-name` and by eye).
+
+- `activity-stream.test.ts`: `publishActivity` reaches subscribers; unsubscribe stops
+  delivery; `recentActivityEvents(n)` returns ≤ n most-recent, well-formed events from the
+  seeded store.
+- `activity-sim.test.ts`: over many runs, `simulateActivity()` returns a well-formed event
+  whose `taskId` exists in the store and whose `projectSlug` matches that task's project;
+  `kind` ∈ {`task-moved`, `comment-added`}; `simulated === true`; never mutates the store.
+- `ActivityBar.test.tsx`: with a stubbed global `EventSource`, dispatching messages
+  accumulates events and renders the latest line + count; the expand toggle reveals the
+  feed; the bar renders `null` when the path is outside `/demo`.
+
+## Verification (pre-push)
+
+Mirror CI's six steps in order (per project CLAUDE.md): framework build →
+`pnpm format:check` → `pnpm typecheck` → `pnpm test:coverage` → `pnpm test:integration` →
+`pnpm --filter site build`. Plus manual run (`verify`/`run` skill) to confirm: the bar
+streams and fills in without blocking first paint; the connection + feed survive
+board↔task↔project navigation; the bar stays rock-steady (no slide/fade) during
+`demo-within` transitions; it disappears on `/docs` and reappears on return.
+
+## File summary
+
+New:
+- `apps/site/src/api.ts`
+- `apps/site/src/demo/activity-stream.ts`
+- `apps/site/src/demo/activity-sim.ts`
+- `apps/site/src/components/demo/ActivityBar.tsx`
+- `apps/site/src/demo/__tests__/activity-stream.test.ts`
+- `apps/site/src/demo/__tests__/activity-sim.test.ts`
+- `apps/site/src/components/demo/__tests__/ActivityBar.test.tsx`
+
+Edited:
+- `apps/site/src/pages/demo/demo-layout.tsx`
+- `apps/site/src/demo/data.ts` (add `listAllTasks`)
+- `apps/site/src/pages/demo/project-board.server.ts` (publish on mutating actions)
+- `apps/site/src/pages/demo/task.server.ts` (publish on mutating actions)
+- `apps/site/src/styles/root.css` (VT isolation + keyframes + content bottom padding)


### PR DESCRIPTION
## What

A prototype that dogfoods two framework capabilities the app had never used: the **`Persist`** component (persistently-mounted UI rendered in `PersistHost`, outside the router) and the **streaming** story. A slim bottom-docked bar on the `/demo/projects` board streams a live activity feed and survives intra-app navigation with no reconnect or reset.

`apps/site`-only; no framework/package changes, no release implications.

## How it works

- **Server (`apps/site/src/api.ts`)** — first use of the framework's auto-mounted `api.ts`. `GET /api/demo/activity` returns `streamSSE` (Hono). An event-driven loop races a 4-8s jittered timer (simulated teammate events from `activity-sim.ts`) against an in-memory bus (`activity-stream.ts`) that the demo's server actions publish real moves/comments/creates to. **Hybrid:** simulated heartbeat is always alive; your own actions echo when same-isolate (Cloudflare may split isolates, so real-echo is best-effort, documented).
- **Client (`components/demo/ActivityBar.tsx`)** — mounted via `<Persist id="demo-activity-bar">` in the demo layout. Opens its own `EventSource`, accumulates a capped feed, collapses/expands. Connection + feed survive board ↔ task ↔ project-list navigation because the instance lives in `PersistHost`.
- **Non-blocking / SSR** — the bar renders `null` on the server and opens the stream post-hydration, so first paint is never gated on it; no hydration mismatch (PersistHost is a separate client-only root).
- **View-transition isolation** — mirrors the sidebar: own `view-transition-name` on the fixed bar element (not the Persist wrapper, which would collapse to zero height) plus a `demo-within`-scoped freeze.
- **Baseline-safe** — path tracking uses a `popstate` + `pushState`/`replaceState` observer (not the View-Transitions phase, which never fires on non-VT browsers), so the bar correctly hides off `/demo/projects` on every browser.

## Verification

All six CI steps green locally (rebased on current `main`): framework build, `format:check`, `typecheck`, `test:coverage` (237 files / 1419 tests), `test:integration` (4/4), site build. New unit tests cover the bus, the simulator invariants, the SSE endpoint, and the component (stubbed `EventSource`, including the no-View-Transitions hide-on-nav path). Reviewed task-by-task plus a final whole-branch review; the one Important finding (View-Transitions-only nav signal) was fixed and re-verified.

Design + plan: `docs/superpowers/specs/2026-06-18-demo-activity-bar-design.md`, `docs/superpowers/plans/2026-06-18-demo-activity-bar.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)