### PR TITLE
feat(iso): type-level tests for typed-routes + hyphenated-param soundness fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # Type-level tests (`*.test-d.ts`) — tsc enforces the typed-routes /
+      # serialization type assertions that the package `tsconfig`s exclude.
+      - name: Type tests
+        run: pnpm test:types
+
       - name: Run tests with coverage
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      # Type-level tests (`*.test-d.ts`) — tsc enforces the typed-routes /
-      # serialization type assertions that the package `tsconfig`s exclude.
+      # Type-level tests (`*.test-d.ts`) — tsc enforces the type assertions
+      # (typed-routes today) that the package `tsconfig`s exclude from typecheck.
       - name: Type tests
         run: pnpm test:types
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,14 @@ The CI pipeline lives in `.github/workflows/ci.yml`. Mirror it locally:
 1. `pnpm --filter '@hono-preact/*' --filter hono-preact --filter hono-preact-ui build` (framework dist must be current; `pnpm typecheck` and `apps/site` resolve cross-package types through the published `dist/`, so stale dist surfaces as fake "missing export" errors).
 2. `pnpm format:check`
 3. `pnpm typecheck`
-4. `pnpm test:coverage` (or `pnpm test` if coverage isn't needed locally).
-5. `pnpm test:integration`
-6. `pnpm --filter site build`
+4. `pnpm test:types` (vitest typecheck mode; runs the `*.test-d.ts` type-level assertions that the package `tsconfig`s exclude from `pnpm typecheck`).
+5. `pnpm test:coverage` (or `pnpm test` if coverage isn't needed locally).
+6. `pnpm test:integration`
+7. `pnpm --filter site build`
 
-If `format:check` fails, run `pnpm format` to fix and commit the result. Do not push commits that you have not personally seen pass these six steps. The single biggest miss is `format:check`, which is fast to run and trivially fixable, but reliably forgotten.
+If `format:check` fails, run `pnpm format` to fix and commit the result. Do not push commits that you have not personally seen pass these seven steps. The single biggest miss is `format:check`, which is fast to run and trivially fixable, but reliably forgotten.
 
-Lighthouse runs in **CI only** and is deliberately **not** part of the six steps above (it builds, serves the worker with `wrangler dev`, and drives Chrome, far too slow for a pre-push gate). The PR-only `lighthouse` job posts a soft sticky comment; the `main` push job commits the `lighthouse-report.json` / `lighthouse-history.jsonl` / `lighthouse-badge.json` baselines alongside the client-size ones. Tooling: `@lhci/cli` (root devDependency); config in `.lighthouserc.json`; extraction and rendering in `scripts/measure-lighthouse.mjs` and `scripts/render-lighthouse-comment.mjs` (unit-tested under `scripts/__tests__/`). The LHCI flow needs two uploads: `temporary-public-storage` (hosted report links) and `filesystem` (writes the `.lighthouseci/manifest.json` the extractor parses).
+Lighthouse runs in **CI only** and is deliberately **not** part of the seven steps above (it builds, serves the worker with `wrangler dev`, and drives Chrome, far too slow for a pre-push gate). The PR-only `lighthouse` job posts a soft sticky comment; the `main` push job commits the `lighthouse-report.json` / `lighthouse-history.jsonl` / `lighthouse-badge.json` baselines alongside the client-size ones. Tooling: `@lhci/cli` (root devDependency); config in `.lighthouserc.json`; extraction and rendering in `scripts/measure-lighthouse.mjs` and `scripts/render-lighthouse-comment.mjs` (unit-tested under `scripts/__tests__/`). The LHCI flow needs two uploads: `temporary-public-storage` (hosted report links) and `filesystem` (writes the `.lighthouseci/manifest.json` the extractor parses).
 
 ## PR workflow
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:types": "vitest run --typecheck.only",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "pnpm -r exec tsc --noEmit",
     "format": "prettier --write \"packages/**/*.{ts,tsx,js,mjs,json}\" \"apps/**/src/**/*.{ts,tsx,mdx}\"",
@@ -32,6 +33,7 @@
     "esbuild": "^0.27.0",
     "happy-dom": "^20.9.0",
     "prettier": "^3.8.3",
+    "typescript": "*",
     "vitest": "^4.1.4"
   }
 }

