### PR TITLE
fix(iso): guard Serialize<any> recursion + AnyLoaderRef for invalidate/prefetch

### DIFF
--- a/packages/iso/src/action.ts
+++ b/packages/iso/src/action.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'preact/hooks';
 import type { Context } from 'hono';
-import type { LoaderRef } from './define-loader.js';
+import type { AnyLoaderRef } from './define-loader.js';
 import { useInvalidate } from './use-invalidate.js';
 import type { ActionUse } from './internal/use-types.js';
 import { beginSubmit, endSubmit } from './internal/form-submit-store.js';
@@ -136,7 +136,7 @@ type UseActionOptionsCommon<TChunk = never> = {
    *
    * See `/docs/reloading` for the full mental model.
    */
-  invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
+  invalidate?: 'auto' | false | ReadonlyArray<AnyLoaderRef>;
   // Chunks arrive over the wire as JSON, so the client sees `Serialize<TChunk>`.
   onChunk?: (chunk: Serialize<TChunk>) => void;
 };

--- a/packages/iso/src/define-loader.ts
+++ b/packages/iso/src/define-loader.ts
@@ -79,6 +79,18 @@ export interface LoaderRef<T> {
 }
 
 /**
+ * A loader reference with its data type erased: for APIs that operate ON a
+ * loader (invalidate, prefetch) without reading its data shape.
+ *
+ * Uses `LoaderRef<any>`, not `LoaderRef<unknown>`, deliberately. `LoaderRef<T>`
+ * is invariant in `T` (it surfaces `T` through `useData(): Serialize<T>`), so a
+ * concrete `LoaderRef<Movie>` is NOT assignable to `LoaderRef<unknown>`. The
+ * `any` argument erases the data type so any loader is accepted; these call
+ * sites never inspect the data with a meaningful type.
+ */
+export type AnyLoaderRef = LoaderRef<any>;
+
+/**
  * Plugin-emitted opts for `defineLoader`. The `__moduleKey` field is threaded
  * in by the `moduleKeyPlugin` Vite transform; user code does not set it.
  * `cache` is an opt-in for sharing a cache instance across multiple loaders;

--- a/packages/iso/src/form.tsx
+++ b/packages/iso/src/form.tsx
@@ -11,7 +11,7 @@ import { FORM_MODULE_FIELD, FORM_ACTION_FIELD } from './internal/contract.js';
 import { setLastActionResult } from './internal/action-result-store.js';
 import { assignSafeRedirect } from './internal/safe-redirect.js';
 import { decodeActionResponse } from './internal/action-envelope.js';
-import type { LoaderRef } from './define-loader.js';
+import type { AnyLoaderRef } from './define-loader.js';
 import type { Serialize } from './internal/serialize.js';
 import { useInvalidate } from './use-invalidate.js';
 
@@ -36,7 +36,7 @@ export type FormProps<TPayload, TResult> = Omit<
     helpers: { reset: (fields?: string[]) => void }
   ) => void;
   onError?: (err: Error) => void;
-  invalidate?: 'auto' | false | ReadonlyArray<LoaderRef<unknown>>;
+  invalidate?: 'auto' | false | ReadonlyArray<AnyLoaderRef>;
   reset?: boolean;
 };
 

--- a/packages/iso/src/index.ts
+++ b/packages/iso/src/index.ts
@@ -35,6 +35,7 @@ export type { Serialize } from './internal/serialize.js';
 export { defineLoader } from './define-loader.js';
 export type {
   LoaderRef,
+  AnyLoaderRef,
   LoaderCtx,
   Loader as LoaderFn,
 } from './define-loader.js';

--- a/packages/iso/src/internal/__tests__/serialize.test-d.ts
+++ b/packages/iso/src/internal/__tests__/serialize.test-d.ts
@@ -35,6 +35,17 @@ expectTypeOf<Serialize<() => void>>().toEqualTypeOf<never>();
 expectTypeOf<Serialize<undefined>>().toEqualTypeOf<never>();
 
 // ---------------------------------------------------------------------------
+// `any` passes through unchanged. Without the up-front `IsAny` guard these
+// would recurse forever ("Type instantiation is excessively deep") and turn a
+// loader/action returning `any` into a hard compile error at the consumer.
+// ---------------------------------------------------------------------------
+expectTypeOf<Serialize<any>>().toBeAny();
+expectTypeOf<Serialize<any[]>>().toEqualTypeOf<any[]>();
+expectTypeOf<Serialize<Record<string, any>>>().not.toBeNever();
+// A nested `any` field also terminates (it would otherwise recurse).
+expectTypeOf<Serialize<{ data: any }>>().toEqualTypeOf<{ data?: any }>();
+
+// ---------------------------------------------------------------------------
 // Objects recurse; Date members become strings; plain shapes are preserved.
 // ---------------------------------------------------------------------------
 expectTypeOf<Serialize<{ a: string; b: number }>>().toEqualTypeOf<{

--- a/packages/iso/src/internal/serialize.ts
+++ b/packages/iso/src/internal/serialize.ts
@@ -20,18 +20,41 @@
 //   - `undefined`, functions, symbols and `bigint` cannot live at a value
 //     position: in an object their KEY is dropped; in an array the ELEMENT
 //     becomes `null`; as a whole value they collapse to `never`, so a
-//     non-serializable loader/action return surfaces as a compile error.
-//     (`bigint` actually THROWS at runtime; `never` flags it.)
+//     non-serializable WHOLE return surfaces as a compile error.
 //   - Arrays / tuples recurse element-wise; tuple shape is preserved.
 //   - `Map` / `Set` serialize to the empty object (no enumerable own props).
 //   - Objects recurse; a key whose value can hold `undefined` becomes optional.
+//   - `any` passes through unchanged (it cannot be meaningfully narrowed, and
+//     recursing it would not terminate).
 //
-// Known imprecision (shared with type-fest's `Jsonify`): for a class instance
-// the transform reads `keyof`, which includes prototype getters, so an
-// accessor-backed property may appear that `JSON.stringify` would omit. Plain
-// data objects -- the overwhelmingly common loader/action return -- are exact.
+// Known imprecisions (shared with type-fest's `Jsonify`):
+//   - For a class instance the transform reads `keyof`, which includes
+//     prototype getters, so an accessor-backed property may appear that
+//     `JSON.stringify` would omit. Plain data objects -- the overwhelmingly
+//     common loader/action return -- are exact.
+//   - A `bigint` is modeled as `never` at its value position (the key is then
+//     dropped from an object). At runtime a `bigint` anywhere in the payload
+//     makes `JSON.stringify` THROW, failing the whole response rather than
+//     dropping just that key; the type flags the whole-value form, not a
+//     bigint buried in an object.
 
 type JsonPrimitive = string | number | boolean | null;
+
+// `any` satisfies every `extends` arm below (including `{ toJSON() }` with
+// `J = any`), which would recurse `Serialize<any>` forever ("excessively
+// deep"). Detect it up front so it -- and any field typed `any` -- passes
+// through unchanged, matching the pre-`Serialize` behavior at the boundary.
+// The canonical detector: `1 & T` is `any` only when `T` is `any`, so only
+// then does `0 extends 1 & T` hold.
+//
+// VARIANCE NOTE: branching `Serialize<T>` on `IsAny<T>` makes TypeScript
+// measure `Serialize<T>` (and anything returning it, notably `LoaderRef<T>`
+// via `useData(): Serialize<T>`) as INVARIANT in `T`. So a concrete
+// `LoaderRef<Movie>` is no longer assignable to `LoaderRef<unknown>`. The
+// data-type-agnostic loader APIs (`invalidate`, `prefetch`) absorb that by
+// accepting `AnyLoaderRef` (= `LoaderRef<any>`) instead. This is inherent to
+// any-detection here, not specific to the `1 & T` form.
+type IsAny<T> = 0 extends 1 & T ? true : false;
 
 // Value-position types JSON cannot represent. `bigint` throws; the others are
 // dropped (object property) or nulled (array element).
@@ -88,16 +111,19 @@ type SerializeObject<T> = Flatten<
  * declared type matches what the client actually receives. See the file header
  * for the full transform.
  */
