### PR TITLE
feat(iso): model wire serialization with Serialize<T> at the loader/action boundary

### DIFF
--- a/apps/site/src/pages/docs/loaders.mdx
+++ b/apps/site/src/pages/docs/loaders.mdx
@@ -19,6 +19,8 @@ A page is a file pair:
 2. **Hydration (first load):** the client reads that embedded data. No fetch is fired.
 3. **Client-side navigation:** the Vite plugin replaces the `serverLoaders` import with a Proxy stub. Accessing `serverLoaders.name` returns a `LoaderRef` whose RPC stub POSTs `{ module, loader, location }` to `POST /__loaders`. The server runs the real function and returns JSON.
 
+Because every value crosses this boundary as JSON, the client receives the _serialized_ shape of a loader's return, not the server-side type. The data hooks reflect that honestly: `loader.useData()` and the `.View()` render argument are typed `Serialize<T>`, the JSON round-trip of the loader's return `T`. A `Date` field is therefore typed (and arrives) as a `string`; values JSON cannot carry (functions, `bigint`, symbols) are dropped, or surface as `never` so a non-serializable return is a compile error. The same `Serialize<T>` applies to action results (`useAction().data`, `<Form onSuccess>`, `useActionResult()`).
+
 ## The `serverLoaders` container
 
 Loaders are exported in a named container symmetric with `serverActions`. Every `.server.*` file uses this shape, whether it has one loader or many:

--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -10,6 +10,7 @@ import {
   type StoredActionResult,
 } from './internal/action-result-store.js';
 import { decodeActionResponse } from './internal/action-envelope.js';