--- a/packages/iso/src/__tests__/build-path.test.ts
+++ b/packages/iso/src/__tests__/build-path.test.ts
@@ -38,4 +38,17 @@ describe('buildPath', () => {
   it('returns the root path unchanged', () => {
     expect(buildPath('/')).toBe('/');
   });
+
+  // A `:name` whose name falls outside `[A-Za-z0-9_]` (e.g. a hyphen) is not a
+  // param: the matcher keeps the segment verbatim. The type agrees
+  // (`RouteParams<'/x/:foo-bar'>` is `{}`), so no params object is required —
+  // before that alignment this call would not have compiled. See typed-routes
+  // `IsParamName` and typed-routes.test-d.ts.
+  it('keeps a hyphenated :param segment verbatim (it is a literal, not a param)', () => {
+    expect(buildPath('/x/:foo-bar')).toBe('/x/:foo-bar');
+  });
+
+  it('substitutes a valid sibling param while keeping a hyphenated literal', () => {
+    expect(buildPath('/x/:foo-bar/y/:id', { id: '7' })).toBe('/x/:foo-bar/y/7');
+  });
 });

--- a/packages/iso/src/internal/__tests__/typed-routes.test-d.ts
+++ b/packages/iso/src/internal/__tests__/typed-routes.test-d.ts
@@ -27,6 +27,13 @@ expectTypeOf<RouteParams<'/files/:rest*'>>().toEqualTypeOf<{ rest?: string }>();
 // Rest `:param+` is required (one-or-more).
 expectTypeOf<RouteParams<'/files/:rest+'>>().toEqualTypeOf<{ rest: string }>();
 
+// The full `[A-Za-z0-9_]` name class is accepted: underscores, digits, and
+// uppercase are all valid param-name characters. These guard `ParamNameChar`
+// against an accidental omission that would silently demote a real param to a
+// literal (the inverse of the #8 over-claim bug fixed below).
+expectTypeOf<RouteParams<'/u/:user_id'>>().toEqualTypeOf<{ user_id: string }>();
+expectTypeOf<RouteParams<'/v/:id2'>>().toEqualTypeOf<{ id2: string }>();
+
 // Multiple params compose. The engine builds the object by intersecting each
 // segment's contribution (`ParamFrom<P> & RouteParams<Rest>`), so the result
 // is the intersection form, not a single merged object literal.
@@ -138,5 +145,7 @@ expectTypeOf<RoutePaths<{ __tree: SampleTree }>>().toEqualTypeOf<
   AbsolutePaths<SampleTree>
 >();
 
-// A path outside the computed union is not a member.
-expectTypeOf<'/not/a/route'>().not.toEqualTypeOf<RoutePaths<SampleTree>>();
+// A path outside the computed union is not a member. `not.toExtend` is the
+// load-bearing form: if `RoutePaths` ever regressed to the bare `string`
+// fallback, '/not/a/route' WOULD extend it and this assertion would fail.
+expectTypeOf<'/not/a/route'>().not.toExtend<RoutePaths<SampleTree>>();