-export type Serialize<T> = T extends { toJSON(): infer J }
-  ? Serialize<J>
-  : T extends JsonPrimitive
+export type Serialize<T> =
+  IsAny<T> extends true
     ? T
-    : T extends NonSerializable
-      ? never
-      : T extends readonly unknown[]
-        ? SerializeArray<T>
-        : T extends ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
-          ? Record<string, never>
-          : T extends object
-            ? SerializeObject<T>
-            : T;
+    : T extends { toJSON(): infer J }
+      ? Serialize<J>
+      : T extends JsonPrimitive
+        ? T
+        : T extends NonSerializable
+          ? never
+          : T extends readonly unknown[]
+            ? SerializeArray<T>
+            : T extends ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
+              ? Record<string, never>
+              : T extends object
+                ? SerializeObject<T>
+                : T;

--- a/packages/iso/src/optimistic-action.ts
+++ b/packages/iso/src/optimistic-action.ts
@@ -5,7 +5,7 @@ import {
   type ActionStub,
 } from './action.js';
 import { useOptimistic, type OptimisticHandle } from './optimistic.js';
-import type { LoaderRef } from './define-loader.js';
+import type { AnyLoaderRef } from './define-loader.js';
 import type { Serialize } from './internal/serialize.js';
 
 export const OPTIMISTIC_BRAND: unique symbol = Symbol('hono-preact.optimistic');
