### PR TITLE
refactor(server): dedupe the middleware dispatch engine + server-chain composition

### DIFF
--- a/packages/iso/src/internal/__tests__/middleware-runner.test.ts
+++ b/packages/iso/src/internal/__tests__/middleware-runner.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import type { Context } from 'hono';
-import { defineServerMiddleware } from '../../define-middleware.js';
-import { dispatchServer, type DispatchResult } from '../middleware-runner.js';
+import {
+  defineServerMiddleware,
+  defineClientMiddleware,
+  type Next,
+} from '../../define-middleware.js';
+import {
+  dispatch,
+  dispatchServer,
+  dispatchClient,
+  type DispatchResult,
+} from '../middleware-runner.js';
 import { redirect, deny, isOutcome } from '../../outcomes.js';
 
 const fakeC = { req: { header: () => undefined } } as unknown as Context;
@@ -280,7 +289,82 @@ describe('dispatchServer — outcomes', () => {
       })
     ).rejects.toThrow('inner-boom');
   });
+});
 
+describe('dispatch — generic engine (Ctx-agnostic)', () => {
+  it('runs arbitrary {fn} middleware in order around inner and threads the value', async () => {
+    const calls: string[] = [];
+    const mk = (id: string) => ({
+      fn: async (_ctx: { n: number }, next: Next) => {
+        calls.push(`${id}:before`);
+        await next();
+        calls.push(`${id}:after`);
+      },
+    });
+    const result = await dispatch<{ n: number }, string>({
+      middleware: [mk('a'), mk('b')],
+      ctx: { n: 1 },
+      inner: async () => 'inner',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value).toBe('inner');
+    expect(calls).toEqual(['a:before', 'b:before', 'b:after', 'a:after']);
+  });
+
+  it('short-circuits on a thrown outcome', async () => {
+    const result = await dispatch<{ n: number }, string>({
+      middleware: [
+        {
+          fn: async () => {
+            throw deny(403, 'no');
+          },
+        },
+      ],
+      ctx: { n: 1 },
+      inner: async () => 'unreached',
+    });
+    expect(result.kind).toBe('outcome');
+    if (result.kind === 'outcome') {
+      expect(result.outcome.__outcome).toBe('deny');
+    }
+  });
+});
+
+describe('dispatchClient — facade over dispatch', () => {
+  it('runs client middleware around inner and returns the value (closes the previously-untested client path)', async () => {
+    const calls: string[] = [];
+    const mw = defineClientMiddleware(async (_ctx, next) => {
+      calls.push('c:before');
+      await next();
+      calls.push('c:after');
+    });
+    const result: DispatchResult<string> = await dispatchClient({
+      middleware: [mw],
+      ctx: { scope: 'page', location: { path: '/' } as never },
+      inner: async () => 'client-value',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') expect(result.value).toBe('client-value');
+    expect(calls).toEqual(['c:before', 'c:after']);
+  });
+
+  it('catches a thrown outcome from client middleware', async () => {
+    const mw = defineClientMiddleware(async () => {
+      throw redirect('/login');
+    });
+    const result = await dispatchClient({
+      middleware: [mw],
+      ctx: { scope: 'page', location: { path: '/' } as never },
+      inner: async () => 'unreached',
+    });
+    expect(result.kind).toBe('outcome');
+    if (result.kind === 'outcome') {
+      expect(result.outcome.__outcome).toBe('redirect');
+    }
+  });
+});
+
+describe('dispatchServer — signal', () => {
   it('AbortSignal aborted mid-chain does not short-circuit (by design)', async () => {
     // The dispatcher intentionally does not read ctx.signal: cancellation is
     // the inner function's responsibility (loaders/actions check signal in

--- a/packages/iso/src/internal/middleware-runner.ts
+++ b/packages/iso/src/internal/middleware-runner.ts
@@ -12,26 +12,48 @@ export type DispatchResult<T> =
   | { kind: 'ok'; value: T }
   | { kind: 'outcome'; outcome: Outcome };
 
-type ServerDispatchArgs<T, S extends Scope> = {
-  middleware: ReadonlyArray<ServerMiddleware<S>>;
-  ctx: ServerCtx<S>;
+// A dispatchable middleware is anything exposing the middleware `fn` contract:
+// it receives the (scope-specific) ctx plus `next`, and either awaits/returns
+// next() or short-circuits by throwing/returning an Outcome. ServerMiddleware<S>
+// and ClientMiddleware both satisfy this structurally, so one engine runs both.
+type Dispatchable<Ctx> = {
+  fn: (ctx: Ctx, next: Next) => Promise<void | Outcome>;
+};
+
+type DispatchArgs<Ctx, T> = {
+  middleware: ReadonlyArray<Dispatchable<Ctx>>;
+  ctx: Ctx;
   inner: () => Promise<T>;
 };
 
-export async function dispatchServer<T, S extends Scope = Scope>(
-  args: ServerDispatchArgs<T, S>
+/**
+ * Run an ordered middleware chain around `inner`, scope-agnostic.
+ *
+ * Each middleware must call `next()` exactly once (to pass control inward) or
+ * short-circuit by throwing/returning an Outcome. Outer middleware runs first
+ * on the way in and last on the way out (the Hono/Express/Koa convention). A
+ * thrown Outcome anywhere unwinds to `{ kind: 'outcome' }`; any other throw
+ * propagates. The inner value is threaded back out through the chain so
+ * `next()` returns it to each middleware and the top-level result carries it.
+ *
+ * `dispatchServer` / `dispatchClient` are thin scope-typed facades over this;
+ * keeping one engine means the chain semantics are written and tested once.
+ */
+export async function dispatch<Ctx, T>(
+  args: DispatchArgs<Ctx, T>
 ): Promise<DispatchResult<T>> {
-  let innerResult: T | undefined;
+  const { middleware, ctx, inner } = args;
 
-  const runChain = async (index: number): Promise<void> => {
-    if (index >= args.middleware.length) {
-      innerResult = await args.inner();
-      return;
-    }
-    const mw = args.middleware[index];
-    let nextCalled = false;
+  const runChain = async (index: number): Promise<T> => {
+    if (index >= middleware.length) return inner();
+    const mw = middleware[index];
+    // `downstream` doubles as the called-once guard: it is set exactly when
+    // next() runs (always to an object, so it stays truthy even when the inner
+    // value is falsy), and the `if (!downstream)` narrowing lets us return the
+    // threaded value as `T` with no cast.
+    let downstream: { value: T } | undefined;
     const next: Next = async () => {
-      if (nextCalled) {
+      if (downstream) {
         throw new Error(
           `Middleware at index ${index} called next() more than once. ` +
             `Each middleware must call next() exactly once: a second call ` +
@@ -39,33 +61,43 @@ export async function dispatchServer<T, S extends Scope = Scope>(
             `with the original ctx, producing duplicate side effects.`
         );
       }
-      nextCalled = true;
-      await runChain(index + 1);
-      return innerResult;
+      downstream = { value: await runChain(index + 1) };
+      return downstream.value;
     };
-    const ret = await mw.fn(args.ctx, next);
-    if (isOutcome(ret)) {
-      throw ret;
-    }
-    if (!nextCalled) {
+    const ret = await mw.fn(ctx, next);
+    if (isOutcome(ret)) throw ret;
+    if (!downstream) {
       throw new Error(
         `Middleware at index ${index} returned without calling next() or short-circuiting via a thrown outcome. ` +
           `Middleware must either: (a) await/return next() to pass control on, or (b) throw a redirect/deny/render outcome to short-circuit. ` +
           `Returning silently is ambiguous and would let downstream code run.`
       );
     }
+    return downstream.value;
   };
 
   try {
-    await runChain(0);
+    const value = await runChain(0);
+    return { kind: 'ok', value };
   } catch (thrown) {
     if (isOutcome(thrown)) {
       return { kind: 'outcome', outcome: thrown };
     }
     throw thrown;
   }
+}
 
-  return { kind: 'ok', value: innerResult as T };
+type ServerDispatchArgs<T, S extends Scope> = {
+  middleware: ReadonlyArray<ServerMiddleware<S>>;
+  ctx: ServerCtx<S>;
+  inner: () => Promise<T>;
+};
+
+/** Scope-typed server facade over {@link dispatch}. */
+export function dispatchServer<T, S extends Scope = Scope>(
+  args: ServerDispatchArgs<T, S>
+): Promise<DispatchResult<T>> {
+  return dispatch<ServerCtx<S>, T>(args);
 }
 
 type ClientDispatchArgs<T> = {
@@ -74,46 +106,9 @@ type ClientDispatchArgs<T> = {
   inner: () => Promise<T>;
 };
 
-export async function dispatchClient<T>(
+/** Page-scope client facade over {@link dispatch}. */
+export function dispatchClient<T>(
   args: ClientDispatchArgs<T>
 ): Promise<DispatchResult<T>> {
-  let innerResult: T | undefined;
-
-  const runChain = async (index: number): Promise<void> => {
-    if (index >= args.middleware.length) {
-      innerResult = await args.inner();
-      return;
-    }
-    const mw = args.middleware[index];
-    let nextCalled = false;
-    const next: Next = async () => {
-      if (nextCalled) {
-        throw new Error(
-          `Middleware at index ${index} called next() more than once. ` +
-            `Each middleware must call next() exactly once: a second call ` +
-            `would re-run the downstream chain (and the inner function) ` +
-            `with the original ctx, producing duplicate side effects.`
-        );
-      }
-      nextCalled = true;
-      await runChain(index + 1);
-      return innerResult;
-    };
-    const ret = await mw.fn(args.ctx, next);
-    if (isOutcome(ret)) throw ret;
-    if (!nextCalled) {
-      throw new Error(
-        `Middleware at index ${index} returned without calling next() or short-circuiting via a thrown outcome.`
-      );
-    }
-  };
-
-  try {
-    await runChain(0);
-  } catch (thrown) {
-    if (isOutcome(thrown)) return { kind: 'outcome', outcome: thrown };
-    throw thrown;
-  }
-
-  return { kind: 'ok', value: innerResult as T };
+  return dispatch<ClientPageCtx, T>(args);
 }

--- a/packages/server/src/__tests__/compose-server-chain.test.ts
+++ b/packages/server/src/__tests__/compose-server-chain.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defineServerMiddleware,
+  defineClientMiddleware,
+  defineStreamObserver,
+} from '@hono-preact/iso';
+import { composeServerChain } from '../compose-server-chain.js';
+
+const baseArgs = {
+  requestSignal: new AbortController().signal,
+  unitTimeoutMs: undefined as number | false | undefined,
+  defaultTimeoutMs: 30_000 as number | false,
+  appConfig: undefined,
+  resolvePageUse: async () => [] as ReadonlyArray<unknown>,
+  path: '/x',
+  unitUse: [] as ReadonlyArray<unknown>,
+};
+
+describe('composeServerChain', () => {
+  it('composes [app, page, unit] server middleware in outer->inner order', async () => {
+    const app = defineServerMiddleware<'action'>(async (_c, n) => {
+      await n();
+    });
+    const page = defineServerMiddleware<'action'>(async (_c, n) => {
+      await n();
+    });
+    const unit = defineServerMiddleware<'action'>(async (_c, n) => {
+      await n();
+    });
+    const { serverMw } = await composeServerChain<'action'>({
+      ...baseArgs,
+      appConfig: { use: [app] },
+      resolvePageUse: async () => [page],
+      unitUse: [unit],
+    });
+    expect(serverMw).toEqual([app, page, unit]);
+  });
+
+  it('keeps only runs===server middleware and partitions observers out', async () => {
+    const srv = defineServerMiddleware<'action'>(async (_c, n) => {
+      await n();
+    });
+    const cli = defineClientMiddleware(async (_c, n) => {
+      await n();
+    });
+    const obs = defineStreamObserver({});
+    const { serverMw, observers } = await composeServerChain<'action'>({
+      ...baseArgs,
+      unitUse: [srv, cli, obs],
+    });
+    expect(serverMw).toEqual([srv]); // client middleware filtered out of the server chain
+    expect(observers).toEqual([obs]); // observer partitioned out
+  });
+
+  it('derives the timeout: unit overrides default, false disables, signal combines', async () => {
+    const reqSignal = new AbortController().signal;
+
+    const withUnit = await composeServerChain<'loader'>({
+      ...baseArgs,
+      requestSignal: reqSignal,
+      unitTimeoutMs: 50,
+    });
+    expect(withUnit.resolvedTimeoutMs).toBe(50);
+    expect(withUnit.timeoutSignal).toBeInstanceOf(AbortSignal);
+    expect(withUnit.signal).not.toBe(reqSignal); // combined via AbortSignal.any
+
+    const withDefault = await composeServerChain<'loader'>({
+      ...baseArgs,
+      requestSignal: reqSignal,
+    });
+    expect(withDefault.resolvedTimeoutMs).toBe(30_000);
+
+    const disabled = await composeServerChain<'loader'>({
+      ...baseArgs,
+      requestSignal: reqSignal,
+      unitTimeoutMs: false,
+    });
+    expect(disabled.resolvedTimeoutMs).toBe(false);
+    expect(disabled.timeoutSignal).toBeUndefined();
+    expect(disabled.signal).toBe(reqSignal); // no timeout -> request signal passes through as-is
+  });
+});

--- a/packages/server/src/compose-server-chain.ts
+++ b/packages/server/src/compose-server-chain.ts
@@ -1,0 +1,97 @@
+import type {
+  AppConfig,
+  Middleware,
+  ServerMiddleware,
+  StreamObserver,
+  Scope,
+} from '@hono-preact/iso';
+import { partitionUse } from '@hono-preact/iso/internal';
+
+export interface ComposeServerChainArgs {
+  /** The incoming request's abort signal (`c.req.raw.signal`). */
+  requestSignal: AbortSignal;
+  /** The unit's own `timeoutMs` (a loader/action), or undefined to fall back. */
+  unitTimeoutMs: number | false | undefined;
+  /** Handler default timeout; `false` disables the default. */
+  defaultTimeoutMs: number | false;
+  /** App-level `use` from defineApp(); its `use` is the outermost layer. */
+  appConfig: AppConfig | undefined;
+  /** Page-layer `use` resolver, keyed by the matched route's path. */
+  resolvePageUse: (
+    path: string
+  ) => ReadonlyArray<unknown> | Promise<ReadonlyArray<unknown>>;
+  /** Matched route path passed to `resolvePageUse`. */
+  path: string;
+  /** The unit's own `use` (a loader's or action's), the innermost layer. */
+  unitUse: ReadonlyArray<unknown>;
+}
+
+export interface ComposedServerChain<S extends Scope> {
+  /** Server middleware in outer->inner order, ready for `dispatchServer`. */
+  serverMw: ReadonlyArray<ServerMiddleware<S>>;
+  /** Stream observers partitioned out of the chain, for the SSE responders. */
+  observers: ReadonlyArray<StreamObserver<unknown, never>>;
+  /** Effective timeout after folding the unit value over the default. */
+  resolvedTimeoutMs: number | false;
+  /** The timeout's signal, or undefined when timeouts are disabled. */
+  timeoutSignal: AbortSignal | undefined;
+  /** Request signal combined with the timeout signal (or the request signal). */
+  signal: AbortSignal;
+}
+
+/**
+ * Build the server-side execution context shared by the loader and action
+ * handlers: the timeout/abort signal, and the partitioned `use` chain in
+ * outer->inner order (`[appConfig.use, resolvePageUse(path), unitUse]`).
+ *
+ * Both handlers composed this identically; centralizing it keeps the chain
+ * ordering, the timeout-derivation rule, and the single `ReadonlyArray<unknown>`
+ * -> typed-element cast in one place. The cast sits at the structural-read
+ * boundary: page-level `use` and a unit's `use` are read off user-defined
+ * modules as `ReadonlyArray<unknown>`, so the concatenation infers `unknown[]`;
+ * we assert the known element type here, the one point the chain re-enters
+ * typed land. The `runs === 'server'` predicate narrows to the caller's scope
+ * `S` (the chain only carries that scope's middleware by construction).
+ *
+ * NOTE: framework-private; intended consumers are loadersHandler and
+ * pageActionHandler.
+ */
+export async function composeServerChain<S extends Scope = Scope>(
+  args: ComposeServerChainArgs
+): Promise<ComposedServerChain<S>> {
+  const {
+    requestSignal,
+    unitTimeoutMs,
+    defaultTimeoutMs,
+    appConfig,
+    resolvePageUse,
+    path,
+    unitUse,
+  } = args;
+
+  const resolvedTimeoutMs: number | false =
+    unitTimeoutMs !== undefined ? unitTimeoutMs : defaultTimeoutMs;
+  const timeoutSignal =
+    resolvedTimeoutMs === false
+      ? undefined
+      : AbortSignal.timeout(resolvedTimeoutMs);
+  const signal = timeoutSignal
+    ? AbortSignal.any([requestSignal, timeoutSignal])
+    : requestSignal;
+
+  // Chain order is outer -> inner: app-level wraps every request, page-level
+  // wraps the route's units, and the unit's own `use` wraps just this call.
+  const rootUse = appConfig?.use ?? [];
+  const pageUse = await resolvePageUse(path);
+  const fullUse: ReadonlyArray<Middleware | StreamObserver<unknown, never>> = [
+    ...rootUse,
+    ...pageUse,
+    ...unitUse,
+  ] as ReadonlyArray<Middleware | StreamObserver<unknown, never>>;
+  const { middleware: allMiddleware, observers } = partitionUse(fullUse);
+  const serverMw = allMiddleware.filter(
+    (m): m is ServerMiddleware<S> => m.runs === 'server'
+  );
+
+  return { serverMw, observers, resolvedTimeoutMs, timeoutSignal, signal };
+}

--- a/packages/server/src/loaders-handler.ts
+++ b/packages/server/src/loaders-handler.ts
@@ -3,16 +3,10 @@ import {
   isOutcome,
   timeoutOutcome,
   type AppConfig,
-  type ServerMiddleware,
   type ServerLoaderCtx,
-  type Middleware,
-  type StreamObserver,
 } from '@hono-preact/iso';
-import {
-  runRequestScope,
-  dispatchServer,
-  partitionUse,
-} from '@hono-preact/iso/internal';
+import { runRequestScope, dispatchServer } from '@hono-preact/iso/internal';
+import { composeServerChain } from './compose-server-chain.js';
 import { translateOutcomeForLoader } from './outcome-translation.js';
 import {
   sseGeneratorResponse,
@@ -230,36 +224,20 @@ export function loadersHandler(
       );
     }
 
-    const resolvedTimeoutMs: number | false =
-      entry.timeoutMs !== undefined ? entry.timeoutMs : defaultTimeoutMs;
-    const timeoutSignal =
-      resolvedTimeoutMs === false
-        ? undefined
-        : AbortSignal.timeout(resolvedTimeoutMs);
-    const signal = timeoutSignal
-      ? AbortSignal.any([c.req.raw.signal, timeoutSignal])
-      : c.req.raw.signal;
-
-    // Chain ordering is outer -> inner: app-level middleware wraps every
-    // request, page-level wraps loaders owned by that page, and per-loader
-    // middleware wraps just this call. Outer middleware runs first on the
-    // way in and last on the way out, matching every middleware system
-    // users have seen (Hono, Express, Koa).
-    const rootUse = appConfig?.use ?? [];
-    const pageUse = await resolvePageUse(validatedLocation.path);
-    // `pageUse` and `entry.use` arrive as ReadonlyArray<unknown>: page-level
-    // `use` and a loader's `use` are read structurally off user-defined modules
-    // (the sanctioned deserialization boundary), so the concatenation infers
-    // unknown[]. Assert the known element type here, the single point the chain
-    // re-enters typed land; page-action-handler carries the identical cast.
-    const fullUse: ReadonlyArray<Middleware | StreamObserver<unknown, never>> =
-      [...rootUse, ...pageUse, ...entry.use] as ReadonlyArray<
-        Middleware | StreamObserver<unknown, never>
-      >;
-    const { middleware: allMiddleware, observers } = partitionUse(fullUse);
-    const serverMw = allMiddleware.filter(
-      (m): m is ServerMiddleware<'loader'> => m.runs === 'server'
-    );
+    // Chain ordering is app (outermost) -> page (loaders owned by the route)
+    // -> per-loader (`use`); composeServerChain owns the ordering, timeout
+    // derivation, partitioning, and the structural-read cast (shared with the
+    // action handler).
+    const { serverMw, observers, resolvedTimeoutMs, timeoutSignal, signal } =
+      await composeServerChain<'loader'>({
+        requestSignal: c.req.raw.signal,
+        unitTimeoutMs: entry.timeoutMs,
+        defaultTimeoutMs,
+        appConfig,
+        resolvePageUse,
+        path: validatedLocation.path,
+        unitUse: entry.use,
+      });
     const ctx: ServerLoaderCtx = {
       scope: 'loader',
       c,

--- a/packages/server/src/page-action-handler.ts
+++ b/packages/server/src/page-action-handler.ts
@@ -3,19 +3,16 @@ import {
   isOutcome,
   timeoutOutcome,
   type AppConfig,
-  type ServerMiddleware,
   type ServerActionCtx,
-  type Middleware,
-  type StreamObserver,
 } from '@hono-preact/iso';
 import {
   runRequestScope,
   setActionResultSlot,
   dispatchServer,
-  partitionUse,
   serializeActionOutcome,
   type ActionResolution,
 } from '@hono-preact/iso/internal';
+import { composeServerChain } from './compose-server-chain.js';
 import {
   FORM_MODULE_FIELD,
   FORM_ACTION_FIELD,
@@ -188,38 +185,21 @@ export function pageActionHandler(
         : c.text(msg, 404);
     }
     const { fn, use: actionUse, timeoutMs } = entry;
-    const resolvedTimeoutMs: number | false =
-      timeoutMs !== undefined ? timeoutMs : defaultTimeoutMs;
-    const timeoutSignal =
-      resolvedTimeoutMs === false
-        ? undefined
-        : AbortSignal.timeout(resolvedTimeoutMs);
-    const signal = timeoutSignal
-      ? AbortSignal.any([c.req.raw.signal, timeoutSignal])
-      : c.req.raw.signal;
+    // Chain order is app (outermost) -> page (route-node `use`) -> action
+    // (defineAction's `use`); composeServerChain owns the ordering, timeout
+    // derivation, partitioning, and the structural-read cast (shared with the
+    // loader handler).
+    const { serverMw, observers, resolvedTimeoutMs, timeoutSignal, signal } =
+      await composeServerChain<'action'>({
+        requestSignal: c.req.raw.signal,
+        unitTimeoutMs: timeoutMs,
+        defaultTimeoutMs,
+        appConfig,
+        resolvePageUse: resolvePageUseByPath,
+        path: urlPath,
+        unitUse: actionUse,
+      });
     const actionCtx = { c, signal };
-
-    // Chain order: app-level (outermost) -> page-level (route-node `use`
-    // composed along the tree, supplied by `resolvePageUseByPath`) ->
-    // action-level (from defineAction's `use` option). Outer middleware runs
-    // first on the way in, last on the way out, matching the convention every
-    // middleware system users have seen (Hono, Express, Koa).
-    const rootUse = appConfig?.use ?? [];
-    const pageUse = await resolvePageUseByPath(urlPath);
-    // `pageUse` and `actionUse` arrive as ReadonlyArray<unknown>: page-level
-    // `use` and an action's `use` are read structurally off user-defined
-    // modules (the sanctioned deserialization boundary in makePageUseResolver
-    // and page-action-resolvers), so the concatenation infers unknown[].
-    // Assert the known element type here, the single point the chain re-enters
-    // typed land; loaders-handler carries the identical cast at the same boundary.
-    const fullUse: ReadonlyArray<Middleware | StreamObserver<unknown, never>> =
-      [...rootUse, ...pageUse, ...actionUse] as ReadonlyArray<
-        Middleware | StreamObserver<unknown, never>
-      >;
-    const { middleware: allMiddleware, observers } = partitionUse(fullUse);
-    const serverMw = allMiddleware.filter(
-      (m): m is ServerMiddleware<'action'> => m.runs === 'server'
-    );
     const ctx: ServerActionCtx = {
       scope: 'action',
       c,


### PR DESCRIPTION
## Summary

Items #3 and #4 from the framework code-quality comparison backlog (the "middleware dedup" cluster). No behavior change; pure dedup + a cast removal, on top of the merged #122.

### #3 — One generic dispatch engine
`dispatchServer<T,S>` and `dispatchClient<T>` were ~50 lines of near-verbatim chain-runner duplication, and `dispatchClient`'s copy of the next-once / forgotten-next / outcome-unwind logic had **no direct test**, so it could regress invisibly.

- Extracted one scope-agnostic `dispatch<Ctx, T>({ middleware, ctx, inner })` engine.
- `dispatchServer` / `dispatchClient` are now thin scope-typed facades that delegate to it, preserving the `ServerMiddleware<S>`/`ServerCtx<S>` vs `ClientMiddleware` typing at all six call sites (zero call-site churn).
- Reshaped `runChain` to **return** the inner value through a `{ value }` box the type narrows, removing the `innerResult as T` cast in both.
- Added direct tests for the generic engine and for `dispatchClient` (closing the untested path); the existing `dispatchServer` suite exercises the shared engine unchanged.

### #4 — `composeServerChain`
`pageActionHandler` and `loadersHandler` composed the server execution context with a verbatim block: timeout/abort-signal derivation, the `[app, page, unit]` use ordering, `partitionUse`, and the `runs === 'server'` filter (plus the identical `ReadonlyArray<unknown>` -> typed-element cast at the structural-read boundary).

- Extracted `composeServerChain<S extends Scope>(...)` -> `{ serverMw, observers, resolvedTimeoutMs, timeoutSignal, signal }` as the single home for that logic.
- Each handler keeps only its scope-specific ctx construction, dispatch, and response handling.
- The `runs === 'server'` predicate and the boundary cast are **relocated, not added to** (no new casts).

## Test plan
Full local CI gate, all green:
- `build` / `format:check` / `typecheck` (noUnusedLocals confirms the now-dead imports were removed)
- `test` (1432 passed) / `test:integration` (4 passed) / `site build`

New tests: `dispatch` generic engine + `dispatchClient` facade (`middleware-runner.test.ts`); `composeServerChain` ordering / server-filter / timeout derivation (`compose-server-chain.test.ts`). All pre-existing handler and middleware-chain tests stay green, which is the behavior-preservation net for a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