--- a/packages/iso/src/internal/__tests__/typed-routes.test-d.ts
+++ b/packages/iso/src/internal/__tests__/typed-routes.test-d.ts
@@ -1,0 +1,142 @@
+// Type-level tests for the typed-routes engine. Run under `pnpm test:types`
+// (`vitest --typecheck.only`); tsc is the oracle, so a regression in the
+// conditional/template-literal types here fails the build. These assert the
+// engine in isolation against small synthetic trees; the app-level companion
+// (`apps/site/src/typed-route-params.assert.ts`) exercises the same engine
+// against the real registered tree.
+import { expectTypeOf } from 'vitest';
+import type {
+  RouteParams,
+  AbsolutePaths,
+  RoutePaths,
+} from '../typed-routes.js';
+
+// ---------------------------------------------------------------------------
+// RouteParams — modifier matrix
+// ---------------------------------------------------------------------------
+
+// Required `:param`.
+expectTypeOf<RouteParams<'/posts/:id'>>().toEqualTypeOf<{ id: string }>();
+
+// Optional `:param?` — the key is optional, not `string | undefined` required.
+expectTypeOf<RouteParams<'/files/:id?'>>().toEqualTypeOf<{ id?: string }>();
+
+// Rest `:param*` is optional (zero-or-more).
+expectTypeOf<RouteParams<'/files/:rest*'>>().toEqualTypeOf<{ rest?: string }>();
+
+// Rest `:param+` is required (one-or-more).
+expectTypeOf<RouteParams<'/files/:rest+'>>().toEqualTypeOf<{ rest: string }>();
+
+// Multiple params compose. The engine builds the object by intersecting each
+// segment's contribution (`ParamFrom<P> & RouteParams<Rest>`), so the result
+// is the intersection form, not a single merged object literal.
+expectTypeOf<
+  RouteParams<'/demo/projects/:projectId/tasks/:taskId'>
+>().toEqualTypeOf<{ projectId: string } & { taskId: string }>();
+
+// A required param followed by an optional one.
+expectTypeOf<RouteParams<'/a/:x/b/:y?'>>().toEqualTypeOf<
+  { x: string } & { y?: string }
+>();
+
+// Param-less patterns (including the root) yield the empty object.
+expectTypeOf<RouteParams<'/docs/components'>>().toEqualTypeOf<{}>();
+expectTypeOf<RouteParams<'/'>>().toEqualTypeOf<{}>();
+
+// ---------------------------------------------------------------------------
+// #8 — hyphenated (and other non-`[A-Za-z0-9_]`) param names are LITERALS.
+//
+// `build-path.ts` (and preact-iso's matcher) only recognize `:name` where name
+// is `[A-Za-z0-9_]+`; `:foo-bar` does not match its `^:([A-Za-z0-9_]+)[?*+]?$`
+// regex, so the runtime keeps the segment verbatim and substitutes nothing.
+// The type grammar must agree: a hyphenated segment contributes NO param,
+// rather than over-claiming a required `foo-bar`. (Written before the fix as
+// the TDD-red cases.)
+// ---------------------------------------------------------------------------
+
+// A lone hyphenated segment yields no params (the segment is a literal).
+expectTypeOf<RouteParams<'/x/:foo-bar'>>().toEqualTypeOf<{}>();
+
+// A hyphenated segment is skipped, but a valid sibling param survives.
+expectTypeOf<RouteParams<'/x/:foo-bar/y/:id'>>().toEqualTypeOf<{
+  id: string;
+}>();
+
+// A dotted name is equally invalid -> literal.
+expectTypeOf<RouteParams<'/x/:a.b'>>().toEqualTypeOf<{}>();
+
+// ---------------------------------------------------------------------------
+// AbsolutePaths — join, layout-group nesting, the `/`-reset, and the
+// type-invisibility of a non-tuple (runtime-spread) tail.
+// ---------------------------------------------------------------------------
+
+// view/layout key presence is read structurally; values are irrelevant.
+type SampleTree = readonly [
+  { readonly path: '/'; readonly view: unknown },
+  { readonly path: '/about'; readonly view: unknown },
+  {
+    readonly path: '/blog';
+    readonly layout: unknown;
+    readonly children: readonly [
+      // index child (`path: ''`) inherits the parent path verbatim
+      { readonly path: ''; readonly view: unknown },
+      // dynamic child joins under the layout
+      { readonly path: ':slug'; readonly view: unknown },
+      // catch-all child
+      { readonly path: '*'; readonly view: unknown },
+    ];
+  },
+];
+
+expectTypeOf<AbsolutePaths<SampleTree>>().toEqualTypeOf<
+  '/' | '/about' | '/blog' | '/blog/:slug' | '/blog/*'
+>();
+
+// A layout/grouping node at `/` resets the child parent to '' so children do
+// not pick up a `//` prefix (mirrors `here === '/' ? '' : here`).
+type RootGroupTree = readonly [
+  {
+    readonly path: '/';
+    readonly layout: unknown;
+    readonly children: readonly [
+      { readonly path: 'about'; readonly view: unknown },
+    ];
+  },
+];
+expectTypeOf<AbsolutePaths<RootGroupTree>>().toEqualTypeOf<'/' | 'about'>();
+
+// A pure grouping node (no view, no layout) contributes only its descendants,
+// never its own path.
+type GroupOnlyTree = readonly [
+  {
+    readonly path: 'group';
+    readonly children: readonly [
+      { readonly path: 'leaf'; readonly view: unknown },
+    ];
+  },
+];
+expectTypeOf<AbsolutePaths<GroupOnlyTree>>().toEqualTypeOf<'group/leaf'>();
+
+// A non-tuple (runtime-spread, e.g. `contentRoutes(import.meta.glob(...))`)
+// tail is type-invisible: it contributes `never`, never widening the union.
+type SpreadTree = readonly [
+  { readonly path: '/x'; readonly view: unknown },
+  ...{ readonly path: string; readonly view: unknown }[],
+];
+expectTypeOf<AbsolutePaths<SpreadTree>>().toEqualTypeOf<'/x'>();
+
+// ---------------------------------------------------------------------------
+// RoutePaths — accepts both the route-tree array and a `{ __tree }` manifest,
+// and resolves to the same union as AbsolutePaths over the tree.
+// ---------------------------------------------------------------------------
+
+expectTypeOf<RoutePaths<SampleTree>>().toEqualTypeOf<
+  '/' | '/about' | '/blog' | '/blog/:slug' | '/blog/*'
+>();
+
+expectTypeOf<RoutePaths<{ __tree: SampleTree }>>().toEqualTypeOf<
+  AbsolutePaths<SampleTree>
+>();
+
+// A path outside the computed union is not a member.
+expectTypeOf<'/not/a/route'>().not.toEqualTypeOf<RoutePaths<SampleTree>>();