@@ -26,7 +26,7 @@ export type UseOptimisticActionOptions<
 > & {
   base: TBase;
   apply: (current: TBase, payload: TPayload) => TBase;
-  invalidate?: 'auto' | ReadonlyArray<LoaderRef<unknown>>;
+  invalidate?: 'auto' | ReadonlyArray<AnyLoaderRef>;
   // The action result reaches the client JSON round-tripped (`Serialize`).
   onSuccess?: (data: Serialize<TResult>) => void;
   onError?: (err: Error) => void;

--- a/packages/iso/src/use-invalidate.ts
+++ b/packages/iso/src/use-invalidate.ts
@@ -1,16 +1,13 @@
 import { useCallback, useContext } from 'preact/hooks';
 import { ReloadContext } from './reload-context.js';
 import { ActiveLoaderIdContext } from './internal/contexts.js';
-import type { LoaderRef } from './define-loader.js';
+import type { AnyLoaderRef } from './define-loader.js';
 
 /** How to update loader caches after an action commits. Same vocabulary as
  * `useAction`'s `invalidate` option: `'auto'` re-runs the active page's loader;
  * an array calls `.invalidate()` on each `LoaderRef` (and re-runs the active
  * loader if it is in the list); `false`/undefined does nothing. */
-export type InvalidateInput =
-  | 'auto'
-  | false
-  | ReadonlyArray<LoaderRef<unknown>>;
+export type InvalidateInput = 'auto' | false | ReadonlyArray<AnyLoaderRef>;
 
 /**
  * Reads the enclosing `ReloadContext` + `ActiveLoaderIdContext` and returns a

--- a/packages/iso/src/use-prefetch.ts
+++ b/packages/iso/src/use-prefetch.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from 'preact/hooks';
 import type { RouteHook } from 'preact-iso';
-import type { LoaderRef } from './define-loader.js';
+import type { AnyLoaderRef } from './define-loader.js';
 import { prefetch } from './prefetch.js';
 import { matchPath } from './route-active.js';
 import { RouteManifestContext } from './internal/route-manifest.js';
@@ -43,7 +43,7 @@ function specificity(pattern: string): number {
  */
 export function usePrefetch(
   href: string,
-  refs: LoaderRef<unknown> | ReadonlyArray<LoaderRef<unknown>>
+  refs: AnyLoaderRef | ReadonlyArray<AnyLoaderRef>
 ): () => void {
   const routes = useContext(RouteManifestContext);
   return useCallback(() => {


### PR DESCRIPTION
Follow-up to #132 (`Serialize<T>` wire-mirror). The deep review of #132 surfaced a HIGH issue after it had already merged; this lands the fix.

## The bug

`Serialize<any>` — and `any[]`, `Record<string, any>`, or any object containing an `any`-typed field — recurses forever: `any` satisfies the `{ toJSON(): infer J }` arm with `J = any`, so the type re-enters `Serialize<any>` and tsc reports **"Type instantiation is excessively deep and possibly infinite"** at every consumer. A loader/action returning `any` (an untyped `fetch().json()`, a third-party return type) would be a hard compile error at the call site — a real regression from the harmless `any` it used to be.

## The fix

1. **`IsAny` guard** (`internal/serialize.ts`): short-circuit `any` up front so it (and any `any`-typed field) passes through unchanged, matching the pre-`Serialize` behavior. Regression assertions added in `serialize.test-d.ts`.

2. **`AnyLoaderRef` for the data-type-agnostic loader APIs.** Branching `Serialize<T>` on `IsAny<T>` makes TypeScript measure `Serialize<T>` — and `LoaderRef<T>` via `useData(): Serialize<T>` — as **invariant** in `T`. So `LoaderRef<Movie>` is no longer assignable to `LoaderRef<unknown>`, which broke `invalidate: [loader]` / `usePrefetch(href, [loaders])` (caught by `apps/site` typecheck). The fix: a new exported `AnyLoaderRef` (= `LoaderRef<any>`) that erases the data type, used at the `invalidate`/`prefetch` positions — they operate on a loader without ever reading its data. `apps/site` typechecks clean again.

   This invariance is inherent to branching on any-detection, not specific to the `1 & T` form (I confirmed an alternative detector flips it identically); `AnyLoaderRef` is the honest expression of "any loader, data type irrelevant."

3. **Comment precision**: the `Serialize` header now notes that a `bigint` buried in an object is modeled as a dropped key, but at runtime `JSON.stringify` *throws* on it (failing the whole response), so the type flags only the whole-value form.

## Verification

All seven pre-push gates pass on top of current `main` (which includes #132): build, format:check, typecheck (exit 0, incl. `apps/site`), test:types, test:coverage (1513 passed), test:integration (4 passed), site build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)