+import type { Serialize } from './internal/serialize.js';
 import { FORM_MODULE_FIELD, FORM_ACTION_FIELD } from './internal/contract.js';
 
 export type ActionStub<TPayload, TResult, TChunk = never> = {
@@ -136,7 +137,8 @@ type UseActionOptionsCommon<TChunk = never> = {
    * See `/docs/reloading` for the full mental model.
    */
   invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
-  onChunk?: (chunk: TChunk) => void;
+  // Chunks arrive over the wire as JSON, so the client sees `Serialize<TChunk>`.
+  onChunk?: (chunk: Serialize<TChunk>) => void;
 };
 
 /**
@@ -148,7 +150,7 @@ type UseActionWithMutate<TPayload, TResult, TChunk, TSnapshot> =
   UseActionOptionsCommon<TChunk> & {
     onMutate: (payload: TPayload) => TSnapshot;
     onError?: (err: Error, snapshot: TSnapshot) => void;
-    onSuccess?: (data: TResult, snapshot: TSnapshot) => void;
+    onSuccess?: (data: Serialize<TResult>, snapshot: TSnapshot) => void;
   };
 
 /**
@@ -159,7 +161,7 @@ type UseActionWithoutMutate<TResult, TChunk> =
   UseActionOptionsCommon<TChunk> & {
     onMutate?: undefined;
     onError?: (err: Error) => void;
-    onSuccess?: (data: TResult) => void;
+    onSuccess?: (data: Serialize<TResult>) => void;
   };
 
 /**
@@ -188,14 +190,14 @@ export type UseActionOptions<
  *   written to the hook's `error` state and passed to `onError`.
  */
 export type MutateResult<TResult> =
-  | { ok: true; data: TResult | undefined }
+  | { ok: true; data: Serialize<TResult> | undefined }
   | { ok: false; error: Error };
 
 export type UseActionResult<TPayload, TResult> = {
   mutate: (payload: TPayload) => Promise<MutateResult<TResult>>;
   pending: boolean;
   error: Error | null;
-  data: TResult | null;
+  data: Serialize<TResult> | null;
 };
 
 function recordOutcome(
@@ -225,7 +227,9 @@ export function useAction<
 ): UseActionResult<TPayload, TResult> {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const [data, setData] = useState<TResult | null>(null);
+  // The hook surfaces the wire value (`Serialize<TResult>`), not the
+  // server-side `TResult`: the result was JSON round-tripped to reach here.
+  const [data, setData] = useState<Serialize<TResult> | null>(null);
   const applyInvalidate = useInvalidate();
 
   const stubRef = useRef(stub);
@@ -249,12 +253,12 @@ export function useAction<
         | {
             kind: 'with-mutate';
             snapshot: TSnapshot;
-            onSuccess?: (data: TResult, snapshot: TSnapshot) => void;
+            onSuccess?: (data: Serialize<TResult>, snapshot: TSnapshot) => void;
             onError?: (err: Error, snapshot: TSnapshot) => void;
           }
         | {
             kind: 'without-mutate';
-            onSuccess?: (data: TResult) => void;
+            onSuccess?: (data: Serialize<TResult>) => void;
             onError?: (err: Error) => void;
           };
 
@@ -271,7 +275,7 @@ export function useAction<
             onError: currentOptions?.onError,
           };
 
-      const invokeSuccess = (data: TResult) => {
+      const invokeSuccess = (data: Serialize<TResult>) => {
         if (callbacks.kind === 'with-mutate') {
           callbacks.onSuccess?.(data, callbacks.snapshot);
         } else {
@@ -291,7 +295,7 @@ export function useAction<
           ? window.location.pathname + window.location.search
           : '/';
 
-      let finalResult: TResult | undefined;
+      let finalResult: Serialize<TResult> | undefined;
       // Tracks whether a branch has already written to the action-result store.
       // The outer catch writes for unclassified errors (network failures, parse
       // errors) only when no branch has already recorded the outcome.
@@ -339,18 +343,20 @@ export function useAction<
         const contentType = response.headers.get('Content-Type') ?? '';
         if (contentType.includes('text/event-stream') && response.body) {
           const { readSSE } = await import('./internal/sse-decoder.js');
-          let resultValue: TResult | undefined;
+          let resultValue: Serialize<TResult> | undefined;
           let streamError: Error | null = null;
           for await (const ev of readSSE(response.body)) {
             if (ev.event === 'message') {
               try {
-                currentOptions?.onChunk?.(JSON.parse(ev.data) as TChunk);
+                currentOptions?.onChunk?.(
+                  JSON.parse(ev.data) as Serialize<TChunk>
+                );
               } catch {
                 // malformed JSON in stream: skip
               }
             } else if (ev.event === 'result') {
               try {
-                resultValue = JSON.parse(ev.data) as TResult;
+                resultValue = JSON.parse(ev.data) as Serialize<TResult>;
               } catch (e) {
                 streamError = new Error(
                   `Malformed result event in stream: ${e instanceof Error ? e.message : String(e)}`
@@ -416,7 +422,7 @@ export function useAction<
             throw new Error(`Malformed envelope (HTTP ${decoded.httpStatus})`);
           }
           if (decoded.kind === 'success') {
-            const data = decoded.data as TResult;
+            const data = decoded.data as Serialize<TResult>;
             setData(data);
             invokeSuccess(data);
             finalResult = data;

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -8,6 +8,7 @@ import { useContext } from 'preact/hooks';
 import type { Context } from 'hono';
 import type { RouteHook } from 'preact-iso';
 import type { RegisteredPaths, RouteParams } from './internal/typed-routes.js';
+import type { Serialize } from './internal/serialize.js';
 import { createCache, type LoaderCache } from './cache.js';
 import { LoaderDataContext, LoaderErrorContext } from './internal/contexts.js';
 import { Loader as LoaderHost } from './internal/loader.js';
@@ -49,7 +50,12 @@ export interface LoaderRef<T> {
    * advertised at the consumer rather than hidden behind `unknown`.
    */
   readonly use: ReadonlyArray<Middleware | StreamObserver<unknown, never>>;
-  useData(): T;
+  /**
+   * The loader's data as the client receives it: `Serialize<T>`, the JSON
+   * round-trip of the server-side return `T` (e.g. a `Date` field arrives as a
+   * string). Typing this as `T` would be a lie on the client/hydration path.
+   */
+  useData(): Serialize<T>;
   useError(): Error | null;
   invalidate(): void;
   Boundary: ComponentType<{
@@ -61,7 +67,7 @@ export interface LoaderRef<T> {
   }>;
   View<P extends Record<string, unknown> = {}>(
     render: (
-      args: P & { data: T; error: Error | null; reload: () => void }
+      args: P & { data: Serialize<T>; error: Error | null; reload: () => void }
     ) => ComponentChildren,
     opts?: {
       fallback?: ComponentChildren;

--- a/packages/iso/src/form.tsx
+++ b/packages/iso/src/form.tsx
@@ -12,6 +12,7 @@ import { setLastActionResult } from './internal/action-result-store.js';
 import { assignSafeRedirect } from './internal/safe-redirect.js';
 import { decodeActionResponse } from './internal/action-envelope.js';
 import type { LoaderRef } from './define-loader.js';
+import type { Serialize } from './internal/serialize.js';
 import { useInvalidate } from './use-invalidate.js';
 
 /**
@@ -31,7 +32,7 @@ export type FormProps<TPayload, TResult> = Omit<
   action: FormActionInput<TPayload, TResult>;
   children?: ComponentChildren;
   onSuccess?: (
-    data: TResult,
+    data: Serialize<TResult>,
     helpers: { reset: (fields?: string[]) => void }
   ) => void;
   onError?: (err: Error) => void;
@@ -166,7 +167,7 @@ export function Form<TPayload, TResult>({
               data: decoded.data,
               submittedPayload: payload,
             });
-            lifecycle.current.onSuccess?.(decoded.data as TResult, {
+            lifecycle.current.onSuccess?.(decoded.data as Serialize<TResult>, {
               reset: resetForm,
             });
             applyInvalidate(lifecycle.current.invalidate);

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -29,6 +29,7 @@ export type {
   RoutePaths,
   RegisteredRoutes,
 } from './internal/typed-routes.js';
+export type { Serialize } from './internal/serialize.js';
 
 // Server bindings.
 export { defineLoader } from './define-loader.js';

--- a/packages/iso/src/internal/__tests__/serialize.test-d.ts
+++ b/packages/iso/src/internal/__tests__/serialize.test-d.ts
@@ -1,0 +1,123 @@
+// Type-level tests for the `Serialize<T>` wire-mirror. Run under
+// `pnpm test:types` (`vitest --typecheck.only`); tsc is the oracle. These pin
+// the JSON round-trip transform applied at the loader/action client boundary.
+import { expectTypeOf } from 'vitest';
+import type { Serialize } from '../serialize.js';
+import type { LoaderRef } from '../../define-loader.js';
+import type { UseActionResult } from '../../action.js';
+import type { ActionResult } from '../../use-action-result.js';
+
+// ---------------------------------------------------------------------------
+// Primitives pass through unchanged.
+// ---------------------------------------------------------------------------
+expectTypeOf<Serialize<string>>().toEqualTypeOf<string>();
+expectTypeOf<Serialize<number>>().toEqualTypeOf<number>();
+expectTypeOf<Serialize<boolean>>().toEqualTypeOf<boolean>();
+expectTypeOf<Serialize<null>>().toEqualTypeOf<null>();
+expectTypeOf<Serialize<'lit'>>().toEqualTypeOf<'lit'>();
+
+// ---------------------------------------------------------------------------
+// toJSON-bearing values serialize as the method's return. Date -> string.
+// ---------------------------------------------------------------------------
+expectTypeOf<Serialize<Date>>().toEqualTypeOf<string>();
+expectTypeOf<Serialize<{ toJSON(): number }>>().toEqualTypeOf<number>();
+expectTypeOf<Serialize<{ toJSON(): { n: Date } }>>().toEqualTypeOf<{
+  n: string;
+}>();
+
+// ---------------------------------------------------------------------------
+// Non-serializable whole values collapse to `never` (surfaces as a compile
+// error when consumed). bigint actually throws at runtime.
+// ---------------------------------------------------------------------------
+expectTypeOf<Serialize<bigint>>().toEqualTypeOf<never>();
+expectTypeOf<Serialize<symbol>>().toEqualTypeOf<never>();
+expectTypeOf<Serialize<() => void>>().toEqualTypeOf<never>();
+expectTypeOf<Serialize<undefined>>().toEqualTypeOf<never>();
+
+// ---------------------------------------------------------------------------
+// Objects recurse; Date members become strings; plain shapes are preserved.
+// ---------------------------------------------------------------------------
+expectTypeOf<Serialize<{ a: string; b: number }>>().toEqualTypeOf<{
+  a: string;
+  b: number;
+}>();
+expectTypeOf<Serialize<{ at: Date; nested: { when: Date } }>>().toEqualTypeOf<{
+  at: string;
+  nested: { when: string };
+}>();
+
+// A key whose value cannot serialize is dropped entirely.
+expectTypeOf<Serialize<{ a: string; fn: () => void }>>().toEqualTypeOf<{
+  a: string;
+}>();
+expectTypeOf<Serialize<{ a: string; big: bigint }>>().toEqualTypeOf<{
+  a: string;
+}>();
+expectTypeOf<Serialize<{ a: string; bad: undefined }>>().toEqualTypeOf<{
+  a: string;
+}>();
+
+// An optional property stays optional; a required `T | undefined` becomes
+// optional (the key is absent on the wire when undefined).
+expectTypeOf<Serialize<{ a?: string }>>().toEqualTypeOf<{ a?: string }>();
+expectTypeOf<Serialize<{ a: string | undefined }>>().toEqualTypeOf<{
+  a?: string;
+}>();
+expectTypeOf<Serialize<{ req: string; opt?: number }>>().toEqualTypeOf<{
+  req: string;
+  opt?: number;
+}>();
+
+// ---------------------------------------------------------------------------
+// Arrays / tuples recurse element-wise.
+// ---------------------------------------------------------------------------
+expectTypeOf<Serialize<{ id: number }[]>>().toEqualTypeOf<{ id: number }[]>();
+expectTypeOf<Serialize<Date[]>>().toEqualTypeOf<string[]>();
+expectTypeOf<Serialize<[string, Date]>>().toEqualTypeOf<[string, string]>();
+
+// A non-serializable array element becomes `null` (JSON.stringify nulls it),
+// including the `undefined`/function arm of a union element.
+expectTypeOf<Serialize<(string | undefined)[]>>().toEqualTypeOf<
+  (string | null)[]
+>();
+expectTypeOf<Serialize<[string, () => void]>>().toEqualTypeOf<[string, null]>();
+
+// ---------------------------------------------------------------------------
+// Map / Set serialize to the empty object.
+// ---------------------------------------------------------------------------
+expectTypeOf<Serialize<Map<string, number>>>().toEqualTypeOf<
+  Record<string, never>
+>();
+expectTypeOf<Serialize<Set<number>>>().toEqualTypeOf<Record<string, never>>();
+
+// ---------------------------------------------------------------------------
+// Deep nesting composes (the common loader-return shape).
+// ---------------------------------------------------------------------------
+expectTypeOf<
+  Serialize<{ items: { id: number; createdAt: Date }[]; total: number }>
+>().toEqualTypeOf<{
+  items: { id: number; createdAt: string }[];
+  total: number;
+}>();
+
+// ---------------------------------------------------------------------------
+// Boundary wiring: the consumer-facing return types actually APPLY Serialize
+// (not just that Serialize<T> works in isolation). A reverted seam fails here.
+// ---------------------------------------------------------------------------
+
+// Loader: `useData()` and the `View` render arg expose the wire shape.
+expectTypeOf<ReturnType<LoaderRef<{ at: Date }>['useData']>>().toEqualTypeOf<{
+  at: string;
+}>();
+
+// Action hook: `useAction().data` is `Serialize<TResult> | null`.
+expectTypeOf<UseActionResult<unknown, { at: Date }>['data']>().toEqualTypeOf<{
+  at: string;
+} | null>();
+
+// PE/SSR action result store: the success `data` is the wire shape.
+type SuccessResult = Extract<
+  ActionResult<unknown, { at: Date }>,
+  { kind: 'success' }
+>;
+expectTypeOf<SuccessResult['data']>().toEqualTypeOf<{ at: string }>();

--- a/packages/iso/src/internal/serialize.ts
+++ b/packages/iso/src/internal/serialize.ts
@@ -1,0 +1,103 @@
+// Models what a value of type `T` becomes after a JSON round-trip
+// (`JSON.parse(JSON.stringify(x))`) -- which is how EVERY loader/action value
+// crosses the server->client wire in this framework. The wire is plain JSON on
+// every path: the SSR embed (`internal/envelope.tsx`), the `/__loaders` fetch
+// and the action `__outcome` envelope (`internal/loader-fetch.ts`,
+// `internal/action-envelope.ts`), and the per-chunk SSE codec
+// (`@hono-preact/server` `sse.ts`) all `JSON.stringify` to encode and
+// `JSON.parse`/`res.json()` to decode. There is no richer codec (no
+// superjson / Date / Map preservation).
+//
+// The client-facing types (`useData()`, `useAction().data`, `onChunk`,
+// `useActionResult().data`) are therefore `Serialize<T>`, not the server-side
+// `T`: typing them as `T` is a latent lie, since a loader returning
+// `{ at: Date }` yields `{ at: string }` once it reaches the client.
+//
+// The transform mirrors `JSON.stringify` exactly:
+//   - JSON primitives (string / number / boolean / null) pass through.
+//   - A value with a `toJSON()` method serializes as that method's return
+//     (`Date` -> its ISO string; any user type implementing `toJSON` likewise).
+//   - `undefined`, functions, symbols and `bigint` cannot live at a value
+//     position: in an object their KEY is dropped; in an array the ELEMENT
+//     becomes `null`; as a whole value they collapse to `never`, so a
+//     non-serializable loader/action return surfaces as a compile error.
+//     (`bigint` actually THROWS at runtime; `never` flags it.)
+//   - Arrays / tuples recurse element-wise; tuple shape is preserved.
+//   - `Map` / `Set` serialize to the empty object (no enumerable own props).
+//   - Objects recurse; a key whose value can hold `undefined` becomes optional.
+//
+// Known imprecision (shared with type-fest's `Jsonify`): for a class instance
+// the transform reads `keyof`, which includes prototype getters, so an
+// accessor-backed property may appear that `JSON.stringify` would omit. Plain
+// data objects -- the overwhelmingly common loader/action return -- are exact.
+
+type JsonPrimitive = string | number | boolean | null;
+
+// Value-position types JSON cannot represent. `bigint` throws; the others are
+// dropped (object property) or nulled (array element).
+type NonSerializable =
+  | undefined
+  | symbol
+  | bigint
+  | ((...args: never[]) => unknown);
+
+// Array element transform: a non-serializable element -- including the
+// `undefined` arm of a union like `(string | undefined)[]` -- becomes `null`,
+// matching how `JSON.stringify` handles array holes / functions / undefined.
+// Naked-`T` distribution splits the union before the check.
+type SerializeElement<T> = T extends NonSerializable ? null : Serialize<T>;
+
+type SerializeArray<T extends readonly unknown[]> = {
+  [K in keyof T]: SerializeElement<T[K]>;
+};
+
+// A key is dropped when its value has no serializable arm at all (e.g. a
+// required `() => void` or `bigint`, whose `Serialize` is `never`). Wrapped in
+// tuples so the `extends never` test is not itself distributive.
+type IsDropped<V> = [Serialize<V>] extends [never] ? true : false;
+
+// Merge an intersection of mapped types into a single object literal,
+// preserving optional/readonly modifiers (homomorphic over `keyof`). Keeps the
+// serialized object types readable when hovered instead of `{ … } & { … }`.
+type Flatten<T> = { [K in keyof T]: T[K] };
+
+// Object transform, split into two mapped types so optionality is faithful:
+// a key that can hold `undefined` (an optional property, or a `T | undefined`
+// value) becomes optional with `undefined` removed from its type; every other
+// retained key stays required. Either way a key whose value drops entirely is
+// removed via the `as never` key filter. `Flatten` re-merges the two halves.
+type SerializeObject<T> = Flatten<
+  {
+    [K in keyof T as undefined extends T[K]
+      ? never
+      : IsDropped<T[K]> extends true
+        ? never
+        : K]: Serialize<T[K]>;
+  } & {
+    [K in keyof T as undefined extends T[K]
+      ? IsDropped<T[K]> extends true
+        ? never
+        : K
+      : never]?: Serialize<T[K]>;
+  }
+>;
+
+/**
+ * The shape a value of type `T` takes after the JSON round-trip the wire
+ * performs (server -> client). Apply at the consumer-facing boundary so the
+ * declared type matches what the client actually receives. See the file header
+ * for the full transform.
+ */
+export type Serialize<T> = T extends { toJSON(): infer J }
+  ? Serialize<J>
+  : T extends JsonPrimitive
+    ? T
+    : T extends NonSerializable
+      ? never
+      : T extends readonly unknown[]
+        ? SerializeArray<T>
+        : T extends ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
+          ? Record<string, never>
+          : T extends object
+            ? SerializeObject<T>
+            : T;

--- a/packages/iso/src/optimistic-action.ts
+++ b/packages/iso/src/optimistic-action.ts
@@ -6,6 +6,7 @@ import {
 } from './action.js';
 import { useOptimistic, type OptimisticHandle } from './optimistic.js';
 import type { LoaderRef } from './define-loader.js';
+import type { Serialize } from './internal/serialize.js';
 
 export const OPTIMISTIC_BRAND: unique symbol = Symbol('hono-preact.optimistic');
 
@@ -26,7 +27,8 @@ export type UseOptimisticActionOptions<
   base: TBase;
   apply: (current: TBase, payload: TPayload) => TBase;
   invalidate?: 'auto' | ReadonlyArray<LoaderRef<unknown>>;
-  onSuccess?: (data: TResult) => void;
+  // The action result reaches the client JSON round-tripped (`Serialize`).
+  onSuccess?: (data: Serialize<TResult>) => void;
   onError?: (err: Error) => void;
   /** Forwarded to the internal `useOptimistic` call. */
   transition?: boolean;

--- a/packages/iso/src/use-action-result.ts
+++ b/packages/iso/src/use-action-result.ts
@@ -7,9 +7,10 @@ import {
 } from './internal/action-result-store.js';
 import { isBrowser } from './is-browser.js';
 import type { ActionStub } from './action.js';
+import type { Serialize } from './internal/serialize.js';
 
 export type ActionResult<TPayload, TResult> =
-  | { kind: 'success'; data: TResult; submittedPayload: TPayload }
+  | { kind: 'success'; data: Serialize<TResult>; submittedPayload: TPayload }
   | {
       kind: 'deny';
       status: number;
@@ -53,7 +54,7 @@ export function useActionResult<TPayload = unknown, TResult = unknown>(
   if (source.kind === 'success') {
     return {
       kind: 'success',
-      data: source.data as TResult,
+      data: source.data as Serialize<TResult>,
       submittedPayload: source.submittedPayload as TPayload,
     };
   }


### PR DESCRIPTION
Implements item **#6** (`Serialize<T>` wire-mirror type) from the framework quality-comparison backlog (`docs/superpowers/research/2026-06-18-framework-quality-comparison.md`). This is the one lens where React Router genuinely exceeds our data subsystem.

## Why

The server→client wire is **plain JSON on every path** (SSR embed, `/__loaders` fetch, the action `__outcome` envelope, and the per-chunk SSE codec): `JSON.stringify` to encode, `JSON.parse`/`res.json()` to decode. There is no richer codec (no superjson / Date / Map preservation). Yet every client-facing data type claimed the **server** return type verbatim, papered over by ~15 `as T` casts at the decode seams.

That is a latent lie: a loader returning `{ at: Date }` is typed `Date` on the client but is actually a `string` after the round-trip — and the hydration path renders with the rich value while the client receives the serialized one.

## What

**`Serialize<T>`** (`packages/iso/src/internal/serialize.ts`) — a faithful model of `JSON.parse(JSON.stringify(x))`:
- JSON primitives pass through.
- `Date` / any `toJSON()`-bearing value → its method's return.
- Objects drop function/symbol/`bigint`-valued keys; a key that can hold `undefined` becomes optional.
- Arrays/tuples recurse element-wise; a non-serializable element → `null`.
- `Map`/`Set` → `{}`.
- Whole-value `bigint`/`symbol`/bare function → `never`, so a genuinely non-serializable return is a **compile error** (this reconciles the report's "transform" reference with its "compile error on non-serializable" ask).

Since JSON *silently transforms* (Date→string) rather than erroring, the faithful model is a transform (RR's actual approach), with the unrepresentable cases collapsing to `never`.

**Applied across the full client-facing boundary** — every place that surfaces *wire* data now reflects `Serialize<T>`:
- `loader.useData()` + `.View()` render data
- `useAction().data`, `mutate()` result, `onChunk`, `onSuccess`
- `useActionResult()` success data
- `useOptimisticAction` `onSuccess`
- `<Form onSuccess>`
- Exported from the `hono-preact` public barrel.

The loader/action **input** generics stay rich (authors can still return a `Date`); only the **consumer** side reflects the wire.

**Tests** (`serialize.test-d.ts`, run via `pnpm test:types`): the full transform matrix, plus **seam-wiring** assertions that prove the boundary actually applies `Serialize` (`ReturnType<LoaderRef<{at: Date}>['useData']>` is `{at: string}`, etc.) — a reverted seam fails the build.

**Docs**: `loaders.mdx` gains a concise note on the wire-shape typing.

## Breaking, but a no-op for current consumers

This is a type-level breaking change (it replaces a lie). `apps/site` typechecks clean because it already crosses the wire with `Date.now()` numbers, not `Date` objects, so `Serialize<T> === T` there. It only changes types for code that returns richer types — correctly.

## Verification

All seven pre-push gates pass locally: build, format:check, typecheck (exit 0, incl. `apps/site`), test:types, test:coverage (1465 passed), test:integration (4 passed), site build.

## Notes / out of scope

- `submittedPayload` (the echoed request payload) is left as-is: it has its own pre-existing documented caveat (form submissions arrive as `FormDataEntryValue`s), a different boundary from the result-serialization this PR models.
- Class instances with prototype getters are a known imprecision shared with type-fest's `Jsonify` (documented in the file header); plain data objects are exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)