--- a/packages/iso/src/internal/typed-routes.ts
+++ b/packages/iso/src/internal/typed-routes.ts
@@ -74,30 +74,30 @@ type IsParamName<S extends string> = S extends ''
       : false
     : false;
 
-type ParamKey<Seg extends string> = Seg extends `${infer Name}?`
-  ? IsParamName<Name> extends true
-    ? { optional: true; name: Name }
-    : { literal: true }
+// Strip a single trailing `?`/`*`/`+` modifier (the runtime regex allows one),
+// recording optionality: `?` and `*` are optional, `+` and a bare name are
+// required. The name itself is validated separately by `IsParamName`.
+type StripModifier<Seg extends string> = Seg extends `${infer Name}?`
+  ? { name: Name; optional: true }
   : Seg extends `${infer Name}*`
-    ? IsParamName<Name> extends true
-      ? { optional: true; name: Name }
-      : { literal: true }
+    ? { name: Name; optional: true }
     : Seg extends `${infer Name}+`
-      ? IsParamName<Name> extends true
-        ? { optional: false; name: Name }
-        : { literal: true }
-      : IsParamName<Seg> extends true
-        ? { optional: false; name: Seg }
-        : { literal: true };
+      ? { name: Name; optional: false }
+      : { name: Seg; optional: false };
 
-// A segment that is not a valid param name resolves to `{ literal: true }`,
-// which fails the `{ name; optional }` match and contributes the empty object
-// (identity under the `&` in `RouteParams`).
+// Map a `:`-stripped segment to its param contribution. A name outside the
+// `[A-Za-z0-9_]` class is a literal: it contributes the empty object (the
+// identity under the `&` in `RouteParams`) rather than over-claiming a param.
 type ParamFrom<Seg extends string> =
-  ParamKey<Seg> extends { name: infer N extends string; optional: infer O }
-    ? O extends true
-      ? { [K in N]?: string }
-      : { [K in N]: string }
+  StripModifier<Seg> extends {
+    name: infer Name extends string;
+    optional: infer Optional;
+  }
+    ? IsParamName<Name> extends true
+      ? Optional extends true
+        ? { [K in Name]?: string }
+        : { [K in Name]: string }
+      : {}
     : {};
 
 /** Extract the path-params object type from an absolute route pattern. */

--- a/packages/iso/src/internal/typed-routes.ts
+++ b/packages/iso/src/internal/typed-routes.ts
@@ -44,20 +44,61 @@ export type AbsolutePaths<
 
 // Param extraction. Handles required `:id`, optional `:id?`, and the preact-iso
 // modifier suffixes `*` / `+`. A pattern with no `:param` yields `{}`.
-type ParamKey<Seg extends string> = Seg extends `${infer Name}?`
-  ? { optional: true; name: Name }
-  : Seg extends `${infer Name}*`
-    ? { optional: true; name: Name }
-    : Seg extends `${infer Name}+`
-      ? { optional: false; name: Name }
-      : { optional: false; name: Seg };
+//
+// The runtime matcher (`build-path.ts`, and preact-iso's `exec`) only treats a
+// segment as a param when it is `:name` where `name` matches `[A-Za-z0-9_]+`,
+// optionally followed by a single `?`/`*`/`+` modifier and nothing else. A
+// segment like `:foo-bar` or `:a.b` does NOT match, so the runtime keeps it as
+// a literal and substitutes nothing. `ParamNameChar` / `IsParamName` mirror
+// that character class so the type grammar agrees: a name outside the class
+// makes the segment a literal that contributes no param, rather than
+// over-claiming a required `foo-bar` the runtime would silently ignore.
+// prettier-ignore
+type ParamNameChar =
+  | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm'
+  | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
+  | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M'
+  | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
+  | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
+  | '_';
 
+// True iff `S` is a non-empty string of `[A-Za-z0-9_]` (the `+` in the runtime
+// regex requires at least one character).
+type IsParamName<S extends string> = S extends ''
+  ? false
+  : S extends `${infer Char}${infer Rest}`
+    ? Char extends ParamNameChar
+      ? Rest extends ''
+        ? true
+        : IsParamName<Rest>
+      : false
+    : false;
+
+type ParamKey<Seg extends string> = Seg extends `${infer Name}?`
+  ? IsParamName<Name> extends true
+    ? { optional: true; name: Name }
+    : { literal: true }
+  : Seg extends `${infer Name}*`
+    ? IsParamName<Name> extends true
+      ? { optional: true; name: Name }
+      : { literal: true }
+    : Seg extends `${infer Name}+`
+      ? IsParamName<Name> extends true
+        ? { optional: false; name: Name }
+        : { literal: true }
+      : IsParamName<Seg> extends true
+        ? { optional: false; name: Seg }
+        : { literal: true };
+
+// A segment that is not a valid param name resolves to `{ literal: true }`,
+// which fails the `{ name; optional }` match and contributes the empty object
+// (identity under the `&` in `RouteParams`).
 type ParamFrom<Seg extends string> =
-  ParamKey<Seg> extends { optional: infer O; name: infer N extends string }
+  ParamKey<Seg> extends { name: infer N extends string; optional: infer O }
     ? O extends true
       ? { [K in N]?: string }
       : { [K in N]: string }
-    : never;
+    : {};
 
 /** Extract the path-params object type from an absolute route pattern. */
 export type RouteParams<Path extends string> =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.21.0))

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "packages/**/src/**/__tests__/**/*.test-d.ts",
+    "packages/**/src/**/__tests__/**/*.test-d.tsx"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -90,6 +90,16 @@ export default defineConfig({
       'apps/site/src/**/__tests__/**/*.test.{ts,tsx}',
       'scripts/__tests__/**/*.test.mjs',
     ],
+    // Type-level tests (`*.test-d.ts`) assert on conditional/template-literal
+    // types via `expectTypeOf`/`@ts-expect-error`. They run ONLY under
+    // `pnpm test:types` (`vitest --typecheck.only`), never on the hot `pnpm
+    // test` path, and tsc enforces the assertions so a type regression fails
+    // the build. They live beside runtime tests under `__tests__/` (which the
+    // package `tsconfig`s exclude from emit), so nothing leaks into `dist/`.
+    typecheck: {
+      include: ['packages/**/src/**/__tests__/**/*.test-d.{ts,tsx}'],
+      tsconfig: './tsconfig.typecheck.json',
+    },
     // websocket-dev.test.ts boots real Vite dev servers (and workerd); it is
     // CPU-heavy and starves the parallel pool. It runs separately via
     // `pnpm test:integration` (vitest.integration.config.ts).


### PR DESCRIPTION
Implements items **#5** (type-level tests for the typed-routes engine) and **#8** (hyphenated-param soundness) from the framework quality-comparison backlog (`docs/superpowers/research/2026-06-18-framework-quality-comparison.md`).

## Why

The report's clearest maturity gap vs React Router / SvelteKit was that the headline typed-routes engine had **zero** type-level coverage. Investigating, the gap was bigger than "add a test file": **nothing in this repo enforced type-level assertions at all**. Every package `tsconfig` excludes `src/**/__tests__/**`, so `pnpm typecheck` never sees test files, vitest typecheck mode was off, and esbuild strips `@ts-expect-error` at transform time. The existing `@ts-expect-error` "guards" in `define-loader.test.ts` / `define-page.test.tsx` were effectively dead. So #5 had to stand up the enforcement mechanism first.

## What

**Enforcement infra (vitest typecheck, dedicated step):**
- `vitest.config.ts` `test.typecheck` over `*.test-d.ts`, a `tsconfig.typecheck.json`, and a `test:types` script (`vitest --typecheck.only`). Type tests live under `__tests__/` (so they never leak into published `dist/`) and run only under `test:types`, never on the hot `pnpm test` path.
- Added `typescript` to **root** devDependencies. Root had none, so `pnpm exec`/vitest's typechecker fell back to a stray **4.9.4** that predates `moduleResolution: bundler`; this pins root to the **6.0.3** the packages and `pnpm typecheck` already resolve via `"*"`.
- CI: new **Type tests** step after Typecheck. CLAUDE.md pre-push list 6 → 7 steps.

**Engine type-tests** (`packages/iso/src/internal/__tests__/typed-routes.test-d.ts`):
- `RouteParams`: required / optional `?` / star `*` / plus `+` modifiers, multi-param composition, param-less + root.
- `AbsolutePaths`: join semantics, layout-group nesting, the `/`-reset (no `//` prefix), and the type-invisibility of a non-tuple runtime spread (`contentRoutes(import.meta.glob(...))` contributes `never`).
- `RoutePaths`: both the route-tree array and a `{ __tree }` manifest resolve to the same union; a bogus path is not a member.

These complement the app-level `apps/site/src/typed-route-params.assert.ts` (which exercises the real registered tree); the new file pins the engine in isolation.

**#8 soundness fix** (`packages/iso/src/internal/typed-routes.ts`):
- `RouteParams` now mirrors the runtime `[A-Za-z0-9_]` param-name class (new `IsParamName`), so `:foo-bar` / `:a.b` type as **literals contributing no param**, instead of over-claiming a required `foo-bar` that `buildPath`'s `^:([A-Za-z0-9_]+)[?*+]?$` matcher silently ignores. Verified red→green against the new harness.
- Runtime witness in `build-path.test.ts`: `buildPath('/x/:foo-bar')` now compiles with no params and stays verbatim (it could not even compile before, since the type demanded a `foo-bar` param).

## Verification

All seven pre-push steps pass locally: build, format:check, typecheck, **test:types**, test:coverage (1465 passed), test:integration (4 passed), site build (confirms the `RouteParams` change is consumer-safe).

## Follow-up (not in this PR)

The dead `@ts-expect-error` guards in `define-loader.test.ts` / `define-page.test.tsx` could now be migrated to enforced `*.test-d.ts` assertions. Worth a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)